### PR TITLE
fix(curriculum): add context for method chaining and this keyword

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362cbb475e21eab726506.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362cbb475e21eab726506.md
@@ -61,33 +61,37 @@ While method chaining can make code more concise and readable, it's important to
 
 Very long chains can become difficult to debug, as it's not immediately clear which step in the chain might be causing an issue. It's often a good practice to break very long chains into multiple steps for better clarity and easier debugging.
 
-You can also chain methods on an object. In this case, each method returns `this`, which means the current object instance, so the next method can run on the same object.
+You can also chain methods on an object. In this case, each method returns `this`, which refers to the current object, allowing the next method in the chain to run on it.
 
 :::interactive_editor
 
 ```js
-const counter = {
-  value: 1,
+const calculator = {
+  total: 0,
   add(n) {
-    this.value += n;
+    this.total += n;
     return this;
   },
-  double() {
-    this.value *= 2;
+  multiply(n) {
+    this.total *= n;
     return this;
   },
-  getValue() {
-    return this.value;
+  subtract(n) {
+    this.total -= n;
+    return this;
+  },
+  getResult() {
+    return this.total;
   }
 };
 
-const result = counter.add(2).double().getValue();
-console.log(result); // 6
+const result = calculator.add(5).multiply(2).subtract(3).getResult();
+console.log(result); // 7
 ```
 
 :::
 
-This provides context for how method chaining works with objects and introduces the role of `this` before moving to the quiz.
+This way, each method returns the same object, so you can keep chaining calls one after another.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362cbb475e21eab726506.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362cbb475e21eab726506.md
@@ -61,6 +61,34 @@ While method chaining can make code more concise and readable, it's important to
 
 Very long chains can become difficult to debug, as it's not immediately clear which step in the chain might be causing an issue. It's often a good practice to break very long chains into multiple steps for better clarity and easier debugging.
 
+You can also chain methods on an object. In this case, each method returns `this`, which means the current object instance, so the next method can run on the same object.
+
+:::interactive_editor
+
+```js
+const counter = {
+  value: 1,
+  add(n) {
+    this.value += n;
+    return this;
+  },
+  double() {
+    this.value *= 2;
+    return this;
+  },
+  getValue() {
+    return this.value;
+  }
+};
+
+const result = counter.add(2).double().getValue();
+console.log(result); // 6
+```
+
+:::
+
+This provides context for how method chaining works with objects and introduces the role of `this` before moving to the quiz.
+
 # --questions--
 
 ## --text--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66925 

<!-- Feel free to add any additional description of changes below this line -->

### Description

The Method Chaining lesson introduces object-based chaining using `this` without prior context, which can confuse learners.

This PR adds a short explanation and example before the quiz section (as suggested) to clarify how method chaining works with objects and the role of `this`.
