### PR TITLE
fix: remove success message from URL after logout

### DIFF
--- a/client/src/components/signout-modal/index.tsx
+++ b/client/src/components/signout-modal/index.tsx
@@ -40,7 +40,25 @@ export const pathAfterSignout = (currentPath: string): string => {
     ...redirectedPaths.map(path => `${path}/`)
   ];
 
-  return allPaths.some(path => currentPath === path) ? '/learn' : currentPath;
+  const basePath = currentPath.split('?')[0];
+
+  return allPaths.some(path => basePath === path)
+    ? '/learn'
+    : currentPath;
+};
+
+export const removeQueryParam = (
+  url: string,
+  param: string
+): string => {
+  const [path, queryString] = url.split('?');
+  if (!queryString) return url;
+
+  const params = new URLSearchParams(queryString);
+  params.delete(param);
+
+  const newQuery = params.toString();
+  return newQuery ? `${path}?${newQuery}` : path;
 };
 
 function SignoutModal(props: SignoutModalProps): JSX.Element {
@@ -55,7 +73,13 @@ function SignoutModal(props: SignoutModalProps): JSX.Element {
     closeSignoutModal();
     callGA({ event: 'sign_out', user_id: undefined });
     const redirect = () => {
-      window.location.pathname = pathAfterSignout(window.location.pathname);
+      const fullPath =
+        window.location.pathname + window.location.search;
+      const redirected = pathAfterSignout(fullPath);
+
+     // Remove the 'messages' query parameter while preserving other query params
+      const cleaned = removeQueryParam(redirected, 'messages');
+      window.location.href = cleaned;
     };
     void fetch(`${apiLocation}/signout`, {
       method: 'GET',


### PR DESCRIPTION
### Description

This PR fixes an issue where a success message (`flash.signin-success`) persists after logout due to the `messages` query parameter remaining in the URL.

### Changes

* Extracted full URL using `pathname + search`
* Removed only the `messages` query parameter during logout
* Preserved any existing query parameters while removing only the `messages` parameter
* Fixed redirect logic to correctly handle paths with query strings

### Result

After logout:

* The incorrect success message is removed
* Other query parameters remain intact
* Redirect behavior works as expected

### Related Issue

Closes #66515

