### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 37-41

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c450eddfaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c450eddfaeb5bdef.md
@@ -43,12 +43,6 @@ assert(__helpers.removeJSComments(code).match(/thirdLetterOfLastName\s*=\s*lastN
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(v){return v;})(thirdLetterOfLastName);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c451eddfaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c451eddfaeb5bdef.md
@@ -43,12 +43,6 @@ assert(__helpers.removeJSComments(code).match(/\.length/g).length > 0);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(v){return v;})(lastLetterOfLastName);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c452eddfaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c452eddfaeb5bdef.md
@@ -43,12 +43,6 @@ assert(__helpers.removeJSComments(code).match(/\.length/g).length > 0);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(v){return v;})(secondToLastLetterOfLastName);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c549eddfaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7123c9c549eddfaeb5bdef.md
@@ -45,12 +45,6 @@ assert(__helpers.removeJSComments(code).match(/firstLetterOfLastName\s*=\s*lastN
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(v){return v;})(firstLetterOfLastName);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/bd7993c9c69feddfaeb7bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7993c9c69feddfaeb7bdef.md
@@ -32,12 +32,6 @@ assert(/\*/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(y){return 'product = '+y;})(product);
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107