### PR TITLE
fix: correct typo in emailSubscriptionRoutes

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -243,7 +243,7 @@ export const build = async (
 
   void fastify.register(publicRoutes.chargeStripeRoute);
   void fastify.register(publicRoutes.signoutRoute);
-  void fastify.register(publicRoutes.emailSubscribtionRoutes);
+  void fastify.register(publicRoutes.emailSubscriptionRoutes);
   void fastify.register(publicRoutes.userPublicGetRoutes);
   void fastify.register(publicRoutes.unprotectedCertificateRoutes);
   void fastify.register(publicRoutes.deprecatedEndpoints);

--- a/api/src/routes/public/email-subscription.ts
+++ b/api/src/routes/public/email-subscription.ts
@@ -9,7 +9,7 @@ import { getRedirectParams } from '../../utils/redirection.js';
  * @param _options Options passed to the plugin via `fastify.register(plugin, options)`.
  * @param done The callback to signal that the plugin is ready.
  */
-export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
+export const emailSubscriptionRoutes: FastifyPluginCallbackTypebox = (
   fastify,
   _options,
   done


### PR DESCRIPTION
## Description

Fixed a typo in the route registration identifier:
- `emailSubscribtionRoutes` -> `emailSubscriptionRoutes`
### Files changed:
1. **`api/src/routes/public/email-subscription.ts`** - Fixed the exported constant name
2. 2. **`api/src/app.ts`** - Updated the reference to use the corrected name
### Safety verification:
- I searched for all references across the entire codebase and updated them consistently to avoid breaking changes
- - The barrel export (`api/src/routes/public/index.ts`) uses `export *`, so no update needed there
- - No test files reference this identifier by name
- - No e2e tests reference this identifier
This change improves code clarity and consistency with no functional impact.