### PR TITLE
fix(api): prevent duplicate challenge submissions #66964

### DIFF
--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -1231,15 +1231,34 @@ async function postModernChallengeCompleted(
     where: { id: userId },
     select: userChallengeSelect
   });
-  const RawProgressTimestamp = user.progressTimestamps as
+
+  const rawProgressTimestamp = user.progressTimestamps as
     | ProgressTimestamp[]
     | null;
-  const points = getPoints(RawProgressTimestamp);
+  const points = getPoints(rawProgressTimestamp);
+
+  // Prevent duplicate submissions from rapid repeated requests.
+  const existingChallenge = user.completedChallenges?.find(c => c.id === id);
+  const duplicateSubmissionWindowMs = 10_000;
+  const now = Date.now();
+
+  if (
+    existingChallenge &&
+    typeof existingChallenge.completedDate === 'number' &&
+    now - existingChallenge.completedDate < duplicateSubmissionWindowMs
+  ) {
+    return {
+      alreadyCompleted: true,
+      points,
+      completedDate: existingChallenge.completedDate,
+      savedChallenges: user.savedChallenges
+    };
+  }
 
   const completedChallenge: CompletedChallenge = {
     id,
     files,
-    completedDate: Date.now()
+    completedDate: now
   };
 
   if (challengeType === challengeTypes.multifileCertProject) {


### PR DESCRIPTION
## PR: Prevent Duplicate Challenge Submissions

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66964

## Description of changes

This PR adds a safeguard in `postModernChallengeCompleted` to prevent duplicate challenge submissions caused by rapid repeated requests (e.g. double-clicking the “Check my code / Submit and continue” button).

Previously, multiple requests sent in quick succession could result in the same challenge being saved multiple times in a user’s timeline.

## Changes

### Duplicate Submission Guard
Introduced a short time-based check before updating user data. If the challenge was completed very recently, the API returns the existing completion data instead of performing another write.

### Return Existing State
When a duplicate submission is detected, the API returns the existing `completedDate`, `points`, and `savedChallenges`, preserving the expected response shape and avoiding redundant database updates.

### Code Improvements
- Replaced repeated `Date.now()` calls with a single `now` variable for consistency  
- Renamed `RawProgressTimestamp` to `rawProgressTimestamp` for improved readability  

## Notes on Testing

- Passed local linting, TypeScript checks, and formatting (`pnpm run lint`)
- Manually tested rapid repeated submissions to confirm duplicate entries are no longer created
- Change is scoped and does not modify database schema or existing data structures