### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 42-44

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/bd7993c9c69feddfaeb8bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/bd7993c9c69feddfaeb8bdef.md
@@ -42,12 +42,6 @@ assert(typeof myArray[1] !== 'undefined' && typeof myArray[1] == 'number');
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return z;})(myArray);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb1bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb1bdef.md
@@ -46,12 +46,6 @@ assert.deepEqual(myArray, [5, 4, 3, 2, 1, 0]);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if(typeof myArray !== "undefined"){(function(){return myArray;})();}
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb3bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb3bdef.md
@@ -42,12 +42,6 @@ assert(/\+/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return 'sum = '+z;})(sum);
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107