### PR TITLE
fix(gha): consolidate PR check comments into single report

### DIFF
--- a/.github/scripts/pr-guidelines/check-linked-issue.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const FOOTER =
-  '\n\n---\nJoin us in our [chat room](https://discord.gg/PRyKn3Vbay) or our [forum](https://forum.freecodecamp.org/c/contributors/3) if you have any questions or need help with contributing.';
-
 async function addDeprioritizedLabel(github, context) {
   await github.rest.issues.addLabels({
     owner: context.repo.owner,
@@ -12,19 +9,8 @@ async function addDeprioritizedLabel(github, context) {
   });
 }
 
-async function addComment(github, context, body) {
-  await github.rest.issues.createComment({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    issue_number: context.payload.pull_request.number,
-    body
-  });
-}
-
 module.exports = async ({ github, context, core, isAllowListed }) => {
   if (isAllowListed === 'true') return;
-
-  const action = context.payload.action;
 
   const result = await github.graphql(
     `query($owner: String!, $repo: String!, $number: Int!) {
@@ -53,23 +39,9 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
   const linkedIssues = pr.closingIssuesReferences.nodes;
 
   if (linkedIssues.length === 0) {
+    core.setOutput('failure_reason', 'no_linked_issue');
     core.setFailed('No linked issue found.');
     await addDeprioritizedLabel(github, context);
-    if (action !== 'edited') {
-      await addComment(
-        github,
-        context,
-        [
-          'Hi there,',
-          '',
-          'Thanks for opening this pull request.',
-          '',
-          'We kindly ask that contributors open an issue before submitting a PR so the change can be discussed and approved before work begins. This helps avoid situations where significant effort goes into something we ultimately cannot merge.',
-          '',
-          'Please open an issue first and allow it to be triaged. Once the issue is open for contribution, you are welcome to update this pull request to reflect the issue consensus. Until then, we will not be able to review your pull request.'
-        ].join('\n') + FOOTER
-      );
-    }
     return;
   }
 
@@ -77,21 +49,9 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
     issue.labels.nodes.some(l => l.name === 'status: waiting triage')
   );
   if (hasWaitingTriage) {
+    core.setOutput('failure_reason', 'waiting_triage');
     core.setFailed('Linked issue has not been triaged yet.');
     await addDeprioritizedLabel(github, context);
-    if (action !== 'edited') {
-      await addComment(
-        github,
-        context,
-        [
-          'Hi there,',
-          '',
-          'Thanks for opening this pull request.',
-          '',
-          'The linked issue has not been triaged yet, and a solution has not been agreed upon. Once the issue is open for contribution, you are welcome to update this pull request to reflect the issue consensus. Until then, we will not be able to review your pull request.'
-        ].join('\n') + FOOTER
-      );
-    }
     return;
   }
 
@@ -117,20 +77,8 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
     )
   );
   if (!isOpenForContribution) {
+    core.setOutput('failure_reason', 'not_open_for_contribution');
     core.setFailed('Linked issue is not open for contribution.');
     await addDeprioritizedLabel(github, context);
-    if (action !== 'edited') {
-      await addComment(
-        github,
-        context,
-        [
-          'Hi there,',
-          '',
-          'Thanks for opening this pull request.',
-          '',
-          'The linked issue is not open for contribution. If you are looking for issues to contribute to, please check out issues labeled [`help wanted`](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or [`first timers only`](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22first+timers+only%22).'
-        ].join('\n') + FOOTER
-      );
-    }
   }
 };

--- a/.github/scripts/pr-guidelines/check-linked-issue.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.js
@@ -21,8 +21,10 @@ async function addComment(github, context, body) {
   });
 }
 
-module.exports = async ({ github, context, isAllowListed }) => {
+module.exports = async ({ github, context, core, isAllowListed }) => {
   if (isAllowListed === 'true') return;
+
+  const action = context.payload.action;
 
   const result = await github.graphql(
     `query($owner: String!, $repo: String!, $number: Int!) {
@@ -51,20 +53,23 @@ module.exports = async ({ github, context, isAllowListed }) => {
   const linkedIssues = pr.closingIssuesReferences.nodes;
 
   if (linkedIssues.length === 0) {
+    core.setFailed('No linked issue found.');
     await addDeprioritizedLabel(github, context);
-    await addComment(
-      github,
-      context,
-      [
-        'Hi there,',
-        '',
-        'Thanks for opening this pull request.',
-        '',
-        'We kindly ask that contributors open an issue before submitting a PR so the change can be discussed and approved before work begins. This helps avoid situations where significant effort goes into something we ultimately cannot merge.',
-        '',
-        'Please open an issue first and allow it to be triaged. Once the issue is open for contribution, you are welcome to update this pull request to reflect the issue consensus. Until then, we will not be able to review your pull request.'
-      ].join('\n') + FOOTER
-    );
+    if (action !== 'edited') {
+      await addComment(
+        github,
+        context,
+        [
+          'Hi there,',
+          '',
+          'Thanks for opening this pull request.',
+          '',
+          'We kindly ask that contributors open an issue before submitting a PR so the change can be discussed and approved before work begins. This helps avoid situations where significant effort goes into something we ultimately cannot merge.',
+          '',
+          'Please open an issue first and allow it to be triaged. Once the issue is open for contribution, you are welcome to update this pull request to reflect the issue consensus. Until then, we will not be able to review your pull request.'
+        ].join('\n') + FOOTER
+      );
+    }
     return;
   }
 
@@ -72,18 +77,21 @@ module.exports = async ({ github, context, isAllowListed }) => {
     issue.labels.nodes.some(l => l.name === 'status: waiting triage')
   );
   if (hasWaitingTriage) {
+    core.setFailed('Linked issue has not been triaged yet.');
     await addDeprioritizedLabel(github, context);
-    await addComment(
-      github,
-      context,
-      [
-        'Hi there,',
-        '',
-        'Thanks for opening this pull request.',
-        '',
-        'The linked issue has not been triaged yet, and a solution has not been agreed upon. Once the issue is open for contribution, you are welcome to update this pull request to reflect the issue consensus. Until then, we will not be able to review your pull request.'
-      ].join('\n') + FOOTER
-    );
+    if (action !== 'edited') {
+      await addComment(
+        github,
+        context,
+        [
+          'Hi there,',
+          '',
+          'Thanks for opening this pull request.',
+          '',
+          'The linked issue has not been triaged yet, and a solution has not been agreed upon. Once the issue is open for contribution, you are welcome to update this pull request to reflect the issue consensus. Until then, we will not be able to review your pull request.'
+        ].join('\n') + FOOTER
+      );
+    }
     return;
   }
 
@@ -109,17 +117,20 @@ module.exports = async ({ github, context, isAllowListed }) => {
     )
   );
   if (!isOpenForContribution) {
+    core.setFailed('Linked issue is not open for contribution.');
     await addDeprioritizedLabel(github, context);
-    await addComment(
-      github,
-      context,
-      [
-        'Hi there,',
-        '',
-        'Thanks for opening this pull request.',
-        '',
-        'The linked issue is not open for contribution. If you are looking for issues to contribute to, please check out issues labeled [`help wanted`](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or [`first timers only`](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22first+timers+only%22).'
-      ].join('\n') + FOOTER
-    );
+    if (action !== 'edited') {
+      await addComment(
+        github,
+        context,
+        [
+          'Hi there,',
+          '',
+          'Thanks for opening this pull request.',
+          '',
+          'The linked issue is not open for contribution. If you are looking for issues to contribute to, please check out issues labeled [`help wanted`](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or [`first timers only`](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22first+timers+only%22).'
+        ].join('\n') + FOOTER
+      );
+    }
   }
 };

--- a/.github/scripts/pr-guidelines/check-pr-template.js
+++ b/.github/scripts/pr-guidelines/check-pr-template.js
@@ -22,7 +22,7 @@ const TEMPLATE_BLOCK = [
   '```'
 ].join('\n');
 
-module.exports = async ({ github, context, isAllowListed }) => {
+module.exports = async ({ github, context, core, isAllowListed }) => {
   if (isAllowListed === 'true') return;
 
   const body = (context.payload.pull_request.body || '').toLowerCase();
@@ -46,25 +46,9 @@ module.exports = async ({ github, context, isAllowListed }) => {
     normalizedBody.includes(`[x] ${item}`)
   );
 
-  if (templatePresent && allRequiredTicked) {
-    // On edit, remove the deprioritized label if the check now passes.
-    if (action === 'edited') {
-      try {
-        await github.rest.issues.removeLabel({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          issue_number: context.payload.pull_request.number,
-          name: 'deprioritized'
-        });
-      } catch {
-        // Label may not exist — ignore.
-      }
-    }
-    return;
-  }
+  if (templatePresent && allRequiredTicked) return;
 
-  // On edit, don't re-comment — the original comment is already there.
-  if (action === 'edited') return;
+  core.setFailed('PR description is missing the required checklist or some items are incomplete.');
 
   await github.rest.issues.addLabels({
     owner: context.repo.owner,
@@ -72,6 +56,9 @@ module.exports = async ({ github, context, isAllowListed }) => {
     issue_number: context.payload.pull_request.number,
     labels: ['deprioritized']
   });
+
+  // On edit, don't re-comment — the original comment is already there.
+  if (action === 'edited') return;
 
   await github.rest.issues.createComment({
     owner: context.repo.owner,

--- a/.github/scripts/pr-guidelines/check-pr-template.js
+++ b/.github/scripts/pr-guidelines/check-pr-template.js
@@ -1,32 +1,9 @@
 'use strict';
 
-const FOOTER =
-  '\n\n---\nJoin us in our [chat room](https://discord.gg/PRyKn3Vbay) or our [forum](https://forum.freecodecamp.org/c/contributors/3) if you have any questions or need help with contributing.';
-
-const TEMPLATE_BLOCK = [
-  '```md',
-  'Checklist:',
-  '',
-  '<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->',
-  '',
-  '- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).',
-  '- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).',
-  "- [ ] My pull request targets the `main` branch of freeCodeCamp.",
-  '- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.',
-  '',
-  '<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->',
-  '',
-  'Closes #XXXXX',
-  '',
-  '<!-- Feel free to add any additional description of changes below this line -->',
-  '```'
-].join('\n');
-
 module.exports = async ({ github, context, core, isAllowListed }) => {
   if (isAllowListed === 'true') return;
 
   const body = (context.payload.pull_request.body || '').toLowerCase();
-  const action = context.payload.action;
 
   // The template must be present and the first 3 checkboxes must be
   // ticked. The last checkbox (tested locally) is acceptable to leave
@@ -48,37 +25,15 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
 
   if (templatePresent && allRequiredTicked) return;
 
-  core.setFailed('PR description is missing the required checklist or some items are incomplete.');
+  core.setOutput('failure_reason', 'incomplete_checklist');
+  core.setFailed(
+    'PR description is missing the required checklist or some items are incomplete.'
+  );
 
   await github.rest.issues.addLabels({
     owner: context.repo.owner,
     repo: context.repo.repo,
     issue_number: context.payload.pull_request.number,
     labels: ['deprioritized']
-  });
-
-  // On edit, don't re-comment — the original comment is already there.
-  if (action === 'edited') return;
-
-  await github.rest.issues.createComment({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    issue_number: context.payload.pull_request.number,
-    body:
-      [
-        'Hi there,',
-        '',
-        'Thank you for the contribution.',
-        '',
-        'The automated checks found a few issues with the PR. Currently the PR description is missing the required checklist or some of its items are not completed:',
-        '',
-        '1. The `Checklist:` heading is present in the PR description.',
-        '2. The checkbox items are ticked (changed from `[ ]` to `[x]`).',
-        '3. You have actually completed the items in the checklist.',
-        '',
-        'Please edit your PR description to include the following template with the checklist items completed.',
-        '',
-        TEMPLATE_BLOCK
-      ].join('\n') + FOOTER
   });
 };

--- a/.github/scripts/pr-guidelines/fix-pr-title.js
+++ b/.github/scripts/pr-guidelines/fix-pr-title.js
@@ -60,9 +60,12 @@ module.exports = async ({ github, context }) => {
     }
   }
 
+  // Fix 4: missing space after colon — "fix:desc" → "fix: desc"
+  newTitle = newTitle.replace(/^(\w+(?:\([^)]+\))?):(\S)/, '$1: $2');
+
   // Catch-all: prefix with "fix: " if still not a valid CC title
   if (!ccRegex.test(newTitle)) {
-    newTitle = `fix: ${title}`;
+    newTitle = `fix: ${newTitle}`;
   }
 
   if (newTitle !== title) {

--- a/.github/scripts/pr-guidelines/report-results.js
+++ b/.github/scripts/pr-guidelines/report-results.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const FOOTER =
+  '\n\n---\nJoin us in our [chat room](https://discord.gg/PRyKn3Vbay) or our [forum](https://forum.freecodecamp.org/c/contributors/3) if you have any questions or need help with contributing.';
+
+const TEMPLATE_BLOCK = [
+  '```md',
+  'Checklist:',
+  '',
+  '<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->',
+  '',
+  '- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).',
+  '- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).',
+  "- [ ] My pull request targets the `main` branch of freeCodeCamp.",
+  '- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.',
+  '',
+  '<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->',
+  '',
+  'Closes #XXXXX',
+  '',
+  '<!-- Feel free to add any additional description of changes below this line -->',
+  '```'
+].join('\n');
+
+const MESSAGES = {
+  incomplete_checklist: [
+    '**Checklist:** The PR description is missing the required checklist or some of its items are not completed:',
+    '',
+    '1. The `Checklist:` heading is present in the PR description.',
+    '2. The checkbox items are ticked (changed from `[ ]` to `[x]`).',
+    '3. You have actually completed the items in the checklist.',
+    '',
+    'Please edit your PR description to include the following template with the checklist items completed.',
+    '',
+    TEMPLATE_BLOCK
+  ].join('\n'),
+
+  no_linked_issue: [
+    '**Linked Issue:** We kindly ask that contributors open an issue before submitting a PR so the change can be discussed and approved before work begins. This helps avoid situations where significant effort goes into something we ultimately cannot merge.',
+    '',
+    'Please open an issue first and allow it to be triaged. Once the issue is open for contribution, you are welcome to update this pull request to reflect the issue consensus. Until then, we will not be able to review your pull request.'
+  ].join('\n'),
+
+  waiting_triage: [
+    '**Linked Issue:** The linked issue has not been triaged yet, and a solution has not been agreed upon. Once the issue is open for contribution, you are welcome to update this pull request to reflect the issue consensus. Until then, we will not be able to review your pull request.'
+  ].join('\n'),
+
+  not_open_for_contribution:
+    '**Linked Issue:** The linked issue is not open for contribution. If you are looking for issues to contribute to, please check out issues labeled [`help wanted`](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or [`first timers only`](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22first+timers+only%22).'
+};
+
+module.exports = async ({
+  github,
+  context,
+  templateResult,
+  templateReason,
+  linkedIssueResult,
+  linkedIssueReason
+}) => {
+  const allPassed =
+    templateResult === 'success' && linkedIssueResult === 'success';
+
+  if (allPassed) {
+    try {
+      await github.rest.issues.removeLabel({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+        name: 'deprioritized'
+      });
+    } catch {
+      // Label may not exist — ignore.
+    }
+    return;
+  }
+
+  // On edit, don't re-comment — the original comment is already there.
+  if (context.payload.action === 'edited') return;
+
+  const sections = [];
+  if (templateResult === 'failure' && MESSAGES[templateReason]) {
+    sections.push(MESSAGES[templateReason]);
+  }
+  if (linkedIssueResult === 'failure' && MESSAGES[linkedIssueReason]) {
+    sections.push(MESSAGES[linkedIssueReason]);
+  }
+
+  if (sections.length === 0) return;
+
+  const body =
+    [
+      'Hi there,',
+      '',
+      'Thanks for opening this pull request.',
+      '',
+      'The automated checks found some issues:',
+      '',
+      sections.join('\n\n')
+    ].join('\n') + FOOTER;
+
+  await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+    body
+  });
+};

--- a/.github/workflows/github-autoclose.yml
+++ b/.github/workflows/github-autoclose.yml
@@ -51,7 +51,7 @@ jobs:
               }
             }
             core.setFailed("Invalid PR detected.");
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/github-lock-closed-prs.yml
+++ b/.github/workflows/github-lock-closed-prs.yml
@@ -1,0 +1,21 @@
+name: GitHub - Lock Closed PRs
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  lock:
+    name: Lock Closed PR
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.lock({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              lock_reason: 'resolved'
+            });

--- a/.github/workflows/github-no-i18n-via-prs.yml
+++ b/.github/workflows/github-no-i18n-via-prs.yml
@@ -23,7 +23,7 @@ jobs:
             }).catch(() => ({status: 404}));
             if (context.payload.pull_request.user.login !== "camperbot" && isDev.status !== 200) {
               core.setFailed('This PR appears to touch translated curriculum files.')
-              github.rest.issues.createComment({
+              await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/github-pr-guidelines.yml
+++ b/.github/workflows/github-pr-guidelines.yml
@@ -115,14 +115,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fn = require('./.github/scripts/pr-guidelines/check-pr-template.js');
-            await fn({ github, context, isAllowListed: '${{ needs.no-web-commits.outputs.is_allow_listed }}' });
+            await fn({ github, context, core, isAllowListed: '${{ needs.no-web-commits.outputs.is_allow_listed }}' });
 
   # Verifies that each PR references a linked, triaged issue before it can be reviewed.
   check-linked-issue:
     name: Check Linked Issue
     runs-on: ubuntu-24.04
     needs: no-web-commits
-    if: needs.no-web-commits.result == 'success' && github.event.action != 'edited'
+    if: needs.no-web-commits.result == 'success'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -134,4 +134,33 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fn = require('./.github/scripts/pr-guidelines/check-linked-issue.js');
-            await fn({ github, context, isAllowListed: '${{ needs.no-web-commits.outputs.is_allow_listed }}' });
+            await fn({ github, context, core, isAllowListed: '${{ needs.no-web-commits.outputs.is_allow_listed }}' });
+
+  # Removes the deprioritized label only when all checks pass.
+  # Individual checks add the label on failure but never remove it,
+  # so this single coordination point prevents one passing check
+  # from removing a label that another failing check requires.
+  update-label:
+    name: Update Label
+    runs-on: ubuntu-24.04
+    needs: [no-web-commits, check-pr-template, check-linked-issue]
+    if: >-
+      always() &&
+      needs.no-web-commits.result == 'success' &&
+      needs.check-pr-template.result == 'success' &&
+      needs.check-linked-issue.result == 'success'
+    steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'deprioritized'
+              });
+            } catch {
+              // Label may not exist — ignore.
+            }

--- a/.github/workflows/github-pr-guidelines.yml
+++ b/.github/workflows/github-pr-guidelines.yml
@@ -104,13 +104,16 @@ jobs:
     runs-on: ubuntu-24.04
     needs: no-web-commits
     if: needs.no-web-commits.result == 'success'
+    outputs:
+      failure_reason: ${{ steps.check.outputs.failure_reason }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: .github/scripts/pr-guidelines
           sparse-checkout-cone-mode: false
 
-      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      - id: check
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -123,6 +126,29 @@ jobs:
     runs-on: ubuntu-24.04
     needs: no-web-commits
     if: needs.no-web-commits.result == 'success'
+    outputs:
+      failure_reason: ${{ steps.check.outputs.failure_reason }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/scripts/pr-guidelines
+          sparse-checkout-cone-mode: false
+
+      - id: check
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fn = require('./.github/scripts/pr-guidelines/check-linked-issue.js');
+            await fn({ github, context, core, isAllowListed: '${{ needs.no-web-commits.outputs.is_allow_listed }}' });
+
+  # Coordinates reporting: posts a single combined comment when checks fail,
+  # or removes the deprioritized label when all checks pass.
+  report:
+    name: Report
+    runs-on: ubuntu-24.04
+    needs: [no-web-commits, check-pr-template, check-linked-issue]
+    if: always() && needs.no-web-commits.result == 'success'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -133,34 +159,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fn = require('./.github/scripts/pr-guidelines/check-linked-issue.js');
-            await fn({ github, context, core, isAllowListed: '${{ needs.no-web-commits.outputs.is_allow_listed }}' });
-
-  # Removes the deprioritized label only when all checks pass.
-  # Individual checks add the label on failure but never remove it,
-  # so this single coordination point prevents one passing check
-  # from removing a label that another failing check requires.
-  update-label:
-    name: Update Label
-    runs-on: ubuntu-24.04
-    needs: [no-web-commits, check-pr-template, check-linked-issue]
-    if: >-
-      always() &&
-      needs.no-web-commits.result == 'success' &&
-      needs.check-pr-template.result == 'success' &&
-      needs.check-linked-issue.result == 'success'
-    steps:
-      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'deprioritized'
-              });
-            } catch {
-              // Label may not exist — ignore.
-            }
+            const fn = require('./.github/scripts/pr-guidelines/report-results.js');
+            await fn({
+              github,
+              context,
+              templateResult: '${{ needs.check-pr-template.result }}',
+              templateReason: '${{ needs.check-pr-template.outputs.failure_reason }}',
+              linkedIssueResult: '${{ needs.check-linked-issue.result }}',
+              linkedIssueReason: '${{ needs.check-linked-issue.outputs.failure_reason }}'
+            });

