### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 17-21

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244bc.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244bc.md
@@ -23,59 +23,28 @@ There should be at least 5 sub-arrays in the list.
 `myList` should be an array.
 
 ```js
-assert(isArray);
+assert(Array.isArray(myList));
 ```
 
 The first elements in each of your sub-arrays should all be strings.
 
 ```js
-assert(hasString);
+assert(myList.every(elem => elem && typeof elem[0] === 'string'));
 ```
 
 The second elements in each of your sub-arrays should all be numbers.
 
 ```js
-assert(hasNumber);
+assert(myList.every(elem => elem && typeof elem[1] === 'number'));
 ```
 
 You should have at least 5 items in your list.
 
 ```js
-assert(count > 4);
+assert(myList.length > 4);
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-var count = 0;
-var isArray = false;
-var hasString = false;
-var hasNumber = false;
-(function(list){
-  if(Array.isArray(myList)) {
-    isArray = true;
-    if(myList.length > 0) {
-      hasString = true;
-      hasNumber = true;
-      for (var elem of myList) {
-        if(!elem || !elem[0] || typeof elem[0] !== 'string') {
-          hasString = false;
-        }
-        if(!elem || typeof elem[1] !== 'number') {
-          hasNumber = false;
-        }
-      }
-    }
-    count = myList.length;
-    return JSON.stringify(myList);
-  } else {
-    return "myList is not an array";
-  }
-
-})(myList);
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244c3.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244c3.md
@@ -38,12 +38,6 @@ assert(/processed\s*=\s*processArg\(\s*7\s*\)/.test(__helpers.removeJSComments(c
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(){return "processed = " + processed})();
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244c7.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244c7.md
@@ -64,12 +64,6 @@ assert(__helpers.removeJSComments(code).match(/testObj\.\w+/g).length > 1);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(a,b) { return "hatValue = '" + a + "', shirtValue = '" + b + "'"; })(hatValue,shirtValue);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244c8.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244c8.md
@@ -68,12 +68,6 @@ assert(__helpers.removeJSComments(code).match(/testObj\s*?\[('|")[^'"]+\1\]/g).l
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(a,b) { return "entreeValue = '" + a + "', drinkValue = '" + b + "'"; })(entreeValue,drinkValue);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244c9.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244c9.md
@@ -72,12 +72,6 @@ assert(/testObj\s*?\[\s*playerNumber\s*\]/.test(__helpers.removeJSComments(code)
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if(typeof player !== "undefined"){(function(v){return v;})(player);}
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107