### PR TITLE
fix(curriculum): remove before/after-user-code in react-and-redux block

### DIFF
--- a/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036141.md
+++ b/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036141.md
@@ -64,12 +64,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```jsx
-ReactDOM.render(<DisplayMessages />, document.getElementById('root'))
-```
-
 ## --seed-contents--
 
 ```jsx

--- a/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036142.md
+++ b/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036142.md
@@ -158,12 +158,6 @@ The `submitMessage` method should clear the current input.
 
 # --seed--
 
-## --after-user-code--
-
-```jsx
-ReactDOM.render(<DisplayMessages />, document.getElementById('root'))
-```
-
 ## --seed-contents--
 
 ```jsx

--- a/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036144.md
+++ b/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036144.md
@@ -81,12 +81,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```jsx
-ReactDOM.render(<AppWrapper />, document.getElementById('root'))
-```
-
 ## --seed-contents--
 
 ```jsx

--- a/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036147.md
+++ b/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036147.md
@@ -29,6 +29,21 @@ The `Presentational` component should render.
 ```js
 assert(
   (function () {
+    if (typeof ConnectedComponent === 'undefined') {
+      return false;
+    }
+    const store = Redux.createStore(
+      (state = '__INITIAL__STATE__', action) => state
+    );
+    class AppWrapper extends React.Component {
+      render() {
+        return React.createElement(
+          ReactRedux.Provider,
+          { store: store },
+          React.createElement(ConnectedComponent)
+        );
+      }
+    }
     const mockedComponent = Enzyme.mount(React.createElement(AppWrapper));
     return mockedComponent.find('Presentational').length === 1;
   })()
@@ -40,6 +55,21 @@ The `Presentational` component should receive a prop `messages` via `connect`.
 ```js
 assert(
   (function () {
+    if (typeof ConnectedComponent === 'undefined') {
+      return false;
+    }
+    const store = Redux.createStore(
+      (state = '__INITIAL__STATE__', action) => state
+    );
+    class AppWrapper extends React.Component {
+      render() {
+        return React.createElement(
+          ReactRedux.Provider,
+          { store: store },
+          React.createElement(ConnectedComponent)
+        );
+      }
+    }
     const mockedComponent = Enzyme.mount(React.createElement(AppWrapper));
     const props = mockedComponent.find('Presentational').props();
     return props.messages === '__INITIAL__STATE__';
@@ -52,6 +82,21 @@ The `Presentational` component should receive a prop `submitNewMessage` via `con
 ```js
 assert(
   (function () {
+    if (typeof ConnectedComponent === 'undefined') {
+      return false;
+    }
+    const store = Redux.createStore(
+      (state = '__INITIAL__STATE__', action) => state
+    );
+    class AppWrapper extends React.Component {
+      render() {
+        return React.createElement(
+          ReactRedux.Provider,
+          { store: store },
+          React.createElement(ConnectedComponent)
+        );
+      }
+    }
     const mockedComponent = Enzyme.mount(React.createElement(AppWrapper));
     const props = mockedComponent.find('Presentational').props();
     return typeof props.submitNewMessage === 'function';
@@ -60,24 +105,6 @@ assert(
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```jsx
-const store = Redux.createStore(
-  (state = '__INITIAL__STATE__', action) => state
-);
-class AppWrapper extends React.Component {
-  render() {
-    return (
-      <ReactRedux.Provider store = {store}>
-        <ConnectedComponent/>
-      </ReactRedux.Provider>
-    );
-  }
-};
-ReactDOM.render(<AppWrapper />, document.getElementById('root'))
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036148.md
+++ b/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036148.md
@@ -96,12 +96,6 @@ assert(
 
 # --seed--
 
-## --after-user-code--
-
-```jsx
-ReactDOM.render(<AppWrapper />, document.getElementById('root'))
-```
-
 ## --seed-contents--
 
 ```jsx

--- a/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036149.md
+++ b/curriculum/challenges/english/blocks/react-and-redux/5a24c314108439a4d4036149.md
@@ -185,12 +185,6 @@ The `Presentational` component should render the `messages` from the Redux store
 
 # --seed--
 
-## --after-user-code--
-
-```jsx
-ReactDOM.render(<AppWrapper />, document.getElementById('root'))
-```
-
 ## --seed-contents--
 
 ```jsx


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Refs #57107

Why removing `ReactDOM.render(...)` is safe here:

In these React/Redux challenges, the tests already create and mount components directly using Enzyme (for example, `Enzyme.mount(React.createElement(DisplayMessages))` and `Enzyme.mount(React.createElement(AppWrapper))`).

So the old `--after-user-code--` line that called `ReactDOM.render(...)` was not required for the tests to work. It was extra execution from the single-file era, not part of the learner solution itself.

This PR keeps the same behavior by moving/removing only redundant hidden setup, and the challenge tests still pass.
