### PR TITLE
fix: add missing test case and fix double semicolon in screaming snake case challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69272dcf1c24b44fd79137c3.md
@@ -55,6 +55,12 @@ assert.equal(toScreamingSnakeCase("user-address"), "USER_ADDRESS");
 assert.equal(toScreamingSnakeCase("username"), "USERNAME");
 ```
 
+`toScreamingSnakeCase("my_variable_name")` should return `"MY_VARIABLE_NAME"`.
+
+```js
+assert.equal(toScreamingSnakeCase("my_variable_name"), "MY_VARIABLE_NAME");
+```
+
 # --seed--
 
 ## --seed-contents--
@@ -73,6 +79,6 @@ function toScreamingSnakeCase(variableName) {
   let temp = variableName.replace(/[-_]+/g, ' ');
   temp = temp.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
   const words = temp.trim().split(/\s+/);
-  return words.join('_').toUpperCase();;
+  return words.join('_').toUpperCase();
 }
 ```

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/69272dcf1c24b44fd79137c3.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/69272dcf1c24b44fd79137c3.md
@@ -70,6 +70,15 @@ TestCase().assertEqual(to_screaming_snake_case("username"), "USERNAME")`)
 }})
 ```
 
+`to_screaming_snake_case("my_variable_name")` should return `"MY_VARIABLE_NAME"`.
+
+```js
+({test: () => { runPython(`
+from unittest import TestCase
+TestCase().assertEqual(to_screaming_snake_case("my_variable_name"), "MY_VARIABLE_NAME")`)
+}})
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
- [x] I have followed the [how to open a pull request guide](https://contribute.freecodecamp.org/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

The Screaming Snake Case daily challenge (#140) had two issues:

1. **Missing test case** — no test verified that underscores in `snake_case` input are preserved in the output. A wrong solution that strips underscores (e.g. returning `"USERID"` instead of `"USER_ID"`) could pass all existing tests. Added `toScreamingSnakeCase("my_variable_name")` → `"MY_VARIABLE_NAME"` to catch this.

2. **Double semicolon in solution** — the return statement had `;;` instead of `;`.