### PR TITLE
fix: correct typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ freeCodeCamp.org offers several free developer certifications that make up the [
 - [Front-End Development Libraries](https://www.freecodecamp.org/learn/front-end-development-libraries-v9/)
 - [Python](https://www.freecodecamp.org/learn/python-v9/)
 - [Relational Databases](https://www.freecodecamp.org/learn/relational-databases-v9/)
-- [Back-End developer and APIs](https://www.freecodecamp.org/learn/back-end-development-and-apis-v9/)
+- [Back-End Development and APIs](https://www.freecodecamp.org/learn/back-end-development-and-apis-v9/)
 
 Each of these certifications involves completing interactive lessons, workshops, labs, reviews, and quizzes. Throughout the certification, you'll need to complete 5 required projects to qualify for the exam. Once you pass the exam, then you can claim the certification.
 
 freeCodeCamp.org also offers free language certifications designed around internationally recognized proficiency levels:
 
 - [A2 English for Developers (Beta)](https://www.freecodecamp.org/learn/a2-english-for-developers/)
-- [B1 English for Developers(Beta)](https://www.freecodecamp.org/learn/b1-english-for-developers/)
-- [A1 Professional Spanish(Beta)](https://www.freecodecamp.org/learn/a1-professional-spanish/)
+- [B1 English for Developers (Beta)](https://www.freecodecamp.org/learn/b1-english-for-developers/)
+- [A1 Professional Spanish (Beta)](https://www.freecodecamp.org/learn/a1-professional-spanish/)
 - [A1 Professional Chinese (Beta)](https://www.freecodecamp.org/learn/a1-professional-chinese/)
 
 Each of these certifications is organized into modules, with sections for warm-ups, lessons, practice exercises, review pages, and quizzes to ensure you fully grasp the material before progressing to the next module. You'll need to complete all of the quizzes in order to qualify for the exam at the end of the certification.
@@ -48,7 +48,7 @@ The one exception to this is if we discover violations of our [Academic Honesty 
 
 In addition, to help prepare for job interviews, freeCodeCamp.org includes The Odin Project (freeCodeCamp Remix), Coding Interview Prep, Project Euler, and Rosetta Code.
 
-A free, professional free Foundational C# with Microsoft Certification is also available.
+A free, professional Foundational C# with Microsoft Certification is also available.
 
 ### The Learning Platform
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

### Description
Fixed the following typos in README.md:
- Added missing space in "B1 English for Developers (Beta)"
- Removed duplicate word "free" in the C# certification line
- Fixed "developer" → "Development" in Back-End APIs bullet point