### PR TITLE
fix(api): reject overflowed daily challenge dates in date parser

### DIFF
--- a/api/src/daily-coding-challenge/utils/helpers.ts
+++ b/api/src/daily-coding-challenge/utils/helpers.ts
@@ -36,5 +36,16 @@ export function dateStringToUtcMidnight(dateStr: string): Date | null {
     number
   ];
 
-  return new Date(Date.UTC(year, month - 1, day));
+  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+  // Reject overflowed dates (e.g. 2026-02-31 -> 2026-03-03).
+  if (
+    parsedDate.getUTCFullYear() !== year ||
+    parsedDate.getUTCMonth() !== month - 1 ||
+    parsedDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsedDate;
 }


### PR DESCRIPTION
- This PR fixes a date parsing bug in the daily coding challenge helper.
- Previously, inputs matching the YYYY-MM-DD pattern were accepted even when the calendar date was invalid (for example, 2026-02-31), because JavaScript Date rolled them into another month.
- The parser now performs strict UTC component validation after parsing and returns null for overflowed dates.

## Impact:
- Invalid calendar dates are correctly rejected.
- Date lookup endpoints no longer risk returning a challenge for the wrong day.

## Scope:
- One file changed.
- No API contract changes, only validation correctness improvement.
