### PR TITLE
chore: fix header comment typo

### DIFF
--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -61,7 +61,7 @@ class Header extends React.Component<Props, { displayMenu: boolean }> {
       // the search bar should not toggle the menu
       this.searchBarRef.current &&
       !this.searchBarRef.current.contains(eventTarget) &&
-      // don't count clicks on searcn bar inputs reset button
+      // don't count clicks on search bar input's reset button
       !eventTarget.closest('.ais-SearchBox-reset') &&
       // don't count clicks on disabled elements
       !eventTarget.closest('[aria-disabled="true"]')


### PR DESCRIPTION
Small documentation-only cleanup in header code comments.

What changed:
Corrected a typo in the search-reset related comment in header logic.

Why:
Keeps code comments clear and professional.
No runtime impact.