### PR TITLE
fix: correct language switch button behavior in header

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -86,7 +86,7 @@
  * Site header language list
  * Using ~ so it still works if more items are added between the button and list.
  */
-.lang-button-nav[aria-expanded='true'] ~ .nav-list {
+.lang-button-nav[aria-expanded='true'] ~ #nav-lang-list {
   -ms-overflow-style: none;
   display: block;
   max-height: calc(100vh - var(--header-height));
@@ -95,7 +95,7 @@
   top: calc(var(--header-height));
 }
 
-.lang-button-nav[aria-expanded='true'] ~ .nav-list::-webkit-scrollbar {
+.lang-button-nav[aria-expanded='true'] ~ #nav-lang-list::-webkit-scrollbar {
   display: none;
 }
 
@@ -455,13 +455,13 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
  * We use ~ because the Donate button is now between the toggle button 
  * and the menu/search elements, so they are no longer right next to each other.
  */
-#universal-nav button[aria-expanded='false'] ~ .nav-list,
-#universal-nav button[aria-expanded='false'] ~ .fcc_searchBar {
+#universal-nav #toggle-button-nav[aria-expanded='false'] ~ .nav-list,
+#universal-nav #toggle-button-nav[aria-expanded='false'] ~ .fcc_searchBar {
   display: none;
 }
 
-#universal-nav button[aria-expanded='true'] ~ .nav-list,
-#universal-nav button[aria-expanded='true'] ~ .fcc_searchBar {
+#universal-nav #toggle-button-nav[aria-expanded='true'] ~ .nav-list,
+#universal-nav #toggle-button-nav[aria-expanded='true'] ~ .fcc_searchBar {
   display: block;
 }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66747

## After
<img width="1436" height="608" alt="Screenshot 2026-04-02 at 9 30 55 PM" src="https://github.com/user-attachments/assets/577a4a98-c366-4b73-95ff-c001ed0bedf4" />
