### PR TITLE
fix(curriculum): remove before/after-user-code in es6 block

### DIFF
--- a/curriculum/challenges/english/blocks/es6/5cdafbd72913098997531681.md
+++ b/curriculum/challenges/english/blocks/es6/5cdafbd72913098997531681.md
@@ -41,14 +41,20 @@ assert(
 Your `then` method should have a callback function with `result` as its parameter.
 
 ```js
-assert(resultIsParameter);
+assert(
+  /\.then\((function\(result\){|result|\(result\)=>)/.test(
+    __helpers.removeWhiteSpace(__helpers.removeJSComments(code))
+  )
+);
 ```
 
 You should log `result` to the console.
 
 ```js
 assert(
-  resultIsParameter &&
+  /\.then\((function\(result\){|result|\(result\)=>)/.test(
+    __helpers.removeWhiteSpace(__helpers.removeJSComments(code))
+  ) &&
     __helpers
       .removeWhiteSpace(__helpers.removeJSComments(code))
       .match(/\.then\(.*?result.*?console.log\(result\).*?\)/)
@@ -56,12 +62,6 @@ assert(
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const resultIsParameter = /\.then\((function\(result\){|result|\(result\)=>)/.test(__helpers.removeWhiteSpace(__helpers.removeJSComments(code)));
-```
 
 ## --seed-contents--
 

--- a/curriculum/challenges/english/blocks/es6/5cdafbe72913098997531682.md
+++ b/curriculum/challenges/english/blocks/es6/5cdafbe72913098997531682.md
@@ -35,14 +35,20 @@ assert(
 Your `catch` method should have a callback function with `error` as its parameter.
 
 ```js
-assert(errorIsParameter);
+assert(
+  /\.catch\((function\(error\){|error|\(error\)=>)/.test(
+    __helpers.removeWhiteSpace(__helpers.removeJSComments(code))
+  )
+);
 ```
 
 You should log `error` to the console.
 
 ```js
 assert(
-  errorIsParameter &&
+  /\.catch\((function\(error\){|error|\(error\)=>)/.test(
+    __helpers.removeWhiteSpace(__helpers.removeJSComments(code))
+  ) &&
     __helpers
       .removeWhiteSpace(__helpers.removeJSComments(code))
       .match(/\.catch\(.*?error.*?console.log\(error\).*?\)/)
@@ -50,12 +56,6 @@ assert(
 ```
 
 # --seed--
-
-## --after-user-code--
-
-```js
-const errorIsParameter = /\.catch\((function\(error\){|error|\(error\)=>)/.test(__helpers.removeWhiteSpace(__helpers.removeJSComments(code)));
-```
 
 ## --seed-contents--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Refs #57107
