### PR TITLE
fix: use session-user endpoint on client

### DIFF
--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -153,7 +153,7 @@ export function getSessionUser(
   signal?: AbortSignal
 ): Promise<ResponseWithData<User | null>> {
   const responseWithData: Promise<ResponseWithData<ApiUserResponse>> = get(
-    '/user/get-session-user',
+    '/user/session-user',
     signal
   );
   // TODO: Once DB is migrated, no longer need to parse `files` -> `challengeFiles` etc.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #XXXXX

This updates the client session-user request to use the new endpoint:

- `GET /user/session-user` is now used by `getSessionUser` in the client ajax helper.
- Backward compatibility is preserved because the server still supports `GET /user/get-session-user`.

Validation performed:

- `pnpm -C client lint src/utils/ajax.ts`
