### PR TITLE
fix: make PR template checklist header check case-insensitive

### DIFF
--- a/.github/scripts/pr-guidelines/check-pr-template.js
+++ b/.github/scripts/pr-guidelines/check-pr-template.js
@@ -25,16 +25,16 @@ const TEMPLATE_BLOCK = [
 module.exports = async ({ github, context, isAllowListed }) => {
   if (isAllowListed === 'true') return;
 
-  const body = context.payload.pull_request.body || '';
+  const body = (context.payload.pull_request.body || '').toLowerCase();
 
   // The template must be present and the first 3 checkboxes must be
   // ticked ([x] or [X]). The last checkbox (tested locally) is
   // acceptable to leave unticked.
-  const templatePresent = /checklist:/i.test(body);
+  const templatePresent = body.includes('checklist:');
   const requiredTicked = [
-    'I have read and followed the contribution guidelines',
-    'I have read and followed the how to open a pull request guide',
-    'My pull request targets the'
+    'i have read and followed the contribution guidelines',
+    'i have read and followed the how to open a pull request guide',
+    'my pull request targets the'
   ];
   // Strip markdown links ([text](url) → text) before matching so contributors
   // who omit the link syntax (e.g. type plain text) still pass the check.

--- a/.github/scripts/pr-guidelines/check-pr-template.js
+++ b/.github/scripts/pr-guidelines/check-pr-template.js
@@ -28,8 +28,8 @@ module.exports = async ({ github, context, isAllowListed }) => {
   const body = (context.payload.pull_request.body || '').toLowerCase();
 
   // The template must be present and the first 3 checkboxes must be
-  // ticked ([x] or [X]). The last checkbox (tested locally) is
-  // acceptable to leave unticked.
+  // ticked. The last checkbox (tested locally) is acceptable to leave
+  // unticked.
   const templatePresent = body.includes('checklist:');
   const requiredTicked = [
     'i have read and followed the contribution guidelines',
@@ -39,7 +39,7 @@ module.exports = async ({ github, context, isAllowListed }) => {
   // Strip markdown links ([text](url) → text) before matching so contributors
   // who omit the link syntax (e.g. type plain text) still pass the check.
   const normalizedBody = body
-    .replace(/\[\s*[xX]\s*\]/g, '[x]')
+    .replace(/\[\s*x\s*\]/g, '[x]')
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
   const allRequiredTicked = requiredTicked.every(item =>
     normalizedBody.includes(`[x] ${item}`)

--- a/.github/scripts/pr-guidelines/check-pr-template.js
+++ b/.github/scripts/pr-guidelines/check-pr-template.js
@@ -30,7 +30,7 @@ module.exports = async ({ github, context, isAllowListed }) => {
   // The template must be present and the first 3 checkboxes must be
   // ticked ([x] or [X]). The last checkbox (tested locally) is
   // acceptable to leave unticked.
-  const templatePresent = body.includes('Checklist:');
+  const templatePresent = /checklist:/i.test(body);
   const requiredTicked = [
     'I have read and followed the contribution guidelines',
     'I have read and followed the how to open a pull request guide',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

The `check-pr-template` automation triggers the "Please add back the following template" message when the PR body does not contain the exact string `Checklist:`. This means contributors who write `checklist:` (lowercase) incorrectly get flagged even if all the required checkboxes are ticked.

For example: https://github.com/freeCodeCamp/freeCodeCamp/pull/66539#issuecomment-4069531247

This PR changes the check from an exact string match to a case-insensitive regex (`/checklist:/i`).
