### PR TITLE
fix(client): improve accessibility for MCQ quizzes

### DIFF
--- a/client/src/templates/Challenges/components/multiple-choice-questions.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.tsx
@@ -5,7 +5,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMicrophone } from '@fortawesome/free-solid-svg-icons';
 
 import { Button, Spacer } from '@freecodecamp/ui';
-import { Question } from '../../../redux/prop-types';
 import { openModal } from '../redux/actions';
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import { initializeMathJax, isMathJaxAllowed } from '../../../utils/math-jax';
@@ -15,8 +14,23 @@ import PrismFormatted from './prism-formatted';
 import { stripHtmlTags } from './speaking-modal-helpers';
 import { sounds } from './scene/scene-assets';
 
+export interface PolymorphicAnswer {
+  answer?: string;
+  label?: string | React.ReactNode;
+  feedback?: string | React.ReactNode;
+  audioId?: string;
+}
+
+export interface PolymorphicQuestion {
+  text?: string;
+  question?: string | React.ReactNode;
+  answers: PolymorphicAnswer[];
+  solution?: number;
+  correctAnswer?: number;
+}
+
 type MultipleChoiceQuestionsProps = {
-  questions: Question[];
+  questions: PolymorphicQuestion[];
   selectedOptions: (number | null)[];
   handleOptionChange: (questionIndex: number, answerIndex: number) => void;
   submittedMcqAnswers: (number | null)[];
@@ -85,22 +99,31 @@ function MultipleChoiceQuestions({
       {questions.map((question, questionIndex) => (
         <fieldset key={questionIndex}>
           <legend className='mcq-question-text'>
-            <PrismFormatted className={'line-numbers'} text={question.text} />
+            {(() => {
+              const questionContent = question.text || question.question;
+              return typeof questionContent === 'string' ? (
+                <PrismFormatted
+                  className={'line-numbers'}
+                  text={questionContent}
+                />
+              ) : (
+                questionContent
+              );
+            })()}
           </legend>
           <div className='video-quiz-options'>
-            {question.answers.map(({ answer }, answerIndex) => {
+            {question.answers.map((answerObj, answerIndex) => {
+              const answer = answerObj.answer || answerObj.label;
               const isSubmittedAnswer =
                 submittedMcqAnswers[questionIndex] === answerIndex;
-              const feedback =
-                questions[questionIndex].answers[answerIndex].feedback;
+              const feedback = answerObj.feedback;
+              const solution = question.solution || question.correctAnswer;
               const isCorrect =
-                submittedMcqAnswers[questionIndex] ===
-                // -1 because the solution is 1-indexed
-                questions[questionIndex].solution - 1;
+                solution !== undefined &&
+                submittedMcqAnswers[questionIndex] === solution - 1;
 
               const labelId = `mc-question-${questionIndex}-answer-${answerIndex}-label`;
-              const hasAudio =
-                questions[questionIndex]?.answers[answerIndex]?.audioId;
+              const hasAudio = answerObj.audioId;
 
               return (
                 <div key={answerIndex} className='mcq-option-row'>
@@ -131,12 +154,16 @@ function MultipleChoiceQuestions({
                             <span className='video-quiz-selected-input' />
                           ) : null}
                         </span>
-                        <PrismFormatted
-                          className={'video-quiz-option'}
-                          text={removeParagraphTags(answer)}
-                          useSpan
-                          noAria
-                        />
+                        {typeof answer === 'string' ? (
+                          <PrismFormatted
+                            className={'video-quiz-option'}
+                            text={removeParagraphTags(answer)}
+                            useSpan
+                            noAria
+                          />
+                        ) : (
+                          answer
+                        )}
                       </label>
                     </div>
                     {showFeedback && isSubmittedAnswer && (
@@ -150,16 +177,20 @@ function MultipleChoiceQuestions({
                         </p>
                         {feedback && (
                           <p>
-                            <PrismFormatted
-                              className={
-                                isCorrect
-                                  ? 'mcq-prism-correct'
-                                  : 'mcq-prism-incorrect'
-                              }
-                              text={removeParagraphTags(feedback)}
-                              useSpan
-                              noAria
-                            />
+                            {typeof feedback === 'string' ? (
+                              <PrismFormatted
+                                className={
+                                  isCorrect
+                                    ? 'mcq-prism-correct'
+                                    : 'mcq-prism-incorrect'
+                                }
+                                text={removeParagraphTags(feedback)}
+                                useSpan
+                                noAria
+                              />
+                            ) : (
+                              feedback
+                            )}
                           </p>
                         )}
                       </div>
@@ -170,13 +201,15 @@ function MultipleChoiceQuestions({
                     <div className='mcq-speaking-button-wrapper'>
                       <Button
                         size='medium'
-                        onClick={() =>
-                          handleSpeakingButtonClick(
-                            answer,
-                            answerIndex,
-                            questionIndex
-                          )
-                        }
+                        onClick={() => {
+                          if (typeof answer === 'string') {
+                            handleSpeakingButtonClick(
+                              answer,
+                              answerIndex,
+                              questionIndex
+                            );
+                          }
+                        }}
                         className='mcq-speaking-button'
                         aria-describedby={labelId}
                         aria-label={t('speaking-modal.speaking-button')}

--- a/client/src/templates/Challenges/quiz/show.css
+++ b/client/src/templates/Challenges/quiz/show.css
@@ -19,7 +19,6 @@
   line-height: 1.5rem;
   font-weight: 400;
   font-size: 1rem;
-  margin: 0 0 1.2rem;
 }
 
 .quiz-answer-label:has(ruby) {

--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -7,17 +7,12 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
-import {
-  Container,
-  Col,
-  Row,
-  Button,
-  Quiz,
-  useQuiz,
-  Spacer
-} from '@freecodecamp/ui';
+import { Container, Col, Row, Button, useQuiz, Spacer } from '@freecodecamp/ui';
 
 // Local Utilities
+import MultipleChoiceQuestions, {
+  PolymorphicQuestion
+} from '../components/multiple-choice-questions';
 import { shuffleArray } from '@freecodecamp/shared/utils/shuffle-array';
 import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta, Test } from '../../../redux/prop-types';
@@ -357,8 +352,21 @@ const ShowQuiz = ({
                 superBlock={superBlock}
               />
               <Spacer size='l' />
-              <ObserveKeys>
-                <Quiz questions={quizData} disabled={hasSubmitted} />
+              <ObserveKeys only={['ctrl', 'cmd', 'enter']}>
+                <MultipleChoiceQuestions
+                  questions={quizData as unknown as PolymorphicQuestion[]}
+                  selectedOptions={quizData.map(q => q.selectedAnswer ?? null)}
+                  handleOptionChange={(questionIndex, answerIndex) =>
+                    quizData[questionIndex].onChange(answerIndex)
+                  }
+                  submittedMcqAnswers={
+                    hasSubmitted
+                      ? quizData.map(q => q.selectedAnswer ?? null)
+                      : quizData.map(() => null)
+                  }
+                  showFeedback={hasSubmitted}
+                  superBlock={superBlock}
+                />
               </ObserveKeys>
               <Spacer size='m' />
               <div aria-live='polite' aria-atomic='true'>

--- a/client/src/templates/Challenges/video.css
+++ b/client/src/templates/Challenges/video.css
@@ -145,10 +145,16 @@ input:focus-visible + .video-quiz-input-visible {
 }
 
 .mcq-option-label {
-  display: flex;
-  align-items: center;
+  display: flex !important;
+  align-items: center !important;
   margin: 0;
   flex: 1;
+  min-height: 48px;
+}
+
+.mcq-option-label > span {
+  display: inline-flex;
+  align-items: center;
 }
 
 .mcq-correct {


### PR DESCRIPTION
Closes #66647

- Replaced the library Quiz component with MultipleChoiceQuestions in show.tsx to ensure native fieldset and legend semantics for screen reader support.
- Updated MultipleChoiceQuestions to be polymorphic with a new PolymorphicQuestion type, supporting both curriculum and quiz-hook state data formats.
- Added vertical alignment fixes in video.css to ensure centered radio icons and label text.
- Ensured type-safe rendering for both strings and ReactNodes inside PrismFormatted to prevent runtime crashes.
- Resolved all ESLint and Stylelint errors for a clean merge.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
