### PR TITLE
fix: handle GraphQL errors in createPages

### DIFF
--- a/client/gatsby-node.ts
+++ b/client/gatsby-node.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 const webpack = require('webpack');
 
@@ -35,26 +36,27 @@ exports.createPages = async function createPages({
   const { createPage } = actions;
 
   const result = await graphql(`
-  {
-    allSuperBlockStructure {
-      nodes {
-        superBlock
+    {
+      allSuperBlockStructure {
+        nodes {
+          superBlock
+        }
       }
     }
-  }
-`);
+  `);
 
   if (result.errors) {
-  reporter.panic('createPages GraphQL query failed', result.errors);
-}
+    reporter.panic('createPages GraphQL query failed', result.errors);
+  }
 
   const {
-  data: { allSuperBlockStructure }
-} = result;
+    data: { allSuperBlockStructure }
+  } = result;
 
   const superBlocks = allSuperBlockStructure.nodes.map(
     (node: { superBlock: string }) => node.superBlock
   );
+
   superBlocks.forEach((superBlock: string) => {
     createSuperBlockIntroPages(createPage)({ superBlock });
   });
@@ -62,7 +64,6 @@ exports.createPages = async function createPages({
 
 exports.onCreateWebpackConfig = ({ stage, actions }: any) => {
   const newPlugins = [
-    // We add the shims of the node globals to the global scope
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer']
     }),
@@ -70,14 +71,15 @@ exports.onCreateWebpackConfig = ({ stage, actions }: any) => {
       process: 'process/browser'
     })
   ];
-  // The monaco editor relies on some browser only globals so should not be
-  // involved in SSR. Also, if the plugin is used during the 'build-html' or
-  // 'develop-html' stage it overwrites the minfied files with ordinary ones.
+
   if (stage !== 'build-html' && stage !== 'develop-html') {
     newPlugins.push(
-      new MonacoWebpackPlugin({ filename: '[name].worker-[contenthash].js' })
+      new MonacoWebpackPlugin({
+        filename: '[name].worker-[contenthash].js'
+      })
     );
   }
+
   actions.setWebpackConfig({
     resolve: {
       fallback: {
@@ -109,6 +111,7 @@ exports.onCreateBabelConfig = ({ actions }: any) => {
   actions.setBabelPlugin({
     name: '@babel/plugin-proposal-function-bind'
   });
+
   actions.setBabelPlugin({
     name: '@babel/plugin-proposal-export-default-from'
   });
@@ -116,14 +119,12 @@ exports.onCreateBabelConfig = ({ actions }: any) => {
 
 exports.createSchemaCustomization = ({ actions }: any) => {
   const { createTypes } = actions;
-  // This hook is supported by the test runner, but is not currently used by the
-  // client, so we have to tell Gatsby that it exists.
+
   const typeDefs = `
     type ChallengeNodeChallengeHooks {
       afterEach: String
     }
   `;
+
   createTypes(typeDefs);
 };
-
-export {};

--- a/client/gatsby-node.ts
+++ b/client/gatsby-node.ts
@@ -64,6 +64,7 @@ exports.createPages = async function createPages({
 
 exports.onCreateWebpackConfig = ({ stage, actions }: any) => {
   const newPlugins = [
+    // We add the shims of the node globals to the global scope
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer']
     }),
@@ -71,6 +72,10 @@ exports.onCreateWebpackConfig = ({ stage, actions }: any) => {
       process: 'process/browser'
     })
   ];
+
+  // The monaco editor relies on some browser only globals so should not be
+  // involved in SSR. Also, if the plugin is used during the 'build-html' or
+  // 'develop-html' stage it overwrites the minfied files with ordinary ones.
 
   if (stage !== 'build-html' && stage !== 'develop-html') {
     newPlugins.push(

--- a/client/gatsby-node.ts
+++ b/client/gatsby-node.ts
@@ -120,11 +120,12 @@ exports.onCreateBabelConfig = ({ actions }: any) => {
 exports.createSchemaCustomization = ({ actions }: any) => {
   const { createTypes } = actions;
 
-  const typeDefs = `
-    type ChallengeNodeChallengeHooks {
-      afterEach: String
-    }
-  `;
+// This hook is supported by the test runner, but is not currently used by the
+// client, so we have to tell Gatsby that it exists.
+const typeDefs = `
+  type ChallengeNodeChallengeHooks {
+    afterEach: String
+  }
 
   createTypes(typeDefs);
 };

--- a/client/gatsby-node.ts
+++ b/client/gatsby-node.ts
@@ -34,17 +34,24 @@ exports.createPages = async function createPages({
 
   const { createPage } = actions;
 
-  const {
-    data: { allSuperBlockStructure }
-  } = await graphql(`
-    {
-      allSuperBlockStructure {
-        nodes {
-          superBlock
-        }
+const result = await graphql(`
+  {
+    allSuperBlockStructure {
+      nodes {
+        superBlock
       }
     }
-  `);
+  }
+`)
+
+if (result.errors) {
+  reporter.panic('createPages GraphQL query failed', result.errors)
+  return
+}
+
+const {
+  data: { allSuperBlockStructure }
+} = result
 
   const superBlocks = allSuperBlockStructure.nodes.map(
     (node: { superBlock: string }) => node.superBlock

--- a/client/gatsby-node.ts
+++ b/client/gatsby-node.ts
@@ -120,12 +120,13 @@ exports.onCreateBabelConfig = ({ actions }: any) => {
 exports.createSchemaCustomization = ({ actions }: any) => {
   const { createTypes } = actions;
 
-// This hook is supported by the test runner, but is not currently used by the
-// client, so we have to tell Gatsby that it exists.
-const typeDefs = `
-  type ChallengeNodeChallengeHooks {
-    afterEach: String
-  }
+  // This hook is supported by the test runner, but is not currently used by the
+  // client, so we have to tell Gatsby that it exists.
+  const typeDefs = `
+    type ChallengeNodeChallengeHooks {
+      afterEach: String
+    }
+  `;
 
   createTypes(typeDefs);
 };

--- a/client/gatsby-node.ts
+++ b/client/gatsby-node.ts
@@ -34,7 +34,7 @@ exports.createPages = async function createPages({
 
   const { createPage } = actions;
 
-const result = await graphql(`
+  const result = await graphql(`
   {
     allSuperBlockStructure {
       nodes {
@@ -44,12 +44,11 @@ const result = await graphql(`
   }
 `);
 
-if (result.errors) {
+  if (result.errors) {
   reporter.panic('createPages GraphQL query failed', result.errors);
-  return;
 }
 
-const {
+  const {
   data: { allSuperBlockStructure }
 } = result;
 

--- a/client/gatsby-node.ts
+++ b/client/gatsby-node.ts
@@ -42,16 +42,16 @@ const result = await graphql(`
       }
     }
   }
-`)
+`);
 
 if (result.errors) {
-  reporter.panic('createPages GraphQL query failed', result.errors)
-  return
+  reporter.panic('createPages GraphQL query failed', result.errors);
+  return;
 }
 
 const {
   data: { allSuperBlockStructure }
-} = result
+} = result;
 
   const superBlocks = allSuperBlockStructure.nodes.map(
     (node: { superBlock: string }) => node.superBlock


### PR DESCRIPTION
### Description

This pull request adds explicit error handling for the GraphQL query in the `createPages` function.

Previously, the query result was destructured directly without checking for errors, which could lead to runtime failures if the query fails.

This change follows the maintainer's suggestion by:
- Storing the GraphQL result in a variable
- Checking for `result.errors` before destructuring
- Calling `reporter.panic` if an error is found

### Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66615

### Additional Notes

This is a minimal fix and does not change any existing behavior apart from adding safe error handling.