### PR TITLE
fix: mention top-level module body in async/await lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
@@ -9,7 +9,7 @@ dashedName: what-is-async-await-and-how-does-it-work
 
 In the previous lessons, you learned about asynchronous programming which allows other code to run while we wait for some time-consuming tasks to complete, like fetching data from a server, reading data from a file, and so on.
 
-`async`/`await`, built on top of promises, makes writing and reading asynchronous code easier. When you put the `async` keyword before a function, it means that function will always return a `Promise`. Only inside an `async` function, you can use the `await` keyword, which allows you to wait for a `Promise` to resolve before moving on to the next line of code. Here's an example to illustrate how `async`/`await` works:
+`async`/`await`, built on top of promises, makes writing and reading asynchronous code easier. When you put the `async` keyword before a function, it means that function will always return a `Promise`. The `await` keyword, which allows you to wait for a `Promise` to resolve before moving on to the next line of code, can only be used inside of asynchronous functions or the top level bodies of modules. Here's an example to illustrate how `async`/`await` works:
 
 :::interactive_editor
 
@@ -108,7 +108,7 @@ Consider the restrictions on where `await` can be placed.
 
 ---
 
-Inside `async` functions.
+Inside `async` functions or at the top level of a module.
 
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66932

## Summary

The async/await lecture currently states that `await` can only be used inside an `async` function, which is incomplete. Since ES2022, `await` can also be used at the top level of ES modules (top-level await).

## Changes

**Lecture prose** — updated the key sentence from:
> "Only inside an `async` function, you can use the `await` keyword, which allows you to wait for a `Promise` to resolve before moving on to the next line of code."

to:
> "The `await` keyword, which allows you to wait for a `Promise` to resolve before moving on to the next line of code, can only be used inside of asynchronous functions or the top level bodies of modules."

**Quiz answer** — updated the correct answer for question 2 ("Where can the `await` keyword be used?") from "Inside `async` functions." to "Inside `async` functions or at the top level of a module." to match the updated content.

This change was reviewed and approved in the issue thread by @naomi-lgbt.