### PR TITLE
fix: correct JSDoc typo and remove improper logging

### DIFF
--- a/api/src/utils/redirection.ts
+++ b/api/src/utils/redirection.ts
@@ -25,7 +25,7 @@ export function getReturnTo(
     params = jwt.verify(encryptedParams, secret);
   } catch (e) {
     // TODO: report to Sentry? Probably not. Remove entirely?
-    console.log(e);
+    
     // something went wrong, use default params
     params = {
       returnTo: `${_homeLocation}/learn`,
@@ -45,7 +45,7 @@ type RedirectParams = {
 };
 
 /**
- * Normalize the parameters, making they're valid.
+ * Normalize the parameters, making sure they're valid.
  *
  * @param arg - The parameters to normalize.
  * @param arg.returnTo - The returnTo value.


### PR DESCRIPTION
Closes #66666 
- Fixed typo in JSDoc comment ("making they're valid" -> "making sure they're valid")
- - Removed console.log(e) in catch block to align with project standards.
- - Improves code quality and documentation clarity.
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] - [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] - [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.