### PR TITLE
docs(devcontainer): clarify cross-platform completion messages

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,10 +1,10 @@
 # To start developing:
 
-Wait for the container to build and start. You will see "Done. Press any key to close the terminal." in the terminal when it's ready. 
+Wait for the container to build and start. You will see "Done. Press any key to close the terminal" in the terminal when it's ready (varies by OS). 
 
 Once it's running, you can start the development server:
 
-**Option 1:** Press `Ctrl+Shift+P`, type "Run Task", select "Start Development"
+**Option 1:** Press `Ctrl+Shift+P`, type "Run Task", select "Start Development."
 **Option 2:** Open a terminal and run:
 
 ```bash


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- No issue to close -->

**What:** Updated devcontainer ready message  
**Before:** Windows-only instruction
**After:** Cross-platform "varies by OS"

**Why:** Linux/Mac users see different terminal output

**AI:** Navigation only; wording manual.
