### PR TITLE
fix(curriculum): repair failing tests for doubly linked list challenge

### DIFF
--- a/curriculum/challenges/english/blocks/data-structures/587d825a367417b2b2512c87.md
+++ b/curriculum/challenges/english/blocks/data-structures/587d825a367417b2b2512c87.md
@@ -155,39 +155,41 @@ assert(
 # --before-each--
 
 ```js
-DoublyLinkedList.prototype = Object.assign(
-  DoublyLinkedList.prototype,
-  {
-  
-  print() {
-    if (this.head == null) {
-      return null;
-    } else {
-      var result = new Array();
-      var node = this.head;
-      while (node.next != null) {
+if (typeof DoublyLinkedList !== 'undefined') {
+  DoublyLinkedList.prototype = Object.assign(
+    DoublyLinkedList.prototype,
+    {
+
+    print() {
+      if (this.head == null) {
+        return null;
+      } else {
+        var result = new Array();
+        var node = this.head;
+        while (node.next != null) {
+          result.push(node.data);
+          node = node.next;
+        };
         result.push(node.data);
-        node = node.next;
+        return result;
       };
-      result.push(node.data);
-      return result;
-    };
-  },
-  printReverse() {
-    if (this.tail == null) {
-      return null;
-    } else {
-      var result = new Array();
-      var node = this.tail;
-      while (node.prev != null) {
+    },
+    printReverse() {
+      if (this.tail == null) {
+        return null;
+      } else {
+        var result = new Array();
+        var node = this.tail;
+        while (node.prev != null) {
+          result.push(node.data);
+          node = node.prev;
+        };
         result.push(node.data);
-        node = node.prev;
+        return result;
       };
-      result.push(node.data);
-      return result;
-    };
-  }
-});
+    }
+  });
+}
 ```
 
 # --seed--


### PR DESCRIPTION
## Description

Fixes failing tests for the "Create a Doubly Linked List" challenge by 
guarding the `--before-each--` prototype assignment with a `typeof` check.

When the test runner evaluates the hook before the constructor is available, 
it throws:
`TypeError: Cannot read properties of undefined (reading 'prototype')`

This change prevents that crash and allows the challenge tests to run as intended.

**Demo:**
[Before & After comparison video]
https://github.com/user-attachments/assets/7bd7bb1a-a917-4b5f-89eb-ee60a91b479c

## Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66922