### PR TITLE
fix: add missing empty line in decimal to binary step 35

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645b9d56b48971997a8055dd.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645b9d56b48971997a8055dd.md
@@ -202,6 +202,7 @@ const decimalToBinary = (input) => {
 
   --fcc-editable-region--
   if (input === 0) {
+  
   }
   --fcc-editable-region--
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66730

Added the missing empty line inside the `if` statement for Step 35 of the Decimal to Binary converter lesson, as requested in the issue.
