### PR TITLE
fix(curriculum): enhance table a11y for availability table lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -22,6 +22,7 @@ demoType: onClick
 1. You should give the `#legend-gradient` element a linear gradient that transitions between all the colors from `--color0` to `--color5`. Each color value should have two color stops (expressed as percentages) to make the transition between colors a hard line.
 1. Your table should have a `caption` element with the text `Weekly Meeting Availability Schedule`.
 1. All table header cells in the first row (the days of the week) should have a `scope` attribute with the value `col`.
+1. All table header cells in the first column (the time cells) should have a `scope` attribute with the value `rowgroup`.
 1. All data cells in your table should have an `aria-label` attribute that describes the availability level (e.g., `0 available`, `1 available`, etc., and `5+ available` for the `available-5` cells).
 
 **Note:** Be sure to link your stylesheet in your HTML to apply your CSS.
@@ -372,7 +373,7 @@ Your `caption` element should have the text `Weekly Meeting Availability Schedul
 
 ```js
 const caption = document.querySelector('table caption');
-assert.equal(caption?.innerText, 'Weekly Meeting Availability Schedule');
+assert.equal(caption?.textContent, 'Weekly Meeting Availability Schedule');
 ```
 
 All table header cells in the first row should have a `scope` attribute with the value `col`.
@@ -382,6 +383,17 @@ const headers = [...document.querySelectorAll('tr:first-child>th:not([class*="ti
 assert.isNotEmpty(headers);
 headers.forEach(header => {
     assert.equal(header.getAttribute('scope'), 'col');
+});
+
+```
+
+All table header cells in the first column should have a `scope` attribute with the value `rowgroup`.
+
+```js
+const timeHeaders = [...document.querySelectorAll('th[class*="time"]')];
+assert.isNotEmpty(timeHeaders);
+timeHeaders.forEach(header => {
+    assert.equal(header.getAttribute('scope'), 'rowgroup');
 });
 ```
 
