### PR TITLE
fix(curriculum): add figure and figcaption lecture before travel agency lab

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-html-fundamentals/69c71a00199c7d47aab13b47.md
+++ b/curriculum/challenges/english/blocks/lecture-html-fundamentals/69c71a00199c7d47aab13b47.md
@@ -1,0 +1,160 @@
+---
+id: 69c71a00199c7d47aab13b47
+title: What Are the Figure and Figcaption Elements and How Are They Used?
+challengeType: 19
+dashedName: what-are-the-figure-and-figcaption-elements
+---
+
+# --interactive--
+
+The `figure` element is used to group self-contained media content such as images, diagrams, or illustrations that are referenced in the main text but could stand on its own.
+
+Here is an example of a `figure` element wrapping an image. Try changing the `src` or `alt` text in the example and observe how the preview updates. To see the previews, you will need to enable the interactive editor.
+
+:::interactive_editor
+
+```html
+<figure>
+  <img src="https://cdn.freecodecamp.org/curriculum/labs/alps.jpg" alt="A scenic view of the Alps" />
+</figure>
+```
+
+:::
+
+The `figcaption` element is placed inside a `figure` element to provide a caption or description for its content. It can appear as the first or last child of the `figure` element.
+
+Try adding a `figcaption` element inside the `figure` to describe the image.
+
+:::interactive_editor
+
+```html
+<figure>
+  <img src="https://cdn.freecodecamp.org/curriculum/labs/alps.jpg" alt="A scenic view of the Alps" />
+  <figcaption>A beautiful view of the Alps mountains.</figcaption>
+</figure>
+```
+
+:::
+
+Using `figure` and `figcaption` together makes your HTML more semantic and accessible. Screen readers can associate the caption with the image, which helps users who rely on assistive technologies understand the content better.
+
+You can also wrap an anchor element inside `figure` so the image becomes a clickable link:
+
+```html
+<figure>
+  <a href="https://www.freecodecamp.org/learn" target="_blank">
+    <img src="https://cdn.freecodecamp.org/curriculum/labs/alps.jpg" alt="A scenic view of the Alps" />
+  </a>
+  <figcaption>Click the image to learn more.</figcaption>
+</figure>
+```
+
+# --questions--
+
+## --text--
+
+What is the purpose of the `figure` element?
+
+## --answers--
+
+It is used to create a figure or shape using CSS.
+
+### --feedback--
+
+Refer back to the explanation of the `figure` element above.
+
+---
+
+It is used to group self-contained media content, such as images or diagrams, that could stand on its own.
+
+---
+
+It is used to define a section of navigation links.
+
+### --feedback--
+
+Refer back to the explanation of the `figure` element above.
+
+---
+
+It is used to embed external content like videos or maps.
+
+### --feedback--
+
+Refer back to the explanation of the `figure` element above.
+
+## --video-solution--
+
+2
+
+## --text--
+
+Where should the `figcaption` element be placed?
+
+## --answers--
+
+Outside the `figure` element, directly after it.
+
+### --feedback--
+
+Review where `figcaption` was explained in the examples above.
+
+---
+
+Inside the `figure` element as its first or last child.
+
+---
+
+Inside the `img` element as an attribute.
+
+### --feedback--
+
+Review where `figcaption` was explained in the examples above.
+
+---
+
+Inside the `head` element of the HTML document.
+
+### --feedback--
+
+Review where `figcaption` was explained in the examples above.
+
+## --video-solution--
+
+2
+
+## --text--
+
+Which of the following correctly uses both `figure` and `figcaption`?
+
+## --answers--
+
+`<figcaption><figure><img src="photo.jpg" alt="A photo" /></figure></figcaption>`
+
+### --feedback--
+
+Review the correct nesting order shown in the examples above.
+
+---
+
+`<figure><img src="photo.jpg" alt="A photo" /><figcaption>A photo</figcaption></figure>`
+
+---
+
+`<figure><figcaption>A photo</figcaption></figure><img src="photo.jpg" alt="A photo" />`
+
+### --feedback--
+
+Review the correct nesting order shown in the examples above.
+
+---
+
+`<img src="photo.jpg" alt="A photo" /><figcaption>A photo</figcaption>`
+
+### --feedback--
+
+Review the correct nesting order shown in the examples above.
+
+## --video-solution--
+
+2

--- a/curriculum/structure/blocks/lecture-html-fundamentals.json
+++ b/curriculum/structure/blocks/lecture-html-fundamentals.json
@@ -20,6 +20,10 @@
     {
       "id": "670838b10ee87a18e5faff62",
       "title": "What Is the Role of the Script Element in HTML, and How Can It Be Used to Link to External JavaScript Files?"
+    },
+    {
+      "id": "69c71a00199c7d47aab13b47",
+      "title": "What Are the Figure and Figcaption Elements and How Are They Used?"
     }
   ]
 }


### PR DESCRIPTION
The HTML Fundamentals section was missing any explanation of \`figure\` and \`figcaption\` before learners hit the Travel Agency Page lab, which asks them to build layouts using those elements. Added a new interactive lecture that walks through what each element does, how to nest them, and how to combine them with images and anchor links. This should give beginners enough context to tackle the lab without getting stuck.

## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the \`main\` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66660