### PR TITLE
fix: Fix/typo in email subscription routes

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -243,7 +243,7 @@ export const build = async (
 
   void fastify.register(publicRoutes.chargeStripeRoute);
   void fastify.register(publicRoutes.signoutRoute);
-  void fastify.register(publicRoutes.emailSubscribtionRoutes);
+  void fastify.register(publicRoutes.emailSubscriptionRoutes);
   void fastify.register(publicRoutes.userPublicGetRoutes);
   void fastify.register(publicRoutes.unprotectedCertificateRoutes);
   void fastify.register(publicRoutes.deprecatedEndpoints);

--- a/api/src/routes/public/email-subscription.ts
+++ b/api/src/routes/public/email-subscription.ts
@@ -9,7 +9,7 @@ import { getRedirectParams } from '../../utils/redirection.js';
  * @param _options Options passed to the plugin via `fastify.register(plugin, options)`.
  * @param done The callback to signal that the plugin is ready.
  */
-export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
+export const emailSubscriptionRoutes: FastifyPluginCallbackTypebox = (
   fastify,
   _options,
   done

--- a/curriculum/structure/blocks/lecture-introduction-to-common-searching-and-sorting-algorithms.json
+++ b/curriculum/structure/blocks/lecture-introduction-to-common-searching-and-sorting-algorithms.json
@@ -2,7 +2,7 @@
   "isUpcomingChange": false,
   "dashedName": "lecture-introduction-to-common-searching-and-sorting-algorithms",
   "helpCategory": "JavaScript",
-  "blockLayout": "challenge-grid",
+  "blockLayout": "challenge-list",
   "challengeOrder": [
     {
       "id": "69691f96a3a2f3f6c220ab52",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66663

<!-- Feel free to add any additional description of changes below this line -->

Fixes a typo in route naming (`emailSubscriptionRoutes`), in the files {`api/src/routes/public/email-subscription.ts`} and {`api/src/app.ts`}