### PR TITLE
feat: add anchor links to block headings

### DIFF
--- a/client/src/templates/Introduction/components/block-header.tsx
+++ b/client/src/templates/Introduction/components/block-header.tsx
@@ -92,6 +92,15 @@ function BlockHeader({
             <InnerBlockHeader />
           </Button>
         )}
+        <a
+          className='block-title-anchor'
+          href={`#${blockDashed}`}
+          aria-label={`Link to ${blockTitle}`}
+          title={`Link to ${blockTitle}`}
+          onClick={event => event.stopPropagation()}
+        >
+          #
+        </a>
       </h3>
       {isExpanded && !isEmpty(blockIntroArr) && (
         <BlockIntros intros={blockIntroArr as string[]} />

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -123,6 +123,20 @@ a.cert-tag:active {
   overflow-wrap: break-word;
 }
 
+.block-title-anchor {
+  color: var(--tertiary-color);
+  font-weight: 700;
+  margin-inline-start: 8px;
+  opacity: 0;
+  text-decoration: none;
+}
+
+.block-grid-title:hover .block-title-anchor,
+.block-grid-title:focus-within .block-title-anchor,
+.block-title-anchor:focus {
+  opacity: 1;
+}
+
 .block-grid .challenge-jump-link {
   margin: 0 25px 25px;
 }


### PR DESCRIPTION
This adds direct hash-link anchors to curriculum block headings on intro/map pages so users can share links to specific sections instead of linking only to individual challenges.
-- Added a heading anchor element for each block using the existing dashed block slug.
-- Added lightweight styling so the anchor appears on hover/focus and does not disrupt layout.
-- Uses existing hash scroll behavior already implemented in intro pages.