### PR TITLE
fix: correct typo 'refering' to 'referring' in grammar explanation

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-learn-contact-information-and-spelling/6939aba64ef7835b338fd665.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-contact-information-and-spelling/6939aba64ef7835b338fd665.md
@@ -10,7 +10,7 @@ lang: es
 
 # --description--
 
-Do you remember verbs are conjugated according to the person they are refering to? If not, now you do!
+Do you remember verbs are conjugated according to the person they are referring to? If not, now you do!
 
 A couple of tasks ago, you learned how to use the verb `poder` to ask if someone was able to do something for you.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66743

<!-- Feel free to add any additional description of changes below this line -->

Fixes a typo in the grammar explanation file task-15.md.

- Changed 'refering' → 'referring' in the Spanish A1 curriculum
- The second file (task-60.md) already had 'precede' spelled correctly
so no changes were needed there.
