### PR TITLE
fix: skip 'help wanted' on linked issue check for Naomi's Sprints assignees

### DIFF
--- a/.github/scripts/pr-guidelines/check-linked-issue.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.js
@@ -32,6 +32,7 @@ module.exports = async ({ github, context, isAllowListed }) => {
             nodes {
               number
               labels(first: 10) { nodes { name } }
+              assignees(first: 10) { nodes { login } }
             }
           }
         }
@@ -85,6 +86,14 @@ module.exports = async ({ github, context, isAllowListed }) => {
     );
     return;
   }
+
+  const prAuthor = context.payload.pull_request.user.login;
+  const isNaomiSprintAssignee = linkedIssues.some(
+    issue =>
+      issue.labels.nodes.some(l => l.name === "Naomi's Sprint") &&
+      issue.assignees.nodes.some(a => a.login === prAuthor)
+  );
+  if (isNaomiSprintAssignee) return;
 
   const isOpenForContribution = linkedIssues.some(issue =>
     issue.labels.nodes.some(

--- a/.github/scripts/pr-guidelines/check-linked-issue.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.js
@@ -90,10 +90,18 @@ module.exports = async ({ github, context, isAllowListed }) => {
   const prAuthor = context.payload.pull_request.user.login;
   const isNaomiSprintAssignee = linkedIssues.some(
     issue =>
-      issue.labels.nodes.some(l => l.name === "Naomi's Sprint") &&
+      issue.labels.nodes.some(l => l.name === "Naomi's Sprints") &&
       issue.assignees.nodes.some(a => a.login === prAuthor)
   );
-  if (isNaomiSprintAssignee) return;
+  if (isNaomiSprintAssignee) {
+    await github.rest.issues.addLabels({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.payload.pull_request.number,
+      labels: ["Naomi's Sprints"]
+    });
+    return;
+  }
 
   const isOpenForContribution = linkedIssues.some(issue =>
     issue.labels.nodes.some(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

The `check-linked-issue` automation currently posts "The linked issue is not open for contribution." on any PR whose linked issue lacks `help wanted` or `first timers only`. This causes noise for contributors working on Naomi's Sprint issues, which intentionally don't carry those labels.

For example: https://github.com/freeCodeCamp/freeCodeCamp/pull/66510#issuecomment-4069525662

This PR updates the script to:
- Skip the "not open for contribution" comment when the linked issue has the `Naomi's Sprint` label and the PR author is one of the issue's assignees
- Add the `Naomi's Sprint` label to the PR
