### PR TITLE
fix(client): preserve html entities in console output

### DIFF
--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -10,15 +10,32 @@ interface OutputProps {
   output: string;
 }
 
+const PRESERVE_HTML_ENTITIES = ['amp', 'lt', 'gt', 'quot', 'apos'];
+
+// Double-encode PRESERVE_HTML_ENTITIES so they survive decoding by sanitizeHtml
+function preserveHtmlEntities(str: string) {
+  const entityPattern = new RegExp(
+    `&(${PRESERVE_HTML_ENTITIES.join('|')})(;?)`,
+    'g'
+  );
+
+  return str.replace(entityPattern, '&amp;$1$2');
+}
+
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-  const message = sanitizeHtml(!isEmpty(output) ? output : defaultOutput, {
+  const message = !isEmpty(output) ? output : defaultOutput;
+
+  const preserved = preserveHtmlEntities(message);
+
+  const sanitizedMessage = sanitizeHtml(preserved, {
     allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
   });
+
   return (
     <pre
       className='output-text'
       data-playwright-test-label='output-text'
-      dangerouslySetInnerHTML={{ __html: message }}
+      dangerouslySetInnerHTML={{ __html: sanitizedMessage }}
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #63788 

<!-- Feel free to add any additional description of changes below this line -->

<details>
     <summary>Image</summary>
    <p align="center">  
       <img width="600" height="400" alt="brave_screenshot_fictional-robot-jjqvr56xv5wg3qp95-8000 app github dev" src="https://github.com/user-attachments/assets/ac39d818-8ba6-48fa-9773-3675a6c58dd9" />
      <img width="600" height="400" alt="brave_screenshot_verbose-system-v6q9pv4x9pvx3pg7q-8000 app github dev (1)" src="https://github.com/user-attachments/assets/70b6328f-07e3-412d-a11e-971fe07cc3d7" />
    </p>
</details>