### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 5-8

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ad.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ad.md
@@ -60,12 +60,6 @@ assert(/let myVar = 11;/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return 'myVar = ' + z;})(myVar);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ae.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ae.md
@@ -55,14 +55,6 @@ assert(/\s+?remainder\s*?=\s*?.*%.*;?/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function (y) {
-  return 'remainder = ' + y;
-})(remainder);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244af.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244af.md
@@ -68,12 +68,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(a,b,c){ return "a = " + a + ", b = " + b + ", c = " + c; })(a,b,c);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b0.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b0.md
@@ -60,12 +60,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(a,b,c){ return "a = " + a + ", b = " + b + ", c = " + c; })(a,b,c);
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107
