### PR TITLE
refactor(challenge-builder): remove legacy head/tail execution path

### DIFF
--- a/packages/challenge-builder/src/build.test.ts
+++ b/packages/challenge-builder/src/build.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
+import {
+  createPoly,
+  type ChallengeFile
+} from '@freecodecamp/shared/utils/polyvinyl';
+
+import { buildChallenge } from './build';
+
+const buildOptions = {
+  preview: false,
+  disableLoopProtectTests: true,
+  disableLoopProtectPreview: true
+};
+
+describe('buildChallenge', () => {
+  it('throws when legacy before/after user code fields are present', async () => {
+    const challengeFile = createPoly({
+      name: 'script',
+      ext: 'js',
+      contents: 'const answer = 42;',
+      head: 'const setup = true;',
+      tail: ''
+    }) as ChallengeFile;
+
+    await expect(
+      buildChallenge(
+        {
+          challengeType: challengeTypes.js,
+          challengeFiles: [challengeFile],
+          required: [],
+          template: '',
+          url: ''
+        },
+        buildOptions
+      )
+    ).rejects.toThrow(
+      'Legacy # --before-user-code-- / # --after-user-code-- sections are no longer supported.'
+    );
+  });
+});

--- a/packages/challenge-builder/src/build.ts
+++ b/packages/challenge-builder/src/build.ts
@@ -53,6 +53,27 @@ const applyFunction =
 const composeFunctions = (...fns: ApplyFunctionProps[]) =>
   fns.map(applyFunction).reduce((f, g) => x => f(x).then(g));
 
