### PR TITLE
fix(curriculum): emphasize double negatives in user stories

### DIFF
--- a/curriculum/challenges/english/blocks/lab-rpg-character/67d83df6f82eda3868dd2a84.md
+++ b/curriculum/challenges/english/blocks/lab-rpg-character/67d83df6f82eda3868dd2a84.md
@@ -54,7 +54,7 @@ assert _Node(_code).has_function('create_character')
 })
 ```
 
-When `create_character` is called with a first argument that is not a string it should return `The character name should be a string`.
+When `create_character` is called with a first argument that is **not** a string it should return `The character name should be a string`.
 
 ```js
 ({
@@ -68,7 +68,7 @@ for wrong_type in wrong_types:
 })
 ```
 
-When `create_character` is called with a first argument that is a string it should not return `The character name should be a string`.
+When `create_character` is called with a first argument that is a string it **should not return** `The character name should be a string`.
 
 ```js
 ({
@@ -90,7 +90,7 @@ assert create_character('', 4, 2, 1) == 'The character should have a name'
 })
 ```
 
-When `create_character` is called with a first argument that is not an empty string, it should not return `The character should have a name`.
+When `create_character` is called with a first argument that is **not** an empty string, **it should not** return `The character should have a name`.
 
 ```js
 ({
@@ -115,7 +115,7 @@ for length in range(11, 27):
 })
 ```
 
-The `create_character` function should not say that the character is too long when it's not longer than 10 characters.
+The `create_character` function **should not** say that the character is too long when it's not longer than 10 characters.
 
 ```js
 ({
@@ -140,7 +140,7 @@ assert create_character('cha cha', 4, 1, 2) == 'The character name should not co
 })
 ```
 
-When `create_character` is called with a first argument that does not contain a space it should not return `The character name should not contain spaces`.
+When `create_character` is called with a first argument that *does not* contain a space it *should not* return `The character name should not contain spaces`.
 
 ```js
 ({
@@ -152,7 +152,7 @@ assert create_character('chacha', 4, 2, 1) != 'The character name should not con
 })
 ```
 
-When `create_character` is called with a second, third or fourth argument that is not an integer it should return `All stats should be integers`.
+When `create_character` is called with a second, third or fourth argument that is **not** an integer it should return `All stats should be integers`.
 
 ```js
 ({
@@ -168,7 +168,7 @@ for wrong_type in wrong_types:
 })
 ```
 
-When `create_character` is called with a second, third and fourth argument that are all integers it should not return `All stats should be integers`.
+When `create_character` is called with a second, third and fourth argument that are all integers it **should not** return `All stats should be integers`.
 
 ```js
 ({
@@ -199,7 +199,7 @@ assert create_character('ren', 4, 4, -1) == expected
 })
 ```
 
-When `create_character` is called with a second, third and fourth argument that are all no less than `1` it should not return `All stats should be no less than 1`.
+When `create_character` is called with a second, third and fourth argument that are all no less than `1` it **should not** return `All stats should be no less than 1`.
 
 ```js
 ({
@@ -225,7 +225,7 @@ assert create_character('ren', 1, 1, 5) == 'All stats should be no more than 4'
 })
 ```
 
-When `create_character` is called with a second, third and fourth argument that are all no more than `4` it should not return `All stats should be no more than 4`.
+When `create_character` is called with a second, third and fourth argument that are all no more than `4` it **should not** return `All stats should be no more than 4`.
 
 ```js
 ({
@@ -237,7 +237,7 @@ assert create_character('ren', 4, 2, 1) != 'All stats should be no more than 4'
 })
 ```
 
-When `create_character` is called with a second, third or fourth argument that do not sum to `7` it should return `The character should start with 7 points`.
+When `create_character` is called with a second, third or fourth argument that **do not** sum to `7` it should return `The character should start with 7 points`.
 
 ```js
 ({
@@ -251,7 +251,7 @@ assert create_character('ren', 1, 2, 3) == 'The character should start with 7 po
 })
 ```
 
-When `create_character` is called with a second, third and fourth argument that sum to `7` it should not return `The character should start with 7 points`.
+When `create_character` is called with a second, third and fourth argument that sum to `7` it **should not** return `The character should start with 7 points`.
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/lab-rpg-character/67d83df6f82eda3868dd2a84.md
+++ b/curriculum/challenges/english/blocks/lab-rpg-character/67d83df6f82eda3868dd2a84.md
@@ -54,7 +54,7 @@ assert _Node(_code).has_function('create_character')
 })
 ```
 
-When `create_character` is called with a first argument that is not a string it should return `The character name should be a string`.
+When `create_character` is called with a first argument that is **not** a string it should return `The character name should be a string`.
 
 ```js
 ({
@@ -68,7 +68,7 @@ for wrong_type in wrong_types:
 })
 ```
 
-When `create_character` is called with a first argument that is a string it should not return `The character name should be a string`.
+When `create_character` is called with a first argument that is a string it **should not** return `The character name should be a string`.
 
 ```js
 ({
@@ -90,7 +90,7 @@ assert create_character('', 4, 2, 1) == 'The character should have a name'
 })
 ```
 
