### PR TITLE
fix(curriculum): clarify async/await explanation in lecture content

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
@@ -9,7 +9,7 @@ dashedName: what-is-async-await-and-how-does-it-work
 
 In the previous lessons, you learned about asynchronous programming which allows other code to run while we wait for some time-consuming tasks to complete, like fetching data from a server, reading data from a file, and so on.
 
-`async`/`await`, built on top of promises, makes writing and reading asynchronous code easier. When you put the `async` keyword before a function, it means that function will always return a `Promise`. Only inside an `async` function, you can use the `await` keyword, which allows you to wait for a `Promise` to resolve before moving on to the next line of code. Here's an example to illustrate how `async`/`await` works:
+`async`/`await`, built on top of promises, makes writing and reading asynchronous code easier. When you put the `async` keyword before a function, it means that function will always return a `Promise`. The `await` keyword, which allows you to wait for a `Promise` to resolve before moving on to the next line of code, can only be used inside of asynchronous functions or the top level bodies of modules. Here's an example to illustrate how `async`/`await` works:
 
 :::interactive_editor
 


### PR DESCRIPTION

## Description

Updates the async/await lecture to clarify where the `await` keyword can be used.

The original text stated that `await` can only be used inside an `async` function, which is incomplete. The corrected text also mentions that `await` can be used at the top level of module bodies.

**Before:**
> Only inside an `async` function, you can use the `await` keyword, which allows you to wait for a `Promise` to resolve before moving on to the next line of code.

**After:**
> The `await` keyword, which allows you to wait for a `Promise` to resolve before moving on to the next line of code, can only be used inside of asynchronous functions or the top level bodies of modules.

## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66932