+function getLegacyHeadTailFiles(challengeFiles: ChallengeFile[]) {
+  return challengeFiles.filter(
+    ({ head, tail }) => Boolean(head?.trim()) || Boolean(tail?.trim())
+  );
+}
+
+function throwIfLegacyHeadTail(challengeFiles: ChallengeFile[]) {
+  const legacyFiles = getLegacyHeadTailFiles(challengeFiles);
+  if (!legacyFiles.length) return;
+
+  const fileList = legacyFiles
+    .map(file => file.path || `${file.name}.${file.ext}`)
+    .join(', ');
+
+  throw new Error(
+    'Legacy # --before-user-code-- / # --after-user-code-- sections are no longer supported. ' +
+      `Found in: ${fileList}. ` +
+      'Move setup/fixtures to # --before-all-- or # --before-each-- and move post-run behavior to hooks/tests.'
+  );
+}
+
 function buildSourceMap(challengeFiles: ChallengeFile[]): Source | undefined {
   // TODO: rename sources.index to sources.contents.
   const source: Source | undefined = challengeFiles?.reduce(
@@ -179,6 +200,7 @@ async function buildDOMChallenge(
 ): Promise<BuildResult> {
   // TODO: make this required in the schema.
   if (!challengeFiles) throw Error('No challenge files provided');
+  throwIfLegacyHeadTail(challengeFiles);
   const hasJsx = challengeFiles.some(
     challengeFile => challengeFile.ext === 'jsx' || challengeFile.ext === 'tsx'
   );
@@ -226,6 +248,7 @@ async function buildJSChallenge(
   options: BuildOptions
 ): Promise<BuildResult> {
   if (!challengeFiles) throw Error('No challenge files provided');
+  throwIfLegacyHeadTail(challengeFiles);
   const pipeLine = composeFunctions(
     ...(getTransformers(options) as unknown as ApplyFunctionProps[])
   );
@@ -237,17 +260,7 @@ async function buildJSChallenge(
 
   return {
     challengeType,
-    build: toBuild
-      .reduce(
-        (body, challengeFile) => [
-          ...body,
-          challengeFile.head,
-          challengeFile.contents,
-          challengeFile.tail
-        ],
-        [] as string[]
-      )
-      .join('\n'),
+    build: toBuild.map(challengeFile => challengeFile.contents).join('\n'),
     sources: buildSourceMap(finalFiles),
     error
   };
@@ -266,6 +279,7 @@ async function buildPythonChallenge({
   challengeType
 }: BuildChallengeData): Promise<BuildResult> {
   if (!challengeFiles) throw new Error('No challenge files provided');
+  throwIfLegacyHeadTail(challengeFiles);
   const pipeLine = composeFunctions(
     ...(getPythonTransformers() as unknown as ApplyFunctionProps[])
   );

--- a/packages/challenge-builder/src/transformers.js
+++ b/packages/challenge-builder/src/transformers.js
@@ -11,8 +11,6 @@ import {
 
 import {
   transformContents,
-  transformHeadTailAndContents,
-  compileHeadTail,
   createSource
 } from '@freecodecamp/shared/utils/polyvinyl';
 import { version } from '@freecodecamp/browser-scripts/package.json';
@@ -118,7 +116,7 @@ const getJSTranspiler = loopProtectOptions => async challengeFile => {
   await loadBabel();
   await loadPresetEnv();
   const babelOptions = getBabelOptions(presetsJS, loopProtectOptions);
-  return transformHeadTailAndContents(
+  return transformContents(
     babelTransformCode(babelOptions),
     challengeFile
   );
@@ -128,7 +126,7 @@ const getJSXTranspiler = loopProtectOptions => async challengeFile => {
   await loadBabel();
   await loadPresetReact();
   const babelOptions = getBabelOptions(presetsJSX, loopProtectOptions);
-  return transformHeadTailAndContents(
+  return transformContents(
     babelTransformCode(babelOptions),
     challengeFile
   );
@@ -151,8 +149,8 @@ const getTSTranspiler = loopProtectOptions => async challengeFile => {
   await setupTSCompiler();
   const babelOptions = getBabelOptions(presetsJS, loopProtectOptions);
   return flow(
-    partial(transformHeadTailAndContents, compileTypeScriptCode),
-    partial(transformHeadTailAndContents, babelTransformCode(babelOptions))
+    partial(transformContents, compileTypeScriptCode),
+    partial(transformContents, babelTransformCode(babelOptions))
   )(challengeFile);
 };
 
@@ -167,8 +165,8 @@ const getTSXModuleTranspiler = loopProtectOptions => async challengeFile => {
     moduleId: 'index' // TODO: this should be dynamic
   };
   return flow(
-    partial(transformHeadTailAndContents, compileTypeScriptCode),
-    partial(transformHeadTailAndContents, babelTransformCode(babelOptions))
+    partial(transformContents, compileTypeScriptCode),
+    partial(transformContents, babelTransformCode(babelOptions))
   )(challengeFile);
 };
 
@@ -407,8 +405,7 @@ const getHtmlTranspiler = scriptOptions =>
 export const getTransformers = loopProtectOptions => [
   createSource,
   replaceNBSP,
-  createTranspiler(loopProtectOptions),
-  partial(compileHeadTail, '')
+  createTranspiler(loopProtectOptions)
 ];
 
 export const getMultifileJSXTransformers = loopProtectOptions => [
@@ -419,6 +416,5 @@ export const getMultifileJSXTransformers = loopProtectOptions => [
 
 export const getPythonTransformers = () => [
   createSource,
-  replaceNBSP,
-  partial(compileHeadTail, '')
+  replaceNBSP
 ];

--- a/packages/shared/src/utils/polyvinyl.ts
+++ b/packages/shared/src/utils/polyvinyl.ts
@@ -121,25 +121,6 @@ export function regenerateMissingProperties(file: IncompleteChallengeFile) {
   return newFile;
 }
 
-async function clearHeadTail(polyP: Promise<ChallengeFile>) {
-  const poly = await polyP;
-  checkPoly(poly);
-  return {
-    ...poly,
-    head: '',
-    tail: ''
-  };
-}
-
-export async function compileHeadTail(padding = '', poly: ChallengeFile) {
-  return clearHeadTail(
-    transformContents(
-      () => [poly.head, poly.contents, poly.tail].join(padding),
-      poly
-    )
-  );
-}
-
 type Wrapper = (x: string) => Promise<string> | string;
 // transformContents will keep a copy of the original
 // code in the `source` property. If the original polyvinyl
@@ -152,21 +133,6 @@ export async function transformContents(
   const poly = await polyP;
   const newPoly = setContent(await wrap(poly.contents), poly, poly.source);
   return newPoly;
-}
-
-export async function transformHeadTailAndContents(
-  wrap: Wrapper,
-  polyP: ChallengeFile | Promise<ChallengeFile>
-) {
-  const poly = await polyP;
-  const contents = await transformContents(wrap, poly);
-  const head = await wrap(poly.head);
-  const tail = await wrap(poly.tail);
-  return {
-    ...contents,
-    head,
-    tail
-  };
 }
 
 // createSource(poly: PolyVinyl) => PolyVinyl


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Refs #57107

---

This is a **draft** PR for deleting legacy head/tail execution logic.

What this changes:
- Removes execution/transpilation paths that used `head` and `tail` in `challenge-builder`.
- Removes unused shared polyvinyl helpers (`compileHeadTail`, `transformHeadTailAndContents`).
- Adds a guard that throws if legacy `head`/`tail` content is still present in challenge files, so we fail loudly instead of silently changing challenge behavior.

Why draft:
- There are still curriculum files in `main` using `## --before-user-code--` / `## --after-user-code--`.
- This should be merged only after all related curriculum migration PRs land.

Validation run:
- `pnpm --filter @freecodecamp/shared build`
- `pnpm --filter @freecodecamp/shared type-check`
- `pnpm --filter @freecodecamp/challenge-builder lint`
- `pnpm --filter @freecodecamp/challenge-builder test`
- `pnpm --filter @freecodecamp/challenge-builder type-check`
- `pnpm --filter @freecodecamp/challenge-builder build`