### PR TITLE
fix(api): show signout success flash message on signout

### DIFF
--- a/api/src/routes/public/signout.test.ts
+++ b/api/src/routes/public/signout.test.ts
@@ -28,9 +28,10 @@ describe('GET /signout', () => {
     expect(setCookie).toHaveLength(3);
   });
 
-  it('should respond with an empty object', async () => {
+  it('should respond with a success message', async () => {
     const res = await superRequest('/signout', { method: 'GET' });
-    expect(res.body).toEqual({});
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(302);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.headers.location).toContain('/learn');
   });
 });

--- a/api/src/routes/public/signout.ts
+++ b/api/src/routes/public/signout.ts
@@ -1,4 +1,5 @@
 import type { FastifyPluginCallback } from 'fastify';
+import { HOME_LOCATION } from '../../utils/env.js';
 
 import { signout } from '../../schemas.js';
 
@@ -26,7 +27,10 @@ export const signoutRoute: FastifyPluginCallback = (
       void reply.clearOurCookies();
       logger.info('User signed out');
 
-      await reply.send({});
+      void reply.redirectWithMessage(`${HOME_LOCATION}/learn`, {
+        type: 'success',
+        content: 'flash.signout-success'
+      });
     }
   );
   done();

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -1072,6 +1072,7 @@
     "oops-not-right": "Oops, something is not right, please request a fresh link to sign in / sign up",
     "expired-link": "Looks like the link you clicked has expired, please request a fresh link, to sign in",
     "signin-success": "Success! You have signed in to your account. Happy Coding!",
+    "signout-success": "Success! You have signed out of your account. Happy Coding!",
     "social-auth-gone": "We are moving away from social authentication for privacy reasons. Next time we recommend using your email address: {{email}} to sign in instead.",
     "name-needed": "We need your name to put it on your certification. Please add your name in your profile and click save. Then we can issue your certification.",
     "incomplete-steps": "It looks like you have not completed the necessary steps. Please complete the required projects to claim the {{name}} Certification.",


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66515

## Description
After logging out, the success message incorrectly showed "You have signed in to your account". This fix updates the signout route to redirect with a new `flash.signout-success` message instead.

## Changes
- Updated signout route to use `redirectWithMessage` with `flash.signout-success`
- Added `signout-success` translation key to `translations.json`
- Updated signout tests to reflect new redirect behavior

## Testing
Tested locally. All signout tests pass.