@@ -499,7 +511,7 @@ cells.forEach(cell => {
             <caption>Weekly Meeting Availability Schedule</caption>
             <tbody>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">9 AM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">9 AM</th>
                     <th scope="col">Monday</th>
                     <th scope="col">Tuesday</th>
                     <th scope="col">Wednesday</th>
@@ -514,7 +526,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">10 AM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">10 AM</th>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
@@ -530,7 +542,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">11 AM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">11 AM</th>
                     <td class="available-0" aria-label="0 available"></td>
                     <td class="available-2" aria-label="2 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
@@ -545,7 +557,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">12 PM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">12 PM</th>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-3" aria-label="3 available"></td>
@@ -560,7 +572,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">1 PM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">1 PM</th>
                     <td class="available-2" aria-label="2 available"></td>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-3" aria-label="3 available"></td>
@@ -575,7 +587,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">2 PM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">2 PM</th>
                     <td class="available-0" aria-label="0 available"></td>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
@@ -590,7 +602,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">3 PM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">3 PM</th>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
@@ -605,7 +617,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">4 PM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">4 PM</th>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>
@@ -620,7 +632,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time">5 PM</th>
+                    <th rowspan="2" class="time" scope="rowgroup">5 PM</th>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>

--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -19,7 +19,10 @@ demoType: onClick
 1. In your `:root` selector, you should define six CSS variables named `--color#`, where `#` is a number from `0` to `5`, and assign them each a color value. Use these variables to set the background color of the corresponding `.available-#` elements.
 1. In your `:root` selector, you should define CSS variables named `--solid-border` and `--dashed-border`. Use these variables to style the bottom borders of your data cells, alternating between solid and dashed borders depending on the row. Give the rows either the class of `sharp` or `half` to style them.
 1. You should have a `div` element with the `id` of `legend`. It should contain a `span` element with the text `Availability` and a `div` element with the `id` of `legend-gradient`.
-1. You should give the `#legend-gradient` element a linear gradient that transitions between all the colors from `--color0` to `--color5` with hard lines.
+1. You should give the `#legend-gradient` element a linear gradient that transitions between all the colors from `--color0` to `--color5`. Each color value should have two color stops (expressed as percentages) to make the transition between colors a hard line.
+1. Your table should have a `caption` element with the text `Weekly Meeting Availability Schedule`.
+1. All table header cells in the first row (the days of the week) should have a `scope` attribute with the value `col`.
+1. All data cells in your table should have an `aria-label` attribute that describes the availability level (e.g., `0 available`, `1 available`, etc., and `5+ available` for the `available-5` cells).
 
 **Note:** Be sure to link your stylesheet in your HTML to apply your CSS.
 
@@ -358,6 +361,100 @@ if (shorthandMatches?.length === EXPECTED_SHORTHAND_STOPS) {
 }
 ```
 
+Your table should have a `caption` element.
+
+```js
+const caption = document.querySelector('table caption');
+assert.isNotNull(caption);
+```
+
+Your `caption` element should have the text `Weekly Meeting Availability Schedule`.
+
+```js
+const caption = document.querySelector('table caption');
+assert.equal(caption?.innerText, 'Weekly Meeting Availability Schedule');
+```
+
+All table header cells in the first row should have a `scope` attribute with the value `col`.
+
+```js
+const headers = [...document.querySelectorAll('tr:first-child>th:not([class*="time"])')];
+assert.isNotEmpty(headers);
+headers.forEach(header => {
+    assert.equal(header.getAttribute('scope'), 'col');
+});
+```
+
+All data cells in your table should have an `aria-label` attribute.
+
+```js
+const dataCells = [...document.querySelectorAll('td[class*="available"]')];
+assert.isNotEmpty(dataCells);
+dataCells.forEach(cell => {
+    assert.isNotNull(cell.getAttribute('aria-label'));
+});
+```
+
+Data cells with the `available-0` class should have an `aria-label` of `0 available`.
+
+```js
+const cells = [...document.querySelectorAll('td.available-0')];
+assert.isNotEmpty(cells);
+cells.forEach(cell => {
+    assert.equal(cell.getAttribute('aria-label'), '0 available');
+});
+```
+
+Data cells with the `available-1` class should have an `aria-label` of `1 available`.
+
+```js
+const cells = [...document.querySelectorAll('td.available-1')];
+assert.isNotEmpty(cells);
+cells.forEach(cell => {
+    assert.equal(cell.getAttribute('aria-label'), '1 available');
+});
+```
+
+Data cells with the `available-2` class should have an `aria-label` of `2 available`.
+
+```js
+const cells = [...document.querySelectorAll('td.available-2')];
+assert.isNotEmpty(cells);
+cells.forEach(cell => {
+    assert.equal(cell.getAttribute('aria-label'), '2 available');
+});
+```
+
+Data cells with the `available-3` class should have an `aria-label` of `3 available`.
+
+```js
+const cells = [...document.querySelectorAll('td.available-3')];
+assert.isNotEmpty(cells);
+cells.forEach(cell => {
+    assert.equal(cell.getAttribute('aria-label'), '3 available');
+});
+```
+
+Data cells with the `available-4` class should have an `aria-label` of `4 available`.
+
+```js
+const cells = [...document.querySelectorAll('td.available-4')];
+assert.isNotEmpty(cells);
+cells.forEach(cell => {
+    assert.equal(cell.getAttribute('aria-label'), '4 available');
+});
+```
+
+Data cells with the `available-5` class should have an `aria-label` of `5+ available`.
+
+```js
+const cells = [...document.querySelectorAll('td.available-5')];
+assert.isNotEmpty(cells);
+cells.forEach(cell => {
+    assert.equal(cell.getAttribute('aria-label'), '5+ available');
+});
+```
+
 # --seed--
 
 ## --seed-contents--
@@ -399,135 +496,136 @@ if (shorthandMatches?.length === EXPECTED_SHORTHAND_STOPS) {
 <body>
     <main>
         <table>
+            <caption>Weekly Meeting Availability Schedule</caption>
             <tbody>
                 <tr class="sharp">
                     <th rowspan="2" class="time">9 AM</th>
-                    <th>Monday</th>
-                    <th>Tuesday</th>
-                    <th>Wednesday</th>
-                    <th>Thursday</th>
-                    <th>Friday</th>
+                    <th scope="col">Monday</th>
+                    <th scope="col">Tuesday</th>
+                    <th scope="col">Wednesday</th>
+                    <th scope="col">Thursday</th>
+                    <th scope="col">Friday</th>
                 </tr>
                 <tr class="half">
-                    <td class="available-0"></td>
-                    <td class="available-1"></td>
-                    <td class="available-2"></td>
-                    <td class="available-2"></td>
-                    <td class="available-5"></td>
+                    <td class="available-0" aria-label="0 available"></td>
+                    <td class="available-1" aria-label="1 available"></td>
+                    <td class="available-2" aria-label="2 available"></td>
+                    <td class="available-2" aria-label="2 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
                     <th rowspan="2" class="time">10 AM</th>
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
-                    <td class="available-4"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
 
                 <tr class="half">
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
                     <th rowspan="2" class="time">11 AM</th>
-                    <td class="available-0"></td>
-                    <td class="available-2"></td>
-                    <td class="available-4"></td>
-                    <td class="available-4"></td>
-                    <td class="available-0"></td>
+                    <td class="available-0" aria-label="0 available"></td>
+                    <td class="available-2" aria-label="2 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-0" aria-label="0 available"></td>
                 </tr>
                 <tr class="half">
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
-                    <td class="available-1"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-1" aria-label="1 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
                     <th rowspan="2" class="time">12 PM</th>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
-                    <td class="available-3"></td>
-                    <td class="available-2"></td>
-                    <td class="available-0"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-2" aria-label="2 available"></td>
+                    <td class="available-0" aria-label="0 available"></td>
                 </tr>
                 <tr class="half">
-                    <td class="available-3"></td>
-                    <td class="available-0"></td>
-                    <td class="available-4"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-0" aria-label="0 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
                     <th rowspan="2" class="time">1 PM</th>
-                    <td class="available-2"></td>
-                    <td class="available-3"></td>
-                    <td class="available-3"></td>
-                    <td class="available-2"></td>
-                    <td class="available-0"></td>
+                    <td class="available-2" aria-label="2 available"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-2" aria-label="2 available"></td>
+                    <td class="available-0" aria-label="0 available"></td>
                 </tr>
                 <tr class="half">
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
-                    <td class="available-4"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
                     <th rowspan="2" class="time">2 PM</th>
-                    <td class="available-0"></td>
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
-                    <td class="available-4"></td>
-                    <td class="available-4"></td>
+                    <td class="available-0" aria-label="0 available"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
                 </tr>
                 <tr class="half">
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
-                    <td class="available-4"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
                     <th rowspan="2" class="time">3 PM</th>
-                    <td class="available-3"></td>
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
-                    <td class="available-5"></td>
-                    <td class="available-4"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
                 </tr>
                 <tr class="half">
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
-                    <td class="available-4"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
                     <th rowspan="2" class="time">4 PM</th>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
-                    <td class="available-4"></td>
-                    <td class="available-4"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
                 </tr>
                 <tr class="half">
-                    <td class="available-3"></td>
-                    <td class="available-0"></td>
-                    <td class="available-4"></td>
-                    <td class="available-2"></td>
-                    <td class="available-5"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-0" aria-label="0 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
+                    <td class="available-2" aria-label="2 available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
                     <th rowspan="2" class="time">5 PM</th>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
-                    <td class="available-5"></td>
-                    <td class="available-3"></td>
-                    <td class="available-4"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-5" aria-label="5+ available"></td>
+                    <td class="available-3" aria-label="3 available"></td>
+                    <td class="available-4" aria-label="4 available"></td>
                 </tr>
                 <tr>
                     <td></td>

--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -16,14 +16,14 @@ demoType: onClick
 1. Cells in the first row should be table headers containing days of the week.
 1. Cells in the first column should be table headers with a `class` of `time` and should contain time values as their text.
 1. All data cells should have the `class` of `available-#`, where `#` is a number from `0` to `5` that specifies the number of available people at that time.
-1. In your `:root` selector, you should define six CSS variables named `--color#`, where `#` is a number from `0` to `5`, and assign them each a color value. Use these variables to set the background color of the corresponding `.available-#` elements.
-1. In your `:root` selector, you should define CSS variables named `--solid-border` and `--dashed-border`. Use these variables to style the bottom borders of your data cells, alternating between solid and dashed borders depending on the row. Give the rows either the class of `sharp` or `half` to style them.
-1. You should have a `div` element with the `id` of `legend`. It should contain a `span` element with the text `Availability` and a `div` element with the `id` of `legend-gradient`.
-1. You should give the `#legend-gradient` element a linear gradient that transitions between all the colors from `--color0` to `--color5`. Each color value should have two color stops (expressed as percentages) to make the transition between colors a hard line.
 1. Your table should have a `caption` element with the text `Weekly Meeting Availability Schedule`.
 1. All table header cells in the first row (the days of the week) should have a `scope` attribute with the value `col`.
 1. All table header cells in the first column (the time cells) should have a `scope` attribute with the value `row`.
 1. All data cells in your table should have an `aria-label` attribute that describes the availability level (e.g., `0 available`, `1 available`, etc., and `5+ available` for the `available-5` cells).
+1. In your `:root` selector, you should define six CSS variables named `--color#`, where `#` is a number from `0` to `5`, and assign them each a color value. Use these variables to set the background color of the corresponding `.available-#` elements.
+1. In your `:root` selector, you should define CSS variables named `--solid-border` and `--dashed-border`. Use these variables to style the bottom borders of your data cells, alternating between solid and dashed borders depending on the row. Give the rows either the class of `sharp` or `half` to style them.
+1. You should have a `div` element with the `id` of `legend`. It should contain a `span` element with the text `Availability` and a `div` element with the `id` of `legend-gradient`.
+1. You should give the `#legend-gradient` element a linear gradient that transitions between all the colors from `--color0` to `--color5` with hard lines.
 
 **Note:** Be sure to link your stylesheet in your HTML to apply your CSS.
 
@@ -407,61 +407,55 @@ dataCells.forEach(cell => {
 });
 ```
 
-Data cells with the `available-0` class should have an `aria-label` of `0 available`.
+Data cells with the `available-0` class should have an `aria-label` of `0 available` if present.
 
 ```js
 const cells = [...document.querySelectorAll('td.available-0')];
-assert.isNotEmpty(cells);
 cells.forEach(cell => {
     assert.equal(cell.getAttribute('aria-label'), '0 available');
 });
 ```
 
-Data cells with the `available-1` class should have an `aria-label` of `1 available`.
+Data cells with the `available-1` class should have an `aria-label` of `1 available` if present.
 
 ```js
 const cells = [...document.querySelectorAll('td.available-1')];
-assert.isNotEmpty(cells);
 cells.forEach(cell => {
     assert.equal(cell.getAttribute('aria-label'), '1 available');
 });
 ```
 
-Data cells with the `available-2` class should have an `aria-label` of `2 available`.
+Data cells with the `available-2` class should have an `aria-label` of `2 available` if present.
 
 ```js
 const cells = [...document.querySelectorAll('td.available-2')];
-assert.isNotEmpty(cells);
 cells.forEach(cell => {
     assert.equal(cell.getAttribute('aria-label'), '2 available');
 });
 ```
 
-Data cells with the `available-3` class should have an `aria-label` of `3 available`.
+Data cells with the `available-3` class should have an `aria-label` of `3 available` if present.
 
 ```js
 const cells = [...document.querySelectorAll('td.available-3')];
-assert.isNotEmpty(cells);
 cells.forEach(cell => {
     assert.equal(cell.getAttribute('aria-label'), '3 available');
 });
 ```
 
-Data cells with the `available-4` class should have an `aria-label` of `4 available`.
+Data cells with the `available-4` class should have an `aria-label` of `4 available` if present.
 
 ```js
 const cells = [...document.querySelectorAll('td.available-4')];
-assert.isNotEmpty(cells);
 cells.forEach(cell => {
     assert.equal(cell.getAttribute('aria-label'), '4 available');
 });
 ```
 
-Data cells with the `available-5` class should have an `aria-label` of `5+ available`.
+Data cells with the `available-5` class should have an `aria-label` of `5+ available` if present.
 
 ```js
 const cells = [...document.querySelectorAll('td.available-5')];
-assert.isNotEmpty(cells);
 cells.forEach(cell => {
     assert.equal(cell.getAttribute('aria-label'), '5+ available');
 });

--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -19,7 +19,7 @@ demoType: onClick
 1. Your table should have a `caption` element with the text `Weekly Meeting Availability Schedule`.
 1. All table header cells in the first row (the days of the week) should have a `scope` attribute with the value `col`.
 1. All table header cells in the first column (the time cells) should have a `scope` attribute with the value `row`.
-1. All data cells in your table should have an `aria-label` attribute that describes the availability level (e.g., `0 available`, `1 available`, etc., and `5+ available` for the `available-5` cells).
+1. All data cells with an availability class should have an `aria-label` attribute that describes the availability level (e.g., `0 available`, `1 available`, etc., and `5+ available` for the `available-5` cells).
 1. In your `:root` selector, you should define six CSS variables named `--color#`, where `#` is a number from `0` to `5`, and assign them each a color value. Use these variables to set the background color of the corresponding `.available-#` elements.
 1. In your `:root` selector, you should define CSS variables named `--solid-border` and `--dashed-border`. Use these variables to style the bottom borders of your data cells, alternating between solid and dashed borders depending on the row. Give the rows either the class of `sharp` or `half` to style them.
 1. You should have a `div` element with the `id` of `legend`. It should contain a `span` element with the text `Availability` and a `div` element with the `id` of `legend-gradient`.
@@ -397,7 +397,7 @@ timeHeaders.forEach(header => {
 });
 ```
 
-All data cells in your table should have an `aria-label` attribute.
+All data cells with an availability class should have an `aria-label` attribute.
 
 ```js
 const dataCells = [...document.querySelectorAll('td[class*="available"]')];

--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -22,7 +22,7 @@ demoType: onClick
 1. You should give the `#legend-gradient` element a linear gradient that transitions between all the colors from `--color0` to `--color5`. Each color value should have two color stops (expressed as percentages) to make the transition between colors a hard line.
 1. Your table should have a `caption` element with the text `Weekly Meeting Availability Schedule`.
 1. All table header cells in the first row (the days of the week) should have a `scope` attribute with the value `col`.
-1. All table header cells in the first column (the time cells) should have a `scope` attribute with the value `rowgroup`.
+1. All table header cells in the first column (the time cells) should have a `scope` attribute with the value `row`.
 1. All data cells in your table should have an `aria-label` attribute that describes the availability level (e.g., `0 available`, `1 available`, etc., and `5+ available` for the `available-5` cells).
 
 **Note:** Be sure to link your stylesheet in your HTML to apply your CSS.
@@ -387,13 +387,13 @@ headers.forEach(header => {
 
 ```
 
-All table header cells in the first column should have a `scope` attribute with the value `rowgroup`.
+All table header cells in the first column should have a `scope` attribute with the value `row`.
 
 ```js
 const timeHeaders = [...document.querySelectorAll('th[class*="time"]')];
 assert.isNotEmpty(timeHeaders);
 timeHeaders.forEach(header => {
-    assert.equal(header.getAttribute('scope'), 'rowgroup');
+    assert.equal(header.getAttribute('scope'), 'row');
 });
 ```
 
@@ -511,7 +511,7 @@ cells.forEach(cell => {
             <caption>Weekly Meeting Availability Schedule</caption>
             <tbody>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">9 AM</th>
+                    <th rowspan="2" class="time" scope="row">9 AM</th>
                     <th scope="col">Monday</th>
                     <th scope="col">Tuesday</th>
                     <th scope="col">Wednesday</th>
@@ -526,7 +526,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">10 AM</th>
+                    <th rowspan="2" class="time" scope="row">10 AM</th>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
@@ -542,7 +542,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">11 AM</th>
+                    <th rowspan="2" class="time" scope="row">11 AM</th>
                     <td class="available-0" aria-label="0 available"></td>
                     <td class="available-2" aria-label="2 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
@@ -557,7 +557,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">12 PM</th>
+                    <th rowspan="2" class="time" scope="row">12 PM</th>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-3" aria-label="3 available"></td>
@@ -572,7 +572,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">1 PM</th>
+                    <th rowspan="2" class="time" scope="row">1 PM</th>
                     <td class="available-2" aria-label="2 available"></td>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-3" aria-label="3 available"></td>
@@ -587,7 +587,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">2 PM</th>
+                    <th rowspan="2" class="time" scope="row">2 PM</th>
                     <td class="available-0" aria-label="0 available"></td>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
@@ -602,7 +602,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">3 PM</th>
+                    <th rowspan="2" class="time" scope="row">3 PM</th>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-3" aria-label="3 available"></td>
                     <td class="available-4" aria-label="4 available"></td>
@@ -617,7 +617,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">4 PM</th>
+                    <th rowspan="2" class="time" scope="row">4 PM</th>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>
@@ -632,7 +632,7 @@ cells.forEach(cell => {
                     <td class="available-5" aria-label="5+ available"></td>
                 </tr>
                 <tr class="sharp">
-                    <th rowspan="2" class="time" scope="rowgroup">5 PM</th>
+                    <th rowspan="2" class="time" scope="row">5 PM</th>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>
                     <td class="available-5" aria-label="5+ available"></td>

--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -19,7 +19,7 @@ demoType: onClick
 1. Your table should have a `caption` element with the text `Weekly Meeting Availability Schedule`.
 1. All table header cells in the first row (the days of the week) should have a `scope` attribute with the value `col`.
 1. All table header cells in the first column (the time cells) should have a `scope` attribute with the value `row`.
-1. All data cells with an availability class should have an `aria-label` attribute that describes the availability level (e.g., `0 available`, `1 available`, etc., and `5+ available` for the `available-5` cells).
+1. All data cells with an availability class should have an `aria-label` attribute that describes the availability level (e.g., `0 available` for the `available-0` cells, `1 available` for the `available-1` cells, etc., and `5+ available` for the `available-5` cells).
 1. In your `:root` selector, you should define six CSS variables named `--color#`, where `#` is a number from `0` to `5`, and assign them each a color value. Use these variables to set the background color of the corresponding `.available-#` elements.
 1. In your `:root` selector, you should define CSS variables named `--solid-border` and `--dashed-border`. Use these variables to style the bottom borders of your data cells, alternating between solid and dashed borders depending on the row. Give the rows either the class of `sharp` or `half` to style them.
 1. You should have a `div` element with the `id` of `legend`. It should contain a `span` element with the text `Availability` and a `div` element with the `id` of `legend-gradient`.
@@ -384,13 +384,12 @@ assert.isNotEmpty(headers);
 headers.forEach(header => {
     assert.equal(header.getAttribute('scope'), 'col');
 });
-
 ```
 
 All table header cells in the first column should have a `scope` attribute with the value `row`.
 
 ```js
-const timeHeaders = [...document.querySelectorAll('th[class*="time"]')];
+const timeHeaders = [...document.querySelectorAll('tr > th:first-child')];
 assert.isNotEmpty(timeHeaders);
 timeHeaders.forEach(header => {
     assert.equal(header.getAttribute('scope'), 'row');


### PR DESCRIPTION
While the original issue #62778 requested `role="grid"` on the table element,  this was intentionally not included. Since this is a curriculum lab focused on reviewing HTML and CSS fundamentals, introducing `role="grid"` would add new ARIA content that hasn't been taught to campers. Per curriculum guidelines, labs should only review previously learned concepts, not introduce new ones.

The accessibility improvements in this PR focus on:
- `<caption>` element for table description
- `scope` attributes on headers (both `col` and `rowgroup`)
- `aria-label` attributes on data cells for screen reader clarity


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #62778

<!-- Feel free to add any additional description of changes below this line -->
