### PR TITLE
fix(curriculum): correct typos in grammar explanations

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-learn-contact-information-and-spelling/6939aba64ef7835b338fd665.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-contact-information-and-spelling/6939aba64ef7835b338fd665.md
@@ -10,7 +10,7 @@ lang: es
 
 # --description--
 
-Do you remember verbs are conjugated according to the person they are refering to? If not, now you do!
+Do you remember verbs are conjugated according to the person they are referring to? If not, now you do!
 
 A couple of tasks ago, you learned how to use the verb `poder` to ask if someone was able to do something for you.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66743

Fixes a typo in the grammar explanations

- Changed 'refering' → 'referring' in 6939aba64ef7835b338fd665.md file
- The second file 68557eeb6959f6ac5de97da2.md already had 'precede' spelled correctly
so no changes were needed there.
