### PR TITLE
fix(e2e): stabilize editor test

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -17,7 +17,7 @@ const setTheme = async (
   });
 
 const testPage =
-  '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3';
+  '/learn/responsive-web-design-v9/workshop-cat-photo-app/step-3';
 
 test.describe('Editor Component', () => {
   test('should allow the user to insert text', async ({ page, isMobile }) => {
@@ -36,9 +36,7 @@ test.describe('Python Terminal', () => {
     browserName,
     isMobile
   }) => {
-    await page.goto(
-      'learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-2'
-    );
+    await page.goto('/learn/python-v9/workshop-caesar-cipher/step-2');
 
     // First enter code that does not generate output
     await focusEditor({ page, isMobile });
@@ -72,9 +70,7 @@ test.describe('Python Terminal', () => {
     isMobile,
     browserName
   }) => {
-    await page.goto(
-      'learn/scientific-computing-with-python/learn-string-manipulation-by-building-a-cipher/step-2'
-    );
+    await page.goto('learn/python-v9/workshop-caesar-cipher/step-2');
 
     await focusEditor({ page, isMobile });
     await clearEditor({ page, browserName, isMobile });
@@ -173,7 +169,10 @@ test.describe('Editor theme if the system theme is light', () => {
       await setTheme(request, 'default');
       await page.goto(testPage);
       // Open the nav menu and toggle the theme
-      await page.getByRole('button', { name: 'Menu' }).click();
+      const menuButton = page.getByRole('button', { name: 'Menu' });
+      await menuButton.click();
+      const menu = page.getByRole('list', { name: 'Menu' });
+      await expect(menu).toBeVisible();
 
       const toggle = page.getByRole('button', { name: 'Night Mode' });
       await expect(toggle).toBeVisible();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The following test case has been failing randomly: 

> [chromium] › editor.spec.ts:169:9 › Editor theme if the system theme is light › If the user is signed in › should switch the editor theme when the user toggles the theme 

- https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/23313784817/job/67809365397?pr=66514
- https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/23259685803/job/67626324420?pr=65773

AFAIK we haven't touched the implementation or the tests recently, so I'm not sure why it's failing now.

This PR is an attempt to stabilize the test by waiting for the nav menu to be fully visible before checking its contents, preventing the race condition where Playwright would look for "Night Mode" before the menu had opened.

<!-- Feel free to add any additional description of changes below this line -->
