### PR TITLE
refactor: rename share hashtag constant

### DIFF
--- a/client/src/components/share/use-share.test.tsx
+++ b/client/src/components/share/use-share.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { useTranslation } from 'react-i18next';
 import { describe, test, expect } from 'vitest';
 import {
-  hastag,
+  hashtag,
   nextLine,
   space,
   useShare,
@@ -29,8 +29,8 @@ describe('useShare', () => {
 
     const freecodecampLearnDomain = 'www.freecodecamp.org/learn';
     const i18nSupportedBlock = t(`intro:${superBlock}.blocks.${block}.title`);
-    const tweetMessage = `I${space}have${space}completed${space}${i18nSupportedBlock}${space}${hastag}freecodecamp`;
-    const redirectFreeCodeCampLearnURL = `https://${freecodecampLearnDomain}/${superBlock}/${hastag}${block}`;
+    const tweetMessage = `I${space}have${space}completed${space}${i18nSupportedBlock}${space}${hashtag}freecodecamp`;
+    const redirectFreeCodeCampLearnURL = `https://${freecodecampLearnDomain}/${superBlock}/${hashtag}${block}`;
 
     expect(shareResult.current.xUrl).toBe(
       `https://${twitterData.domain}/${twitterData.action}?original_referer=${twitterData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`
@@ -45,7 +45,7 @@ describe('useShare', () => {
     );
 
     expect(shareResult.current.facebookUrl).toBe(
-      `https://www.facebook.com/sharer/sharer.php?u=${redirectFreeCodeCampLearnURL}&hashtag=${hastag}freecodecamp`
+      `https://www.facebook.com/sharer/sharer.php?u=${redirectFreeCodeCampLearnURL}&hashtag=${hashtag}freecodecamp`
     );
   });
 });

--- a/client/src/components/share/use-share.tsx
+++ b/client/src/components/share/use-share.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { ShareProps } from './types';
 
 export const space = '%20';
-export const hastag = '%23';
+export const hashtag = '%23';
 export const nextLine = '%0A';
 const freecodecampLearnDomainURL = 'www.freecodecamp.org/learn';
 
@@ -38,18 +38,18 @@ interface ShareUrls {
 
 export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
   const { t } = useTranslation();
-  const redirectFreeCodeCampLearnURL = `https://${freecodecampLearnDomainURL}/${superBlock}/${hastag}${block}`;
+  const redirectFreeCodeCampLearnURL = `https://${freecodecampLearnDomainURL}/${superBlock}/${hashtag}${block}`;
 
   const i18nSupportedBlock = t(`intro:${superBlock}.blocks.${block}.title`);
 
-  const tweetMessage = `I${space}have${space}completed${space}${i18nSupportedBlock}${space}${hastag}freecodecamp`;
+  const tweetMessage = `I${space}have${space}completed${space}${i18nSupportedBlock}${space}${hashtag}freecodecamp`;
   const xRedirectURL = `https://${twitterData.domain}/${twitterData.action}?original_referer=${twitterData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
 
   const blueSkyRedirectURL = `https://${blueSkyData.domain}/${blueSkyData.action}?original_referer=${blueSkyData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
 
   const threadRedirectURL = `https://${threadsData.domain}/${threadsData.action}?original_referer=${threadsData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
 
-  const facebookRedirectURL = `https://${facebookData.domain}/${facebookData.action}?u=${redirectFreeCodeCampLearnURL}&hashtag=${hastag}freecodecamp`;
+  const facebookRedirectURL = `https://${facebookData.domain}/${facebookData.action}?u=${redirectFreeCodeCampLearnURL}&hashtag=${hashtag}freecodecamp`;
 
   return {
     xUrl: xRedirectURL,


### PR DESCRIPTION
This is a naming cleanup in share utilities: a misspelled constant was renamed for clarity and consistency.

What changed:

1. Renamed hastag to hashtag in the share URL builder.
2. Updated all references in the share tests.
3. No behavior or output URL changes.