### PR TITLE
fix(client):  add anchor links to curriculum section headings

### DIFF
--- a/client/src/templates/Introduction/components/block-header.test.tsx
+++ b/client/src/templates/Introduction/components/block-header.test.tsx
@@ -38,11 +38,31 @@ describe('<BlockHeader />', () => {
       />
     );
 
-    const link = screen.getByRole('link');
+    const links = screen.getAllByRole('link', { name: /test block title/i });
+    const link = links.find(el => el.classList.contains('block-header'));
+
+    expect(link).toBeDefined();
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', '/learn/test-block');
     expect(link).not.toHaveAttribute('aria-expanded');
     expect(link).not.toHaveAttribute('aria-controls');
+  });
+
+  it('should render an anchor link for direct navigation when blockUrl is provided in accordion mode', () => {
+    render(
+      <BlockHeader
+        {...defaultProps}
+        accordion={true}
+        blockUrl='/learn/test-block'
+        onLinkClick={() => {}}
+      />
+    );
+
+    const anchorLink = screen.getByRole('link', {
+      name: 'Direct link to Test Block Title'
+    });
+    expect(anchorLink).toBeInTheDocument();
+    expect(anchorLink).toHaveAttribute('href', '#test-block');
   });
 
   it('should set aria-expanded to true when isExpanded is true', () => {

--- a/client/src/templates/Introduction/components/block-header.tsx
+++ b/client/src/templates/Introduction/components/block-header.tsx
@@ -92,6 +92,13 @@ function BlockHeader({
             <InnerBlockHeader />
           </Button>
         )}
+        <a
+          href={`#${blockDashed}`}
+          className='block-anchor-link'
+          aria-label={`Direct link to ${blockTitle}`}
+        >
+          <span aria-hidden='true'>#</span>
+        </a>
       </h3>
       {isExpanded && !isEmpty(blockIntroArr) && (
         <BlockIntros intros={blockIntroArr as string[]} />

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -406,7 +406,7 @@ export class Block extends Component<BlockProps> {
     const AccordionBlock = accordion ? (
       <>
         <Element name={block}>
-          <span className='hide-scrollable-anchor'></span>
+          <span className='hide-scrollable-anchor' id={block}></span>
         </Element>
         <div
           className={`block block-grid block-grid-no-border challenge-grid-block ${isExpanded ? 'open' : ''}`}
@@ -462,7 +462,7 @@ export class Block extends Component<BlockProps> {
     ) : (
       <>
         <Element name={block}>
-          <span className='hide-scrollable-anchor'></span>
+          <span className='hide-scrollable-anchor' id={block}></span>
         </Element>
         <div
           className={`block block-grid challenge-grid-block ${isExpanded ? 'open' : ''}`}
@@ -521,7 +521,7 @@ export class Block extends Component<BlockProps> {
     const LinkBlock = (
       <>
         <Element name={block}>
-          <span className='hide-scrollable-anchor'></span>
+          <span className='hide-scrollable-anchor' id={block}></span>
         </Element>
         <BlockHeader
           blockDashed={block}

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -121,6 +121,28 @@ a.cert-tag:active {
   font-size: 1rem;
   margin: 0;
   overflow-wrap: break-word;
+  position: relative;
+}
+
+.block-anchor-link {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  color: var(--quaternary-color);
+  text-decoration: none;
+  font-size: 0.85rem;
+  padding: 4px 6px;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.block-grid-title:hover .block-anchor-link,
+.block-anchor-link:focus {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .block-grid .challenge-jump-link {

--- a/e2e/block-navigation.spec.ts
+++ b/e2e/block-navigation.spec.ts
@@ -77,7 +77,8 @@ test.describe('Block Navigation - Hash Updates', () => {
 
     // Click on the certification project link
     const projectLink = page.getByRole('link', {
-      name: 'Build a Markdown to HTML Converter'
+      name: 'Build a Markdown to HTML Converter , Not started Certification Project',
+      exact: true
     });
     await expect(projectLink).toBeVisible();
     await projectLink.click();


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62555

## Impact: 

Users can now hover over a block heading, click the # icon that appears, and get a shareable URL that directly links to that section


https://github.com/user-attachments/assets/2c17d2fb-e1f1-4a3b-89df-61e907aca450

