### PR TITLE
docs: add macOS Homebrew PATH setup note for new contributors

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -13,6 +13,16 @@ pnpm run develop
 
 ## Optional setup
 
+> ** macOS users:** After installing Homebrew during setup, if you see
+> `brew: command not found`, you need to add Homebrew to your PATH first.
+> Run this in your terminal:
+>
+> ```bash
+> eval "$(/usr/local/bin/brew shellenv zsh)"
+> ```
+>
+> To make this permanent, add it to your `~/.zprofile` file.
+
 For E2E tests:
 
 ```bash


### PR DESCRIPTION
## What does this PR do?
Adds a helpful note for macOS users who may encounter the 
`brew: command not found` error after installing Homebrew.

## Why is this needed?
As a first-time contributor setting up freeCodeCamp on macOS, 
I ran into this issue myself. Homebrew does not automatically 
add itself to the PATH, which causes brew commands to fail. 
This note helps other macOS contributors avoid this confusion.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
