### PR TITLE
fix(curriculum): correct WeakSet example with valid references

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-maps-and-sets/6733ab269b378bf724c9ac71.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-maps-and-sets/6733ab269b378bf724c9ac71.md
@@ -218,13 +218,18 @@ const treeWeakSet = new WeakSet();
 ```javascript
 const treeWeakSet = new WeakSet();
 
-treeWeakSet.add({ name: 'Baobab' });
-treeWeakSet.add({ name: 'Jackalberry' });
-treeWeakSet.add({ name: 'Mopane Tree' });
-treeWeakSet.add({ name: 'Breadfruit' });
+const baobab = { name: "Baobab" };
+const jackalberry = { name: "Jackalberry" };
+const mopaneTree = { name: "Mopane Tree" };
+const breadfruit = { name: "Breadfruit" };
 
-treeWeakSet.delete('Jackalberry');
-console.log(treeWeakSet.has('Jackalberry')); // false
+treeWeakSet.add(baobab);
+treeWeakSet.add(jackalberry);
+treeWeakSet.add(mopaneTree);
+treeWeakSet.add(breadfruit);
+
+treeWeakSet.delete(jackalberry);
+console.log(treeWeakSet.has(jackalberry)); // false
 
 console.log(treeWeakSet);
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Updated the WeakSet example to pass object variables to treeWeakSet.add() instead of object literals, and to pass an object variable to treeWeakSet.has() instead of a string.

1. Passing an object literal directly to .add() leaves no variable that points to the added object, so there is no way to reference it later. A subsequent .has() call with a literal that looks identical will still return false, because each literal evaluates to a distinct object and WeakSet compares entries by reference identity.
2. Separately, because WeakSet holds only weak references, an object added via a bare literal has no remaining strong reference once the statement completes, making it eligible for garbage collection and potentially disappearing from the WeakSet before any later check.
3. Passing a string to .has() always returns false, because WeakSet can only store objects.