### PR TITLE
fix: correct Back-End Development and APIs cert name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ freeCodeCamp.org offers several free developer certifications that make up the [
 - [Front-End Development Libraries](https://www.freecodecamp.org/learn/front-end-development-libraries-v9/)
 - [Python](https://www.freecodecamp.org/learn/python-v9/)
 - [Relational Databases](https://www.freecodecamp.org/learn/relational-databases-v9/)
-- [Back-End developer and APIs](https://www.freecodecamp.org/learn/back-end-development-and-apis-v9/)
+- [Back-End Development and APIs](https://www.freecodecamp.org/learn/back-end-development-and-apis-v9/)
 
 Each of these certifications involves completing interactive lessons, workshops, labs, reviews, and quizzes. Throughout the certification, you'll need to complete 5 required projects to qualify for the exam. Once you pass the exam, then you can claim the certification.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This PR fixes a small typo in README.md where "Back-End developer" is changed to "Back-End Development" for consistent capitalization.

Closes #66567