### PR TITLE
fix: show "Terminal" tab label for Python lessons on mobile layout

### DIFF
--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -17,11 +17,13 @@ import {
   showPreviewPaneSelector
 } from '../redux/selectors';
 import { TOOL_PANEL_HEIGHT } from '../../../../config/misc';
+import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
 import PreviewPortal from '../components/preview-portal';
 import Notes from '../components/notes';
 import EditorTabs from './editor-tabs';
 
 interface MobileLayoutProps {
+  challengeType: number;
   editor: JSX.Element | null;
   hasEditableBoundaries: boolean;
   hasPreview: boolean;
@@ -148,6 +150,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
   render(): JSX.Element {
     const { currentTab } = this.state;
     const {
+      challengeType,
       hasEditableBoundaries,
       instructions,
       editor,
@@ -166,6 +169,16 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       windowTitle,
       usesMultifileEditor
     } = this.props;
+
+    const isPythonChallenge =
+      challengeType === challengeTypes.python ||
+      challengeType === challengeTypes.multifilePythonCertProject ||
+      challengeType === challengeTypes.pyLab ||
+      challengeType === challengeTypes.dailyChallengePy;
+
+    const previewTabText = isPythonChallenge
+      ? i18next.t('learn.editor-tabs.terminal')
+      : i18next.t('learn.editor-tabs.preview');
 
     const displayPreviewPane = hasPreview && showPreviewPane;
     const displayPreviewPortal = hasPreview && showPreviewPortal;
@@ -239,9 +252,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               {i18next.t('learn.editor-tabs.console')}
             </TabsTrigger>
             {hasPreview && (
-              <TabsTrigger value={tabs.preview}>
-                {i18next.t('learn.editor-tabs.preview')}
-              </TabsTrigger>
+              <TabsTrigger value={tabs.preview}>{previewTabText}</TabsTrigger>
             )}
           </TabsList>
 

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -476,6 +476,7 @@ function ShowClassic({
         <Helmet title={windowTitle} />
         {isMobile ? (
           <MobileLayout
+            challengeType={challengeType}
             editor={renderEditor({
               isMobileLayout: true,
               isUsingKeyboardInTablist: usingKeyboardInTablist


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63047

The mobile layout was always showing "Preview" as the tab label, even for Python challenges where it should say "Terminal". The desktop layout (action-row.tsx) already handled this correctly via an `isPythonChallenge` check, but that logic was missing from the mobile layout.

Changes:
- Added `challengeType` prop to `MobileLayoutProps`
- Added `isPythonChallenge` check using the same challenge types as the desktop layout
- Updated the tab label to conditionally render "Terminal" or "Preview"
- Passed `challengeType` from `show.tsx` to `MobileLayout`
