### PR TITLE
fix(curriculum): correct typos in lessons

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67acb31f4e94b6106c23df4d.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-express-disagreement/67acb31f4e94b6106c23df4d.md
@@ -46,7 +46,7 @@ Bob agrees with Anna, so he wouldn't completely disagree. Instead, he wants to a
 
 # --explanation--
 
-`True, but…` allows to agree with someone while adding a different point of view. This phrase is useful in discussions where you want to recognize a valid point while presenting your own argument. For example:
+`True, but…` allows you to agree with someone while adding a different point of view. This phrase is useful in discussions where you want to recognize a valid point while presenting your own argument. For example:
 
 - **Quinn:** `AI tools can speed up coding.`
 

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829061f03543726ea6f318.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829061f03543726ea6f318.md
@@ -15,7 +15,7 @@ Visit <a href="https://github.com" target="_blank">GitHub's website</a>, make su
 
 The first option you'll see there is the ability to choose a template. You likely do not have one of these set up yet, but a template is a special kind of repository that you can use as a springboard for your new repositories. These are helpful for including documentation or issue templates in all of your projects.
 
-Your next option is to select on owner, you can choose your user account or any organizations you own or have access to. Then you can name the repository - in general, you'll want to use a name that succinctly describes the project you are building. As a general best practice, you want to avoid spaces in your repo name. GitHub will automatically replace them with hyphens.
+Your next option is to select an owner, you can choose your user account or any organizations you own or have access to. Then you can name the repository - in general, you'll want to use a name that succinctly describes the project you are building. As a general best practice, you want to avoid spaces in your repo name. GitHub will automatically replace them with hyphens.
 
 Next, you can optionally add a description which will appear on the repository's home page.
 

--- a/curriculum/challenges/english/blocks/workshop-medical-data-validator/6846a1f2805ac73ce671a5d8.md
+++ b/curriculum/challenges/english/blocks/workshop-medical-data-validator/6846a1f2805ac73ce671a5d8.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-As you learned in a previous lesson, the `enumerate` function allows to keep track of the index while looping over an iterable:
+As you learned in a previous lesson, the `enumerate` function allows you to keep track of the index while looping over an iterable:
 
 ```py
 person = {'name': 'John', 'age': 33}

--- a/curriculum/challenges/english/blocks/workshop-pin-extractor/685578aae65e4106ad2b4300.md
+++ b/curriculum/challenges/english/blocks/workshop-pin-extractor/685578aae65e4106ad2b4300.md
@@ -7,7 +7,7 @@ dashedName: step-7
 
 # --description--
 
-As you learned in a previous lesson, the `enumerate` function allows to keep track of the index while looping over an iterable:
+As you learned in a previous lesson, the `enumerate` function allows you to keep track of the index while looping over an iterable:
 
 ```py
 fruits = ['apple', 'plum', 'bananas']


### PR DESCRIPTION
## Summary
Fixed a typo in the Introduction to Git and GitHub lecture where "select on owner" should be "select an owner."

**File:** `curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829061f03543726ea6f318.md`

**Before:** "Your next option is to select on owner, you can choose your user account..."
**After:** "Your next option is to select an owner, you can choose your user account..."

## Checklist
- [x] Typo/grammar fix only
- [x] No functional changes