### PR TITLE
fix(ci): allow spaces around x in PR template checkboxes

### DIFF
--- a/.github/scripts/pr-guidelines/check-pr-template.js
+++ b/.github/scripts/pr-guidelines/check-pr-template.js
@@ -36,8 +36,9 @@ module.exports = async ({ github, context, isAllowListed }) => {
     'I have read and followed the [how to open a pull request guide]',
     'My pull request targets the'
   ];
-  const allRequiredTicked = requiredTicked.every(
-    item => body.includes(`[x] ${item}`) || body.includes(`[X] ${item}`)
+  const normalizedBody = body.replace(/\[\s*[xX]\s*\]/g, '[x]');
+  const allRequiredTicked = requiredTicked.every(item =>
+    normalizedBody.includes(`[x] ${item}`)
   );
 
   if (templatePresent && allRequiredTicked) return;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Ref #66474

The PR template check currently only accepts `[x]` or `[X]` as valid checkbox syntax. Contributors who add a space (e.g. `[ x]` or `[x ]`) get the bot reminder comment even though their intent is clear, as seen in #66474.

This change normalizes all variations of `[\s*x\s*]` to `[x]` before checking, so `[ x]`, `[x ]`, `[ X ]`, etc. are all accepted.
