### PR TITLE
feat: add flash message on sign out

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -1050,6 +1050,7 @@
     "oops-not-right": "Oops, something is not right, please request a fresh link to sign in / sign up",
     "expired-link": "Looks like the link you clicked has expired, please request a fresh link, to sign in",
     "signin-success": "Success! You have signed in to your account. Happy Coding!",
+    "signout-success": "Success! You have signed out.",
     "social-auth-gone": "We are moving away from social authentication for privacy reasons. Next time we recommend using your email address: {{email}} to sign in instead.",
     "name-needed": "We need your name to put it on your certification. Please add your name in your profile and click save. Then we can issue your certification.",
     "incomplete-steps": "It looks like you have not completed the necessary steps. Please complete the required projects to claim the {{name}} Certification.",

--- a/client/src/components/signout-modal/index.tsx
+++ b/client/src/components/signout-modal/index.tsx
@@ -55,7 +55,8 @@ function SignoutModal(props: SignoutModalProps): JSX.Element {
     closeSignoutModal();
     callGA({ event: 'sign_out', user_id: undefined });
     const redirect = () => {
-      window.location.pathname = pathAfterSignout(window.location.pathname);
+      const path = pathAfterSignout(window.location.pathname);
+      window.location.href = `${path}?messages=success%5B0%5D%3Dflash.signout-success`;
     };
     void fetch(`${apiLocation}/signout`, {
       method: 'GET',


### PR DESCRIPTION
This PR implements a success flash message upon signing out, as requested in issue #66515.

**Changes:**
- Added `signout-success` translation to the English locale.
- Updated the `SignoutModal` client-side logic to redirect with the flash message query parameter.

This ensures a consistent user experience between signing in and signing out.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66515