### PR TITLE
refactor: normalize share threads URL naming

### DIFF
--- a/client/src/components/share/index.tsx
+++ b/client/src/components/share/index.tsx
@@ -17,7 +17,7 @@ export const Share = ({
     <ShareTemplate
       xRedirectURL={redirectURLs.xUrl}
       blueSkyRedirectURL={redirectURLs.blueSkyUrl}
-      threadsRedirectURL={redirectURLs.threadsURL}
+      threadsRedirectURL={redirectURLs.threadsUrl}
       facebookRedirectURL={redirectURLs.facebookUrl}
       minified={minified}
     />

--- a/client/src/components/share/use-share.test.tsx
+++ b/client/src/components/share/use-share.test.tsx
@@ -40,7 +40,7 @@ describe('useShare', () => {
       `https://${blueSkyData.domain}/${blueSkyData.action}?original_referer=${blueSkyData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`
     );
 
-    expect(shareResult.current.threadsURL).toBe(
+    expect(shareResult.current.threadsUrl).toBe(
       `https://${threadsData.domain}/${threadsData.action}?original_referer=${threadsData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`
     );
 

--- a/client/src/components/share/use-share.tsx
+++ b/client/src/components/share/use-share.tsx
@@ -32,7 +32,7 @@ export const facebookData = {
 interface ShareUrls {
   xUrl: string;
   blueSkyUrl: string;
-  threadsURL: string;
+  threadsUrl: string;
   facebookUrl: string;
 }
 
@@ -54,7 +54,7 @@ export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
   return {
     xUrl: xRedirectURL,
     blueSkyUrl: blueSkyRedirectURL,
-    threadsURL: threadRedirectURL,
+    threadsUrl: threadRedirectURL,
     facebookUrl: facebookRedirectURL
   };
 };


### PR DESCRIPTION
This normalizes property naming in the share URL object to match existing camelCase conventions.

What changed:

1. Renamed threadsURL to threadsUrl in share utility return type and object.
2. Updated share component consumption.
3. Updated related unit test assertions.