### PR TITLE
fix: corrected definition which says a higher order function must take a f…

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript-higher-order-functions/6723ca6c6db3deb21cb1bf19.md
+++ b/curriculum/challenges/english/blocks/review-javascript-higher-order-functions/6723ca6c6db3deb21cb1bf19.md
@@ -27,7 +27,7 @@ numbers.forEach((number) => {
 
 ## Higher Order Functions
 
-- **Definition**: A higher order function takes one or more functions for the arguments and returns a function or value for the result.
+- **Definition**: A higher order function takes one or more functions for the arguments or returns a function for the result.
 
 :::interactive_editor
 


### PR DESCRIPTION
…unction and return a function

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Public definition uses AND logic when it should use OR logic.
