### PR TITLE
fix(curriculum): fix remove method in doubly linked list solution

### DIFF
--- a/curriculum/challenges/english/blocks/data-structures/587d825a367417b2b2512c87.md
+++ b/curriculum/challenges/english/blocks/data-structures/587d825a367417b2b2512c87.md
@@ -212,5 +212,71 @@ var DoublyLinkedList = function() {
 # --solutions--
 
 ```js
-// solution required
+var Node = function(data, prev) {
+  this.data = data;
+  this.prev = prev;
+  this.next = null;
+};
+
+var DoublyLinkedList = function() {
+  this.head = null;
+  this.tail = null;
+  // Only change code below this line
+
+  this.add = function (data) {
+    let node = new Node(data, this.tail);
+    if (!this.head) {
+      this.head = node;
+      this.tail = node;
+    } else {
+      let tempNode = this.tail;
+      tempNode.next = node;
+      this.tail = node;
+    }
+  };
+
+  this.remove = function (data) {
+    if (this.head === null) return null;
+
+    let tempNode = this.head;
+
+    while (tempNode !== this.tail) {
+      if (tempNode.data === data) {
+
+        if (tempNode === this.head) {
+          this.head = tempNode.next;
+
+          if (this.head) {
+            this.head.prev = null;
+          } else {
+            this.tail = null;
+          }
+
+        } else {
+          let prevNode = tempNode.prev;
+          prevNode.next = tempNode.next;
+
+          if (tempNode.next) {
+            tempNode.next.prev = prevNode;
+          }
+        }
+      }
+
+      tempNode = tempNode.next;
+    }
+
+    if (tempNode && tempNode.data === data) {
+      this.tail = tempNode.prev;
+
+      if (this.tail) {
+        this.tail.next = null;
+      } else {
+        this.head = null;
+      }
+    }
+  };
+
+  // Only change code above this line
+};
+
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66922 
<!-- Feel free to add any additional description of changes below this line -->
## Description

The suggested solution for the "Create a Doubly Linked List" challenge was not passing the tests due to issues in the `remove` method.

## Issue
- The `prev` pointer of the next node was not updated when removing a node
- Unsafe operations could cause errors when `next` or `prev` was `null`
- Edge cases like removing the only node did not correctly reset both `head` and `tail`

## Fix

- Added missing pointer update:
   `if (tempNode.next) {tempNode.next.prev = prevNode;}`
- Added null-safe handling for head removal:
   `if (this.head) {this.head.prev = null; } else {this.tail = null;}`
- Added null-safe handling for tail removal:
   `if (this.tail) {this.tail.next = null; } else { this.head = null;}`
