### PR TITLE
fix: Fix/sandpack console snapshot

### DIFF
--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -31,6 +31,25 @@ const InteractiveEditor = ({ files }: Props) => {
       string,
       { code: string; active?: boolean; hidden?: boolean }
     >;
+
+    const consoleOverride = `\n
+const __originalLog = console.log;
+
+console.log = (...args) => {
+  const safeArgs = args.map(arg => {
+    if (typeof arg === "object" && arg !== null) {
+      try {
+        return structuredClone(arg);
+      } catch {
+        return JSON.parse(JSON.stringify(arg));
+      }
+    }
+    return arg;
+  });
+
+  __originalLog(...safeArgs);
+};`;
+
     files.forEach(file => {
       const ext = file.ext;
       let path = '';
@@ -42,8 +61,18 @@ const InteractiveEditor = ({ files }: Props) => {
       else if (ext === 'jsx') path = '/App.jsx';
       else if (ext === 'tsx') path = '/App.tsx';
       else path = `/index.${ext}`;
-      // TODO: Consider making active file first file in markdown
-      obj[path] = { code: file.contents, active: path === '/index.html' };
+
+      const isScriptFile =
+        ext === 'js' || ext === 'ts' || ext === 'jsx' || ext === 'tsx';
+
+      // Inject console override into script files to ensure console.log
+      // captures snapshots instead of live references (fixes Sandpack behavior)
+      obj[path] = {
+        code: isScriptFile
+          ? consoleOverride + '\n' + file.contents
+          : file.contents,
+        active: path === '/index.html'
+      };
     });
     return obj;
   }, [files]);

--- a/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
+++ b/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
@@ -262,6 +262,7 @@ Calling `validateManifest()` with `{}` should return the new object `{ container
 
 ```js
 const testObj = {
+
 };
 
 const expected = {
@@ -277,6 +278,27 @@ assert.isObject(copy);
 assert.deepEqual(copy, expected, "validateManifest() did not return the expected object for missing properties");
 assert.notStrictEqual(copy, testObj, "validateManifest() should return a new object, not mutate the original");
 assert.equal(Object.keys(testObj).length, 0, "validateManifest() should return a new object, not mutate the original")
+```
+
+Calling `validateManifest()` with `{ containerId: null, destination: "Santa Cruz", weight: 304, unit: "kg", hazmat: false }` should return the new object `{ containerId: "Invalid" }` without mutating the source input.
+
+```js
+const testObj = {
+  containerId: null,
+  destination: "Santa Cruz",
+  weight: 304,
+  unit: "kg",
+  hazmat: false
+};
+
+const expected = {
+  containerId: "Invalid"
+};
+
+const copy = validateManifest(testObj);
+assert.isObject(copy);
+assert.deepEqual(copy, expected, "validateManifest() did not return the expected object for null containerId");
+assert.notStrictEqual(copy, testObj, "validateManifest() should return a new object, not mutate the original");
 ```
 
 Calling `validateManifest()` with `{ containerId: 0, destination: 405, weight: -84, unit: "pounds", hazmat: "no" }` should return the new object `{ containerId: "Invalid", destination: "Invalid", weight: "Invalid", unit: "Invalid", hazmat: "Invalid" }` without mutating the source input.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes locally.

Closes #66501

---

### Description

The Sandpack console currently logs arrays and objects as live references, causing all console outputs to reflect their final mutated state instead of their value at the time `console.log()` is called.

This behavior differs from environments like Node.js and can be confusing for learners working with mutation-based concepts.

This PR fixes the issue by overriding `console.log` in the sandbox runtime to clone objects before logging. This ensures that values are displayed as snapshots at the time of invocation.

### Example

```js
let arr = [1];
console.log(arr);

arr.push(2);
console.log(arr);
```

**Before (incorrect):**
```js
[1, 2]
[1, 2]
``` 

**After (correct):**
```js
[1]
[1, 2]
```