### PR TITLE
fix(curriculum): allow multiple attribute selector operators in book inventory app lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -27,9 +27,9 @@ saveSubmissionToDB: true
 1. You should use an attribute selector to target the `span` elements with the class of `status` that are descendants of `tr` elements with the class of `in-progress` and set their `border` and `background-image` properties.
 1. You should use an attribute selector to target the `span` elements with the class of `status` and the `span` elements with the class value starting with `rate` and set their `height`, `width`, and `padding` properties.
 1. You should use an attribute selector to target the `span` elements which are direct children of `span` elements with the `class` value starting with `rate` and set their `border`, `border-radius`, `margin`, `height`, `width`, and `background-color` properties.
-1. You should use an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value and set its `background-image` property to use a `linear-gradient`.
-1. You should use an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
-1. You should use an attribute selector to target the three `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
+1. You should use an attribute selector to target the first descendant of `span` elements whose `class` value contains `one` and set its `background-image` property to use a `linear-gradient`.
+1. You should use an attribute selector to target the first two descendants of `span` elements whose `class` value contains `two` and set their `background-image` property to use a `linear-gradient`.
+1. You should use an attribute selector to target the three `span` elements that are descendants of `span` elements whose `class` value contains `three` and set their `background-image` property to use a `linear-gradient`.
 
 # --hints--
 
@@ -381,132 +381,212 @@ You should use an attribute selector to target the `span` elements which are dir
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('span[class^="rate"] > span')?.getPropVal('background-color'));
 ```
 
-You should have an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value.
+You should have an attribute selector to target the first descendant of `span` elements whose `class` value contains `one`.
 
 ```js
 const selectors = [
   'span[class~="one"] :first-child',
+  'span[class*="one"] :first-child',
   'span[class~="one"] :nth-child(1)',
+  'span[class*="one"] :nth-child(1)',
   'span[class~="one"] :first-of-type',
+  'span[class*="one"] :first-of-type',
   'span[class~="one"] span:first-child',
+  'span[class*="one"] span:first-child',
   'span[class~="one"] span:nth-child(1)',
+  'span[class*="one"] span:nth-child(1)',
   'span[class~="one"] span:first-of-type',
+  'span[class*="one"] span:first-of-type',
   'span[class~="one"] > :first-child',
+  'span[class*="one"] > :first-child',
   'span[class~="one"] > :nth-child(1)',
+  'span[class*="one"] > :nth-child(1)',
   'span[class~="one"] > :first-of-type',
+  'span[class*="one"] > :first-of-type',
   'span[class~="one"] > span:first-child',
+  'span[class*="one"] > span:first-child',
   'span[class~="one"] > span:nth-child(1)',
-  'span[class~="one"] > span:first-of-type'
+  'span[class*="one"] > span:nth-child(1)',
+  'span[class~="one"] > span:first-of-type',
+  'span[class*="one"] > span:first-of-type'
 ]
 assert.isNotNull(new __helpers.CSSHelp(document).getStyleAny(selectors));
 ```
 
-You should use an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value and set its `background-image` property to use a `linear-gradient`.
+You should use an attribute selector to target the first descendant of `span` elements whose `class` value contains `one` and set its `background-image` property to use a `linear-gradient`.
 
 ```js
 const selectors = [
   'span[class~="one"] :first-child',
+  'span[class*="one"] :first-child',
   'span[class~="one"] :nth-child(1)',
+  'span[class*="one"] :nth-child(1)',
   'span[class~="one"] :first-of-type',
+  'span[class*="one"] :first-of-type',
   'span[class~="one"] span:first-child',
+  'span[class*="one"] span:first-child',
   'span[class~="one"] span:nth-child(1)',
+  'span[class*="one"] span:nth-child(1)',
   'span[class~="one"] span:first-of-type',
+  'span[class*="one"] span:first-of-type',
   'span[class~="one"] > :first-child',
+  'span[class*="one"] > :first-child',
   'span[class~="one"] > :nth-child(1)',
+  'span[class*="one"] > :nth-child(1)',
   'span[class~="one"] > :first-of-type',
+  'span[class*="one"] > :first-of-type',
   'span[class~="one"] > span:first-child',
+  'span[class*="one"] > span:first-child',
   'span[class~="one"] > span:nth-child(1)',
-  'span[class~="one"] > span:first-of-type'
+  'span[class*="one"] > span:nth-child(1)',
+  'span[class~="one"] > span:first-of-type',
+  'span[class*="one"] > span:first-of-type'
 ]
 assert.isTrue(new __helpers.CSSHelp(document).getStyleAny(selectors)?.getPropVal('background-image').includes('linear-gradient('));
 ```
 
