### PR TITLE
fix(curriculum): add missing closing backticks to a block in review-javascript

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript-audio-and-video/6723cf27c6e9a0c3f3041385.md
+++ b/curriculum/challenges/english/blocks/review-javascript-audio-and-video/6723cf27c6e9a0c3f3041385.md
@@ -29,6 +29,7 @@ dashedName: review-javascript-audio-and-video
     audio.play();
   });
 </script>
+```
 
 :::
 
@@ -55,6 +56,7 @@ dashedName: review-javascript-audio-and-video
     });
   });
 </script>
+```
 
 :::
 

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -3191,6 +3191,7 @@ console.log(date.toLocaleDateString("en-GB", options)); // "Wednesday, 15 Octobe
     audio.play();
   });
 </script>
+```
 
 :::
 

--- a/curriculum/challenges/english/blocks/review-js-a11y/683766860f71d4a96e429f3a.md
+++ b/curriculum/challenges/english/blocks/review-js-a11y/683766860f71d4a96e429f3a.md
@@ -24,12 +24,14 @@ dashedName: review-js-a11y
     btn.setAttribute("aria-expanded", String(!expanded));
   });
 </script>
+```
 
 :::
 
 - **`aria-haspopup` attribute**: This state is used to indicate that an interactive element will trigger a pop-up element when activated. You can only use the `aria-haspopup` attribute when the pop-up has one of the following roles: `menu`, `listbox`, `tree`, `grid`, or `dialog`. The value of `aria-haspopup` must be either one of these roles or `true`, which is the same as `menu`.
 
 :::interactive_editor
+
 ```html
 <button
   id="menubutton"
@@ -328,4 +330,3 @@ Here is an example of a live region that is dynamically updated by JavaScript:
 # --assignment--
 
 Review the JavaScript and Accessibility topics and concepts.
-


### PR DESCRIPTION
This fixes missing closing backticks in the review-javascript file, which affects the translation of subsequent parts of the file.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.
