### PR TITLE
fix(curriculum): correct truncate_text inconsistency in description and tests

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69a890af247de743333bd4d2.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69a890af247de743333bd4d2.md
@@ -24,7 +24,7 @@ The table above includes all upper and lower case letters. Additionally:
 - Periods (`"."`) have a width of 1
 
 - If the given string is 50 units or less, return the string as-is, otherwise
-- Truncate the string and add three periods at the end (`"..."`) so it's total width, including the three periods, is as close as possible to 60 units without going over.
+- Truncate the string and add three periods at the end (`"..."`) so it's total width, including the three periods, is as close as possible to 50 units without going over.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/69a890af247de743333bd4d2.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/69a890af247de743333bd4d2.md
@@ -24,7 +24,7 @@ The table above includes all upper and lower case letters. Additionally:
 - Periods (`"."`) have a width of 1
 
 - If the given string is 50 units or less, return the string as-is, otherwise
-- Truncate the string and add three periods at the end (`"..."`) so it's total width, including the three periods, is as close as possible to 60 units without going over.
+- Truncate the string and add three periods at the end (`"..."`) so it's total width, including the three periods, is as close as possible to 50 units without going over.
 
 # --hints--
 
@@ -37,7 +37,7 @@ TestCase().assertEqual(truncate_text("The quick brown fox"), "The quick brown f.
 }})
 ```
 
-`truncate_text("The silky smooth sloth")` should return `truncate_text("The silky smooth sloth")`.
+`truncate_text("The silky smooth sloth")` should return `"The silky smooth s..."`.
 
 ```js
 ({test: () => { runPython(`

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/69a890af247de743333bd4d2.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/69a890af247de743333bd4d2.md
@@ -42,7 +42,7 @@ TestCase().assertEqual(truncate_text("The quick brown fox"), "The quick brown f.
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(truncate_text("The silky smooth sloth"), truncate_text("The silky smooth sloth"))`)
+TestCase().assertEqual(truncate_text("The silky smooth sloth"), "The silky smooth s..."))`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/69a890af247de743333bd4d2.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/69a890af247de743333bd4d2.md
@@ -42,7 +42,7 @@ TestCase().assertEqual(truncate_text("The quick brown fox"), "The quick brown f.
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(truncate_text("The silky smooth sloth"), "The silky smooth s..."))`)
+TestCase().assertEqual(truncate_text("The silky smooth sloth"), "The silky smooth s...")`)
 }})
 ```
 


### PR DESCRIPTION
## Description

This PR fixes inconsistencies in the `truncate_text` challenge.

### Changes

* Corrected the description from 60 units to 50 units in the Python challenge
* Corrected the description from 60 units to 50 units in the JavaScript challenge
* Fixed incorrect expected output in test 2:

  * Updated to: "The silky smooth s..."

### Checklist:

* [x] I have read and followed the contribution guidelines.
* [x] I have read and followed the how to open a pull request guide.
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66646
