### PR TITLE
fix(curriculum): remove invalid closing tags from input elements

### DIFF
--- a/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
+++ b/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
@@ -138,18 +138,18 @@ assert.isFalse(submitButton?.hasAttribute("required"));
   <form>
     
     Full Name:
-    <input type="text" name="name"></input>
+    <input type="text" name="name">
 
     Email Address:
     <input type="text" name="email">
 
     Donation Amount ($):
-    <input type="number" name="amount"></input>
+    <input type="number" name="amount">
 
-    <input type="checkbox" name="newsletter"></input>
+    <input type="checkbox" name="newsletter">
     Subscribe
 
-    <input type="submit" value="Send"></input>
+    <input type="submit" value="Send">
   </form>
 </body>
 </html>


### PR DESCRIPTION
Removed invalid closing tags from input elements.

According to HTML specifications, input is a void element and should not have a closing tag.

No functional changes.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.



<!-- Feel free to add any additional description of changes below this line -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Fixed an objective issue in the curriculum content.

This change is minimal and does not affect functionality.