### PR TITLE
fix(curriculum): correct 'it's width' to 'its width'

### DIFF
--- a/curriculum/challenges/english/blocks/top-learn-css-foundations-projects/63ee3ff1381756f9716727f2.md
+++ b/curriculum/challenges/english/blocks/top-learn-css-foundations-projects/63ee3ff1381756f9716727f2.md
@@ -12,7 +12,7 @@ With this exercise, we've provided you a completed HTML file, so you will only h
 1. You should see a `width` of `300px` on the `avatar` and `proportioned` class.
 1. You should give it a height so that it retains its original square proportions (don't hardcode in a pixel value for the height!).
 1. You should give the elements with both the `avatar` and `distorted` classes a `width` of `200px`.
-1. You should give it a `height` twice as big as it's width.
+1. You should give it a `height` twice as big as its width.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #66769

This PR corrects a grammatical error in:

curriculum/challenges/english/blocks/top-learn-css-foundations-projects/63ee3ff1381756f9716727f2.md

Changed:
it's width → its width