--- a/.github/workflows/github-spam.yml
+++ b/.github/workflows/github-spam.yml
@@ -12,12 +12,15 @@ jobs:
         with:
           github-token: ${{secrets.CAMPERBOT_NO_TRANSLATE}}
           script: |
-            const isSpam = context.payload.pull_request.labels.find(label => label.name === "spam");
-            if (isSpam) {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "We are marking this pull request as spam. Please note that if you are participating in Hacktoberfest, two or more PRs marked as spam will result in your permanent disqualification.\n\nIf you are interested in making quality and genuine contributions to our projects, check out our [contributing guidelines](https://contribute.freecodecamp.org)."
-              })
+            if (context.payload.label.name === "spam") {
+              try {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: "We are marking this pull request as spam. Please note that if you are participating in Hacktoberfest, two or more PRs marked as spam will result in your permanent disqualification.\n\nIf you are interested in making quality and genuine contributions to our projects, check out our [contributing guidelines](https://contribute.freecodecamp.org)."
+                });
+              } catch {
+                // Conversation may already be locked — ignore.
+              }
             }

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           github-token: ${{secrets.CAMPERBOT_NO_TRANSLATE}}
           script: |
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
Move commenting out of individual check scripts into a centralized report job. When multiple checks fail, contributors now receive one combined comment instead of separate comments per check.

- check-pr-template.js: pure validator, outputs failure_reason
- check-linked-issue.js: pure validator, outputs failure_reason
- report-results.js: composes combined comment or removes label
- Workflow report job reads check outputs and coordinates response