### PR TITLE
fix: strip markdown links when checking PR template checkboxes

### DIFF
--- a/.github/scripts/pr-guidelines/check-pr-template.js
+++ b/.github/scripts/pr-guidelines/check-pr-template.js
@@ -32,11 +32,15 @@ module.exports = async ({ github, context, isAllowListed }) => {
   // acceptable to leave unticked.
   const templatePresent = body.includes('Checklist:');
   const requiredTicked = [
-    'I have read and followed the [contribution guidelines]',
-    'I have read and followed the [how to open a pull request guide]',
+    'I have read and followed the contribution guidelines',
+    'I have read and followed the how to open a pull request guide',
     'My pull request targets the'
   ];
-  const normalizedBody = body.replace(/\[\s*[xX]\s*\]/g, '[x]');
+  // Strip markdown links ([text](url) → text) before matching so contributors
+  // who omit the link syntax (e.g. type plain text) still pass the check.
+  const normalizedBody = body
+    .replace(/\[\s*[xX]\s*\]/g, '[x]')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
   const allRequiredTicked = requiredTicked.every(item =>
     normalizedBody.includes(`[x] ${item}`)
   );


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

The `check-pr-template` workflow triggered a false positive on #66491 (and others): the contributor had filled in all required checkboxes, but wrote the checklist items as plain text instead of preserving the markdown link syntax (e.g. `contribution guidelines` instead of `[contribution guidelines](url)`). The script was checking for the bracketed link text literally, so the match failed.

The fix strips markdown links (`[text](url)` → `text`) from the PR body before matching, so contributors who omit or alter the link syntax still pass the check as long as the checkbox text is otherwise correct.
