### PR TITLE
fix(curriculum): correct Spanish number example for 81

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-learn-numbers-61-to-100/6972c4b262c368b1f2ba7846.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-numbers-61-to-100/6972c4b262c368b1f2ba7846.md
@@ -31,7 +31,7 @@ These numbers are formed by using the tens word `ochenta` (80), followed by the 
 
 The number `ochenta y uno` (81) is unique in this range because it becomes `ochenta y un` before a masculine noun. For example:
 
-`Ochenta y cuatro años` - Eighty-four years.
+`Ochenta y un años` - Eighty-one years.
 
 # --instructions--
 


### PR DESCRIPTION
## Summary
- correct the masculine noun example in the Spanish numbers 61-100 lesson
- update the English gloss to match the corrected Spanish example

Closes #66540

## Validation
- git diff --check
- git grep -n 'Ochenta y un años' -- curriculum/challenges/english/blocks/es-a1-learn-numbers-61-to-100/6972c4b262c368b1f2ba7846.md