### PR TITLE
fix(curriculum): fix lab-scatterplot-graph not passing test-curriculum-content

### DIFF
--- a/curriculum/challenges/english/blocks/lab-scatterplot-graph/bd7178d8c242eddfaeb5bd13.md
+++ b/curriculum/challenges/english/blocks/lab-scatterplot-graph/bd7178d8c242eddfaeb5bd13.md
@@ -1179,7 +1179,7 @@ d3.json(url)
         return y(d.Time);
       })
       .attr('data-xvalue', function (d) {
-        return d.Year;
+        return d.Year + '-01-02';
       })
       .attr('data-yvalue', function (d) {
         return d.Time.toISOString();


### PR DESCRIPTION
The block lab-scatterplot-test is failing the test with pnpm test-curriculum-content in all languages, including English, due to a timezone issue with d.Year that makes it come up with the previous year instead of the current. d.Year is set to midnight of 01-01, but, depending on the timezone, it will return 12-31 of the previous year. Adding a day to line 1182 fixes the issue.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.
