### PR TITLE
fix: URL names for prompting course

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1384,19 +1384,19 @@
     ],
     "note": "",
     "blocks": {
-      "learn-prompting-fundamentals-foundations-of-ai-and-language-models": {
+      "foundations-of-ai-and-language-models": {
         "title": "Foundations of AI & Language Models",
         "intro": [
           "Explore the basics of AI, machine learning, linguistics, and language models to build a solid foundation for effective prompting."
         ]
       },
-      "learn-prompting-fundamentals-core-concepts": {
-        "title": "Core Concepts",
+      "prompting-core-concepts": {
+        "title": "Prompting Core Concepts",
         "intro": [
           "Learn key prompting techniques, and understand how to use ChatGPT effectively."
         ]
       },
-      "learn-prompting-fundamentals-practical-application-and-best-practices": {
+      "practical-application-and-best-practices": {
         "title": "Practical Application & Best Practices",
         "intro": [
           "Discover best practices for effective prompts, explore vectors and text embeddings, and review key takeaways."

--- a/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/introduction-to-ai-video.md
+++ b/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/introduction-to-ai-video.md
@@ -3,7 +3,7 @@ id: 69a7646b5a27934b29e1eac1
 title: Introduction to AI
 challengeType: 11
 videoId: 5v13GqqDRng
-dashedName: introduction-to-ai-learn-prompting-fundamentals
+dashedName: introduction-to-ai
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/introduction-video.md
+++ b/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/introduction-video.md
@@ -3,7 +3,7 @@ id: 69a761d55a27934b29e1eabf
 title: Introduction
 challengeType: 11
 videoId: tb0HeceXvZY
-dashedName: introduction-learn-prompting-fundamentals
+dashedName: introduction
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/language-models-video.md
+++ b/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/language-models-video.md
@@ -3,7 +3,7 @@ id: 69a767d55a27934b29e1eac4
 title: Language Models
 challengeType: 11
 videoId: PAG0W_o6jDk
-dashedName: language-models-learn-prompting-fundamentals
+dashedName: language-models
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/linguistics-video.md
+++ b/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/linguistics-video.md
@@ -3,7 +3,7 @@ id: 69a7672a5a27934b29e1eac3
 title: Linguistics
 challengeType: 11
 videoId: ggfB0O9Pf64
-dashedName: linguistics-learn-prompting-fundamentals
+dashedName: linguistics
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/what-is-prompt-engineering-video.md
+++ b/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/what-is-prompt-engineering-video.md
@@ -3,7 +3,7 @@ id: 69a7633b5a27934b29e1eac0
 title: What is Prompt Engineering?
 challengeType: 11
 videoId: 2Q-GMmhXP-k
-dashedName: what-is-prompt-engineering-learn-prompting-fundamentals
+dashedName: what-is-prompt-engineering
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/why-is-prompt-engineering-useful-video.md
+++ b/curriculum/challenges/english/blocks/foundations-of-ai-and-language-models/why-is-prompt-engineering-useful-video.md
@@ -3,7 +3,7 @@ id: 69a765395a27934b29e1eac2
 title: Why is Prompt Engineering Useful?
 challengeType: 11
 videoId: kUfSMBysZE4
-dashedName: why-is-prompt-engineering-useful-useful-learn-prompting-fundamentals
+dashedName: why-is-prompt-engineering-useful
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/practical-application-and-best-practices/ai-hallucinations-video.md
+++ b/curriculum/challenges/english/blocks/practical-application-and-best-practices/ai-hallucinations-video.md
@@ -3,7 +3,7 @@ id: 69a774515a27934b29e1eac9
 title: AI Hallucinations
 challengeType: 11
 videoId: LbeAbfCszLg
-dashedName: ai-hallucinations-learn-prompting-fundamentals
+dashedName: ai-hallucinations
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/practical-application-and-best-practices/best-practices-video.md
+++ b/curriculum/challenges/english/blocks/practical-application-and-best-practices/best-practices-video.md
@@ -3,7 +3,7 @@ id: 69a772165a27934b29e1eac7
 title: Best Practices
 challengeType: 11
 videoId: z_4Esan2kus
-dashedName: best-practices-learn-prompting-fundamentals
+dashedName: best-practices
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/practical-application-and-best-practices/vectors-text-embeddings-video.md
+++ b/curriculum/challenges/english/blocks/practical-application-and-best-practices/vectors-text-embeddings-video.md
@@ -3,7 +3,7 @@ id: 69a774ec5a27934b29e1eaca
 title: Vectors / Text Embeddings
 challengeType: 11
 videoId: 3tBOmjve79Y
-dashedName: vectors-text-embeddings-learn-prompting-fundamentals
+dashedName: vectors-text-embeddings
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/practical-application-and-best-practices/zero-shot-and-few-shot-prompts-video.md
+++ b/curriculum/challenges/english/blocks/practical-application-and-best-practices/zero-shot-and-few-shot-prompts-video.md
@@ -3,7 +3,7 @@ id: 69a773545a27934b29e1eac8
 title: Zero Shot and Few Shot Prompts
 challengeType: 11
 videoId: 9SQRxWk4Myc
-dashedName: zero-shot-and-few-shot-prompts-learn-prompting-fundamentals
+dashedName: zero-shot-and-few-shot-prompts
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/prompting-core-concepts/prompt-engineering-mindset-video.md
+++ b/curriculum/challenges/english/blocks/prompting-core-concepts/prompt-engineering-mindset-video.md
@@ -3,7 +3,7 @@ id: 69a769365a27934b29e1eac5
 title: Prompt Engineering Mindset
 challengeType: 11
 videoId: vzwYXMiXH9A
-dashedName: prompt-engineering-mindset-learn-prompting-fundamentals
+dashedName: prompt-engineering-mindset
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/prompting-core-concepts/using-chatgpt-video.md
+++ b/curriculum/challenges/english/blocks/prompting-core-concepts/using-chatgpt-video.md
@@ -3,7 +3,7 @@ id: 69a76a395a27934b29e1eac6
 title: Using ChatGPT
 challengeType: 11
 videoId: JFY9xLY2AXU
-dashedName: using-chatgpt-learn-prompting-fundamentals
+dashedName: using-chatgpt
 ---
 
 # --description--

--- a/curriculum/structure/blocks/foundations-of-ai-and-language-models.json
+++ b/curriculum/structure/blocks/foundations-of-ai-and-language-models.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": false,
   "blockLabel": "lecture",
   "blockLayout": "challenge-list",
-  "dashedName": "learn-prompting-fundamentals-foundations-of-ai-and-language-models",
+  "dashedName": "foundations-of-ai-and-language-models",
   "helpCategory": "General",
   "challengeOrder": [
     {

--- a/curriculum/structure/blocks/practical-application-and-best-practices.json
+++ b/curriculum/structure/blocks/practical-application-and-best-practices.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": false,
   "blockLabel": "lecture",
   "blockLayout": "challenge-list",
-  "dashedName": "learn-prompting-fundamentals-practical-application-and-best-practices",
+  "dashedName": "practical-application-and-best-practices",
   "helpCategory": "General",
   "challengeOrder": [
     {

--- a/curriculum/structure/blocks/prompting-core-concepts.json
+++ b/curriculum/structure/blocks/prompting-core-concepts.json
@@ -1,9 +1,9 @@
 {
-  "name": "Core Concepts",
+  "name": "Prompting Core Concepts",
   "isUpcomingChange": false,
   "blockLabel": "lecture",
   "blockLayout": "challenge-list",
-  "dashedName": "learn-prompting-fundamentals-core-concepts",
+  "dashedName": "prompting-core-concepts",
   "helpCategory": "General",
   "challengeOrder": [
     {

--- a/curriculum/structure/superblocks/learn-prompting-fundamentals.json
+++ b/curriculum/structure/superblocks/learn-prompting-fundamentals.json
@@ -1,7 +1,7 @@
 {
   "blocks": [
-    "learn-prompting-fundamentals-foundations-of-ai-and-language-models",
-    "learn-prompting-fundamentals-core-concepts",
-    "learn-prompting-fundamentals-practical-application-and-best-practices"
+    "foundations-of-ai-and-language-models",
+    "prompting-core-concepts",
+    "practical-application-and-best-practices"
   ]
 }


### PR DESCRIPTION
This cleans up some of the URLs based on the naming convention we discussed a few days ago.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


