### PR TITLE
fix(client): add missing translation string

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -970,6 +970,7 @@
     "github": "Link to {{username}}'s GitHub",
     "website": "Link to {{username}}'s website",
     "twitter": "Link to {{username}}'s X",
+    "bluesky": "Link to {{username}}'s Bluesky",
     "next-month": "Go to next month",
     "previous-month": "Go to previous month",
     "first-page": "Go to first page",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Adds a missing translation string. The string is used here:

https://github.com/freeCodeCamp/freeCodeCamp/blob/3c77e8b2d48aa0ec18e38d00829d000775ef2589/client/src/components/profile/components/social-icons.tsx#L91

---

This was caught by #61970.

<!-- Feel free to add any additional description of changes below this line -->
