### PR TITLE
fix(tools): add a group name for clarity

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: freecodecamp-local
+
 services:
   db:
     image: mongo:8.0


### PR DESCRIPTION
This creates a group name instead of generic 'docker' to avoid auto naming an conflicts