### PR TITLE
fix(curriculum): remove before/after-user-code from rosetta challenges 36-40

### DIFF
--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/596e457071c35c882915b3e4.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/596e457071c35c882915b3e4.md
@@ -21,6 +21,12 @@ Given a list of arbitrarily many strings, implement a function for each of the f
   <li>test if every string is lexically less than the one after it  (i.e. whether the list is in strict ascending order)</li>
 </ul>
 
+# --before-each--
+
+```js
+const testCases = [['AA', 'AA', 'AA', 'AA'], ['AA', 'ACB', 'BB', 'CC'], [], ['AA'], ['BB', 'AA']];
+```
+
 # --hints--
 
 `allEqual` should be a function.
@@ -96,12 +102,6 @@ assert(!azSorted(testCases[4]));
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const testCases = [['AA', 'AA', 'AA', 'AA'], ['AA', 'ACB', 'BB', 'CC'], [], ['AA'], ['BB', 'AA']];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/596fd036dc1ab896c5db98b1.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/596fd036dc1ab896c5db98b1.md
@@ -50,6 +50,13 @@ Demonstrate that it passes the following three test-cases:
   </li>
 </ul>
 
+# --before-each--
+
+```js
+const testCases = [7259, 86400, 6000000];
+const results = ['2 hr, 59 sec', '1 d', '9 wk, 6 d, 10 hr, 40 min'];
+```
+
 # --hints--
 
 `convertSeconds` should be a function.
@@ -77,13 +84,6 @@ assert.equal(convertSeconds(testCases[2]), results[2]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const testCases = [7259, 86400, 6000000];
-const results = ['2 hr, 59 sec', '1 d', '9 wk, 6 d, 10 hr, 40 min'];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/596fda99c69f779975a1b67d.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/596fda99c69f779975a1b67d.md
@@ -23,6 +23,14 @@ The matching should yield the highest number of non-overlapping matches.
 
 In general, this essentially means matching from left-to-right or right-to-left.
 
+# --before-each--
+
+```js
+const testCases = ['the three truths', 'ababababab', 'abaabba*bbaba*bbab'];
+const searchString = ['th', 'abab', 'a*b'];
+const results = [3, 2, 2];
+```
+
 # --hints--
 
 `countSubstring` should be a function.
@@ -50,14 +58,6 @@ assert.equal(countSubstring(testCases[2], searchString[2]), results[2]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const testCases = ['the three truths', 'ababababab', 'abaabba*bbaba*bbab'];
-const searchString = ['th', 'abab', 'a*b'];
-const results = [3, 2, 2];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/59713da0a428c1a62d7db430.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/59713da0a428c1a62d7db430.md
@@ -34,6 +34,26 @@ $\\begin{cases} 2w-x+5y+z=-3 \\\\ 3w+2x+2y-6z=-32 \\\\ w+3x+3y-z=-47 \\\\ 5w-2x-
 
 solve for $w$, $x$, $y$ and $z$, using Cramer's rule.
 
+# --before-each--
+
+```js
+const matrices = [
+  [
+    [2, -1, 5, 1],
+    [3, 2, 2, -6],
+    [1, 3, 3, -1],
+    [5, -2, -3, 3]
+  ],
+  [
+    [3, 1, 1],
+    [2, 2, 5],
+    [1, -3, -4]
+  ]
+];
+const freeTerms = [[-3, -32, -47, 49], [3, -1, 2]];
+const answers = [[2, -12, -4, 1], [1, 1, -1]];
+```
+
 # --hints--
 
 `cramersRule` should be a function.
@@ -55,27 +75,6 @@ assert.deepEqual(cramersRule(matrices[1], freeTerms[1]), answers[1]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const matrices = [
-  [
-    [2, -1, 5, 1],
-    [3, 2, 2, -6],
-    [1, 3, 3, -1],
-    [5, -2, -3, 3]
-  ],
-  [
-    [3, 1, 1],
-    [2, 2, 5],
-    [1, -3, -4]
-  ]
-];
-const freeTerms = [[-3, -32, -47, 49], [3, -1, 2]];
-
-const answers = [[2, -12, -4, 1], [1, 1, -1]];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/597f1e7fbc206f0e9ba95dc4.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/597f1e7fbc206f0e9ba95dc4.md
@@ -12,6 +12,12 @@ Write a function that returns the factors of a positive integer as an array.
 
 These factors are the positive integers by which the number being factored can be divided to yield a positive integer result.
 
+# --before-each--
+
+```js
+const ans=[[1,3,5,9,15,45],[1,53],[1,2,4,8,16,32,64]];
+```
+
 # --hints--
 
 `factors` should be a function.
@@ -39,12 +45,6 @@ assert.deepEqual(factors(64), ans[2]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const ans=[[1,3,5,9,15,45],[1,53],[1,2,4,8,16,32,64]];
-```
 
 ## --seed-contents--
 


### PR DESCRIPTION
Continuation of #66344, limited to the next 5 Rosetta files (36-40).