### PR TITLE
fix(client): allow touchmove scrolling in classic editor on mobile

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -155,9 +155,16 @@ const BASE_LAYOUT = {
   testsPane: { flex: 0.3 }
 };
 
+const isTouchDevice = (): boolean =>
+  typeof window !== 'undefined' && 'ontouchstart' in window;
+
 // Used to prevent monaco from stealing mouse/touch events on the upper jaw
 // content widget so they can trigger their default actions. (Issue #46166)
 const handleContentWidgetEvents = (e: MouseEvent | TouchEvent): void => {
+  if (e.type === 'touchmove' && isTouchDevice()) {
+    return;
+  }
+
   const target = e.target as HTMLElement;
   if (target?.closest('.editor-upper-jaw')) {
     e.stopPropagation();


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64798

On Chrome for Android, vertical scrolling in the classic JavaScript 
challenge editor was blocked or inconsistent, making it difficult to 
access instructions, code, or the console on mobile devices.

Added a touch-device check using `'ontouchstart' in window` and skipped 
touchmove interception on touch devices. Desktop behavior and horizontal 
scrolling inside the editor remain unchanged.