### PR TITLE
fix(curriculum): correct incomplete code snippet in example question

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-bash-scripting/688166750663c22e2b1c8e80.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-bash-scripting/688166750663c22e2b1c8e80.md
@@ -91,7 +91,7 @@ The shebang appears at the very beginning of a script file.
 
 ## --text--
 
-In the example script, what does the line for server in `"${servers[@]}"` accomplish?
+In the example script, what does the line `for server in "${servers[@]}"` accomplish?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66802 

<!-- Feel free to add any additional description of changes below this line -->

Fixes an incomplete code reference in the “Understanding Bash Scripting” lecture question.

The original text showed only part of the loop ("${servers[@]}"), which could be confusing. This updates it to the full statement:
`for server in "${servers[@]}"`
so learners can clearly understand the context of the question.

All tests passed for the affected block:
`FCC_BLOCK='lecture-understanding-bash-scripting' pnpm test-curriculum-content`
