### PR TITLE
fix(curriculum): enable bubbling for click event in lightbox test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
+++ b/curriculum/challenges/english/blocks/lab-lightbox-viewer/66db57ad34c7089b9b41bfd6.md
@@ -178,7 +178,7 @@ function getComputedDisplay(element) {
 assert.strictEqual(getComputedDisplay(lightbox), "none");
 
 const galleryItem = document.querySelector(".gallery-item");
-galleryItem.dispatchEvent(new Event("click"));
+galleryItem.dispatchEvent(new Event("click",{ bubbles : true}));
 
 assert.strictEqual(getComputedDisplay(lightbox), "flex");
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66899 

<!-- Feel free to add any additional description of changes below this line -->

### Description

One of the tests for the Lightbox Viewer challenge dispatches a click event without enabling bubbling:

```js
galleryItem.dispatchEvent(new Event("click"));
```

This causes valid solutions that use event delegation on the .gallery element to fail, since the event does not bubble up to the parent.

This PR updates the test to:
```js

galleryItem.dispatchEvent(new Event("click", { bubbles: true }));
```

so that the event behaves like a real user click. This makes the test consistent with other click tests in the challenge and allows delegated handlers to work correctly.
