### PR TITLE
fix: updated the instructions to use only ~= selector operator on building book inventory

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -27,9 +27,9 @@ saveSubmissionToDB: true
 1. You should use an attribute selector to target the `span` elements with the class of `status` that are descendants of `tr` elements with the class of `in-progress` and set their `border` and `background-image` properties.
 1. You should use an attribute selector to target the `span` elements with the class of `status` and the `span` elements with the class value starting with `rate` and set their `height`, `width`, and `padding` properties.
 1. You should use an attribute selector to target the `span` elements which are direct children of `span` elements with the `class` value starting with `rate` and set their `border`, `border-radius`, `margin`, `height`, `width`, and `background-color` properties.
-1. You should use an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value and set its `background-image` property to use a `linear-gradient`.
-1. You should use an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
-1. You should use an attribute selector to target the three `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
+1. You should use an attribute selector to target the first descendant of `span` elements that have `one` as a separate class name (for example, `span[class~="one"]`) and set its `background-image` property to use a `linear-gradient`.
+1. You should use an attribute selector to target the first two descendants of `span` elements that have `two` as a separate class name (for example, `span[class~="two"]`) and set their `background-image` property to use a `linear-gradient`.
+1. You should use an attribute selector to target the three `span` elements that are descendants of `span` elements that have `three` as a separate class name (for example, `span[class~="three"]`) and set their `background-image` property to use a `linear-gradient`.
 
 # --hints--
 
@@ -381,7 +381,7 @@ You should use an attribute selector to target the `span` elements which are dir
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('span[class^="rate"] > span')?.getPropVal('background-color'));
 ```
 
-You should have an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value.
+You should have an attribute selector to target the first descendant of `span` elements that have `one` as a separate class name (using `[class~="one"]`).
 
 ```js
 const selectors = [
@@ -401,7 +401,7 @@ const selectors = [
 assert.isNotNull(new __helpers.CSSHelp(document).getStyleAny(selectors));
 ```
 
-You should use an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value and set its `background-image` property to use a `linear-gradient`.
+You should use an attribute selector to target the first descendant of `span` elements that have `one` as a separate class name (using `[class~="one"]`) and set its `background-image` property to use a `linear-gradient`.
 
 ```js
 const selectors = [
@@ -421,7 +421,7 @@ const selectors = [
 assert.isTrue(new __helpers.CSSHelp(document).getStyleAny(selectors)?.getPropVal('background-image').includes('linear-gradient('));
 ```
 
-You should have an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value.
+You should have an attribute selector to target the first two descendants of `span` elements that have `two` as a separate class name (using `[class~="two"]`).
 
 ```js
 
@@ -456,7 +456,7 @@ const selectors = [
 assert.isNotNull(new __helpers.CSSHelp(document).getStyleAny(selectors));
 ```
 
-You should use an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
+You should use an attribute selector to target the first two descendants of `span` elements that have `two` as a separate class name (using `[class~="two"]`) and set their `background-image` property to use a `linear-gradient`.
 
 ```js
 const selectors = [
@@ -491,7 +491,7 @@ const selectors = [
 assert.isTrue(new __helpers.CSSHelp(document).getStyleAny(selectors)?.backgroundImage.includes('linear-gradient(')) 
 ```
 
-You should have an attribute selector to target the `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value.
+You should have an attribute selector to target the `span` elements that are descendants of `span` elements that have `three` as a separate class name (using `[class~="three"]`).
 
 ```js
 const selectors = [
@@ -501,7 +501,7 @@ const selectors = [
 assert.exists(new __helpers.CSSHelp(document).getStyleAny(selectors));
 ```
 
-You should use an attribute selector to target the `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
+You should use an attribute selector to target the `span` elements that are descendants of `span` elements that have `three` as a separate class name (using `[class~="three"]`) and set their `background-image` property to use a `linear-gradient`.
 
 ```js
 const selectors = [

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645c9e6cf5c7251f7b3308f6.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645c9e6cf5c7251f7b3308f6.md
@@ -204,7 +204,6 @@ const countdown = (number) => {
   if (number === 0) {
     return;
   }else{
-    
   }
 --fcc-editable-region--
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645c9e6cf5c7251f7b3308f6.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645c9e6cf5c7251f7b3308f6.md
@@ -203,7 +203,6 @@ const countdown = (number) => {
 --fcc-editable-region--
   if (number === 0) {
     return;
-  }else{
   }
 --fcc-editable-region--
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645c9e6cf5c7251f7b3308f6.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645c9e6cf5c7251f7b3308f6.md
@@ -203,6 +203,8 @@ const countdown = (number) => {
 --fcc-editable-region--
   if (number === 0) {
     return;
+  }else{
+    
   }
 --fcc-editable-region--
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ca381c8f87f263034954f.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ca381c8f87f263034954f.md
@@ -209,6 +209,7 @@ const countdown = (number) => {
   if (number === 0) {
     return;
   } else {
+    
   }
 --fcc-editable-region--
 };

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a0102e761a245bb1cbd8e7.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a0102e761a245bb1cbd8e7.md
@@ -22,7 +22,7 @@ assert.deepEqual(myList, initList());
 You should log a call to `isEmpty(myList)` to the console.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\(isEmpty\(myList\)\)/)
+assert.match(__helpers.removeJSComments(code), /console\.log\(isEmpty\(myList\)\);?/)
 ```
 
 You should call `add` with `myList` and a number of your choice as the parameters.
@@ -34,13 +34,13 @@ assert.match(__helpers.removeJSComments(code), /add\s*\(\s*myList\s*,\s*\d+\s*\)
 You should log your `myList` variable to the console.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\(myList\)/)
+assert.match(__helpers.removeJSComments(code), /console\.log\(myList\);?/)
 ```
 
 You should log `isEmpty(myList)` to the console again.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\(myList\)\s*console\.log\(isEmpty\(myList\)\)/)
+assert.match(__helpers.removeJSComments(code), /console\.log\(myList\);?\s*console\.log\(isEmpty\(myList\)\);?/)
 ```
 
 


### PR DESCRIPTION
Checklist:
Have updated the instruction to use only ~= operator in selecting span elements of classes. The solution allows using ~= operator to find class name appopriately. 

You should use an attribute selector to target the first descendant of `span` elements that have `one` as a separate class name (using `[class~="one"]`) and set its `background-image` property to use a `linear-gradient`.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66786 

<!-- Feel free to add any additional description of changes below this line -->
