### PR TITLE
fix: fix typo in README: Back-End developer → Back-End Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ freeCodeCamp.org offers several free developer certifications that make up the [
 - [Front-End Development Libraries](https://www.freecodecamp.org/learn/front-end-development-libraries-v9/)
 - [Python](https://www.freecodecamp.org/learn/python-v9/)
 - [Relational Databases](https://www.freecodecamp.org/learn/relational-databases-v9/)
-- [Back-End developer and APIs](https://www.freecodecamp.org/learn/back-end-development-and-apis-v9/)
+- [Back-End Development and APIs](https://www.freecodecamp.org/learn/back-end-development-and-apis-v9/)
 
 Each of these certifications involves completing interactive lessons, workshops, labs, reviews, and quizzes. Throughout the certification, you'll need to complete 5 required projects to qualify for the exam. Once you pass the exam, then you can claim the certification.
 


### PR DESCRIPTION
Fixes #66567

Corrects a typo in `README.md` where the certification name was listed as "Back-End developer and APIs" instead of the correct "Back-End Development and APIs". Updates the list item to match the official certification title.