### PR TITLE
fix(curriculum): remove before/after-user-code from basic javascript challenges 45-47

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb4bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb4bdef.md
@@ -39,12 +39,6 @@ assert(/difference=45-33;?/.test(__helpers.removeWhiteSpace(__helpers.removeJSCo
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return 'difference = '+z;})(difference);
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb5bdef.md
@@ -54,12 +54,6 @@ assert.deepEqual(myArray, [1, 2, 3, 4, 5]);
 
 # --seed--
 
-## --after-user-code--
-
-```js
-if (typeof myArray !== "undefined"){(function(){return myArray;})();}
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb6bdef.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/cf1111c1c11feddfaeb6bdef.md
@@ -39,12 +39,6 @@ assert(/\d+\s*\/\s*\d+/.test(__helpers.removeJSComments(code)));
 
 # --seed--
 
-## --after-user-code--
-
-```js
-(function(z){return 'quotient = '+z;})(quotient);
-```
-
 ## --seed-contents--
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

In plain words:
These challenges had hidden --after-user-code-- snippets that mostly acted like old debug wrappers (IIFEs/console output) and were not needed for challenge assertions.

The tests still assert against learner-visible variables and behavior, so removing those tails does not change expected outcomes.

If a helper was actually required by tests or hints, it was not dropped. It was moved to # --before-each-- so behavior stays the same while keeping seed code clean.

Refs #57107