### PR TITLE
fix(curriculum): correct example for ochenta y uno gender rule

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-61-to-100/6972c4b262c368b1f2ba7846.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-61-to-100/6972c4b262c368b1f2ba7846.md
@@ -31,7 +31,7 @@ These numbers are formed by using the tens word `ochenta` (80), followed by the 
 
 The number `ochenta y uno` (81) is unique in this range because it becomes `ochenta y un` before a masculine noun. For example:
 
-`Ochenta y cuatro años` - Eighty-four years.
+`Ochenta y un años` - Eighty-one years.
 
 # --instructions--
 


### PR DESCRIPTION

Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66540

<!-- Feel free to add any additional description of changes below this line -->

## Summary

- Fixed the example for the `ochenta y uno` → `ochenta y un` gender agreement rule
- The example incorrectly showed `Ochenta y cuatro años` (eighty-four years) instead of `Ochenta y un años` (eighty-one years), which is the number the rule actually applies to