### PR TITLE
fix(curriculum): update block layout from challenge-grid to challenge-list

### DIFF
--- a/curriculum/structure/blocks/lecture-introduction-to-common-searching-and-sorting-algorithms.json
+++ b/curriculum/structure/blocks/lecture-introduction-to-common-searching-and-sorting-algorithms.json
@@ -2,7 +2,7 @@
   "isUpcomingChange": false,
   "dashedName": "lecture-introduction-to-common-searching-and-sorting-algorithms",
   "helpCategory": "JavaScript",
-  "blockLayout": "challenge-grid",
+  "blockLayout": "challenge-list",
   "challengeOrder": [
     {
       "id": "69691f96a3a2f3f6c220ab52",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66834

<!-- Feel free to add any additional description of changes below this line -->

Summary
-------
Change the block layout for "Introduction to Common Searching and Sorting Algorithms" from `challenge-grid` to `challenge-list`. This fixes a UI inconsistency where a `lecture` block was rendered with the step/grid appearance (like a workshop) due to its layout being `challenge-grid`.

Files changed
-------------
- [curriculum/structure/blocks/lecture-introduction-to-common-searching-and-sorting-algorithms.json](curriculum/structure/blocks/lecture-introduction-to-common-searching-and-sorting-algorithms.json#L1-L40)

Rationale
---------
The block's semantic label remains `lecture` (badge text comes from `blockLabel`), but the `challenge-grid` layout made it render as numbered step tiles. Switching to `challenge-list` keeps the lecture badge (`Theory`) while rendering the challenges in a list format consistent with other lecture blocks.

Screenshots
-----------
Before:
<img width="669" height="150" alt="image" src="https://github.com/user-attachments/assets/9a890632-a8c3-41a9-866f-b5bd8b196c67" />
After:
<img width="740" height="175" alt="image" src="https://github.com/user-attachments/assets/a9d92933-bdf3-4843-a85e-6961d25360e5" />


