### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 22-26

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/5675e877dbd60be8ad28edc6.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/5675e877dbd60be8ad28edc6.md
@@ -52,12 +52,6 @@ assert(!__helpers.removeWhiteSpace(__helpers.removeJSComments(code)).match(/tota
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(){if(typeof total !== 'undefined') { return "total = " + total; } else { return "total is undefined";}})()
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392ca.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392ca.md
@@ -64,12 +64,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if(typeof myArray !== "undefined" && typeof myData !== "undefined"){(function(y,z){return 'myArray = ' + JSON.stringify(y) + ', myData = ' + JSON.stringify(z);})(myArray, myData);}
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392cb.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392cb.md
@@ -53,12 +53,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return 'myArray = ' + JSON.stringify(z);})(myArray);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392cc.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392cc.md
@@ -65,12 +65,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if (typeof removedFromMyArray !== 'undefined') (function(y, z){return 'myArray = ' + JSON.stringify(y) + ' & removedFromMyArray = ' + JSON.stringify(z);})(myArray, removedFromMyArray);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392cd.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392cd.md
@@ -61,12 +61,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if (typeof removedFromMyArray !== 'undefined') (function(y, z){return 'myArray = ' + JSON.stringify(y) + ' & removedFromMyArray = ' + JSON.stringify(z);})(myArray, removedFromMyArray);
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107