### PR TITLE
fix(client): update unauthenticated email sign-up button text

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -915,6 +915,7 @@
     "unsubscribed": "You have successfully been unsubscribed",
     "keep-coding": "Whatever you go on to, keep coding!",
     "email-signup": "Email Sign Up",
+    "email-signup-not-signed-in": "Sign in to adjust your newsletter preferences.",
     "brand-new-account": "Welcome to your brand new freeCodeCamp account. Let's get started.",
     "duplicate-account-warning": "If you meant to sign into an existing account instead of creating this account, <0>click here to delete this account</0> and try another email address.",
     "quincy": "- Quincy Larson, the teacher who founded freeCodeCamp.org",

--- a/client/src/components/email-options.tsx
+++ b/client/src/components/email-options.tsx
@@ -44,8 +44,9 @@ export function EmailListOptIn({
       <Row>
         <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
           <Spacer size='xs' />
+          <p className='text-center'>{t('misc.email-signup-not-signed-in')}</p>
           <Button block={true} variant='primary' href={`${apiLocation}/signin`}>
-            {t('buttons.sign-up-email-list')}
+            {t('buttons.sign-in')}
           </Button>
           <Spacer size='xs' />
         </Col>

--- a/client/src/components/email-options.tsx
+++ b/client/src/components/email-options.tsx
@@ -45,7 +45,12 @@ export function EmailListOptIn({
         <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
           <Spacer size='xs' />
           <p className='text-center'>{t('misc.email-signup-not-signed-in')}</p>
-          <Button block={true} variant='primary' href={`${apiLocation}/signin`}>
+          <Button
+            block={true}
+            variant='primary'
+            href={`${apiLocation}/signin`}
+            data-playwright-test-label='email-signup-sign-in-btn'
+          >
             {t('buttons.sign-in')}
           </Button>
           <Spacer size='xs' />

--- a/e2e/quincy-email-sign-up.spec.ts
+++ b/e2e/quincy-email-sign-up.spec.ts
@@ -26,10 +26,9 @@ test.describe('Email sign-up page when user is not signed in', () => {
       page.getByText(translations.misc['email-blast'])
     ).toBeVisible();
     await expect(
-      page.getByRole('link', {
-        name: translations.buttons['sign-up-email-list']
-      })
+      page.getByText(translations.misc['email-signup-not-signed-in'])
     ).toBeVisible();
+    await expect(page.getByTestId('email-signup-sign-in-btn')).toBeVisible();
   });
 
   test("should not enable Quincy's weekly newsletter when the user clicks the sign up button", async ({
@@ -40,9 +39,7 @@ test.describe('Email sign-up page when user is not signed in', () => {
       page.getByText(translations.misc['email-blast'])
     ).toBeVisible();
 
-    const signupLink = page.getByRole('link', {
-      name: translations.buttons['sign-up-email-list']
-    });
+    const signupLink = page.getByTestId('email-signup-sign-in-btn');
 
     await expect(signupLink).toBeVisible();
     await expect(signupLink).toHaveAttribute('href', `${apiLocation}/signin`);


### PR DESCRIPTION
This PR updates the email sign-up button text for unauthenticated users. The previous button label "Sign up for email list" was misleading as it implied the user would be subscribed to the newsletter, when in reality it only redirects to sign in. The button label has been updated to "Sign in" and an explanatory line "Sign in to adjust your newsletter preferences." has been added above it, so the behaviour is clear to the user.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62151

