### PR TITLE
fix (client): prevent completion modal in multi-file labs

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -623,6 +623,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         monaco.KeyMod.WinCtrl | monaco.KeyCode.Enter
       ],
       run: () => {
+        const shouldShowCompletionModal = !props.showIndependentLowerJaw;
         if (props.usesMultifileEditor && !isProjectBased(props.challengeType)) {
           if (challengeIsComplete()) {
             tryToSubmitChallenge();
@@ -630,7 +631,9 @@ const Editor = (props: EditorProps): JSX.Element => {
             tryToExecuteChallenge();
           }
         } else {
-          props.executeChallenge({ showCompletionModal: true });
+          props.executeChallenge({
+            showCompletionModal: shouldShowCompletionModal
+          });
         }
       }
     });

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -482,6 +482,7 @@ function ShowClassic({
       instructionsPanelRef={instructionsPanelRef}
       usesMultifileEditor={usesMultifileEditor}
       editorRef={editorRef}
+      showIndependentLowerJaw={showIndependentLowerJaw}
     >
       <LearnLayout>
         <Helmet title={windowTitle} />

--- a/client/src/templates/Challenges/components/hotkeys.tsx
+++ b/client/src/templates/Challenges/components/hotkeys.tsx
@@ -97,6 +97,7 @@ export type HotkeysProps = Pick<
     openShortcutsModal: () => void;
     playScene?: () => void;
     keyboardShortcuts: boolean;
+    showIndependentLowerJaw?: boolean;
   };
 
 function Hotkeys({
@@ -119,7 +120,8 @@ function Hotkeys({
   isHelpModalOpen,
   isResetModalOpen,
   isShortcutsModalOpen,
-  isProjectPreviewModalOpen
+  isProjectPreviewModalOpen,
+  showIndependentLowerJaw
 }: HotkeysProps): JSX.Element {
   const submitChallenge = useSubmit();
 
@@ -167,7 +169,7 @@ function Hotkeys({
           executeChallenge();
         }
       } else {
-        executeChallenge({ showCompletionModal: true });
+        executeChallenge({ showCompletionModal: !showIndependentLowerJaw });
       }
     },
     ...(keyboardShortcuts

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -231,5 +231,7 @@ test('Ctrl+Enter should not open completion modal in multifile editor (uses lowe
 
   await expect(page.getByRole('dialog')).toHaveCount(0);
 
-  await expect(page.locator('#editor-lower-jaw')).toBeVisible();
+  await expect(
+    page.locator('[data-playwright-test-label="independentLowerJaw-container"]')
+  ).toBeVisible();
 });

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -25,7 +25,9 @@ const links = {
   multipleChoiceQuestion:
     '/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-7',
   assignment:
-    '/learn/responsive-web-design-v9/review-semantic-html/review-semantic-html'
+    '/learn/responsive-web-design-v9/review-semantic-html/review-semantic-html',
+  multifileLab:
+    '/learn/responsive-web-design-v9/lab-debug-camperbots-profile-page/lab-debug-camperbots-profile-page'
 };
 
 const titles = {
@@ -214,4 +216,20 @@ test('User can use Cmd+Enter to submit their answer in an assignment-type challe
 
   // Completion modal shows up
   await expect(page.getByRole('dialog')).toBeVisible();
+});
+
+test('Ctrl+Enter should not open completion modal in multifile editor (uses lower jaw)', async ({
+  page
+}) => {
+  await page.goto(links.multifileLab);
+
+  const editorLayout = page.locator('#editor-layout');
+  await expect(editorLayout).toBeVisible();
+  await editorLayout.click();
+
+  await page.keyboard.press('Control+Enter');
+
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+
+  await expect(page.locator('#editor-lower-jaw')).toBeVisible();
 });

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -225,13 +225,37 @@ test('Ctrl+Enter should not open completion modal in multifile editor (uses lowe
 
   const editorLayout = page.locator('#editor-layout');
   await expect(editorLayout).toBeVisible();
-  await editorLayout.click();
+
+  await page.getByRole('button', { name: /run the tests/i }).click();
+
+  const lowerJaw = page.locator(
+    '[data-playwright-test-label="independentLowerJaw-container"]'
+  );
+  await expect(lowerJaw).toBeVisible();
 
   await page.keyboard.press('Control+Enter');
 
   await expect(page.getByRole('dialog')).toHaveCount(0);
+  await expect(lowerJaw).toBeVisible();
+});
 
-  await expect(
-    page.locator('[data-playwright-test-label="independentLowerJaw-container"]')
-  ).toBeVisible();
+test('Cmd+Enter should not open completion modal in multifile editor (uses lower jaw)', async ({
+  page
+}) => {
+  await page.goto(links.multifileLab);
+
+  const editorLayout = page.locator('#editor-layout');
+  await expect(editorLayout).toBeVisible();
+
+  await page.getByRole('button', { name: /run the tests/i }).click();
+
+  const lowerJaw = page.locator(
+    '[data-playwright-test-label="independentLowerJaw-container"]'
+  );
+  await expect(lowerJaw).toBeVisible();
+
+  await page.keyboard.press('Meta+Enter');
+
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+  await expect(lowerJaw).toBeVisible();
 });

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -226,7 +226,7 @@ test('Ctrl+Enter should not open completion modal in multifile editor (uses lowe
   const editorLayout = page.locator('#editor-layout');
   await expect(editorLayout).toBeVisible();
 
-  await page.getByRole('button', { name: /run the tests/i }).click();
+  await page.getByTestId('independentLowerJaw-check-button').click();
 
   const lowerJaw = page.locator(
     '[data-playwright-test-label="independentLowerJaw-container"]'
@@ -247,7 +247,7 @@ test('Cmd+Enter should not open completion modal in multifile editor (uses lower
   const editorLayout = page.locator('#editor-layout');
   await expect(editorLayout).toBeVisible();
 
-  await page.getByRole('button', { name: /run the tests/i }).click();
+  await page.getByTestId('independentLowerJaw-check-button').click();
 
   const lowerJaw = page.locator(
     '[data-playwright-test-label="independentLowerJaw-container"]'

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 
 import translations from '../client/i18n/locales/english/translations.json';
 import { authedRequest } from './utils/request';
-import { getEditors } from './utils/editor';
+import { clearEditor, getEditors } from './utils/editor';
 import { alertToBeVisible } from './utils/alerts';
 
 const links = {
@@ -39,6 +39,15 @@ const titles = {
 };
 type PageId = keyof typeof titles;
 
+const multifileLabSolution = `<h1>Hello from Camperbot!</h1>
+
+<h2>About</h2>
+
+<p>My name is Camperbot and I love learning new things.</p>
+
+<h3>Background and Interests</h3>
+<p>I enjoy solving puzzles.</p>`;
+
 // The hotkeys are attached to specific elements, so we need to wait for the
 // wrapper to be focused before we can test the hotkeys.
 const waitUntilListening = async (page: Page) =>
@@ -50,6 +59,31 @@ const waitUntilHydrated = async (page: Page, pageId: PageId) => {
   await page.waitForURL(links[pageId]);
   await expect(page).toHaveTitle(titles[pageId]);
   await waitUntilListening(page);
+};
+
+const completeMultifileLabWithHotkey = async ({
+  browserName,
+  hotkey,
+  page
+}: {
+  browserName: string;
+  hotkey: 'Control+Enter' | 'Meta+Enter';
+  page: Page;
+}) => {
+  await page.goto(links.multifileLab);
+
+  const editor = getEditors(page);
+  await editor.focus();
+  await expect(editor).toBeFocused();
+  await clearEditor({ page, browserName });
+  await editor.fill(multifileLabSolution);
+
+  await page.keyboard.press(hotkey);
+
+  await expect(
+    page.getByTestId('independentLowerJaw-submit-button')
+  ).toBeVisible();
+  await expect(page.getByRole('dialog')).toHaveCount(0);
 };
 
 test.beforeAll(async ({ request }) => {
@@ -219,43 +253,23 @@ test('User can use Cmd+Enter to submit their answer in an assignment-type challe
 });
 
 test('Ctrl+Enter should not open completion modal in multifile editor (uses lower jaw)', async ({
-  page
+  page,
+  browserName
 }) => {
-  await page.goto(links.multifileLab);
-
-  const editorLayout = page.locator('#editor-layout');
-  await expect(editorLayout).toBeVisible();
-
-  await page.getByTestId('independentLowerJaw-check-button').click();
-
-  const lowerJaw = page.locator(
-    '[data-playwright-test-label="independentLowerJaw-container"]'
-  );
-  await expect(lowerJaw).toBeVisible();
-
-  await page.keyboard.press('Control+Enter');
-
-  await expect(page.getByRole('dialog')).toHaveCount(0);
-  await expect(lowerJaw).toBeVisible();
+  await completeMultifileLabWithHotkey({
+    browserName,
+    hotkey: 'Control+Enter',
+    page
+  });
 });
 
 test('Cmd+Enter should not open completion modal in multifile editor (uses lower jaw)', async ({
-  page
+  page,
+  browserName
 }) => {
-  await page.goto(links.multifileLab);
-
-  const editorLayout = page.locator('#editor-layout');
-  await expect(editorLayout).toBeVisible();
-
-  await page.getByTestId('independentLowerJaw-check-button').click();
-
-  const lowerJaw = page.locator(
-    '[data-playwright-test-label="independentLowerJaw-container"]'
-  );
-  await expect(lowerJaw).toBeVisible();
-
-  await page.keyboard.press('Meta+Enter');
-
-  await expect(page.getByRole('dialog')).toHaveCount(0);
-  await expect(lowerJaw).toBeVisible();
+  await completeMultifileLabWithHotkey({
+    browserName,
+    hotkey: 'Meta+Enter',
+    page
+  });
 });

--- a/e2e/navigation-from-last-challenge.spec.ts
+++ b/e2e/navigation-from-last-challenge.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import solution from './fixtures/build-a-personal-portfolio-webpage.json';
 import { clearEditor, focusEditor } from './utils/editor';
 import { isMacOS } from './utils/user-agent';
@@ -81,9 +81,11 @@ test.describe('Should take you to the next superblock (with editor solution)', (
 
     await page.keyboard.press('Control+Enter');
 
-    await page
-      .getByRole('button', { name: 'Submit and go to next challenge' })
-      .click();
+    const submitButton = page.locator(
+      '[data-playwright-test-label="independentLowerJaw-submit-button"]'
+    );
+    await expect(submitButton).toBeVisible();
+    await submitButton.click();
     await page.waitForURL(rwdChallenge.nextUrl);
   });
 });

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -243,13 +243,13 @@ test.describe('JavaScript projects can be submitted and then viewed in /settings
   });
 });
 
-test.describe('Completion modal should be shown after submitting a project', () => {
+test.describe('Submit button should be shown after submitting a project', () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
     'Only chromium allows us to use the clipboard API.'
   );
 
-  test('Ctrl + enter triggers the completion modal on multifile projects', async ({
+  test('Ctrl + enter triggers the submit button on multifile projects', async ({
     page,
     context,
     isMobile
@@ -280,7 +280,9 @@ test.describe('Completion modal should be shown after submitting a project', () 
 
     await page.keyboard.press('Control+Enter');
     await page
-      .getByRole('button', { name: 'Go to next challenge', exact: false })
+      .locator(
+        '[data-playwright-test-label="independentLowerJaw-submit-button"]'
+      )
       .click();
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66359

---

## Description

Fixes an issue where pressing `Ctrl+Enter` (or `Cmd+Enter`) in multifile editor challenges (labs, daily challenges, etc.) triggered both the completion modal and the lower jaw UI, causing duplicate UI elements.
