### PR TITLE
fix(client): adding curriculum heading link functionality

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, createRef } from 'react';
 import type { TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -78,12 +78,54 @@ interface BlockProps {
 
 export class Block extends Component<BlockProps> {
   static displayName: string;
+  private observer: IntersectionObserver | null = null;
+  private blockRef = createRef<HTMLElement>();
+
   constructor(props: BlockProps) {
     super(props);
 
     this.handleBlockClick = this.handleBlockClick.bind(this);
     this.handleChallengeClick = this.handleChallengeClick.bind(this);
   }
+
+  componentDidMount() {
+    this.setupObserver();
+  }
+
+  componentWillUnmount() {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  }
+
+  setupObserver = () => {
+    if (this.props.accordion) return;
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window))
+      return;
+
+    const { block } = this.props;
+    const dashedBlock = block
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9-]/g, '');
+
+    this.observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            if (window.location.hash !== `#${dashedBlock}`) {
+              window.history.replaceState(null, '', `#${dashedBlock}`);
+            }
+          }
+        });
+      },
+      { rootMargin: '-20% 0px -50% 0px' }
+    );
+
+    if (this.blockRef.current) {
+      this.observer.observe(this.blockRef.current);
+    }
+  };
 
   handleBlockClick = (): void => {
     const { block, toggleBlock } = this.props;
@@ -551,16 +593,12 @@ export class Block extends Component<BlockProps> {
       [BlockLayouts.DialogueGrid]: TaskGridBlock
     };
 
-    return (
-      !isEmptyBlock && (
-        <>
-          {layoutToComponent[blockLayout]}
-          {!chapterBasedSuperBlocks.includes(superBlock) && (
-            <Spacer size='xs' />
-          )}
-        </>
-      )
-    );
+    return !isEmptyBlock ? (
+      <section ref={this.blockRef} className='block-scrollspy-wrapper'>
+        {layoutToComponent[blockLayout]}
+        {!chapterBasedSuperBlocks.includes(superBlock) && <Spacer size='xs' />}
+      </section>
+    ) : null;
   }
 }
 

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode, createRef } from 'react';
+import React, { Component, ReactNode } from 'react';
 import type { TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -37,6 +37,8 @@ import '../intro.css';
 import './block.css';
 
 const { curriculumLocale } = envData;
+
+let lastScrollSpyHash = '';
 
 const mapStateToProps = (state: unknown, ownProps: { block: string }) => {
   const expandedSelector = makeExpandedBlockSelector(ownProps.block);
@@ -79,7 +81,6 @@ interface BlockProps {
 export class Block extends Component<BlockProps> {
   static displayName: string;
   private observer: IntersectionObserver | null = null;
-  private blockRef = createRef<HTMLElement>();
 
   constructor(props: BlockProps) {
     super(props);
@@ -108,12 +109,21 @@ export class Block extends Component<BlockProps> {
       .toLowerCase()
       .replace(/\s+/g, '-')
       .replace(/[^a-z0-9-]/g, '');
+    if (lastScrollSpyHash === '' && window.location.hash) {
+      lastScrollSpyHash = window.location.hash;
+    }
+    const el = document.getElementById(dashedBlock);
+    if (!el) return;
 
     this.observer = new IntersectionObserver(
       entries => {
         entries.forEach(entry => {
           if (entry.isIntersecting) {
-            if (window.location.hash !== `#${dashedBlock}`) {
+            const currentHash = window.location.hash;
+            const observerOwnsHash =
+              currentHash === '' || currentHash === lastScrollSpyHash;
+            if (observerOwnsHash) {
+              lastScrollSpyHash = `#${dashedBlock}`;
               window.history.replaceState(null, '', `#${dashedBlock}`);
             }
           }
@@ -121,10 +131,7 @@ export class Block extends Component<BlockProps> {
       },
       { rootMargin: '-20% 0px -50% 0px' }
     );
-
-    if (this.blockRef.current) {
-      this.observer.observe(this.blockRef.current);
-    }
+    this.observer.observe(el);
   };
 
   handleBlockClick = (): void => {
@@ -200,6 +207,10 @@ export class Block extends Component<BlockProps> {
     const isGridBlock = blockLayout === BlockLayouts.ChallengeGrid;
 
     const isEmptyBlock = !challenges.length;
+    const dashedBlock = block
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9-]/g, '');
 
     const courseCompletionStatus = () => {
       if (completedCount === 0) {
@@ -217,7 +228,7 @@ export class Block extends Component<BlockProps> {
      * Example: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/#basic-javascript
      */
     const LegacyChallengeListBlock = (
-      <Element name={block}>
+      <Element name={block} id={dashedBlock}>
         <div className={`block ${isExpanded ? 'open' : ''}`}>
           <div className='block-header'>
             <h3 className='big-block-title'>{blockTitle}</h3>
@@ -273,7 +284,7 @@ export class Block extends Component<BlockProps> {
      * Example: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/#javascript-algorithms-and-data-structures-projects
      */
     const ProjectListBlock = (
-      <Element name={block}>
+      <Element name={block} id={dashedBlock}>
         <div className='block'>
           <div className='block-header'>
             <h3 className='big-block-title'>{blockTitle}</h3>
@@ -303,7 +314,7 @@ export class Block extends Component<BlockProps> {
      * Example: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/#learn-basic-javascript-by-building-a-role-playing-game
      */
     const LegacyChallengeGridBlock = (
-      <Element name={block}>
+      <Element name={block} id={dashedBlock}>
         <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
           <BlockHeader
             blockDashed={block}
@@ -353,7 +364,7 @@ export class Block extends Component<BlockProps> {
      * Example: https://www.freecodecamp.org/learn/a2-english-for-developers/#learn-greetings-in-your-first-day-at-the-office
      */
     const TaskGridBlock = (
-      <Element name={block}>
+      <Element name={block} id={dashedBlock}>
         <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
           <BlockHeader
             blockDashed={block}
@@ -402,7 +413,7 @@ export class Block extends Component<BlockProps> {
      * Example: https://www.freecodecamp.org/learn/2022/responsive-web-design/#build-a-survey-form-project
      */
     const LegacyLinkBlock = (
-      <Element name={block}>
+      <Element name={block} id={dashedBlock}>
         <div className='block block-grid grid-project-block'>
           <div className='tags-wrapper'>
             <span className='cert-tag' aria-hidden='true'>
@@ -593,12 +604,16 @@ export class Block extends Component<BlockProps> {
       [BlockLayouts.DialogueGrid]: TaskGridBlock
     };
 
-    return !isEmptyBlock ? (
-      <section ref={this.blockRef} className='block-scrollspy-wrapper'>
-        {layoutToComponent[blockLayout]}
-        {!chapterBasedSuperBlocks.includes(superBlock) && <Spacer size='xs' />}
-      </section>
-    ) : null;
+    return (
+      !isEmptyBlock && (
+        <>
+          {layoutToComponent[blockLayout]}
+          {!chapterBasedSuperBlocks.includes(superBlock) && (
+            <Spacer size='xs' />
+          )}
+        </>
+      )
+    );
   }
 }
 

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -128,7 +128,7 @@ const Chapter = ({
         });
       });
     }
-  }, []);
+  }, [dashedName]);
   const chapterButtonContent = (
     <>
       <div className='chapter-button-left'>

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo } from 'react';
+import React, { ReactNode, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 // TODO: Add this component to freecodecamp/ui and remove this dependency
 import { Disclosure } from '@headlessui/react';
@@ -96,7 +96,39 @@ const Chapter = ({
   const { t } = useTranslation();
   const isComplete = completedSteps === totalSteps && totalSteps > 0;
   const chapterLabel = t(`intro:${superBlock}.chapters.${dashedName}`);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window))
+      return;
+    const el = document.getElementById(dashedName);
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            if (window.location.hash !== `#${dashedName}`) {
+              window.history.replaceState(null, '', `#${dashedName}`);
+            }
+          }
+        });
+      },
+      { rootMargin: '-20% 0px -50% 0px' }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [dashedName]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const hash = window.location.hash.replace(/^#/, '');
+    if (hash === dashedName) {
+      requestAnimationFrame(() => {
+        document.getElementById(dashedName)?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start'
+        });
+      });
+    }
+  }, []);
   const chapterButtonContent = (
     <>
       <div className='chapter-button-left'>
@@ -125,7 +157,7 @@ const Chapter = ({
 
   if (isLinkChapter && examSlug) {
     return (
-      <li className='chapter'>
+      <li className='chapter' id={dashedName}>
         <Link
           className='chapter-button'
           data-playwright-test-label='chapter-button'
@@ -138,7 +170,12 @@ const Chapter = ({
   }
 
   return (
-    <Disclosure as='li' className='chapter' defaultOpen={isExpanded}>
+    <Disclosure
+      as='li'
+      className='chapter'
+      id={dashedName}
+      defaultOpen={isExpanded}
+    >
       <Disclosure.Button
         className='chapter-button'
         data-playwright-test-label='chapter-button'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62555

<!-- Feel free to add any additional description of changes below this line -->

Added functionality of linked headings to allow for easier sharing of subject sections of a curriculum/certifications as described in the issue.

Testing:
Manual testing on local machine. Confirmed that behaviour matches expected recorded behaviour as seen in ticket's video for both legacy curriculums and v9 curriculums.
