### PR TITLE
fix(i18n): align Chinese A1 chapter 3/4 icons with Spanish

### DIFF
--- a/client/src/assets/chapter-icon.tsx
+++ b/client/src/assets/chapter-icon.tsx
@@ -20,8 +20,7 @@ import {
   faCubes,
   faDoorOpen,
   faHands,
-  faIdCard,
-  faPeopleGroup
+  faIdCard
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -47,7 +46,9 @@ const iconMap = {
   [A1ChineseChapters.zhA1Welcome]: faDoorOpen,
   [A1ChineseChapters.zhA1PinYin]: faCubes,
   [A1ChineseChapters.zhA1Greetings]: faComments,
-  [A1ChineseChapters.zhA1Family]: faPeopleGroup,
+  [A1ChineseChapters.zhA1GreetingsLegacy]: faComments,
+  [A1ChineseChapters.zhA1NumbersAndPersonalInformation]: faIdCard,
+  [A1ChineseChapters.zhA1Family]: faIdCard,
   [A1ChineseChapters.zhA1Expressing]: faHands,
   [A1SpanishChapters.esA1Welcome]: faDoorOpen,
   [A1SpanishChapters.esA1Fundamentals]: faCubes,

--- a/packages/shared/src/config/chapters.ts
+++ b/packages/shared/src/config/chapters.ts
@@ -30,7 +30,9 @@ export enum FsdChapters {
 export enum A1ChineseChapters {
   zhA1Welcome = 'zh-a1-chapter-welcome-to-a1-professional-chinese',
   zhA1PinYin = 'zh-a1-chapter-pinyin',
-  zhA1Greetings = 'zh-a1-chapter-greeting-and-self-introduction',
+  zhA1Greetings = 'zh-a1-chapter-greetings-and-introductions',
+  zhA1GreetingsLegacy = 'zh-a1-chapter-greeting-and-self-introduction',
+  zhA1NumbersAndPersonalInformation = 'zh-a1-chapter-numbers-and-personal-information',
   zhA1Family = 'zh-a1-chapter-introducing-colleagues-and-family',
   zhA1Expressing = 'zh-a1-chapter-expressing-what-you-can-and-cant-do'
 }


### PR DESCRIPTION
## Summary
- align Chinese A1 Chapter 3 icon with Spanish Chapter 3 (comments icon)
- align Chinese A1 Chapter 4 icon with Spanish Chapter 4 (ID-card icon)
- add/update Chinese chapter enum entries so current and legacy chapter keys are both mapped

## Validation
- pnpm --filter client run type-check
- pnpm --filter @freecodecamp/shared run type-check
- pnpm --filter client exec eslint src/assets/chapter-icon.tsx

## Notes
- keeps compatibility with older Chinese chapter dashed names while supporting the current structure