### PR TITLE
fix(client): prevent non-serializable editor instance in save actions

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -655,12 +655,12 @@ const Editor = (props: EditorProps): JSX.Element => {
         monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
         monaco.KeyMod.WinCtrl | monaco.KeyCode.KeyS
       ],
-      run:
+      run: () =>
         props.saveSubmissionToDB && props.isSignedIn
           ? // save to database
-            props.saveChallenge
+            props.saveChallenge()
           : // save to local storage
-            props.saveEditorContent
+            props.saveEditorContent()
     });
     editor.addAction({
       id: 'toggle-accessibility',


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66413

---

Monaco's `editor.addAction({ run })` callback passes the editor instance as the first argument. The `save-editor-content` action was passing `props.saveChallenge` / `props.saveEditorContent` directly as the `run` callback, which caused the non-serializable Monaco editor instance to be dispatched as the Redux action payload.

This fix wraps the action creators in an arrow function so no arguments are forwarded, matching the pattern already used by other `addAction` calls in the same file (e.g., `execute-challenge`, `leave-editor`).