### PR TITLE
fix(.github): correct affected page help text in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/02--issues-with-software-on-platforms.yml
+++ b/.github/ISSUE_TEMPLATE/02--issues-with-software-on-platforms.yml
@@ -14,7 +14,7 @@ body:
   - type: input
     attributes:
       label: Affected Page
-      description: Add a link to the coding challenge with the problem.
+      description: Add a link to the page with the problem.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/03--issues-with-content-on-articles-and-docs.yml
+++ b/.github/ISSUE_TEMPLATE/03--issues-with-content-on-articles-and-docs.yml
@@ -17,7 +17,7 @@ body:
   - type: input
     attributes:
       label: Affected Page
-      description: Add a link to the coding challenge with the problem.
+      description: Add a link to the article or documentation page with the problem.
     validations:
       required: true
   - type: textarea

--- a/curriculum/challenges/english/blocks/lab-project-idea-board/67051431a73f1ca25d9a6f25.md
+++ b/curriculum/challenges/english/blocks/lab-project-idea-board/67051431a73f1ca25d9a6f25.md
@@ -230,9 +230,6 @@ let techProjects = new ProjectIdeaBoard("Tech Projects Board");
 // Create an empty board
 let emptyBoard = new ProjectIdeaBoard("Empty Board");
 
-// Attempt to unpin a project from an empty board
-emptyBoard.unpin(smartHome);
-
 assert.equal(emptyBoard.formatToString(), "Empty Board has 0 idea(s)\n");
 ```
 

--- a/curriculum/challenges/english/blocks/lab-project-idea-board/67051431a73f1ca25d9a6f25.md
+++ b/curriculum/challenges/english/blocks/lab-project-idea-board/67051431a73f1ca25d9a6f25.md
@@ -230,6 +230,9 @@ let techProjects = new ProjectIdeaBoard("Tech Projects Board");
 // Create an empty board
 let emptyBoard = new ProjectIdeaBoard("Empty Board");
 
+// Attempt to unpin a project from an empty board
+emptyBoard.unpin(smartHome);
+
 assert.equal(emptyBoard.formatToString(), "Empty Board has 0 idea(s)\n");
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66815

## Summary
- correct the reused `Affected Page` helper text in the platform/UI issue form
- correct the reused `Affected Page` helper text in the articles/docs issue form
- leave the coding-challenges issue form unchanged, since that wording is already correct there

## Testing
- validated both edited issue-template files parse successfully as YAML locally