### PR TITLE
test: use tsconfig when available

### DIFF
--- a/curriculum/src/test/test-challenges.js
+++ b/curriculum/src/test/test-challenges.js
@@ -38,10 +38,22 @@ vi.mock(
       '@freecodecamp/browser-scripts/ts-compiler'
     );
     const compiler = new tsCompiler.Compiler(ts, tsvfs);
-    await compiler.setup({ useNodeModules: true });
+    let previousTsconfig;
+    let hasConfiguredCompiler = false;
+
+    const mustSetup = tsconfig =>
+      !hasConfiguredCompiler ||
+      JSON.stringify(tsconfig) !== JSON.stringify(previousTsconfig);
+
     return {
       ...actual,
-      setupTSCompiler: () => Promise.resolve(true),
+      setupTSCompiler: tsconfig => {
+        if (mustSetup(tsconfig)) {
+          compiler.setup({ useNodeModules: true, tsconfig });
+          previousTsconfig = lodash.cloneDeep(tsconfig);
+          hasConfiguredCompiler = true;
+        }
+      },
       compileTypeScriptCode: code => {
         const { result, error } = compiler.compile(code, 'index.tsx');
         if (error) throw error;


### PR DESCRIPTION
Since configuring TypeScript is slow, I've made the assumption that tsconfig doesn't change very often. If that's true, the expensive setup calls should be minimized.

This is necessary for https://github.com/freeCodeCamp/freeCodeCamp/pull/66073

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
