### PR TITLE
fix(curriculum): replace deepEqual with property-based assertions in …

### DIFF
--- a/curriculum/challenges/english/blocks/lab-project-idea-board/67051431a73f1ca25d9a6f25.md
+++ b/curriculum/challenges/english/blocks/lab-project-idea-board/67051431a73f1ca25d9a6f25.md
@@ -190,7 +190,7 @@ let smartHome = new ProjectIdea(
 let techProjects = new ProjectIdeaBoard("Tech Projects Board");
 techProjects.pin(smartHome);
 
-// Correct the assertion to compare the first idea in the array
+// Correct the assertions to compare the first idea in the array
 assert.equal(techProjects.ideas[0].title, "Smart Home System");
 assert.equal(
   techProjects.ideas[0].description,

--- a/curriculum/challenges/english/blocks/lab-project-idea-board/67051431a73f1ca25d9a6f25.md
+++ b/curriculum/challenges/english/blocks/lab-project-idea-board/67051431a73f1ca25d9a6f25.md
@@ -191,11 +191,15 @@ let techProjects = new ProjectIdeaBoard("Tech Projects Board");
 techProjects.pin(smartHome);
 
 // Correct the assertion to compare the first idea in the array
-assert.deepEqual(techProjects.ideas[0], {
-    title: 'Smart Home System',
-    description: 'An integrated system to control lighting, temperature, and security devices remotely.',
-    status: { description: 'Pending Execution' }
-});
+assert.equal(techProjects.ideas[0].title, "Smart Home System");
+assert.equal(
+  techProjects.ideas[0].description,
+  "An integrated system to control lighting, temperature, and security devices remotely."
+);
+assert.equal(
+  techProjects.ideas[0].status.description,
+  "Pending Execution"
+);
 ```
 
 You should be able to unpin a `ProjectIdea` object to your `ProjectIdeaBoard` using the `unpin` method.


### PR DESCRIPTION
## Description
Fixes an issue in the "Build a Project Idea Board" challenge where a test relied on strict deep object comparison.

## Problem
The existing test used `assert.deepEqual` to compare entire objects. This can cause valid user solutions to fail due to differences in object references or internal structure, even when the implementation is correct.

## Solution
Replaced the deep object comparison with property-based assertions. This ensures that the test validates the required fields (`title`, `description`, and `status.description`) without being overly restrictive.

## Result
- Improves test reliability  
- Prevents false negatives for correct solutions  
- Maintains correct validation of expected behavior  

---

## Related Issue
Reference: https://github.com/freeCodeCamp/freeCodeCamp/issues/66832

---

## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally (curriculum update).