### PR TITLE
fix: Correct '60 units' to '50 units' in Challenge 229 (Closes #66646)

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69a890af247de743333bd4d2.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69a890af247de743333bd4d2.md
@@ -24,7 +24,7 @@ The table above includes all upper and lower case letters. Additionally:
 - Periods (`"."`) have a width of 1
 
 - If the given string is 50 units or less, return the string as-is, otherwise
-- Truncate the string and add three periods at the end (`"..."`) so it's total width, including the three periods, is as close as possible to 60 units without going over.
+- Truncate the string and add three periods at the end (`"..."`) so it's total width, including the three periods, is as close as possible to 50 units without going over.
 
 # --hints--
 


### PR DESCRIPTION
## Description

Fixes #66646 - Challenge 229 (JavaScript) contains the same typo as the Python version.

**Problem:**
- The challenge description states MAX_WIDTH = 50 (line 10)
- But line 19 says "as close as possible to **60 units**" - this is a typo
- Should be "50 units" to match the defined MAX_WIDTH

**Solution:**
- Changed "as close as possible to **60 units**" to "as close as possible to **50 units**"

This mirrors the fix made in the Python version (PR #66657).

## Changes

- Modified: `curriculum/challenges/english/blocks/daily-coding-challenges-javascript/69a890af247de743333bd4d2.md`

## Testing

- Verified the change by reading the file after modification
- Confirmed the typo was corrected from 60 to 50 units

---

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66646