### PR TITLE
fix(curriculum): remove before/after-user-code in redux block

### DIFF
--- a/curriculum/challenges/english/blocks/redux/5a24c314108439a4d4036153.md
+++ b/curriculum/challenges/english/blocks/redux/5a24c314108439a4d4036153.md
@@ -55,12 +55,6 @@ assert.strictEqual(store.getState(), count);
 
 # --seed--
 
-## --before-user-code--
-
-```js
-count = 0;
-```
-
 ## --seed-contents--
 
 ```js

--- a/curriculum/challenges/english/blocks/redux/5a24c314108439a4d4036157.md
+++ b/curriculum/challenges/english/blocks/redux/5a24c314108439a4d4036157.md
@@ -37,7 +37,12 @@ assert(typeof store.getState() === 'number');
 The Redux store should initialize with a `state` of 0.
 
 ```js
-assert(_store.getState() === 0);
+assert(
+  (function () {
+    const _store = Redux.createStore(counterReducer);
+    return _store.getState() === 0;
+  })()
+);
 ```
 
 Dispatching `incAction` on the Redux store should increment the `state` by 1.
@@ -45,6 +50,7 @@ Dispatching `incAction` on the Redux store should increment the `state` by 1.
 ```js
 assert(
   (function () {
+    const _store = Redux.createStore(counterReducer);
     const initialState = _store.getState();
     _store.dispatch(incAction());
     const incState = _store.getState();
@@ -58,6 +64,7 @@ Dispatching `decAction` on the Redux store should decrement the `state` by 1.
 ```js
 assert(
   (function () {
+    const _store = Redux.createStore(counterReducer);
     const initialState = _store.getState();
     _store.dispatch(decAction());
     const decState = _store.getState();
@@ -87,12 +94,6 @@ const incAction = null; // Define an action creator for incrementing
 const decAction = null; // Define an action creator for decrementing
 
 const store = null; // Define the Redux store here, passing in your reducers
-```
-
-## --after-user-code--
-
-```js
-const _store = Redux.createStore(counterReducer)
 ```
 
 # --solutions--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Refs #57107

Why this is safe:

This challenge previously depended on hidden setup in `--after-user-code--` (`const _store = Redux.createStore(counterReducer)`).

In this PR, each assertion creates its own store inside an IIFE. That keeps each test independent and avoids hidden shared state between assertions.

So we removed hidden boilerplate, but kept the same expected behavior and checks.
