### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 9-12

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b1.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b1.md
@@ -62,12 +62,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(a,b,c){ return "a = " + a + ", b = " + b + ", c = " + c; })(a,b,c);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b2.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b2.md
@@ -62,12 +62,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(a,b,c){ return "a = " + a + ", b = " + b + ", c = " + c; })(a,b,c);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b5.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b5.md
@@ -46,18 +46,6 @@ assert(/I am a "double quoted" string inside "double quotes(\."|"\.)$/.test(mySt
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(){
-  if(typeof myStr === 'string') {
-    console.log("myStr = \"" + myStr + "\"");
-  } else {
-    console.log("myStr is undefined");
-  }
-})();
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b7.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b7.md
@@ -63,18 +63,6 @@ assert(/myStr\s*=/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(){
-  if(typeof myStr === 'string') {
-    return 'myStr = "' + myStr + '"';
-  } else {
-    return 'myStr is not a string';
-  }
-})();
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107
