### PR TITLE
fix(curriculum): clarify attribute selector operator in book inventory lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
+++ b/curriculum/challenges/english/blocks/lab-book-inventory-app/66a207974c806a19d6607073.md
@@ -27,9 +27,9 @@ saveSubmissionToDB: true
 1. You should use an attribute selector to target the `span` elements with the class of `status` that are descendants of `tr` elements with the class of `in-progress` and set their `border` and `background-image` properties.
 1. You should use an attribute selector to target the `span` elements with the class of `status` and the `span` elements with the class value starting with `rate` and set their `height`, `width`, and `padding` properties.
 1. You should use an attribute selector to target the `span` elements which are direct children of `span` elements with the `class` value starting with `rate` and set their `border`, `border-radius`, `margin`, `height`, `width`, and `background-color` properties.
-1. You should use an attribute selector to target the first descendant of `span` elements that have the word `one` as a part of their `class` value and set its `background-image` property to use a `linear-gradient`.
-1. You should use an attribute selector to target the first two descendants of `span` elements that have the word `two` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
-1. You should use an attribute selector to target the three `span` elements that are descendants of `span` elements that have the word `three` as a part of their `class` value and set their `background-image` property to use a `linear-gradient`.
+1. You should use the `~=` attribute selector to target the first descendant of `span` elements whose class list includes the word `one` and set its `background-image` property to use a `linear-gradient`.
+1. You should use the `~=` attribute selector to target the first two descendants of `span` elements whose class list includes the word `two` and set their `background-image` property to use a `linear-gradient`.
+1. You should use the `~=` attribute selector to target the three `span` elements that are descendants of `span` elements whose class list includes the word `three` and set their `background-image` property to use a `linear-gradient`.
 
 # --hints--
 


### PR DESCRIPTION
Update the instructions for the Book Inventory lab to use the ~= attribute selector when targeting class values like "one", "two", and "three".
I noticed the instructions only mentioned using an attribute selector without specifying the operator. The tests expect ~=, but *= produces similar visual results and does not pass, which can be confusing.
This change makes the expected selector explicit in the instructions.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66786