### PR TITLE
fix: minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ The content of this repository is bound by the following licenses:
 
 - The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
 - The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories therein are copyright © 2014 freeCodeCamp.org.
-Fix: minor typo in README
+

--- a/README.md
+++ b/README.md
@@ -92,4 +92,5 @@ Copyright © 2014 freeCodeCamp.org
 The content of this repository is bound by the following licenses:
 
 - The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
-- The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories therein are copyright © 2014 freeCodeCamp.org
+- The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories therein are copyright © 2014 freeCodeCamp.org.
+Fix: minor typo in README


### PR DESCRIPTION
This PR fixes a minor typo in the README by adding missing punctuation.

This is a small documentation improvement.
