### PR TITLE
fix(client): correct flash message text on user logout

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -1072,6 +1072,7 @@
     "oops-not-right": "Oops, something is not right, please request a fresh link to sign in / sign up",
     "expired-link": "Looks like the link you clicked has expired, please request a fresh link, to sign in",
     "signin-success": "Success! You have signed in to your account. Happy Coding!",
+    "signout-success": "Success! You have signed out of your account.",
     "social-auth-gone": "We are moving away from social authentication for privacy reasons. Next time we recommend using your email address: {{email}} to sign in instead.",
     "name-needed": "We need your name to put it on your certification. Please add your name in your profile and click save. Then we can issue your certification.",
     "incomplete-steps": "It looks like you have not completed the necessary steps. Please complete the required projects to claim the {{name}} Certification.",

--- a/client/i18n/locales/korean/translations.json
+++ b/client/i18n/locales/korean/translations.json
@@ -1054,6 +1054,7 @@
     "oops-not-right": "Oops, something is not right, please request a fresh link to sign in / sign up",
     "expired-link": "Looks like the link you clicked has expired, please request a fresh link, to sign in",
     "signin-success": "Success! You have signed in to your account. Happy Coding!",
+    "signout-success": "Success! You have signed out of your account.",
     "social-auth-gone": "We are moving away from social authentication for privacy reasons. Next time we recommend using your email address: {{email}} to sign in instead.",
     "name-needed": "We need your name to put it on your certification. Please add your name in your profile and click save. Then we can issue your certification.",
     "incomplete-steps": "It looks like you have not completed the necessary steps. Please complete the required projects to claim the {{name}} Certification.",

--- a/client/src/components/Flash/redux/flash-messages.ts
+++ b/client/src/components/Flash/redux/flash-messages.ts
@@ -50,6 +50,7 @@ export enum FlashMessages {
   ReallyWeird = 'flash.really-weird',
   ReportSent = 'flash.report-sent',
   SigninSuccess = 'flash.signin-success',
+  SignoutSuccess = 'flash.signout-success',
   StartProjectErr = 'flash.start-project-err',
   SurveyErr1 = 'flash.survey.err-1',
   SurveyErr2 = 'flash.survey.err-2',

--- a/client/src/components/signout-modal/index.tsx
+++ b/client/src/components/signout-modal/index.tsx
@@ -3,10 +3,12 @@ import { bindActionCreators, Dispatch, AnyAction } from 'redux';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import qs from 'query-string';
 import { Button, Modal, Spacer } from '@freecodecamp/ui';
 
 import { closeSignoutModal } from '../../redux/actions';
 import { isSignoutModalOpenSelector } from '../../redux/selectors';
+import { FlashMessages } from '../Flash/redux/flash-messages';
 import { apiLocation } from '../../../config/env.json';
 import callGA from '../../analytics/call-ga';
 
@@ -43,6 +45,17 @@ export const pathAfterSignout = (currentPath: string): string => {
   return allPaths.some(path => currentPath === path) ? '/learn' : currentPath;
 };
 
+export const redirectPathWithSignoutMessage = (currentPath: string): string =>
+  `${pathAfterSignout(currentPath)}?${qs.stringify(
+    {
+      messages: qs.stringify(
+        { success: [FlashMessages.SignoutSuccess] },
+        { arrayFormat: 'index' }
+      )
+    },
+    { arrayFormat: 'index' }
+  )}`;
+
 function SignoutModal(props: SignoutModalProps): JSX.Element {
   const { show, closeSignoutModal } = props;
   const { t } = useTranslation();
@@ -55,7 +68,9 @@ function SignoutModal(props: SignoutModalProps): JSX.Element {
     closeSignoutModal();
     callGA({ event: 'sign_out', user_id: undefined });
     const redirect = () => {
-      window.location.pathname = pathAfterSignout(window.location.pathname);
+      window.location.assign(
+        redirectPathWithSignoutMessage(window.location.pathname)
+      );
     };
     void fetch(`${apiLocation}/signout`, {
       method: 'GET',

--- a/client/src/components/signout-modal/signout-modal.test.ts
+++ b/client/src/components/signout-modal/signout-modal.test.ts
@@ -1,6 +1,7 @@
+import qs from 'query-string';
 import { describe, it, expect } from 'vitest';
 
-import { pathAfterSignout } from '.';
+import { pathAfterSignout, redirectPathWithSignoutMessage } from '.';
 
 describe('pathAfterSignout', () => {
   it('should default to the supplied path', () => {
@@ -27,5 +28,15 @@ describe('pathAfterSignout', () => {
     const newPaths = similarPaths.map(pathAfterSignout);
 
     expect(newPaths).toEqual(similarPaths);
+  });
+
+  it('should append a signout success message to the redirect path', () => {
+    const redirectPath = redirectPathWithSignoutMessage('/learn');
+    const [path, search = ''] = redirectPath.split('?');
+    const { messages } = qs.parse(search, { arrayFormat: 'index' });
+    const flashMap = qs.parse(messages as string, { arrayFormat: 'index' });
+
+    expect(path).toBe('/learn');
+    expect(flashMap).toEqual({ success: ['flash.signout-success'] });
   });
 });


### PR DESCRIPTION
Closes #66515 

**Description:**
- Resolves an issue where the post-logout flash message incorrectly stated the user had logged in.
- The UI on /learn now displays the correct sign-out confirmation text.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

**Screenshots:**

**Before:**
<img width="1900" height="965" alt="Screenshot 2026-04-08 010844" src="https://github.com/user-attachments/assets/04ec1c5c-28bc-4b6a-a394-32df9c6965cd" />

**After:**
<img width="1911" height="971" alt="Screenshot 2026-04-08 010750" src="https://github.com/user-attachments/assets/47aad697-9b41-4d66-93fb-d6c42a2fa9fb" />

Also checked that sigin message remains unchanged I just fixed signout message.