### PR TITLE
fix(api): prevent trimTags from throwing on null or undefined input

### DIFF
--- a/api/src/utils/validation.test.ts
+++ b/api/src/utils/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isObjectID } from './validation.js';
+import { isObjectID, trimTags } from './validation.js';
 
 describe('Validation', () => {
   describe('isObjectID', () => {
@@ -12,6 +12,21 @@ describe('Validation', () => {
       expect(isObjectID('5f1e0f3b5d2c12b0b8f7a6b99')).toBe(false);
       expect(isObjectID('5f1e0f3b5d2c12b0b8f7a6b-')).toBe(false);
       expect(isObjectID(undefined)).toBe(false);
+    });
+  });
+  describe('trimTags', () => {
+    it('should not throw when input is undefined', () => {
+      expect(() => trimTags(undefined)).not.toThrow();
+      expect(trimTags(undefined)).toBe('');
+    });
+
+    it('should not throw when input is null', () => {
+      expect(() => trimTags(null as unknown as string)).not.toThrow();
+      expect(trimTags(null as unknown as string)).toBe('');
+    });
+
+    it('should remove HTML tags from string', () => {
+      expect(trimTags('<p>Hello</p>')).toBe('Hello');
     });
   });
 });

--- a/api/src/utils/validation.ts
+++ b/api/src/utils/validation.ts
@@ -18,7 +18,8 @@ export const isObjectID = (id?: string): boolean =>
  * @param value A string to sanitize.
  * @returns A string with HTML tags removed.
  */
-export const trimTags = (value: string): string => {
+export const trimTags = (value?: string): string => {
+  if (typeof value !== 'string') return '';
   const tagBody = '(?:[^"\'>]|"[^"]*"|\'[^\']*\')*';
   const tagOrComment = new RegExp(
     '<(?:' +


### PR DESCRIPTION
Closes #66678

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## Description

The `trimTags` utility function assumes the input is always a string. However, if `null` or `undefined` is passed, it throws a runtime error when calling `.replace()`.

This PR adds a safeguard to handle non-string inputs gracefully by returning an empty string.

## Changes

- Updated `trimTags` to safely handle `null` and `undefined`
- Added tests to verify behavior for invalid inputs
- Ensured no changes to existing functionality

## Notes

Some local tests (e.g. auth0 plugin tests) may fail due to environment/timeouts, but this change is isolated to `trimTags` and does not affect those areas.