-You should have an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value.
+You should have an attribute selector to target the first two descendants of `span` elements whose `class` value contains `two`.
 
 ```js
 
 const selectors = [
   'span[class~="two"] :nth-child(1), span[class~="two"] :nth-child(2)',
+  'span[class*="two"] :nth-child(1), span[class*="two"] :nth-child(2)',
   'span[class~="two"] :nth-child(2), span[class~="two"] :nth-child(1)',
+  'span[class*="two"] :nth-child(2), span[class*="two"] :nth-child(1)',
   'span[class~="two"] :first-child, span[class~="two"] :nth-child(2)',
+  'span[class*="two"] :first-child, span[class*="two"] :nth-child(2)',
   'span[class~="two"] :nth-child(2), span[class~="two"] :first-child',
+  'span[class*="two"] :nth-child(2), span[class*="two"] :first-child',
   'span[class~="two"] :nth-of-type(-n+2)',
+  'span[class*="two"] :nth-of-type(-n+2)',
   'span[class~="two"] :nth-child(-n+2)',
+  'span[class*="two"] :nth-child(-n+2)',
   'span[class~="two"] span:nth-child(1), span[class~="two"] span:nth-child(2)',
+  'span[class*="two"] span:nth-child(1), span[class*="two"] span:nth-child(2)',
   'span[class~="two"] span:nth-child(2), span[class~="two"] span:nth-child(1)',
+  'span[class*="two"] span:nth-child(2), span[class*="two"] span:nth-child(1)',
   'span[class~="two"] span:first-child, span[class~="two"] span:nth-child(2)',
+  'span[class*="two"] span:first-child, span[class*="two"] span:nth-child(2)',
   'span[class~="two"] span:nth-child(2), span[class~="two"] span:first-child',
+  'span[class*="two"] span:nth-child(2), span[class*="two"] span:first-child',
   'span[class~="two"] span:nth-of-type(-n+2)',
+  'span[class*="two"] span:nth-of-type(-n+2)',
   'span[class~="two"] span:nth-child(-n+2)',
+  'span[class*="two"] span:nth-child(-n+2)',
   'span[class~="two"] > :nth-child(1), span[class~="two"] > :nth-child(2)',
+  'span[class*="two"] > :nth-child(1), span[class*="two"] > :nth-child(2)',
   'span[class~="two"] > :nth-child(2), span[class~="two"] > :nth-child(1)',
+  'span[class*="two"] > :nth-child(2), span[class*="two"] > :nth-child(1)',
   'span[class~="two"] > :first-child, span[class~="two"] > :nth-child(2)',
+  'span[class*="two"] > :first-child, span[class*="two"] > :nth-child(2)',
   'span[class~="two"] > :nth-child(2), span[class~="two"] > :first-child',
+  'span[class*="two"] > :nth-child(2), span[class*="two"] > :first-child',
   'span[class~="two"] > :nth-of-type(-n+2)',
+  'span[class*="two"] > :nth-of-type(-n+2)',
   'span[class~="two"] > :first-child, span[class~="two"] > :nth-of-type(2)',
+  'span[class*="two"] > :first-child, span[class*="two"] > :nth-of-type(2)',
   'span[class~="two"] > :nth-of-type(2), span[class~="two"] > :first-child',
+  'span[class*="two"] > :nth-of-type(2), span[class*="two"] > :first-child',
   'span[class~="two"] > :nth-child(-n+2)',
+  'span[class*="two"] > :nth-child(-n+2)',
   'span[class~="two"] > span:nth-child(1), span[class~="two"] > span:nth-child(2)',
+  'span[class*="two"] > span:nth-child(1), span[class*="two"] > span:nth-child(2)',
   'span[class~="two"] > span:nth-child(2), span[class~="two"] > span:nth-child(1)',
+  'span[class*="two"] > span:nth-child(2), span[class*="two"] > span:nth-child(1)',
   'span[class~="two"] > span:first-child, span[class~="two"] > span:nth-child(2)',
+  'span[class*="two"] > span:first-child, span[class*="two"] > span:nth-child(2)',
   'span[class~="two"] > span:nth-child(2), span[class~="two"] > span:first-child',
+  'span[class*="two"] > span:nth-child(2), span[class*="two"] > span:first-child',
   'span[class~="two"] > span:nth-of-type(-n+2)',
-  'span[class~="two"] > span:nth-child(-n+2)'
-  ]
+  'span[class*="two"] > span:nth-of-type(-n+2)',
+  'span[class~="two"] > span:nth-child(-n+2)',
+  'span[class*="two"] > span:nth-child(-n+2)'
+]
 assert.isNotNull(new __helpers.CSSHelp(document).getStyleAny(selectors));
 ```
 
