### PR TITLE
fix: change Preview button to Terminal for Python lessons

### DIFF
--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import { Tabs, TabsContent, TabsTrigger, TabsList } from '@freecodecamp/ui';
+import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
 
 import {
   removePortalWindow,
@@ -22,6 +23,7 @@ import Notes from '../components/notes';
 import EditorTabs from './editor-tabs';
 
 interface MobileLayoutProps {
+  challengeType: number;
   editor: JSX.Element | null;
   hasEditableBoundaries: boolean;
   hasPreview: boolean;
@@ -240,7 +242,13 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             </TabsTrigger>
             {hasPreview && (
               <TabsTrigger value={tabs.preview}>
-                {i18next.t('learn.editor-tabs.preview')}
+                {this.props.challengeType === challengeTypes.python ||
+                this.props.challengeType ===
+                  challengeTypes.multifilePythonCertProject ||
+                this.props.challengeType === challengeTypes.pyLab ||
+                this.props.challengeType === challengeTypes.dailyChallengePy
+                  ? i18next.t('learn.editor-tabs.terminal')
+                  : i18next.t('learn.editor-tabs.preview')}
               </TabsTrigger>
             )}
           </TabsList>

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -477,6 +477,7 @@ function ShowClassic({
         <Helmet title={windowTitle} />
         {isMobile ? (
           <MobileLayout
+            challengeType={challengeType}
             editor={renderEditor({
               isMobileLayout: true,
               isUsingKeyboardInTablist: usingKeyboardInTablist


### PR DESCRIPTION
## Description

The mobile layout shows "Preview" for all challenge types including Python lessons. However, Python lessons run in a terminal environment, not a browser preview. The desktop layout (action-row.tsx) already correctly shows "Terminal" for Python challenges, but this logic was missing from the mobile layout.

### Changes
- Added `challengeType` prop to `MobileLayout` component
- Imported `challengeTypes` from shared config
- Conditionally render "Terminal" instead of "Preview" for Python challenge types (`python`, `multifilePythonCertProject`, `pyLab`, `dailyChallengePy`)
- Passed `challengeType` from `show.tsx` to `MobileLayout`

Closes #63047

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings