### PR TITLE
fix(curriculum): clarify mutations challenge checks unique letters only

### DIFF
--- a/curriculum/challenges/english/blocks/basic-algorithm-scripting/af2170cad53daa0770fabdea.md
+++ b/curriculum/challenges/english/blocks/basic-algorithm-scripting/af2170cad53daa0770fabdea.md
@@ -8,7 +8,7 @@ dashedName: mutations
 
 # --description--
 
-Return `true` if the string in the first element of the array contains all of the letters of the string in the second element of the array.
+Return `true` if the string in the first element of the array contains all of the unique letters of the string in the second element of the array.
 
 For example, `["hello", "Hello"]`, should return `true` because all of the letters in the second string are present in the first, ignoring case.
 


### PR DESCRIPTION
While working on the Mutations challenge, I noticed that the wording "contains all of the letters" can be confusing. It sounds like we need to check letter frequency, but the tests and solution only check unique letters. For example, mutation(["Mary", "Aarmy"]) returns true even though counts don't match.

This PR updates the description to say "unique letters" for clarity.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66761