### PR TITLE
feat: add Facebook share button to allow users to share workshop prog…

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -116,6 +116,7 @@
     "share-on-x": "Share on X",
     "share-on-bluesky": "Share on BlueSky",
     "share-on-threads": "Share on Threads",
+    "share-on-facebook": "Share on Facebook",
     "play-scene": "Press Play",
     "download-latest-version": "Download the Latest Version",
     "more-ways-to-sign-in": "More ways to sign in",
@@ -442,6 +443,7 @@
     "edit-my-profile": "Edit My Profile",
     "add-bluesky": "Share this certification on BlueSky",
     "add-threads": "Share this certification on Threads",
+    "add-facebook": "Share this certification on Facebook",
     "experience": {
       "heading": "Experience",
       "share-experience": "Share your professional experience",

--- a/client/src/components/share/index.tsx
+++ b/client/src/components/share/index.tsx
@@ -18,6 +18,7 @@ export const Share = ({
       xRedirectURL={redirectURLs.xUrl}
       blueSkyRedirectURL={redirectURLs.blueSkyUrl}
       threadsRedirectURL={redirectURLs.threadsURL}
+      facebookRedirectURL={redirectURLs.facebookUrl}
       minified={minified}
     />
   );

--- a/client/src/components/share/share-template.test.tsx
+++ b/client/src/components/share/share-template.test.tsx
@@ -11,6 +11,7 @@ describe('Share Template Testing', () => {
       xRedirectURL={redirectURL}
       blueSkyRedirectURL={redirectURL}
       threadsRedirectURL={redirectURL}
+      facebookRedirectURL={redirectURL}
     />
   );
   test('Testing share template Click Redirect Event', () => {
@@ -34,5 +35,12 @@ describe('Share Template Testing', () => {
 
     expect(threadsLink).toBeInTheDocument();
     expect(threadsLink).toHaveAttribute('href', 'string');
+
+    const facebookLink = screen.queryByRole('link', {
+      name: 'buttons.share-on-facebook aria.opens-new-window'
+    });
+
+    expect(facebookLink).toBeInTheDocument();
+    expect(facebookLink).toHaveAttribute('href', 'string');
   });
 });

--- a/client/src/components/share/share-template.tsx
+++ b/client/src/components/share/share-template.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import {
   faXTwitter,
   faBluesky,
-  faInstagram
+  faInstagram,
+  faFacebook
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ShareRedirectProps } from './types';
@@ -12,6 +13,7 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
   xRedirectURL,
   blueSkyRedirectURL,
   threadsRedirectURL,
+  facebookRedirectURL,
   minified
 }) => {
   const { t } = useTranslation();
@@ -48,6 +50,17 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
       >
         <FontAwesomeIcon icon={faInstagram} size='1x' aria-hidden='true' />
         {!minified && t('buttons.share-on-threads')}
+        <span className='sr-only'>{t('aria.opens-new-window')}</span>
+      </a>
+      <a
+        data-testid='share-on-facebook'
+        className='btn fade-in'
+        href={facebookRedirectURL}
+        target='_blank'
+        rel='noreferrer'
+      >
+        <FontAwesomeIcon icon={faFacebook} size='1x' aria-hidden='true' />
+        {!minified && t('buttons.share-on-facebook')}
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>
     </>

--- a/client/src/components/share/types.ts
+++ b/client/src/components/share/types.ts
@@ -8,5 +8,6 @@ export interface ShareRedirectProps {
   xRedirectURL: string;
   blueSkyRedirectURL: string;
   threadsRedirectURL: string;
+  facebookRedirectURL: string;
   minified?: boolean;
 }

--- a/client/src/components/share/use-share.test.tsx
+++ b/client/src/components/share/use-share.test.tsx
@@ -45,7 +45,7 @@ describe('useShare', () => {
     );
 
     expect(shareResult.current.facebookUrl).toBe(
-      `https://www.facebook.com/sharer/sharer.php?u=${redirectFreeCodeCampLearnURL}&quote=${tweetMessage}`
+      `https://www.facebook.com/sharer/sharer.php?u=${redirectFreeCodeCampLearnURL}&hashtag=${hastag}freecodecamp`
     );
   });
 });

