### PR TITLE
fix: clear flash message and query string on logout

### DIFF
--- a/client/src/components/Flash/redux/flash-messages.ts
+++ b/client/src/components/Flash/redux/flash-messages.ts
@@ -50,6 +50,7 @@ export enum FlashMessages {
   ReallyWeird = 'flash.really-weird',
   ReportSent = 'flash.report-sent',
   SigninSuccess = 'flash.signin-success',
+  SignoutSuccess = 'flash.signout-success',
   StartProjectErr = 'flash.start-project-err',
   SurveyErr1 = 'flash.survey.err-1',
   SurveyErr2 = 'flash.survey.err-2',

--- a/client/src/components/signout-modal/index.tsx
+++ b/client/src/components/signout-modal/index.tsx
@@ -9,6 +9,7 @@ import { closeSignoutModal } from '../../redux/actions';
 import { isSignoutModalOpenSelector } from '../../redux/selectors';
 import { apiLocation } from '../../../config/env.json';
 import callGA from '../../analytics/call-ga';
+import { removeFlashMessage } from '../Flash/redux';
 
 const mapStateToProps = createSelector(
   isSignoutModalOpenSelector,
@@ -20,13 +21,15 @@ const mapStateToProps = createSelector(
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
   bindActionCreators(
     {
-      closeSignoutModal
+      closeSignoutModal,
+      removeFlashMessage
     },
     dispatch
   );
 
 type SignoutModalProps = {
   closeSignoutModal: () => void;
+  removeFlashMessage: () => void;
   show: boolean;
 };
 
@@ -44,7 +47,7 @@ export const pathAfterSignout = (currentPath: string): string => {
 };
 
 function SignoutModal(props: SignoutModalProps): JSX.Element {
-  const { show, closeSignoutModal } = props;
+  const { show, closeSignoutModal, removeFlashMessage } = props;
   const { t } = useTranslation();
 
   const handleModalHide = () => {
@@ -53,9 +56,16 @@ function SignoutModal(props: SignoutModalProps): JSX.Element {
 
   const handleSignout = () => {
     closeSignoutModal();
+    // Clear any existing flash messages (e.g., "logged in" success message)
+    // to prevent it from persisting after logout
+    removeFlashMessage();
+
     callGA({ event: 'sign_out', user_id: undefined });
     const redirect = () => {
+      // Clear the query string to remove any flash message parameters
+      // (e.g., ?success=signin) before redirecting
       window.location.pathname = pathAfterSignout(window.location.pathname);
+      window.location.search = '';
     };
     void fetch(`${apiLocation}/signout`, {
       method: 'GET',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66515

<!-- Feel free to add any additional description of changes below this line -->
## Description
Fixes #66515 - Success message after logging out shows "logged in" instead of "logged out"

**Problem:** When a user logs out, the flash message and URL query string from signin (e.g., `?success=signin`) were not being cleared, causing the "logged in" success message to persist after logout.

**Solution:** 
- Call `removeFlashMessage()` in the signout handler to clear any existing flash messages
- Set `window.location.search = ''` to remove query string parameters that could trigger the wrong flash message
