### PR TITLE
fix: Add Instagram sharing support and improve Threads integration in Share component

### DIFF
--- a/client/src/components/share/index.tsx
+++ b/client/src/components/share/index.tsx
@@ -18,6 +18,7 @@ export const Share = ({
       xRedirectURL={redirectURLs.xUrl}
       blueSkyRedirectURL={redirectURLs.blueSkyUrl}
       threadsRedirectURL={redirectURLs.threadsURL}
+      instagramRedirectURL={redirectURLs.instagramUrl}
       facebookRedirectURL={redirectURLs.facebookUrl}
       minified={minified}
     />

--- a/client/src/components/share/share-template.tsx
+++ b/client/src/components/share/share-template.tsx
@@ -4,7 +4,8 @@ import {
   faXTwitter,
   faBluesky,
   faInstagram,
-  faFacebook
+  faFacebook,
+  faThreads
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ShareRedirectProps } from './types';
@@ -13,6 +14,7 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
   xRedirectURL,
   blueSkyRedirectURL,
   threadsRedirectURL,
+  instagramRedirectURL,
   facebookRedirectURL,
   minified
 }) => {
@@ -42,13 +44,24 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>
       <a
+        data-testid='share-on-instagram'
+        className='btn fade-in'
+        href={instagramRedirectURL}
+        target='_blank'
+        rel='noreferrer'
+      >
+        <FontAwesomeIcon icon={faInstagram} size='1x' aria-hidden='true' />
+        {!minified && t('buttons.share-on-instagram')}
+        <span className='sr-only'>{t('aria.opens-new-window')}</span>
+      </a>
+      <a
         data-testid='share-on-threads'
         className='btn fade-in'
         href={threadsRedirectURL}
         target='_blank'
         rel='noreferrer'
       >
-        <FontAwesomeIcon icon={faInstagram} size='1x' aria-hidden='true' />
+        <FontAwesomeIcon icon={faThreads} size='1x' aria-hidden='true' />
         {!minified && t('buttons.share-on-threads')}
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>

--- a/client/src/components/share/types.ts
+++ b/client/src/components/share/types.ts
@@ -8,6 +8,7 @@ export interface ShareRedirectProps {
   xRedirectURL: string;
   blueSkyRedirectURL: string;
   threadsRedirectURL: string;
+  instagramRedirectURL: string;
   facebookRedirectURL: string;
   minified?: boolean;
 }

--- a/client/src/components/share/use-share.tsx
+++ b/client/src/components/share/use-share.tsx
@@ -33,6 +33,7 @@ interface ShareUrls {
   xUrl: string;
   blueSkyUrl: string;
   threadsURL: string;
+  instagramUrl: string;
   facebookUrl: string;
 }
 
@@ -45,6 +46,7 @@ export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
   const tweetMessage = `I${space}have${space}completed${space}${i18nSupportedBlock}${space}${hashtag}freecodecamp`;
   const xRedirectURL = `https://${twitterData.domain}/${twitterData.action}?original_referer=${twitterData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
 
+  const instagramRedirectURL = 'https://www.instagram.com/';
   const blueSkyRedirectURL = `https://${blueSkyData.domain}/${blueSkyData.action}?original_referer=${blueSkyData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
 
   const threadRedirectURL = `https://${threadsData.domain}/${threadsData.action}?original_referer=${threadsData.developerDomainURL}&text=${tweetMessage}${nextLine}&url=${redirectFreeCodeCampLearnURL}`;
@@ -55,6 +57,7 @@ export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
     xUrl: xRedirectURL,
     blueSkyUrl: blueSkyRedirectURL,
     threadsURL: threadRedirectURL,
+    instagramUrl: instagramRedirectURL,
     facebookUrl: facebookRedirectURL
   };
 };


### PR DESCRIPTION
Closes #66788

This PR updates the Share component to support Instagram sharing separately while also improving the Threads sharing implementation with a proper icon and structure.

Previously, Threads and Instagram were either conflated or incorrectly represented. This update ensures both platforms are handled independently with their own redirect URLs, labels, and UI elements.

Changes Made:-

Added support for Instagram share URL in useShare
Updated ShareProps / ShareRedirectProps to include instagramRedirectURL

Modified ShareTemplate to:-

Render a separate Instagram share button
Use appropriate redirect URL
Add accessibility improvements (sr-only text)

Updated Threads share button:-

Uses a dedicated Threads icon (fallback if not available in FontAwesome)
Clearly separated from Instagram
Ensured all share buttons include proper accessibility text for screen readers

I had basicly added 2 function insta and thread both as by the direct link insta can't  upload post etc.

Technical Details:-

 Extended return object from useShare to include:
     instagramUrl

Passed the new prop through Share → ShareTemplate
Updated UI to render both:

Instagram share button
Threads share button

Maintained consistent behavior for X, Bluesky, and Facebook sharin
