### PR TITLE
fix(curriculum): correct grammar in enumerate function description

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-medical-data-validator/6846a1f2805ac73ce671a5d8.md
+++ b/curriculum/challenges/english/blocks/workshop-medical-data-validator/6846a1f2805ac73ce671a5d8.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-As you learned in a previous lesson, the `enumerate` function allows to keep track of the index while looping over an iterable:
+As you learned in a previous lesson, the `enumerate` function allows you to keep track of the index while looping over an iterable:
 
 ```py
 person = {'name': 'John', 'age': 33}

--- a/curriculum/challenges/english/blocks/workshop-pin-extractor/685578aae65e4106ad2b4300.md
+++ b/curriculum/challenges/english/blocks/workshop-pin-extractor/685578aae65e4106ad2b4300.md
@@ -7,7 +7,7 @@ dashedName: step-7
 
 # --description--
 
-As you learned in a previous lesson, the `enumerate` function allows to keep track of the index while looping over an iterable:
+As you learned in a previous lesson, the `enumerate` function allows you to keep track of the index while looping over an iterable:
 
 ```py
 fruits = ['apple', 'plum', 'bananas']


### PR DESCRIPTION
## Summary
Fixed a grammatical error where "allows to keep track" should be "allows you to keep track" in two curriculum files:

- `curriculum/challenges/english/blocks/workshop-pin-extractor/685578aae65e4106ad2b4300.md`
- `curriculum/challenges/english/blocks/workshop-medical-data-validator/6846a1f2805ac73ce671a5d8.md`

The verb "allow" requires an object before the infinitive (e.g., "allows you to" rather than "allows to").

## Checklist
- [x] Grammar fix only
- [x] No functional changes
- [x] Same fix applied consistently across both files that share this text