### PR TITLE
fix(client): simplify search box text so less likely to ellipsis

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -916,8 +916,8 @@
   "search": {
     "label": "Search",
     "placeholder": {
-      "default": "Search our news articles, tutorials, and books",
-      "numbered": "Search {{ roundedTotalRecords }}+ news articles, tutorials, and books"
+      "default": "Search our books and courses",
+      "numbered": "Search {{ roundedTotalRecords }}+ of our books and courses"
     },
     "see-results": "See all results for {{searchQuery}}",
     "try": "Looking for something? Try the search bar on this page.",

--- a/client/tools/generate-search-placeholder.test.ts
+++ b/client/tools/generate-search-placeholder.test.ts
@@ -144,7 +144,7 @@ describe('Search bar placeholder tests:', () => {
   if (clientLocale === 'english') {
     describe('Placeholder strings', () => {
       test('When the total number of hits is less than 100 the expected placeholder is generated', async () => {
-        const expected = 'Search our news articles, tutorials, and books';
+        const expected = 'Search our books and courses';
         const placeholderText = await generateSearchPlaceholder({
           mockRecordsNum: 99,
           locale: 'english'
@@ -158,7 +158,7 @@ describe('Search bar placeholder tests:', () => {
           mockRecordsNum: 100,
           locale: 'english'
         });
-        const expected = 'Search 100+ news articles, tutorials, and books';
+        const expected = 'Search 100+ of our books and courses';
 
         expect(placeholderText).toEqual(expected);
       });
@@ -168,7 +168,7 @@ describe('Search bar placeholder tests:', () => {
           mockRecordsNum: 11000,
           locale: 'english'
         });
-        const expected = 'Search 11,000+ news articles, tutorials, and books';
+        const expected = 'Search 11,000+ of our books and courses';
 
         expect(placeholderText).toEqual(expected);
       });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.