--- a/client/src/components/share/use-share.test.tsx
+++ b/client/src/components/share/use-share.test.tsx
@@ -45,7 +45,7 @@ describe('useShare', () => {
     );
 
     expect(shareResult.current.facebookUrl).toBe(
-      `https://www.facebook.com/sharer/sharer.php?u=${redirectFreeCodeCampLearnURL}`
+      `https://www.facebook.com/sharer/sharer.php?u=${redirectFreeCodeCampLearnURL}&quote=${tweetMessage}`
     );
   });
 });

--- a/client/src/components/share/use-share.test.tsx
+++ b/client/src/components/share/use-share.test.tsx
@@ -43,5 +43,9 @@ describe('useShare', () => {
     expect(shareResult.current.threadsURL).toBe(
       `https://${threadsData.domain}/${threadsData.action}?original_referer=${threadsData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`
     );
+
+    expect(shareResult.current.facebookUrl).toBe(
+      `https://www.facebook.com/sharer/sharer.php?u=${redirectFreeCodeCampLearnURL}`
+    );
   });
 });

--- a/client/src/components/share/use-share.tsx
+++ b/client/src/components/share/use-share.tsx
@@ -49,7 +49,7 @@ export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
 
   const threadRedirectURL = `https://${threadsData.domain}/${threadsData.action}?original_referer=${threadsData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
 
-  const facebookRedirectURL = `https://${facebookData.domain}/${facebookData.action}?u=${redirectFreeCodeCampLearnURL}`;
+  const facebookRedirectURL = `https://${facebookData.domain}/${facebookData.action}?u=${redirectFreeCodeCampLearnURL}&quote=${tweetMessage}`;
 
   return {
     xUrl: xRedirectURL,

--- a/client/src/components/share/use-share.tsx
+++ b/client/src/components/share/use-share.tsx
@@ -24,10 +24,16 @@ export const threadsData = {
   developerDomainURL: 'https://developers.facebook.com'
 };
 
+export const facebookData = {
+  action: 'sharer/sharer.php',
+  domain: 'www.facebook.com'
+};
+
 interface ShareUrls {
   xUrl: string;
   blueSkyUrl: string;
   threadsURL: string;
+  facebookUrl: string;
 }
 
 export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
@@ -43,9 +49,12 @@ export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
 
   const threadRedirectURL = `https://${threadsData.domain}/${threadsData.action}?original_referer=${threadsData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
 
+  const facebookRedirectURL = `https://${facebookData.domain}/${facebookData.action}?u=${redirectFreeCodeCampLearnURL}`;
+
   return {
     xUrl: xRedirectURL,
     blueSkyUrl: blueSkyRedirectURL,
-    threadsURL: threadRedirectURL
+    threadsURL: threadRedirectURL,
+    facebookUrl: facebookRedirectURL
   };
 };

--- a/client/src/components/share/use-share.tsx
+++ b/client/src/components/share/use-share.tsx
@@ -49,7 +49,7 @@ export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
 
   const threadRedirectURL = `https://${threadsData.domain}/${threadsData.action}?original_referer=${threadsData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
 
-  const facebookRedirectURL = `https://${facebookData.domain}/${facebookData.action}?u=${redirectFreeCodeCampLearnURL}&quote=${tweetMessage}`;
+  const facebookRedirectURL = `https://${facebookData.domain}/${facebookData.action}?u=${redirectFreeCodeCampLearnURL}&hashtag=${hastag}freecodecamp`;
 
   return {
     xUrl: xRedirectURL,


### PR DESCRIPTION


This PR adds a Facebook share button after each workshop to allow users to share their learning progress with friends and followers.

Currently, there is no option to share workshop completion on Facebook, which limits users who primarily use that platform. This feature improves social engagement and helps users showcase their achievements more easily.

## After

<img width="521" height="192" alt="Screenshot 2026-03-24 at 7 20 21 PM" src="https://github.com/user-attachments/assets/843df0de-e6a0-44eb-a498-61b1fc6393f5" />

<img width="551" height="635" alt="Screenshot 2026-03-24 at 7 39 12 PM" src="https://github.com/user-attachments/assets/350c4f34-3a3e-4fa6-b2f9-df9e52108e6f" />


## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66570