### PR TITLE
feat: increase socrates description max length

### DIFF
--- a/api/src/schemas/socrates/ask-socrates.ts
+++ b/api/src/schemas/socrates/ask-socrates.ts
@@ -13,7 +13,7 @@ const usageFields = {
 export const askSocrates = {
   body: Type.Object(
     {
-      description: Type.String({ minLength: 1, maxLength: 2000 }),
+      description: Type.String({ minLength: 1, maxLength: 10000 }),
       userInput: Type.Optional(Type.String({ minLength: 1, maxLength: 50000 })),
       seed: Type.String({ minLength: 1, maxLength: 50000 }),
       hints: Type.Array(socratesHint, { maxItems: 200 })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66871

<!-- Feel free to add any additional description of changes below this line -->
This PR increases the maxLength for the Socrates description field from 2000 to 5000. This resolves a validation error where longer prompts (like those in the Mood Board lab) were being rejected by the API with a 400 Bad Request.