### PR TITLE
fix: Docs/add comments to docker compose

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-learn-contact-information-and-spelling/6939aba64ef7835b338fd665.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-contact-information-and-spelling/6939aba64ef7835b338fd665.md
@@ -10,7 +10,7 @@ lang: es
 
 # --description--
 
-Do you remember verbs are conjugated according to the person they are refering to? If not, now you do!
+Do you remember verbs are conjugated according to the person they are referring to? If not, now you do!
 
 A couple of tasks ago, you learned how to use the verb `poder` to ask if someone was able to do something for you.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,10 @@
+# Docker Compose for local development
+# Usage: docker compose -f docker/docker-compose.yml up -d
+# This sets up MongoDB (with replica set) and Mailpit for local email testing.
+
 services:
+  # MongoDB database service with replica set enabled
+  # (required by freeCodeCamp API)
   db:
     image: mongo:8.0
     container_name: mongodb
@@ -6,21 +12,23 @@ services:
     restart: unless-stopped
     hostname: mongodb
     ports:
-      - 27017:27017
+      - 27017:27017 # Default MongoDB port
     volumes:
-      - db-data:/data/db
+      - db-data:/data/db # Persist database data between restarts
     healthcheck:
       test: ['CMD', 'mongosh', '--eval', "db.adminCommand('ping')"]
       interval: 2s
       retries: 5
 
+  # One-time setup service that initializes the MongoDB replica set
   setup:
     image: mongo:8.0
     depends_on:
       db:
         condition: service_healthy
     restart: on-failure
-    # This will try to initiate the replica set, until it succeeds twice (i.e. until the replica set is already initialized)
+    # This will try to initiate the replica set, until it succeeds twice
+    # (i.e. until the replica set is already initialized)
     command: >
       mongosh --host mongodb:27017 --eval '
         var cfg = {
@@ -36,13 +44,15 @@ services:
         }
       '
 
+  # Mailpit - local email testing tool
+  # Access the web UI at http://localhost:8025 to view sent emails
   mailpit:
     restart: unless-stopped
     image: axllent/mailpit
     ports:
-      - '1025:1025'
-      - '8025:8025'
+      - '1025:1025' # SMTP port for sending emails
+      - '8025:8025' # Web UI port for viewing emails
 
 volumes:
   db-data:
-    driver: local
+    driver: local # Local volume to persist MongoDB data


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66818

<!-- Feel free to add any additional description of changes below this line -->
## What does this PR do?
Adds explanatory comments to docker/docker-compose.yml to help 
new contributors understand the local development setup.

## Changes made:
- Added a header comment explaining the file purpose and usage command
- Added comments to the `db` service explaining why MongoDB needs 
  a replica set
- Added comments to the `setup` service explaining what it does
- Added port comments explaining what each port is used for
- Added a comment to `mailpit` explaining how to access the web UI
  at http://localhost:8025
- Added a comment to the volume explaining its purpose
