### PR TITLE
fix(curriculum): remove before/after-user-code from rosetta challenges 41-45

### DIFF
--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/59f40b17e79dbf1ab720ed7a.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/59f40b17e79dbf1ab720ed7a.md
@@ -34,6 +34,30 @@ Write a program which outputs all valid combinations as an array.
 [6, 4, 2] [6, 5, 1]
 ```
 
+# --before-each--
+
+```js
+const nums = [1, 2, 3, 4, 5, 6, 7];
+const total = 12;
+const len = 14;
+const result = [
+  [2, 3, 7],
+  [2, 4, 6],
+  [2, 6, 4],
+  [2, 7, 3],
+  [4, 1, 7],
+  [4, 2, 6],
+  [4, 3, 5],
+  [4, 5, 3],
+  [4, 6, 2],
+  [4, 7, 1],
+  [6, 1, 5],
+  [6, 2, 4],
+  [6, 4, 2],
+  [6, 5, 1]
+];
+```
+
 # --hints--
 
 `combinations` should be a function.
@@ -61,30 +85,6 @@ assert.deepEqual(combinations(nums, total), result);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const nums = [1, 2, 3, 4, 5, 6, 7];
-const total = 12;
-const len = 14;
-const result = [
-  [2, 3, 7],
-  [2, 4, 6],
-  [2, 6, 4],
-  [2, 7, 3],
-  [4, 1, 7],
-  [4, 2, 6],
-  [4, 3, 5],
-  [4, 5, 3],
-  [4, 6, 2],
-  [4, 7, 1],
-  [6, 1, 5],
-  [6, 2, 4],
-  [6, 4, 2],
-  [6, 5, 1]
-];
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5a23c84252665b21eecc7e76.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5a23c84252665b21eecc7e76.md
@@ -14,6 +14,14 @@ The Gamma function can be defined as:
 
 <div style='padding-left: 4em;'><big><big>$\Gamma(x) = \displaystyle\int_0^\infty t^{x-1}e^{-t} dt$</big></big></div>
 
+# --before-each--
+
+```js
+function round(x) {
+  return Number(x).toPrecision(13);
+}
+```
+
 # --hints--
 
 `gamma` should be a function.
@@ -59,14 +67,6 @@ assert.equal(round(gamma(0.5)), round(1.7724538509055159));
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-function round(x) {
-  return Number(x).toPrecision(13);
-}
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5a23c84252665b21eecc7e7a.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5a23c84252665b21eecc7e7a.md
@@ -10,6 +10,18 @@ dashedName: generate-lower-case-ascii-alphabet
 
 Write a function to generate an array of lower case ASCII characters for a given range. For example, given the range `['a', 'd']`, the function should return `['a', 'b', 'c', 'd']`.
 
+# --before-each--
+
+```js
+let results=[
+  [ 'a', 'b', 'c', 'd' ],
+  [ 'c', 'd', 'e', 'f', 'g', 'h', 'i' ],
+  [ 'm', 'n', 'o', 'p', 'q' ],
+  [ 'k', 'l', 'm', 'n' ],
+  [ 't', 'u', 'v', 'w', 'x', 'y', 'z' ]
+]
+```
+
 # --hints--
 
 `lascii` should be a function.
@@ -55,18 +67,6 @@ assert.deepEqual(lascii('t', 'z'), results[4]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-let results=[
-  [ 'a', 'b', 'c', 'd' ],
-  [ 'c', 'd', 'e', 'f', 'g', 'h', 'i' ],
-  [ 'm', 'n', 'o', 'p', 'q' ],
-  [ 'k', 'l', 'm', 'n' ],
-  [ 't', 'u', 'v', 'w', 'x', 'y', 'z' ]
-]
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5a23c84252665b21eecc7eb1.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5a23c84252665b21eecc7eb1.md
@@ -18,6 +18,15 @@ An *identity matrix* is a square matrix of size \\( n \\times n \\), where the d
 
 Write a function that takes a number `n` as a parameter and returns the identity matrix of order \\( n \\times n \\).
 
+# --before-each--
+
+```js
+let results=[[ [ 1 ] ],
+[ [ 1, 0 ], [ 0, 1 ] ],
+[ [ 1, 0, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ],
+[ [ 1, 0, 0, 0 ], [ 0, 1, 0, 0 ], [ 0, 0, 1, 0 ], [ 0, 0, 0, 1 ] ]]
+```
+
 # --hints--
 
 `idMatrix` should be a function.
@@ -57,15 +66,6 @@ assert.deepEqual(idMatrix(4), results[3]);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-let results=[[ [ 1 ] ],
-[ [ 1, 0 ], [ 0, 1 ] ],
-[ [ 1, 0, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ],
-[ [ 1, 0, 0, 0 ], [ 0, 1, 0, 0 ], [ 0, 0, 1, 0 ], [ 0, 0, 0, 1 ] ]]
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/rosetta-code-challenges/5a23c84252665b21eecc7ed2.md
+++ b/curriculum/challenges/english/blocks/rosetta-code-challenges/5a23c84252665b21eecc7ed2.md
@@ -16,136 +16,56 @@ You are given an array of objects representing items to be put in a knapsack. Th
 
 Write a function to solve the knapsack problem. The function is given the array of objects and the maximum weight as parameters. It should return the maximum total value possible.
 
+# --before-each--
+
+```js
+const data = [
+  { name: 'map', weight: 9, value: 150, pieces: 1 },
+  { name: 'compass', weight: 13, value: 35, pieces: 1 },
+  { name: 'water', weight: 153, value: 200, pieces: 2 },
+  { name: 'sandwich', weight: 50, value: 60, pieces: 2 },
+  { name: 'glucose', weight: 15, value: 60, pieces: 2 },
+  { name: 'tin', weight: 68, value: 45, pieces: 3 },
+  { name: 'banana', weight: 27, value: 60, pieces: 3 },
+  { name: 'apple', weight: 39, value: 40, pieces: 3 },
+  { name: 'cheese', weight: 23, value: 30, pieces: 1 },
+  { name: 'beer', weight: 52, value: 10, pieces: 3 },
+  { name: 'suntan, cream', weight: 11, value: 70, pieces: 1 },
+  { name: 'camera', weight: 32, value: 30, pieces: 1 },
+  { name: 'T-shirt', weight: 24, value: 15, pieces: 2 }
+];
+```
+
 # --hints--
 
 `findBestPack([{ name:'map', weight:9, value:150, pieces:1 }, { name:'compass', weight:13, value:35, pieces:1 }, { name:'water', weight:153, value:200, pieces:2 }, { name:'sandwich', weight:50, value:60, pieces:2 }, { name:'glucose', weight:15, value:60, pieces:2 }, { name:'tin', weight:68, value:45, pieces:3 }, { name:'banana', weight:27, value:60, pieces:3 }, { name:'apple', weight:39, value:40, pieces:3 }, { name:'cheese', weight:23, value:30, pieces:1 }, { name:'beer', weight:52, value:10, pieces:3 }, { name:'suntan, cream', weight:11, value:70, pieces:1 }, { name:'camera', weight:32, value:30, pieces:1 }, { name:'T-shirt', weight:24, value:15, pieces:2 }], 300)` should return `755`.
 
 ```js
-assert.equal(
-  findBestPack(
-    [
-      { name: 'map', weight: 9, value: 150, pieces: 1 },
-      { name: 'compass', weight: 13, value: 35, pieces: 1 },
-      { name: 'water', weight: 153, value: 200, pieces: 2 },
-      { name: 'sandwich', weight: 50, value: 60, pieces: 2 },
-      { name: 'glucose', weight: 15, value: 60, pieces: 2 },
-      { name: 'tin', weight: 68, value: 45, pieces: 3 },
-      { name: 'banana', weight: 27, value: 60, pieces: 3 },
-      { name: 'apple', weight: 39, value: 40, pieces: 3 },
-      { name: 'cheese', weight: 23, value: 30, pieces: 1 },
-      { name: 'beer', weight: 52, value: 10, pieces: 3 },
-      { name: 'suntan, cream', weight: 11, value: 70, pieces: 1 },
-      { name: 'camera', weight: 32, value: 30, pieces: 1 },
-      { name: 'T-shirt', weight: 24, value: 15, pieces: 2 }
-    ],
-    300
-  ),
-  755
-);
+assert.equal(findBestPack(data, 300), 755);
 ```
 
 `findBestPack([{ name:'map', weight:9, value:150, pieces:1 }, { name:'compass', weight:13, value:35, pieces:1 }, { name:'water', weight:153, value:200, pieces:2 }, { name:'sandwich', weight:50, value:60, pieces:2 }, { name:'glucose', weight:15, value:60, pieces:2 }, { name:'tin', weight:68, value:45, pieces:3 }, { name:'banana', weight:27, value:60, pieces:3 }, { name:'apple', weight:39, value:40, pieces:3 }, { name:'cheese', weight:23, value:30, pieces:1 }, { name:'beer', weight:52, value:10, pieces:3 }, { name:'suntan, cream', weight:11, value:70, pieces:1 }, { name:'camera', weight:32, value:30, pieces:1 }, { name:'T-shirt', weight:24, value:15, pieces:2 }], 400)` should return `875`.
 
 ```js
-assert.equal(
-  findBestPack(
-    [
-      { name: 'map', weight: 9, value: 150, pieces: 1 },
-      { name: 'compass', weight: 13, value: 35, pieces: 1 },
-      { name: 'water', weight: 153, value: 200, pieces: 2 },
-      { name: 'sandwich', weight: 50, value: 60, pieces: 2 },
-      { name: 'glucose', weight: 15, value: 60, pieces: 2 },
-      { name: 'tin', weight: 68, value: 45, pieces: 3 },
-      { name: 'banana', weight: 27, value: 60, pieces: 3 },
-      { name: 'apple', weight: 39, value: 40, pieces: 3 },
-      { name: 'cheese', weight: 23, value: 30, pieces: 1 },
-      { name: 'beer', weight: 52, value: 10, pieces: 3 },
-      { name: 'suntan, cream', weight: 11, value: 70, pieces: 1 },
-      { name: 'camera', weight: 32, value: 30, pieces: 1 },
-      { name: 'T-shirt', weight: 24, value: 15, pieces: 2 }
-    ],
-    400
-  ),
-  875
-);
+assert.equal(findBestPack(data, 400), 875);
 ```
 
 `findBestPack([{ name:'map', weight:9, value:150, pieces:1 }, { name:'compass', weight:13, value:35, pieces:1 }, { name:'water', weight:153, value:200, pieces:2 }, { name:'sandwich', weight:50, value:60, pieces:2 }, { name:'glucose', weight:15, value:60, pieces:2 }, { name:'tin', weight:68, value:45, pieces:3 }, { name:'banana', weight:27, value:60, pieces:3 }, { name:'apple', weight:39, value:40, pieces:3 }, { name:'cheese', weight:23, value:30, pieces:1 }, { name:'beer', weight:52, value:10, pieces:3 }, { name:'suntan, cream', weight:11, value:70, pieces:1 }, { name:'camera', weight:32, value:30, pieces:1 }, { name:'T-shirt', weight:24, value:15, pieces:2 }], 500)` should return `1015`.
 
 ```js
-assert.equal(
-  findBestPack(
-    [
-      { name: 'map', weight: 9, value: 150, pieces: 1 },
-      { name: 'compass', weight: 13, value: 35, pieces: 1 },
-      { name: 'water', weight: 153, value: 200, pieces: 2 },
-      { name: 'sandwich', weight: 50, value: 60, pieces: 2 },
-      { name: 'glucose', weight: 15, value: 60, pieces: 2 },
-      { name: 'tin', weight: 68, value: 45, pieces: 3 },
-      { name: 'banana', weight: 27, value: 60, pieces: 3 },
-      { name: 'apple', weight: 39, value: 40, pieces: 3 },
-      { name: 'cheese', weight: 23, value: 30, pieces: 1 },
-      { name: 'beer', weight: 52, value: 10, pieces: 3 },
-      { name: 'suntan, cream', weight: 11, value: 70, pieces: 1 },
-      { name: 'camera', weight: 32, value: 30, pieces: 1 },
-      { name: 'T-shirt', weight: 24, value: 15, pieces: 2 }
-    ],
-    500
-  ),
-  1015
-);
+assert.equal(findBestPack(data, 500), 1015);
 ```
 
 `findBestPack([{ name:'map', weight:9, value:150, pieces:1 }, { name:'compass', weight:13, value:35, pieces:1 }, { name:'water', weight:153, value:200, pieces:2 }, { name:'sandwich', weight:50, value:60, pieces:2 }, { name:'glucose', weight:15, value:60, pieces:2 }, { name:'tin', weight:68, value:45, pieces:3 }, { name:'banana', weight:27, value:60, pieces:3 }, { name:'apple', weight:39, value:40, pieces:3 }, { name:'cheese', weight:23, value:30, pieces:1 }, { name:'beer', weight:52, value:10, pieces:3 }, { name:'suntan, cream', weight:11, value:70, pieces:1 }, { name:'camera', weight:32, value:30, pieces:1 }, { name:'T-shirt', weight:24, value:15, pieces:2 }], 600)` should return `1120`.
 
 ```js
-assert.equal(
-  findBestPack(
-    [
-      { name: 'map', weight: 9, value: 150, pieces: 1 },
-      { name: 'compass', weight: 13, value: 35, pieces: 1 },
-      { name: 'water', weight: 153, value: 200, pieces: 2 },
-      { name: 'sandwich', weight: 50, value: 60, pieces: 2 },
-      { name: 'glucose', weight: 15, value: 60, pieces: 2 },
-      { name: 'tin', weight: 68, value: 45, pieces: 3 },
-      { name: 'banana', weight: 27, value: 60, pieces: 3 },
-      { name: 'apple', weight: 39, value: 40, pieces: 3 },
-      { name: 'cheese', weight: 23, value: 30, pieces: 1 },
-      { name: 'beer', weight: 52, value: 10, pieces: 3 },
-      { name: 'suntan, cream', weight: 11, value: 70, pieces: 1 },
-      { name: 'camera', weight: 32, value: 30, pieces: 1 },
-      { name: 'T-shirt', weight: 24, value: 15, pieces: 2 }
-    ],
-    600
-  ),
-  1120
-);
+assert.equal(findBestPack(data, 600), 1120);
 ```
 
 `findBestPack([{ name:'map', weight:9, value:150, pieces:1 }, { name:'compass', weight:13, value:35, pieces:1 }, { name:'water', weight:153, value:200, pieces:2 }, { name:'sandwich', weight:50, value:60, pieces:2 }, { name:'glucose', weight:15, value:60, pieces:2 }, { name:'tin', weight:68, value:45, pieces:3 }, { name:'banana', weight:27, value:60, pieces:3 }, { name:'apple', weight:39, value:40, pieces:3 }, { name:'cheese', weight:23, value:30, pieces:1 }, { name:'beer', weight:52, value:10, pieces:3 }, { name:'suntan, cream', weight:11, value:70, pieces:1 }, { name:'camera', weight:32, value:30, pieces:1 }, { name:'T-shirt', weight:24, value:15, pieces:2 }], 700)` should return `1225`.
 
 ```js
-assert.equal(
-  findBestPack(
-    [
-      { name: 'map', weight: 9, value: 150, pieces: 1 },
-      { name: 'compass', weight: 13, value: 35, pieces: 1 },
-      { name: 'water', weight: 153, value: 200, pieces: 2 },
-      { name: 'sandwich', weight: 50, value: 60, pieces: 2 },
-      { name: 'glucose', weight: 15, value: 60, pieces: 2 },
-      { name: 'tin', weight: 68, value: 45, pieces: 3 },
-      { name: 'banana', weight: 27, value: 60, pieces: 3 },
-      { name: 'apple', weight: 39, value: 40, pieces: 3 },
-      { name: 'cheese', weight: 23, value: 30, pieces: 1 },
-      { name: 'beer', weight: 52, value: 10, pieces: 3 },
-      { name: 'suntan, cream', weight: 11, value: 70, pieces: 1 },
-      { name: 'camera', weight: 32, value: 30, pieces: 1 },
-      { name: 'T-shirt', weight: 24, value: 15, pieces: 2 }
-    ],
-    700
-  ),
-  1225
-);
+assert.equal(findBestPack(data, 700), 1225);
 ```
 
 # --seed--


### PR DESCRIPTION
Continuation of #66344, limited to the next 5 Rosetta files (41-45).
]