### PR TITLE
fix(curriculum): remove before/after-user-code in functional-programming block

### DIFF
--- a/curriculum/challenges/english/blocks/functional-programming/9d7123c8c441eeafaeb5bdef.md
+++ b/curriculum/challenges/english/blocks/functional-programming/9d7123c8c441eeafaeb5bdef.md
@@ -42,13 +42,25 @@ assert(!__helpers.removeJSComments(code).match(/\.?[\s\S]*?splice/g));
 You should not mutate the original array passed to the function.
 
 ```js
-assert.deepEqual(_inputCities, ["Chicago", "Delhi", "Islamabad", "London", "Berlin"]);
+assert(
+  (function () {
+    const _inputCities = ["Chicago", "Delhi", "Islamabad", "London", "Berlin"];
+    nonMutatingSplice(_inputCities);
+    return (
+      JSON.stringify(_inputCities) ===
+      JSON.stringify(["Chicago", "Delhi", "Islamabad", "London", "Berlin"])
+    );
+  })()
+);
 ```
 
 `nonMutatingSplice(["Chicago", "Delhi", "Islamabad", "London", "Berlin"])` should return `["Chicago", "Delhi", "Islamabad"]`.
 
 ```js
-assert.deepEqual(nonMutatingSplice(_inputCities), ["Chicago", "Delhi", "Islamabad"]);
+assert.deepEqual(
+  nonMutatingSplice(["Chicago", "Delhi", "Islamabad", "London", "Berlin"]),
+  ["Chicago", "Delhi", "Islamabad"]
+);
 ```
 
 # --seed--
@@ -60,12 +72,6 @@ function nonMutatingSplice(cities) {
 
   return cities.splice(3);
 }
-```
-
-## --after-user-code--
-
-```js
-const _inputCities = ["Chicago", "Delhi", "Islamabad", "London", "Berlin"];
 ```
 
 # --solutions--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Refs #57107

Why this is safe:

This challenge previously used a hidden `_inputCities` array from `--after-user-code--`.

In this PR, the tests now pass a fresh inline array directly inside each assertion. That keeps the mutation check explicit and avoids relying on hidden shared data.

So the learner-facing behavior stays the same, while the hidden boilerplate is removed.
