### PR TITLE
fix: preserve HTML entities in console output

### DIFF
--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -11,9 +11,16 @@ interface OutputProps {
 }
 
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-  const message = sanitizeHtml(!isEmpty(output) ? output : defaultOutput, {
-    allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
+  const rawMessage = !isEmpty(output) ? output : defaultOutput;
+
+  // Sanitize HTML but preserve entities by disabling entity decoding
+  const message = sanitizeHtml(rawMessage, {
+    allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr'],
+    parser: {
+      decodeEntities: false
+    }
   });
+
   return (
     <pre
       className='output-text'


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63788

The in-app console was decoding HTML entities back to their original characters. This caused confusion in the HTML Entity Converter challenge where users would see `&` instead of `&` even when their code was correct.

The fix adds `parser: { decodeEntities: false }` to the `sanitizeHtml` configuration in the Output component, which preserves HTML entities in the console output while still sanitizing potentially dangerous HTML tags.
