### PR TITLE
fix: apply aria-label to all code blocks for screen reader accessibility

### DIFF
--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -60,14 +60,13 @@ export function enhancePrismAccessibility(
     cpp: 'C++'
   };
   const parent = prismEnv?.element?.parentElement;
-  if (
-    !parent ||
-    parent.nodeName !== 'PRE' ||
-    parent.tabIndex !== 0 ||
-    parent.dataset.noAria === 'true'
-  ) {
-    return;
-  }
+if (
+  !parent ||
+  parent.nodeName !== 'PRE' ||
+  parent.dataset.noAria === 'true'
+) {
+  return;
+}
 
   parent.setAttribute('role', 'region');
   const codeType = prismEnv.element?.className


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## What does this PR do?
Removes the `tabIndex !== 0` condition from `enhancePrismAccessibility` 
so that aria-labels are applied to ALL code blocks, not just overflowing ones.

## Why?
JAWS screen reader was only saying "Code example" instead of reading 
the actual language name (e.g. "Python code example") because the 
aria-label was never being set on non-overflowing code blocks.

## Forum Issue
https://forum.freecodecamp.org/t/screen-reader-accessibility-of-python-and-java-script-courses