### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 27-31

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392ce.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392ce.md
@@ -52,12 +52,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(y, z){return 'myArray = ' + JSON.stringify(y);})(myArray);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392cf.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392cf.md
@@ -31,6 +31,31 @@ You can call or <dfn>invoke</dfn> this function by using its name followed by pa
   </li>
 </ol>
 
+# --before-each--
+
+```js
+function testConsole() {
+  var originalConsole = console;
+  var nativeLog = console.log;
+  var hiWorldWasLogged = false;
+  console.log = function (message) {
+    if (message === 'Hi World') {
+      console.warn(message);
+      hiWorldWasLogged = true;
+    }
+    if (nativeLog.apply) {
+      nativeLog.apply(originalConsole, arguments);
+    } else {
+      var nativeMsg = Array.prototype.slice.apply(arguments).join(' ');
+      nativeLog(nativeMsg);
+    }
+  };
+  reusableFunction();
+  console.log = nativeLog;
+  return hiWorldWasLogged;
+}
+```
+
 # --hints--
 
 `reusableFunction` should be a function.
@@ -54,35 +79,6 @@ assert(/reusableFunction\(\)/.test(codeWithoutFunction));
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-
-function testConsole() {
-  var logOutput = "";
-  var originalConsole = console;
-  var nativeLog = console.log;
-  var hiWorldWasLogged = false;
-  console.log = function (message) {
-    if(message === 'Hi World')  {
-      console.warn(message)
-      hiWorldWasLogged = true;
-    }
-    if(message && message.trim) logOutput = message.trim();
-    if(nativeLog.apply) {
-      nativeLog.apply(originalConsole, arguments);
-    } else {
-      var nativeMsg = Array.prototype.slice.apply(arguments).join(' ');
-      nativeLog(nativeMsg);
-    }
-  };
-  reusableFunction();
-  console.log = nativeLog;
-  return hiWorldWasLogged;
-}
-
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392d0.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392d0.md
@@ -129,12 +129,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return z;})(myDog);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392d1.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392d1.md
@@ -43,12 +43,6 @@ assert(/"name": "Coder"/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return z;})(myDog);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392d2.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392d2.md
@@ -57,12 +57,6 @@ assert(!/bark[^\n]:/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return z;})(myDog);
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107