### PR TITLE
fix: truncate search input placeholder on mobile viewports

### DIFF
--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -44,6 +44,8 @@
   font-size: 18px;
   display: inline-block;
   height: var(--header-element-size);
+  text-wrap: nowrap;
+  text-overflow: ellipsis;
 }
 
 .ais-SearchBox-submit,


### PR DESCRIPTION

* [x] I have read and followed the [[contribution guidelines](https://contribute.freecodecamp.org/)](https://contribute.freecodecamp.org).
* [x] I have read and followed the [[how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes locally.

Closes #66320

## Description

On mobile viewports, the placeholder text in the navigation search bar gets clipped because the input field does not have enough space to display the full text.

This PR adds truncation styles to the search input so that the placeholder text is displayed with an ellipsis (`...`) instead of being cut off.

## After
Placeholder text truncates properly with ellipsis.

<img width="347" height="375" alt="Screenshot 2026-03-14 at 12 48 33 PM" src="https://github.com/user-attachments/assets/4a99d953-8267-4f30-a53b-cca1e80d106d" />