-When `create_character` is called with a first argument that is not an empty string, it should not return `The character should have a name`.
+When `create_character` is called with a first argument that is **not** an empty string, it **should not** return `The character should have a name`.
 
 ```js
 ({
@@ -115,7 +115,7 @@ for length in range(11, 27):
 })
 ```
 
-The `create_character` function should not say that the character is too long when it's not longer than 10 characters.
+The `create_character` function **should not** say that the character is too long when it's not longer than 10 characters.
 
 ```js
 ({
@@ -140,7 +140,7 @@ assert create_character('cha cha', 4, 1, 2) == 'The character name should not co
 })
 ```
 
-When `create_character` is called with a first argument that does not contain a space it should not return `The character name should not contain spaces`.
+When `create_character` is called with a first argument that *does not* contain a space it *should not* return `The character name should not contain spaces`.
 
 ```js
 ({
@@ -152,7 +152,7 @@ assert create_character('chacha', 4, 2, 1) != 'The character name should not con
 })
 ```
 
-When `create_character` is called with a second, third or fourth argument that is not an integer it should return `All stats should be integers`.
+When `create_character` is called with a second, third or fourth argument that is **not** an integer it should return `All stats should be integers`.
 
 ```js
 ({
@@ -168,7 +168,7 @@ for wrong_type in wrong_types:
 })
 ```
 
-When `create_character` is called with a second, third and fourth argument that are all integers it should not return `All stats should be integers`.
+When `create_character` is called with a second, third and fourth argument that are all integers it **should not** return `All stats should be integers`.
 
 ```js
 ({
@@ -199,7 +199,7 @@ assert create_character('ren', 4, 4, -1) == expected
 })
 ```
 
-When `create_character` is called with a second, third and fourth argument that are all no less than `1` it should not return `All stats should be no less than 1`.
+When `create_character` is called with a second, third and fourth argument that are all no less than `1` it **should not** return `All stats should be no less than 1`.
 
 ```js
 ({
@@ -225,7 +225,7 @@ assert create_character('ren', 1, 1, 5) == 'All stats should be no more than 4'
 })
 ```
 
-When `create_character` is called with a second, third and fourth argument that are all no more than `4` it should not return `All stats should be no more than 4`.
+When `create_character` is called with a second, third and fourth argument that are all no more than `4` it **should not** return `All stats should be no more than 4`.
 
 ```js
 ({
@@ -237,7 +237,7 @@ assert create_character('ren', 4, 2, 1) != 'All stats should be no more than 4'
 })
 ```
 
-When `create_character` is called with a second, third or fourth argument that do not sum to `7` it should return `The character should start with 7 points`.
+When `create_character` is called with a second, third or fourth argument that **do not** sum to `7` it should return `The character should start with 7 points`.
 
 ```js
 ({
@@ -251,7 +251,7 @@ assert create_character('ren', 1, 2, 3) == 'The character should start with 7 po
 })
 ```
 
-When `create_character` is called with a second, third and fourth argument that sum to `7` it should not return `The character should start with 7 points`.
+When `create_character` is called with a second, third and fourth argument that sum to `7` it **should not** return `The character should start with 7 points`.
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/workshop-countup/69447054012a22f38c944ff0.md
+++ b/curriculum/challenges/english/blocks/workshop-countup/69447054012a22f38c944ff0.md
@@ -21,7 +21,7 @@ When `number` is less than `1` the function should return an empty array.
 assert.deepStrictEqual(countup(0), []);
 ```
 
-When `number` is not less than `1` the function should not return anything.
+When `number` is **not** less than `1` the function **should not** return anything.
 
 ```js
 assert.isUndefined(countup(1)); 

--- a/curriculum/challenges/english/blocks/workshop-media-catalogue/68b702892910ab7b495de081.md
+++ b/curriculum/challenges/english/blocks/workshop-media-catalogue/68b702892910ab7b495de081.md
@@ -42,7 +42,7 @@ Your `__str__` method should return `Media Catalogue (empty)` when `self.items` 
 })
 ```
 
-Your `__str__` method should not return `Media Catalogue (empty)` when `self.items` is not empty.
+Your `__str__` method **should not** return `Media Catalogue (empty)` when `self.items` is **not** empty.
 
 ```js
 ({


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

PR opened as suggested by @majestic-owl448

<!-- Feel free to add any additional description of changes below this line -->

Some people struggle to see the difference between user stories that require checking a positive outcome followed by a user story that checks for the negative outcome. So we want to emphasize the wording the stories that use double negatives or that are paired together (positive and negative) to show the differences between them more easily.
Eg.
```

When `create_character` is called with a first argument that is not a string it should return `The character name should be a string`.

```js
({
    test: () => runPython(
        `
wrong_types = [3, 5, {'a': 3}, 3.1, [1, 2], (1, 2), {1, 2}]
for wrong_type in wrong_types:
    assert create_character(wrong_type, 1, 2, 4) == 'The character name should be a string'
`
    )
})
```

When `create_character` is called with a first argument that is a string it should not return `The character name should be a string`.

```js

The first one is looking for a positive outcome of returning a specific string. The 2nd is a reverse check: the string should _not_ be returned.

To resolve this, I added emphasis around the words `should not` in some cases and around the word `not` in others (or around `do not`)

