### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 32-36

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392d3.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56bbb991ad1ed5201cd392d3.md
@@ -59,12 +59,6 @@ assert(__helpers.removeJSComments(code).match(/"tails": 1/g).length > 0);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return z;})(myDog);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/5a2efd662fb457916e1fe604.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/5a2efd662fb457916e1fe604.md
@@ -72,12 +72,6 @@ assert.equal(i, 11);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if(typeof myArray !== "undefined"){(function(){return myArray;})();}
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c441eddfaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c441eddfaeb5bdef.md
@@ -32,12 +32,6 @@ assert(welcomeToBooleans() === true);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-welcomeToBooleans();
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c443eddfaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c443eddfaeb5bdef.md
@@ -41,12 +41,6 @@ assert(/var\s+myName\s*;/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if(typeof myName !== "undefined"){(function(v){return v;})(myName);}
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c444eddfaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c444eddfaeb5bdef.md
@@ -66,12 +66,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if(typeof myFirstName !== "undefined" && typeof myLastName !== "undefined"){(function(){return myFirstName + ', ' + myLastName;})();}
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107