### PR TITLE
fix: Enhancement: Add test case for null containerId validation in cargo m…

### DIFF
--- a/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
+++ b/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
@@ -262,6 +262,7 @@ Calling `validateManifest()` with `{}` should return the new object `{ container
 
 ```js
 const testObj = {
+
 };
 
 const expected = {
@@ -277,6 +278,27 @@ assert.isObject(copy);
 assert.deepEqual(copy, expected, "validateManifest() did not return the expected object for missing properties");
 assert.notStrictEqual(copy, testObj, "validateManifest() should return a new object, not mutate the original");
 assert.equal(Object.keys(testObj).length, 0, "validateManifest() should return a new object, not mutate the original")
+```
+
+Calling `validateManifest()` with `{ containerId: null, destination: "Santa Cruz", weight: 304, unit: "kg", hazmat: false }` should return the new object `{ containerId: "Invalid" }` without mutating the source input.
+
+```js
+const testObj = {
+  containerId: null,
+  destination: "Santa Cruz",
+  weight: 304,
+  unit: "kg",
+  hazmat: false
+};
+
+const expected = {
+  containerId: "Invalid"
+};
+
+const copy = validateManifest(testObj);
+assert.isObject(copy);
+assert.deepEqual(copy, expected, "validateManifest() did not return the expected object for null containerId");
+assert.notStrictEqual(copy, testObj, "validateManifest() should return a new object, not mutate the original");
 ```
 
 Calling `validateManifest()` with `{ containerId: 0, destination: 405, weight: -84, unit: "pounds", hazmat: "no" }` should return the new object `{ containerId: "Invalid", destination: "Invalid", weight: "Invalid", unit: "Invalid", hazmat: "Invalid" }` without mutating the source input.


### PR DESCRIPTION
…anifest lab

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66674

## Description

Added a test case to validate handling of `null` values for `containerId` in the cargo manifest validator lab.

## Problem

Existing tests did not cover the case where `containerId` is explicitly set to `null`, allowing incorrect implementations (e.g., using `== null`) to pass.

## Solution

Added a new test case to ensure `containerId: null` is treated as `"Invalid"` instead of `"Missing"`.

## Result

Improves test coverage and ensures correct differentiation between `undefined` and `null`.