-You should use an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
+You should use an attribute selector to target the first two descendants of `span` elements whose `class` value contains `two` and set their `background-image` property to use a `linear-gradient`.
 
 ```js
 const selectors = [
   'span[class~="two"] :nth-child(1), span[class~="two"] :nth-child(2)',
+  'span[class*="two"] :nth-child(1), span[class*="two"] :nth-child(2)',
   'span[class~="two"] :nth-child(2), span[class~="two"] :nth-child(1)',
+  'span[class*="two"] :nth-child(2), span[class*="two"] :nth-child(1)',
   'span[class~="two"] :first-child, span[class~="two"] :nth-child(2)',
+  'span[class*="two"] :first-child, span[class*="two"] :nth-child(2)',
   'span[class~="two"] :nth-child(2), span[class~="two"] :first-child',
+  'span[class*="two"] :nth-child(2), span[class*="two"] :first-child',
   'span[class~="two"] :nth-of-type(-n+2)',
+  'span[class*="two"] :nth-of-type(-n+2)',
   'span[class~="two"] :nth-child(-n+2)',
+  'span[class*="two"] :nth-child(-n+2)',
   'span[class~="two"] span:nth-child(1), span[class~="two"] span:nth-child(2)',
+  'span[class*="two"] span:nth-child(1), span[class*="two"] span:nth-child(2)',
   'span[class~="two"] span:nth-child(2), span[class~="two"] span:nth-child(1)',
+  'span[class*="two"] span:nth-child(2), span[class*="two"] span:nth-child(1)',
   'span[class~="two"] span:first-child, span[class~="two"] span:nth-child(2)',
+  'span[class*="two"] span:first-child, span[class*="two"] span:nth-child(2)',
   'span[class~="two"] span:nth-child(2), span[class~="two"] span:first-child',
+  'span[class*="two"] span:nth-child(2), span[class*="two"] span:first-child',
   'span[class~="two"] span:nth-of-type(-n+2)',
+  'span[class*="two"] span:nth-of-type(-n+2)',
   'span[class~="two"] span:nth-child(-n+2)',
+  'span[class*="two"] span:nth-child(-n+2)',
   'span[class~="two"] > :nth-child(1), span[class~="two"] > :nth-child(2)',
+  'span[class*="two"] > :nth-child(1), span[class*="two"] > :nth-child(2)',
   'span[class~="two"] > :nth-child(2), span[class~="two"] > :nth-child(1)',
+  'span[class*="two"] > :nth-child(2), span[class*="two"] > :nth-child(1)',
   'span[class~="two"] > :first-child, span[class~="two"] > :nth-child(2)',
+  'span[class*="two"] > :first-child, span[class*="two"] > :nth-child(2)',
   'span[class~="two"] > :nth-child(2), span[class~="two"] > :first-child',
+  'span[class*="two"] > :nth-child(2), span[class*="two"] > :first-child',
   'span[class~="two"] > :first-child, span[class~="two"] > :nth-of-type(2)',
+  'span[class*="two"] > :first-child, span[class*="two"] > :nth-of-type(2)',
   'span[class~="two"] > :nth-of-type(2), span[class~="two"] > :first-child',
+  'span[class*="two"] > :nth-of-type(2), span[class*="two"] > :first-child',
   'span[class~="two"] > :nth-of-type(-n+2)',
+  'span[class*="two"] > :nth-of-type(-n+2)',
   'span[class~="two"] > :nth-child(-n+2)',
+  'span[class*="two"] > :nth-child(-n+2)',
   'span[class~="two"] > span:nth-child(1), span[class~="two"] > span:nth-child(2)',
+  'span[class*="two"] > span:nth-child(1), span[class*="two"] > span:nth-child(2)',
   'span[class~="two"] > span:nth-child(2), span[class~="two"] > span:nth-child(1)',
+  'span[class*="two"] > span:nth-child(2), span[class*="two"] > span:nth-child(1)',
   'span[class~="two"] > span:first-child, span[class~="two"] > span:nth-child(2)',
+  'span[class*="two"] > span:first-child, span[class*="two"] > span:nth-child(2)',
   'span[class~="two"] > span:nth-child(2), span[class~="two"] > span:first-child',
+  'span[class*="two"] > span:nth-child(2), span[class*="two"] > span:first-child',
   'span[class~="two"] > span:nth-of-type(-n+2)',
-  'span[class~="two"] > span:nth-child(-n+2)'
-  ]
+  'span[class*="two"] > span:nth-of-type(-n+2)',
+  'span[class~="two"] > span:nth-child(-n+2)',
+  'span[class*="two"] > span:nth-child(-n+2)'
+]
 
 assert.isTrue(new __helpers.CSSHelp(document).getStyleAny(selectors)?.backgroundImage.includes('linear-gradient(')) 
 ```
 
