### PR TITLE
fix(curriculum): clarify which anchor element to modify in cat photo app step 15

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dfa2407b521be39a3de7be1.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dfa2407b521be39a3de7be1.md
@@ -17,7 +17,7 @@ Here is the basic syntax for an `a` element with a `target` attribute:
 <a href="https://www.freecodecamp.org" target="_blank">freeCodeCamp</a>
 ```
 
-Add a `target` attribute with the value `_blank` to the anchor (`a`) element's opening tag, so that the link opens in a new tab.
+Add a `target` attribute with the value `_blank` to the `cat photos` anchor (`a`) element's opening tag, so that the link opens in a new tab.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This tries to clarify a long-lasting confusion on this step about which `a` element should have the `target` attribute.