### PR TITLE
feat(client): show unsaved changes dialog on certification projects

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -103,6 +103,8 @@
     "finish-exam": "Finish the exam",
     "finish": "Finish",
     "exit-quiz": "Exit the quiz",
+    "stay-on-page": "Stay on page",
+    "leave-page": "Leave page",
     "finish-quiz": "Finish the quiz",
     "submit-exam-results": "Submit my results",
     "verify-trophy": "Verify Trophy",

--- a/client/src/templates/Challenges/classic/exit-project-modal.tsx
+++ b/client/src/templates/Challenges/classic/exit-project-modal.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Button, Modal, Spacer } from '@freecodecamp/ui';
+
+import { closeModal } from '../redux/actions';
+import { isExitProjectModalOpenSelector } from '../redux/selectors';
+
+interface ExitProjectModalProps {
+  closeExitProjectModal: () => void;
+  isExitProjectModalOpen: boolean;
+  onExit: () => void;
+}
+
+const mapStateToProps = (state: unknown) => ({
+  isExitProjectModalOpen: isExitProjectModalOpenSelector(state) as boolean
+});
+
+const mapDispatchToProps = {
+  closeExitProjectModal: () => closeModal('exitProject')
+};
+
+const ExitProjectModal = ({
+  closeExitProjectModal,
+  isExitProjectModalOpen,
+  onExit
+}: ExitProjectModalProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      onClose={closeExitProjectModal}
+      open={isExitProjectModalOpen}
+      variant='danger'
+    >
+      <Modal.Header closeButtonClassNames='close'>
+        {t('misc.navigation-warning')}
+      </Modal.Header>
+      <Modal.Body alignment='center'>
+        {t('misc.navigation-warning')}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button block variant='primary' onClick={closeExitProjectModal}>
+          {t('buttons.stay-on-page')}
+        </Button>
+        <Spacer size='xxs' />
+        <Button block variant='danger' onClick={onExit}>
+          {t('buttons.leave-page')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+ExitProjectModal.displayName = 'ExitProjectModal';
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExitProjectModal);

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -1,5 +1,5 @@
-import { graphql } from 'gatsby';
-import React, { useState, useEffect, useRef } from 'react';
+import { graphql, navigate } from 'gatsby';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -43,6 +43,7 @@ import Preview, { type PreviewProps } from '../components/preview';
 import ProjectPreviewModal from '../components/project-preview-modal';
 import SidePanel from '../components/side-panel';
 import VideoModal from '../components/video-modal';
+import { usePageLeave } from '../hooks';
 import {
   cancelTests,
   challengeMounted,
@@ -55,6 +56,7 @@ import {
   previewMounted,
   updateChallengeMeta,
   openModal,
+  closeModal,
   setEditorFocusability,
   setIsAdvancing
 } from '../redux/actions';
@@ -70,6 +72,7 @@ import envData from '../../../../config/env.json';
 import ToolPanel from '../components/tool-panel';
 import { getChallengePaths } from '../utils/challenge-paths';
 import { challengeHasPreview, isJavaScriptChallenge } from '../utils/build';
+import ExitProjectModal from './exit-project-modal';
 import { XtermTerminal } from './xterm';
 import MultifileEditor from './multifile-editor';
 import DesktopLayout from './desktop-layout';
@@ -100,6 +103,9 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
       cancelTests,
       previewMounted,
       openModal,
+      closeModal,
+      openExitProjectModal: () => openModal('exitProject'),
+      closeExitProjectModal: () => closeModal('exitProject'),
       setEditorFocusability,
       setIsAdvancing
     },
@@ -124,6 +130,9 @@ interface ShowClassicProps extends Pick<PreviewProps, 'previewMounted'> {
   pageContext: PageContext | DailyCodingChallengePageContext;
   updateChallengeMeta: (arg0: ChallengeMeta) => void;
   openModal: (modal: string) => void;
+  closeModal: (modal: string) => void;
+  openExitProjectModal: () => void;
+  closeExitProjectModal: () => void;
   setDailyCodingChallengeLanguage: (
     language: DailyCodingChallengeLanguages
   ) => void;
@@ -235,6 +244,8 @@ function ShowClassic({
   setDailyCodingChallengeLanguage,
   updateChallengeMeta,
   openModal,
+  openExitProjectModal,
+  closeExitProjectModal,
   setIsAdvancing,
   savedChallenges,
   isChallengeCompleted,
@@ -251,6 +262,49 @@ function ShowClassic({
   const xtermFitRef = useRef<FitAddon | null>(null);
   const isMobile = useMediaQuery({
     query: `(max-width: ${MAX_MOBILE_WIDTH}px)`
+  });
+
+  // Exit project modal state (only used for cert projects with saveSubmissionToDB)
+  const exitConfirmed = useRef(false);
+  const [exitPathname, setExitPathname] = useState('');
+
+  const handleExitProjectModalBtnClick = () => {
+    exitConfirmed.current = true;
+    void navigate(
+      exitPathname || challengeMeta.blockHashSlug || '/learn',
+      { replace: true }
+    );
+    closeExitProjectModal();
+  };
+
+  const onWindowClose = useCallback(
+    (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      window.confirm(t('misc.navigation-warning'));
+    },
+    [t]
+  );
+
+  const onHistoryChange = useCallback(
+    (targetPathname: string): boolean => {
+      if (exitConfirmed.current) {
+        return false;
+      }
+
+      if (targetPathname) {
+        setExitPathname(targetPathname);
+      }
+
+      openExitProjectModal();
+      return true;
+    },
+    [openExitProjectModal]
+  );
+
+  usePageLeave({
+    onWindowClose,
+    onHistoryChange,
+    enabled: !!saveSubmissionToDB
   });
 
   const guideUrl = getGuideUrl({ forumTopicId, title });
@@ -569,6 +623,9 @@ function ShowClassic({
         />
         <ShortcutsModal />
         <MobileAppModal superBlock={superBlock} />
+        {saveSubmissionToDB && (
+          <ExitProjectModal onExit={handleExitProjectModalBtnClick} />
+        )}
       </LearnLayout>
     </Hotkeys>
   );

--- a/client/src/templates/Challenges/hooks/use-page-leave.ts
+++ b/client/src/templates/Challenges/hooks/use-page-leave.ts
@@ -4,12 +4,19 @@ import { useLocation } from '@gatsbyjs/reach-router';
 interface Props {
   onWindowClose: (event: BeforeUnloadEvent) => void;
   onHistoryChange: (targetPathname: string) => boolean;
+  enabled?: boolean;
 }
 
-export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
+export const usePageLeave = ({
+  onWindowClose,
+  onHistoryChange,
+  enabled = true
+}: Props) => {
   const curLocation = useLocation();
 
   useEffect(() => {
+    if (!enabled) return;
+
     window.addEventListener('beforeunload', onWindowClose);
     // Push a dummy state so that navigating back will restore the current page,
     // allowing us to manually handle navigation.
@@ -45,5 +52,5 @@ export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
       window.removeEventListener('popstate', handlePopState);
       document.removeEventListener('click', handleLinkClick, true);
     };
-  }, [onWindowClose, onHistoryChange, curLocation]);
+  }, [onWindowClose, onHistoryChange, curLocation, enabled]);
 };

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -44,6 +44,7 @@ const initialState = {
     exitExam: false,
     finishExam: false,
     exitQuiz: false,
+    exitProject: false,
     finishQuiz: false,
     examResults: false,
     survey: false,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -47,6 +47,8 @@ export const isSurveyModalOpenSelector = state => state[ns].modal.survey;
 export const isExamResultsModalOpenSelector = state =>
   state[ns].modal.examResults;
 export const isExitQuizModalOpenSelector = state => state[ns].modal.exitQuiz;
+export const isExitProjectModalOpenSelector = state =>
+  state[ns].modal.exitProject;
 export const isFinishQuizModalOpenSelector = state =>
   state[ns].modal.finishQuiz;
 export const isProjectPreviewModalOpenSelector = state =>


### PR DESCRIPTION
## Description

Adds a leave-page confirmation dialog to certification project editor pages. When users navigate away from a cert project with unsaved code, a modal warns them before losing their work.

Only activates on challenges where `saveSubmissionToDB` is true (certification projects with manual save). Regular step challenges are unaffected.

### Implementation

Reuses the existing `usePageLeave` hook (added `enabled` parameter to conditionally activate). The modal follows the quiz exit modal pattern (`exit-quiz-modal.tsx`):

- Native `beforeunload` dialog handles tab close/browser refresh
- Custom `ExitProjectModal` handles in-app navigation (back button, link clicks)
- Uses `@freecodecamp/ui` Modal with danger variant
- Translation key `misc.navigation-warning` for the message text
- New translation keys `buttons.stay-on-page` and `buttons.leave-page`

### Files changed

- `classic/exit-project-modal.tsx` (new) - Modal component
- `classic/show.tsx` - Hook integration, gated on `saveSubmissionToDB`
- `hooks/use-page-leave.ts` - Added `enabled` parameter
- `redux/index.js` - Added `exitProject` modal state
- `redux/selectors.js` - Added `isExitProjectModalOpenSelector`
- `translations.json` - Added button translation keys

Closes #54796

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally or by using Gitpod.

This contribution was developed with AI assistance (Claude Code).