-You should have an attribute selector to target the `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value.
+You should have an attribute selector to target the `span` elements that are descendants of `span` elements whose `class` value contains `three`.
 
 ```js
 const selectors = [
   'span[class~="three"] span',
-  'span[class~="three"] > span'
+  'span[class*="three"] span',
+  'span[class~="three"] > span',
+  'span[class*="three"] > span'
 ]
 assert.exists(new __helpers.CSSHelp(document).getStyleAny(selectors));
 ```
 
-You should use an attribute selector to target the `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
+You should use an attribute selector to target the `span` elements that are descendants of `span` elements whose `class` value contains `three` and set their `background-image` property to use a `linear-gradient`.
 
 ```js
 const selectors = [
   'span[class~="three"] span',
-  'span[class~="three"] > span'
+  'span[class*="three"] span',
+  'span[class~="three"] > span',
+  'span[class*="three"] > span'
 ]
 assert.include(new __helpers.CSSHelp(document).getStyleAny(selectors)?.getPropVal('background-image'), 'linear-gradient(');
 ```


### PR DESCRIPTION
### Summary of Changes
This PR updates the "Build a Book Inventory App" lab to be more flexible with CSS attribute selectors for the "one", "two", and "three" rating classes (Tests 48-53). 

Previously, the tests strictly required the word-match operator `[class~="word"]`. However, the substring-match operator `[class*="substring"]` also produces the same visual result and is a technically valid CSS approach in this context. The existing strictness caused significant confusion for learners who used `*=` and saw the correct visual output but were blocked by failing tests.

### Specific Changes
- **Updated User Stories**: Modified steps 30, 31, and 32 to use the phrase "class value contains" instead of "have the word," making the instructions more inclusive of different valid selectors.
- **Expanded Test Selectors**: Updated hint selectors 48-53 to include both `~=` and `*=` variations.
- **Updated Hint Descriptions**: Revised the wording of the failing test messages to stay consistent with the updated instructions.

### Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

