### PR TITLE
fix(curriculum): correct graphs quiz answer

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-graphs-and-trees/67f4138c34cd9c4ac783ceef.md
+++ b/curriculum/challenges/english/blocks/quiz-graphs-and-trees/67f4138c34cd9c4ac783ceef.md
@@ -55,7 +55,7 @@ communications networks
 
 #### --answer--
 
-virtual private networks
+temperature measurements over time
 
 ### --question--
 


### PR DESCRIPTION
## Summary
- fix the incorrect answer in the Graphs and Trees quiz
- replace `virtual private networks` with `temperature measurements over time`

Closes #66520.

## Validation
- `Select-String -Path curriculum/challenges/english/blocks/quiz-graphs-and-trees/67f4138c34cd9c4ac783ceef.md -Pattern ''temperature measurements over time'' -Quiet`
- `git diff --check`