### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 1-4

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/56104e9e514f539506016a5c.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56104e9e514f539506016a5c.md
@@ -42,12 +42,6 @@ assert.deepEqual(myArray, [1, 3, 5, 7, 9]);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if(typeof myArray !== "undefined"){(function(){return myArray;})();}
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56105e7b514f539506016a5e.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56105e7b514f539506016a5e.md
@@ -50,12 +50,6 @@ assert.deepEqual(myArray, [9, 7, 5, 3, 1]);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if(typeof myArray !== "undefined"){(function(){return myArray;})();}
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244aa.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244aa.md
@@ -46,12 +46,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(a,b,c){ return "a = " + a + ", b = " + b + ", c = '" + c + "'"; })(a,b,c);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ac.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ac.md
@@ -56,12 +56,6 @@ assert(/let myVar = 87;/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return 'myVar = ' + z;})(myVar);
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107
