### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 13-16

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b8.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b8.md
@@ -47,18 +47,6 @@ assert(__helpers.removeJSComments(code).match(/myStr\s*\+=\s*(["']).*\1/g));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(){
-  if(typeof myStr === 'string') {
-    return 'myStr = "' + myStr + '"';
-  } else {
-    return 'myStr is not a string';
-  }
-})();
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b9.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244b9.md
@@ -39,25 +39,6 @@ assert(__helpers.removeJSComments(code).match(/["']\s*\+\s*myName\s*\+\s*["']/g)
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(){
-  var output = [];
-  if(typeof myName === 'string') {
-    output.push('myName = "' + myName + '"');
-  } else {
-    output.push('myName is not a string');
-  }
-  if(typeof myStr === 'string') {
-    output.push('myStr = "' + myStr + '"');
-  } else {
-    output.push('myStr is not a string');
-  }
-  return output.join('\n');
-})();
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ba.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244ba.md
@@ -44,12 +44,6 @@ assert(/myStr = "Jello World"/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(v){return "myStr = " + v;})(myStr);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244bb.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244bb.md
@@ -30,6 +30,16 @@ You will need to use the string concatenation operator `+` to build a new string
 
 You will also need to account for spaces in your string, so that the final sentence has spaces between all the words. The result should be a complete sentence.
 
+# --before-each--
+
+```js
+const removeAssignments = str => str
+  .replace(/myNoun\s*=\s*["']dog["']/g, '')
+  .replace(/myAdjective\s*=\s*["']big["']/g, '')
+  .replace(/myVerb\s*=\s*["']ran["']/g, '')
+  .replace(/myAdverb\s*=\s*["']quickly["']/g, '');
+```
+
 # --hints--
 
 `wordBlanks` should be a string.
@@ -73,16 +83,6 @@ assert(
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const removeAssignments = str => str
-  .replace(/myNoun\s*=\s*["']dog["']/g, '')
-  .replace(/myAdjective\s*=\s*["']big["']/g, '')
-  .replace(/myVerb\s*=\s*["']ran["']/g, '')
-  .replace(/myAdverb\s*=\s*["']quickly["']/g, '');
-```
 
 ## --seed-contents--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107
