### PR TITLE
feat: improve solution download format to ZIP project structure

### DIFF
--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -97,8 +97,7 @@ function CompletionModal({
     // leak URL objects.
     if (downloadURL) URL.revokeObjectURL(downloadURL);
     if (challengeFiles?.length) {
-      const allFileContents = combineFileData(challengeFiles);
-      const blob = new Blob([allFileContents], { type: 'text/json' });
+      const blob = createZipBlob(challengeFiles);
       setDownloadURL(URL.createObjectURL(blob));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -194,7 +193,7 @@ function CompletionModal({
             block={true}
             size='large'
             variant='primary'
-            download={`${dashedName}.txt`}
+            download={`${dashedName}.zip`}
             href={downloadURL}
           >
             {t('learn.download-solution')}
@@ -212,6 +211,103 @@ export default connect(
   mapDispatchToProps
 )(withTranslation()(CompletionModal));
 
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc ^= data[i];
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+export function createZipBlob(
+  challengeFiles: DownloadableChallengeFile[]
+): Blob {
+  const encoder = new TextEncoder();
+  const files = challengeFiles.map(file => ({
+    name: `${file.name}.${file.ext}`,
+    data: encoder.encode(file.contents)
+  }));
+
+  const parts: Uint8Array[] = [];
+  const centralDir: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const nameBytes = encoder.encode(file.name);
+    const crc = crc32(file.data);
+
+    // Local file header
+    const localHeader = new ArrayBuffer(30 + nameBytes.length);
+    const lhView = new DataView(localHeader);
+    lhView.setUint32(0, 0x04034b50, true); // signature
+    lhView.setUint16(4, 20, true); // version needed
+    lhView.setUint16(6, 0, true); // flags
+    lhView.setUint16(8, 0, true); // compression (store)
+    lhView.setUint16(10, 0, true); // mod time
+    lhView.setUint16(12, 0, true); // mod date
+    lhView.setUint32(14, crc, true); // crc32
+    lhView.setUint32(18, file.data.length, true); // compressed size
+    lhView.setUint32(22, file.data.length, true); // uncompressed size
+    lhView.setUint16(26, nameBytes.length, true); // name length
+    lhView.setUint16(28, 0, true); // extra length
+    new Uint8Array(localHeader).set(nameBytes, 30);
+
+    parts.push(new Uint8Array(localHeader));
+    parts.push(file.data);
+
+    // Central directory entry
+    const cdEntry = new ArrayBuffer(46 + nameBytes.length);
+    const cdView = new DataView(cdEntry);
+    cdView.setUint32(0, 0x02014b50, true); // signature
+    cdView.setUint16(4, 20, true); // version made by
+    cdView.setUint16(6, 20, true); // version needed
+    cdView.setUint16(8, 0, true); // flags
+    cdView.setUint16(10, 0, true); // compression
+    cdView.setUint16(12, 0, true); // mod time
+    cdView.setUint16(14, 0, true); // mod date
+    cdView.setUint32(16, crc, true); // crc32
+    cdView.setUint32(20, file.data.length, true); // compressed size
+    cdView.setUint32(24, file.data.length, true); // uncompressed size
+    cdView.setUint16(28, nameBytes.length, true); // name length
+    cdView.setUint16(30, 0, true); // extra length
+    cdView.setUint16(32, 0, true); // comment length
+    cdView.setUint16(34, 0, true); // disk number
+    cdView.setUint16(36, 0, true); // internal attrs
+    cdView.setUint32(38, 0, true); // external attrs
+    cdView.setUint32(42, offset, true); // local header offset
+    new Uint8Array(cdEntry).set(nameBytes, 46);
+
+    centralDir.push(new Uint8Array(cdEntry));
+    offset += 30 + nameBytes.length + file.data.length;
+  }
+
+  const centralDirOffset = offset;
+  let centralDirSize = 0;
+  for (const entry of centralDir) {
+    parts.push(entry);
+    centralDirSize += entry.length;
+  }
+
+  // End of central directory
+  const eocd = new ArrayBuffer(22);
+  const eocdView = new DataView(eocd);
+  eocdView.setUint32(0, 0x06054b50, true); // signature
+  eocdView.setUint16(4, 0, true); // disk number
+  eocdView.setUint16(6, 0, true); // central dir disk
+  eocdView.setUint16(8, files.length, true); // entries on disk
+  eocdView.setUint16(10, files.length, true); // total entries
+  eocdView.setUint32(12, centralDirSize, true); // central dir size
+  eocdView.setUint32(16, centralDirOffset, true); // central dir offset
+  eocdView.setUint16(20, 0, true); // comment length
+  parts.push(new Uint8Array(eocd));
+
+  return new Blob(parts, { type: 'application/zip' });
+}
+
+// Keep for backward compatibility in tests
 export function combineFileData(challengeFiles: DownloadableChallengeFile[]) {
   return challengeFiles.reduce<string>(function (
     allFiles: string,


### PR DESCRIPTION
## Description

Improves the solution download experience by bundling challenge files into a ZIP archive with proper project structure, instead of a single concatenated `.txt` file.

**Before:** All files merged into one `.txt` with `** start of ... **` markers
**After:** Each file (`index.html`, `styles.css`, `script.js`) is a separate entry in a `.zip` file

### Implementation Details
- Uses native browser APIs (`ArrayBuffer`, `DataView`, `TextEncoder`) to generate valid ZIP files
- No external dependencies added (no JSZip etc.)
- Implements CRC-32 checksum for ZIP file integrity
- Downloads as `{challenge-name}.zip` instead of `{challenge-name}.txt`
- Backward compatible: `combineFileData` export preserved for existing tests

Closes #65887

## Type of change
- [x] Enhancement (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings