### PR TITLE
fix: Fixed Linkedin

### DIFF
--- a/client/i18n/locales/chinese-traditional/translations.json
+++ b/client/i18n/locales/chinese-traditional/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "分享到 BlueSky",
     "share-on-threads": "分享到 Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "按播放鍵",
     "download-latest-version": "下載最新版本",
     "more-ways-to-sign-in": "更多登錄方式",

--- a/client/i18n/locales/chinese/translations.json
+++ b/client/i18n/locales/chinese/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "分享到 BlueSky",
     "share-on-threads": "分享到 Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "按播放键",
     "download-latest-version": "下载最新版本",
     "more-ways-to-sign-in": "更多登录方式",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -118,6 +118,7 @@
     "share-on-bluesky": "Share on BlueSky",
     "share-on-threads": "Share on Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Press Play",
     "download-latest-version": "Download the Latest Version",
     "more-ways-to-sign-in": "More ways to sign in",

--- a/client/i18n/locales/espanol/translations.json
+++ b/client/i18n/locales/espanol/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "Compartir en BlueSky",
     "share-on-threads": "Compartir en Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Presione Play",
     "download-latest-version": "Descargue la última versión",
     "more-ways-to-sign-in": "Más formas de iniciar sesión",

--- a/client/i18n/locales/german/translations.json
+++ b/client/i18n/locales/german/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "Share on BlueSky",
     "share-on-threads": "Share on Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Press Play",
     "download-latest-version": "Die neueste Version herunterladen",
     "more-ways-to-sign-in": "More ways to sign in",

--- a/client/i18n/locales/italian/translations.json
+++ b/client/i18n/locales/italian/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "Share on BlueSky",
     "share-on-threads": "Share on Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Press Play",
     "download-latest-version": "Download the Latest Version",
     "more-ways-to-sign-in": "More ways to sign in",

--- a/client/i18n/locales/japanese/translations.json
+++ b/client/i18n/locales/japanese/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "Bluesky でシェア",
     "share-on-threads": "Threads でシェア",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Press Play",
     "download-latest-version": "Download the Latest Version",
     "more-ways-to-sign-in": "More ways to sign in",

--- a/client/i18n/locales/korean/translations.json
+++ b/client/i18n/locales/korean/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "Share on BlueSky",
     "share-on-threads": "Share on Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Press Play",
     "download-latest-version": "Download the Latest Version",
     "more-ways-to-sign-in": "More ways to sign in",

--- a/client/i18n/locales/portuguese/translations.json
+++ b/client/i18n/locales/portuguese/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "Compartilhar no BlueSky",
     "share-on-threads": "Compartilhe no Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Aperte para começar",
     "download-latest-version": "Baixe a versão mais recente",
     "more-ways-to-sign-in": "Mais maneiras de fazer login",

--- a/client/i18n/locales/swahili/translations.json
+++ b/client/i18n/locales/swahili/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "Share on BlueSky",
     "share-on-threads": "Share on Threads",
     "share-on-facebook": "Share on Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Press Play",
     "download-latest-version": "Download the Latest Version",
     "more-ways-to-sign-in": "More ways to sign in",

--- a/client/i18n/locales/ukrainian/translations.json
+++ b/client/i18n/locales/ukrainian/translations.json
@@ -118,6 +118,8 @@
     "share-on-bluesky": "Поділитись на BlueSky",
     "share-on-threads": "Поділитись на Threads",
     "share-on-facebook": "Поділитись на Facebook",
+    "share-on-linkedin": "Share on LinkedIn",
+    "share-on-linkedin": "Share on LinkedIn",
     "play-scene": "Натисніть «Відтворити»",
     "download-latest-version": "Завантажити найновішу версію",
     "more-ways-to-sign-in": "Більше способів увійти",

--- a/client/src/components/share/index.tsx
+++ b/client/src/components/share/index.tsx
@@ -19,6 +19,7 @@ export const Share = ({
       blueSkyRedirectURL={redirectURLs.blueSkyUrl}
       threadsRedirectURL={redirectURLs.threadsURL}
       facebookRedirectURL={redirectURLs.facebookUrl}
+      linkedInRedirectURL={redirectURLs.linkedInUrl}
       minified={minified}
     />
   );

--- a/client/src/components/share/share-template.test.tsx
+++ b/client/src/components/share/share-template.test.tsx
@@ -12,6 +12,7 @@ describe('Share Template Testing', () => {
       blueSkyRedirectURL={redirectURL}
       threadsRedirectURL={redirectURL}
       facebookRedirectURL={redirectURL}
+      linkedInRedirectURL={redirectURL}
     />
   );
   test('Testing share template Click Redirect Event', () => {
@@ -42,5 +43,12 @@ describe('Share Template Testing', () => {
 
     expect(facebookLink).toBeInTheDocument();
     expect(facebookLink).toHaveAttribute('href', 'string');
+
+    const linkedInLink = screen.queryByRole('link', {
+      name: 'buttons.share-on-linkedin aria.opens-new-window'
+    });
+
+    expect(linkedInLink).toBeInTheDocument();
+    expect(linkedInLink).toHaveAttribute('href', 'string');
   });
 });

--- a/client/src/components/share/share-template.tsx
+++ b/client/src/components/share/share-template.tsx
@@ -4,7 +4,8 @@ import {
   faXTwitter,
   faBluesky,
   faThreads,
-  faFacebook
+  faFacebook,
+  faLinkedin
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ShareRedirectProps } from './types';
@@ -14,6 +15,7 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
   blueSkyRedirectURL,
   threadsRedirectURL,
   facebookRedirectURL,
+  linkedInRedirectURL,
   minified
 }) => {
   const { t } = useTranslation();
@@ -61,6 +63,17 @@ export const ShareTemplate: React.ComponentType<ShareRedirectProps> = ({
       >
         <FontAwesomeIcon icon={faFacebook} size='1x' aria-hidden='true' />
         {!minified && t('buttons.share-on-facebook')}
+        <span className='sr-only'>{t('aria.opens-new-window')}</span>
+      </a>
+      <a
+        data-testid='share-on-linkedin'
+        className='btn fade-in'
+        href={linkedInRedirectURL}
+        target='_blank'
+        rel='noreferrer'
+      >
+        <FontAwesomeIcon icon={faLinkedin} size='1x' aria-hidden='true' />
+        {!minified && t('buttons.share-on-linkedin')}
         <span className='sr-only'>{t('aria.opens-new-window')}</span>
       </a>
     </>

--- a/client/src/components/share/types.ts
+++ b/client/src/components/share/types.ts
@@ -9,5 +9,6 @@ export interface ShareRedirectProps {
   blueSkyRedirectURL: string;
   threadsRedirectURL: string;
   facebookRedirectURL: string;
+  linkedInRedirectURL: string;
   minified?: boolean;
 }

--- a/client/src/components/share/use-share.test.tsx
+++ b/client/src/components/share/use-share.test.tsx
@@ -8,7 +8,8 @@ import {
   useShare,
   twitterData,
   blueSkyData,
-  threadsData
+  threadsData,
+  linkedInData
 } from './use-share';
 
 describe('useShare', () => {
@@ -46,6 +47,10 @@ describe('useShare', () => {
 
     expect(shareResult.current.facebookUrl).toBe(
       `https://www.facebook.com/sharer/sharer.php?u=${redirectFreeCodeCampLearnURL}&hashtag=${hashtag}freecodecamp`
+    );
+
+    expect(shareResult.current.linkedInUrl).toBe(
+      `https://${linkedInData.domain}/${linkedInData.action}?mini=true&url=${redirectFreeCodeCampLearnURL}&title=${tweetMessage}&summary=${tweetMessage}`
     );
   });
 });

--- a/client/src/components/share/use-share.tsx
+++ b/client/src/components/share/use-share.tsx
@@ -29,11 +29,17 @@ export const facebookData = {
   domain: 'www.facebook.com'
 };
 
+export const linkedInData = {
+  action: 'shareArticle',
+  domain: 'www.linkedin.com'
+};
+
 interface ShareUrls {
   xUrl: string;
   blueSkyUrl: string;
   threadsURL: string;
   facebookUrl: string;
+  linkedInUrl: string;
 }
 
 export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
@@ -51,10 +57,13 @@ export const useShare = ({ superBlock, block }: ShareProps): ShareUrls => {
 
   const facebookRedirectURL = `https://${facebookData.domain}/${facebookData.action}?u=${redirectFreeCodeCampLearnURL}&hashtag=${hashtag}freecodecamp`;
 
+  const linkedInRedirectURL = `https://${linkedInData.domain}/${linkedInData.action}?mini=true&url=${redirectFreeCodeCampLearnURL}&title=${tweetMessage}&summary=${tweetMessage}`;
+
   return {
     xUrl: xRedirectURL,
     blueSkyUrl: blueSkyRedirectURL,
     threadsURL: threadRedirectURL,
-    facebookUrl: facebookRedirectURL
+    facebookUrl: facebookRedirectURL,
+    linkedInUrl: linkedInRedirectURL
   };
 };

--- a/client/src/templates/Challenges/components/independent-lower-jaw.test.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.test.tsx
@@ -56,6 +56,7 @@ describe('<IndependentLowerJaw />', () => {
     expect(screen.getByTestId('share-on-x')).toBeInTheDocument();
     expect(screen.getByTestId('share-on-bluesky')).toBeInTheDocument();
     expect(screen.getByTestId('share-on-threads')).toBeInTheDocument();
+    expect(screen.getByTestId('share-on-linkedin')).toBeInTheDocument();
   });
 
   it('does not show share buttons when the block is not completed', () => {


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66787 

## Description

Adds a LinkedIn sharing button to the challenge completion section, allowing users to share their completed blocks/workshops professionally on LinkedIn alongside existing platforms (X, BlueSky, Threads, Facebook).

## Problem

After completing a challenge (e.g., "Build a Wildlife Tracker"), the sharing panel included X, BlueSky, Threads, and Facebook — but lacked LinkedIn, which is the most relevant platform for showcasing professional learning achievements.

## Changes Made

### Share Integration
- Added `linkedInRedirectURL` to share props
- Implemented LinkedIn share URL using:
  `linkedin.com/shareArticle?mini=true&url=...`
- Passed LinkedIn URL through the share flow into the UI
- Added LinkedIn button with icon and `data-testid="share-on-linkedin"`

### Tests
- Added tests for:
  - LinkedIn URL generation
  - Button rendering
  - Integration with challenge completion flow
- Ensured all existing share-related tests continue to pass

### i18n
- Added `"share-on-linkedin": "Share on LinkedIn"` to all supported locale files:
  - english, espanol, chinese, chinese-traditional, german, italian, japanese, korean, portuguese, swahili, ukrainian

## Testing

- Verified LinkedIn share link opens correctly with the expected URL
- Confirmed button appears in the correct order after Facebook
- All tests pass successfully


