### PR TITLE
fix(api): prevent duplicate timeline entries on rapid submission

### DIFF
--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -58,7 +58,8 @@ const userChallengeSelect = {
   partiallyCompletedChallenges: true,
   progressTimestamps: true,
   needsModeration: true,
-  savedChallenges: true
+  savedChallenges: true,
+  updateCount: true
 };
 
 /**

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -1000,7 +1000,8 @@ async function postCoderoadChallengeCompleted(
     const { userId } = tokenInfo;
 
     const user = await this.prisma.user.findFirstOrThrow({
-      where: { id: userId }
+      where: { id: userId },
+      select: userChallengeSelect
     });
 
     if (!user) {

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -2,7 +2,7 @@ import { type FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebo
 import jwt from 'jsonwebtoken';
 import { CompletedExam, ExamResults, SavedChallengeFile } from '@prisma/client';
 import type { FastifyBaseLogger, FastifyInstance, FastifyReply } from 'fastify';
-import { uniqBy, matches } from 'lodash-es';
+import { matches } from 'lodash-es';
 
 import validator from 'validator';
 
@@ -1013,8 +1013,7 @@ async function postCoderoadChallengeCompleted(
     }
 
     const completedDate = Date.now();
-    const { completedChallenges = [], partiallyCompletedChallenges = [] } =
-      user;
+    const { completedChallenges = [] } = user;
 
     const isCompleted = completedChallenges.some(
       challenge => challenge.id === challengeId
@@ -1026,13 +1025,13 @@ async function postCoderoadChallengeCompleted(
         completedDate
       };
 
-      await this.prisma.user.update({
-        where: { id: userId },
+      await this.prisma.user.updateMany({
+        where: {
+          id: userId,
+          partiallyCompletedChallenges: { none: { id: challengeId } }
+        },
         data: {
-          partiallyCompletedChallenges: uniqBy(
-            [finalChallenge, ...partiallyCompletedChallenges],
-            'id'
-          )
+          partiallyCompletedChallenges: { push: finalChallenge }
         }
       });
     } else {
@@ -1141,27 +1140,28 @@ async function postDailyCodingChallengeCompleted(
       languages: [language]
     };
 
-    const newCompletedChallenges = [
-      ...completedDailyCodingChallenges,
-      newCompletedChallenge
-    ];
-
     const newProgressTimestamps = Array.isArray(progressTimestamps)
       ? [...progressTimestamps, newCompletedDate]
       : [newCompletedDate];
 
-    await this.prisma.user.update({
-      where: { id: req.user?.id },
-      data: {
-        completedDailyCodingChallenges: newCompletedChallenges,
-        progressTimestamps: newProgressTimestamps
-      }
-    });
+    const { completedDailyCodingChallenges: updatedChallenges } =
+      await this.prisma.user.update({
+        where: { id: req.user?.id },
+        select: {
+          completedDailyCodingChallenges: true
+        },
+        data: {
+          completedDailyCodingChallenges: {
+            push: newCompletedChallenge
+          },
+          progressTimestamps: newProgressTimestamps
+        }
+      });
     return reply.send({
       alreadyCompleted,
       points: points + 1,
       completedDate: newCompletedDate,
-      completedDailyCodingChallenges: newCompletedChallenges
+      completedDailyCodingChallenges: updatedChallenges
     });
   }
 }

--- a/api/src/utils/common-challenge-functions.test.ts
+++ b/api/src/utils/common-challenge-functions.test.ts
@@ -89,4 +89,52 @@ describe('updateUserChallengeData', () => {
     // Called twice: once after first lock miss to fetch fresh state, once after successful lock to get updated saved challenges
     expect(findUniqueOrThrow).toHaveBeenCalledTimes(2);
   });
+
+  it('returns latest persisted state when all OCC retries are exhausted', async () => {
+    const completedChallenge = {
+      id: 'challenge-1',
+      completedDate: 1713225600000
+    };
+
+    const user = {
+      id: 'user-1',
+      completedChallenges: [],
+      needsModeration: false,
+      savedChallenges: [],
+      progressTimestamps: [],
+      partiallyCompletedChallenges: [],
+      updateCount: 0
+    };
+
+    const persistedUser = {
+      ...user,
+      completedChallenges: [completedChallenge]
+    };
+
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const findUniqueOrThrow = vi.fn().mockResolvedValue(persistedUser);
+
+    const fastify = {
+      prisma: {
+        user: {
+          updateMany,
+          findUniqueOrThrow
+        }
+      }
+    } as const;
+
+    const result = await updateUserChallengeData(
+      fastify as never,
+      user,
+      completedChallenge.id,
+      completedChallenge
+    );
+
+    expect(result).toEqual({
+      alreadyCompleted: true,
+      completedDate: completedChallenge.completedDate,
+      userSavedChallenges: []
+    });
+    expect(updateMany).toHaveBeenCalledTimes(10);
+  });
 });

--- a/api/src/utils/common-challenge-functions.test.ts
+++ b/api/src/utils/common-challenge-functions.test.ts
@@ -137,4 +137,63 @@ describe('updateUserChallengeData', () => {
     });
     expect(updateMany).toHaveBeenCalledTimes(10);
   });
+
+  it('does not throw when existing completions contain legacy date shapes', async () => {
+    const legacyChallenge = {
+      id: 'legacy-challenge',
+      completedDate: { $date: { $numberLong: '1713225600000' } }
+    };
+
+    const completedChallenge = {
+      id: 'challenge-1',
+      completedDate: 1713225600000
+    };
+
+    const user = {
+      id: 'user-1',
+      completedChallenges: [legacyChallenge],
+      needsModeration: false,
+      savedChallenges: [],
+      progressTimestamps: [],
+      partiallyCompletedChallenges: [],
+      updateCount: 0
+    };
+
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const findUniqueOrThrow = vi
+      .fn()
+      .mockResolvedValue({ savedChallenges: [] });
+
+    const fastify = {
+      prisma: {
+        user: {
+          updateMany,
+          findUniqueOrThrow
+        }
+      }
+    } as const;
+
+    await expect(
+      updateUserChallengeData(
+        fastify as never,
+        user as never,
+        completedChallenge.id,
+        completedChallenge
+      )
+    ).resolves.toMatchObject({
+      alreadyCompleted: false,
+      userSavedChallenges: []
+    });
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: 'user-1', updateCount: 0 },
+      data: {
+        completedChallenges: [legacyChallenge, completedChallenge],
+        needsModeration: undefined,
+        partiallyCompletedChallenges: [],
+        progressTimestamps: [1713225600000],
+        savedChallenges: []
+      }
+    });
+  });
 });

--- a/api/src/utils/common-challenge-functions.test.ts
+++ b/api/src/utils/common-challenge-functions.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { updateUserChallengeData } from './common-challenge-functions.js';
+
+describe('updateUserChallengeData', () => {
+  it('retries after a stale write and keeps a single completion entry', async () => {
+    const completedChallenge = {
+      id: 'challenge-1',
+      completedDate: 1713225600000
+    };
+
+    const firstUser = {
+      id: 'user-1',
+      completedChallenges: [],
+      needsModeration: false,
+      savedChallenges: [],
+      progressTimestamps: [],
+      partiallyCompletedChallenges: [],
+      updateCount: 0
+    };
+
+    const secondUser = {
+      ...firstUser,
+      completedChallenges: [completedChallenge],
+      updateCount: 1
+    };
+
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 });
+    const update = vi.fn();
+    const findUniqueOrThrow = vi.fn().mockResolvedValue(secondUser);
+    const transaction = vi.fn(
+      (
+        callback: (transaction: {
+          user: {
+            updateMany: typeof updateMany;
+            update: typeof update;
+          };
+        }) => Promise<{ count: number }>
+      ) => {
+        return callback({
+          user: {
+            updateMany,
+            update
+          }
+        });
+      }
+    );
+
+    const fastify = {
+      prisma: {
+        $transaction: transaction,
+        user: {
+          updateMany,
+          update,
+          findUniqueOrThrow
+        }
+      }
+    } as const;
+
+    const result = await updateUserChallengeData(
+      fastify as never,
+      firstUser,
+      completedChallenge.id,
+      completedChallenge
+    );
+
+    expect(result).toEqual({
+      alreadyCompleted: true,
+      completedDate: completedChallenge.completedDate,
+      userSavedChallenges: []
+    });
+
+    expect(updateMany).toHaveBeenCalledTimes(2);
+    expect(updateMany).toHaveBeenNthCalledWith(1, {
+      where: { id: 'user-1', updateCount: 0 },
+      data: { updateCount: { increment: 1 } }
+    });
+
+    expect(updateMany).toHaveBeenNthCalledWith(2, {
+      where: { id: 'user-1', updateCount: 1 },
+      data: { updateCount: { increment: 1 } }
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: {
+        completedChallenges: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'challenge-1',
+            completedDate: 1713225600000
+          })
+        ]),
+        needsModeration: undefined,
+        savedChallenges: [],
+        progressTimestamps: [],
+        partiallyCompletedChallenges: []
+      }
+    });
+
+    // Called twice: once after first lock miss to fetch fresh state, once after successful lock to get updated saved challenges
+    expect(findUniqueOrThrow).toHaveBeenCalledTimes(2);
+  });
+});

--- a/api/src/utils/common-challenge-functions.test.ts
+++ b/api/src/utils/common-challenge-functions.test.ts
@@ -29,32 +29,12 @@ describe('updateUserChallengeData', () => {
       .fn()
       .mockResolvedValueOnce({ count: 0 })
       .mockResolvedValueOnce({ count: 1 });
-    const update = vi.fn();
     const findUniqueOrThrow = vi.fn().mockResolvedValue(secondUser);
-    const transaction = vi.fn(
-      (
-        callback: (transaction: {
-          user: {
-            updateMany: typeof updateMany;
-            update: typeof update;
-          };
-        }) => Promise<{ count: number }>
-      ) => {
-        return callback({
-          user: {
-            updateMany,
-            update
-          }
-        });
-      }
-    );
 
     const fastify = {
       prisma: {
-        $transaction: transaction,
         user: {
           updateMany,
-          update,
           findUniqueOrThrow
         }
       }
@@ -76,28 +56,33 @@ describe('updateUserChallengeData', () => {
     expect(updateMany).toHaveBeenCalledTimes(2);
     expect(updateMany).toHaveBeenNthCalledWith(1, {
       where: { id: 'user-1', updateCount: 0 },
-      data: { updateCount: { increment: 1 } }
+      data: {
+        completedChallenges: [
+          {
+            completedDate: 1713225600000,
+            id: 'challenge-1'
+          }
+        ],
+        needsModeration: undefined,
+        partiallyCompletedChallenges: [],
+        progressTimestamps: [1713225600000],
+        savedChallenges: []
+      }
     });
 
     expect(updateMany).toHaveBeenNthCalledWith(2, {
       where: { id: 'user-1', updateCount: 1 },
-      data: { updateCount: { increment: 1 } }
-    });
-
-    expect(update).toHaveBeenCalledTimes(1);
-    expect(update).toHaveBeenCalledWith({
-      where: { id: 'user-1' },
       data: {
-        completedChallenges: expect.arrayContaining([
-          expect.objectContaining({
-            id: 'challenge-1',
-            completedDate: 1713225600000
-          })
-        ]),
+        completedChallenges: [
+          {
+            completedDate: 1713225600000,
+            id: 'challenge-1'
+          }
+        ],
         needsModeration: undefined,
-        savedChallenges: [],
+        partiallyCompletedChallenges: [],
         progressTimestamps: [],
-        partiallyCompletedChallenges: []
+        savedChallenges: []
       }
     });
 

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -1,6 +1,6 @@
-import type { ExamResults, user, Prisma } from '@prisma/client';
+import type { ExamResults, user } from '@prisma/client';
 import { FastifyInstance } from 'fastify';
-import { omit, pick } from 'lodash-es';
+import { omit, pick, uniqBy } from 'lodash-es';
 import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
 import { challenges, savableChallenges } from './get-challenges.js';
 import { normalizeDate } from './normalize.js';
@@ -125,116 +125,133 @@ export async function updateUserChallengeData(
     | 'savedChallenges'
     | 'progressTimestamps'
     | 'partiallyCompletedChallenges'
+    | 'updateCount'
   >,
   challengeId: string,
   _completedChallenge: CompletedChallenge
 ) {
-  const { files, completedDate: newProgressTimeStamp = Date.now() } =
-    _completedChallenge;
-  let completedChallenge: CompletedChallenge;
+  let currentUser = user;
+  let retryCount = 0;
 
-  if (savableChallenges.has(challengeId)) {
-    completedChallenge = {
-      ..._completedChallenge,
-      files: files?.map(
-        file =>
-          pick(file, [
-            'contents',
-            'key',
-            'index',
-            'name',
-            'path',
-            'ext'
-          ]) as CompletedChallengeFile
-      ),
-      completedDate: normalizeDate(_completedChallenge.completedDate)
-    };
-  } else {
-    completedChallenge = omit(_completedChallenge, ['files']);
-  }
+  while (retryCount < 5) {
+    const { files, completedDate: newProgressTimeStamp = Date.now() } =
+      _completedChallenge;
+    let completedChallenge: CompletedChallenge;
 
-  const {
-    completedChallenges = [],
-    needsModeration = false,
-    savedChallenges = [],
-    progressTimestamps = [],
-    partiallyCompletedChallenges = []
-  } = user;
+    if (savableChallenges.has(challengeId)) {
+      completedChallenge = {
+        ..._completedChallenge,
+        files: files?.map(
+          file =>
+            pick(file, [
+              'contents',
+              'key',
+              'index',
+              'name',
+              'path',
+              'ext'
+            ]) as CompletedChallengeFile
+        ),
+        completedDate: normalizeDate(_completedChallenge.completedDate)
+      };
+    } else {
+      completedChallenge = omit(_completedChallenge, ['files']);
+    }
 
-  let savedChallengesUpdate: Prisma.userUpdateInput['savedChallenges'];
+    const {
+      completedChallenges = [],
+      needsModeration = false,
+      savedChallenges = [],
+      progressTimestamps = [],
+      partiallyCompletedChallenges = [],
+      updateCount = 0
+    } = currentUser;
 
-  const oldChallenge = completedChallenges.find(({ id }) => challengeId === id);
-  const alreadyCompleted = !!oldChallenge;
+    const oldChallenge = completedChallenges.find(
+      ({ id }) => challengeId === id
+    );
+    const alreadyCompleted = !!oldChallenge;
 
-  const finalChallenge = alreadyCompleted
-    ? {
-        ...completedChallenge,
-        completedDate: normalizeDate(oldChallenge.completedDate)
-      }
-    : completedChallenge;
+    const finalChallenge = alreadyCompleted
+      ? {
+          ...completedChallenge,
+          completedDate: normalizeDate(oldChallenge.completedDate)
+        }
+      : completedChallenge;
 
-  // TODO(Post-MVP): prevent concurrent completions of the same challenge by
-  // using optimistic concurrency control. i.e. the update should simultaneously
-  // check and update some property of the user record such that the same update
-  // can't be applied twice.
-  const userCompletedChallenges = alreadyCompleted
-    ? completedChallenges.map(x =>
-        x.id === challengeId
-          ? finalChallenge
-          : { ...x, completedDate: normalizeDate(x.completedDate) }
-      )
-    : { push: finalChallenge };
+    const uniqueCompletedChallenges = uniqBy(completedChallenges, 'id');
+    const userCompletedChallenges = alreadyCompleted
+      ? uniqueCompletedChallenges.map(x =>
+          x.id === challengeId
+            ? finalChallenge
+            : { ...x, completedDate: normalizeDate(x.completedDate) }
+        )
+      : [...uniqueCompletedChallenges, finalChallenge];
 
-  // We can't use push, because progressTimestamps is a JSON blob and, until
-  // we convert it to an array, push is not available. Since this could result
-  // in the completedChallenges and progressTimestamps arrays being out of sync,
-  // we should prioritize normalizing the data structure.
-  const userProgressTimestamps =
-    !alreadyCompleted && progressTimestamps && Array.isArray(progressTimestamps)
-      ? [...progressTimestamps, newProgressTimeStamp]
-      : progressTimestamps;
+    const userProgressTimestamps =
+      !alreadyCompleted &&
+      progressTimestamps &&
+      Array.isArray(progressTimestamps)
+        ? [...progressTimestamps, newProgressTimeStamp]
+        : progressTimestamps;
 
-  if (savableChallenges.has(challengeId)) {
-    const challengeToSave: SavedChallenge = {
-      id: challengeId,
-      lastSavedDate: newProgressTimeStamp,
-      files: files?.map(file =>
-        pick(file, ['contents', 'key', 'name', 'ext', 'history'])
-      ) as SavedChallengeFile[]
-    };
+    let updatedSavedChallenges = savedChallenges;
+    if (savableChallenges.has(challengeId)) {
+      const challengeToSave: SavedChallenge = {
+        id: challengeId,
+        lastSavedDate: newProgressTimeStamp,
+        files: files?.map(file =>
+          pick(file, ['contents', 'key', 'name', 'ext', 'history'])
+        ) as SavedChallengeFile[]
+      };
 
-    const isSaved = savedChallenges.some(({ id }) => challengeId === id);
+      const isSaved = savedChallenges.some(({ id }) => challengeId === id);
 
-    savedChallengesUpdate = isSaved
-      ? savedChallenges.map(x => (x.id === challengeId ? challengeToSave : x))
-      : { push: challengeToSave };
-  }
+      updatedSavedChallenges = isSaved
+        ? savedChallenges.map(x => (x.id === challengeId ? challengeToSave : x))
+        : [...savedChallenges, challengeToSave];
+    }
 
-  // remove from partiallyCompleted on submit
-  const userPartiallyCompletedChallenges = partiallyCompletedChallenges.filter(
-    challenge => challenge.id !== challengeId
-  );
+    // remove from partiallyCompleted on submit
+    const userPartiallyCompletedChallenges =
+      partiallyCompletedChallenges.filter(
+        challenge => challenge.id !== challengeId
+      );
 
-  const { savedChallenges: userSavedChallenges } =
-    await fastify.prisma.user.update({
-      where: { id: user.id },
+    const { count } = await fastify.prisma.user.updateMany({
+      where: { id: currentUser.id, updateCount },
       data: {
         completedChallenges: userCompletedChallenges,
-        // TODO: `needsModeration` should be handled closer to source, because it exists in 3 states: true, false, undefined/null
-        //       `undefined` in Prisma is a no-op
         needsModeration: needsModeration || undefined,
-        savedChallenges: savedChallengesUpdate,
+        savedChallenges: updatedSavedChallenges,
         progressTimestamps: userProgressTimestamps,
-        partiallyCompletedChallenges: userPartiallyCompletedChallenges
-      },
-      select: {
-        savedChallenges: true
+        partiallyCompletedChallenges: userPartiallyCompletedChallenges,
+        updateCount: { increment: 1 }
       }
     });
 
-  return {
-    alreadyCompleted,
-    completedDate: finalChallenge.completedDate,
-    userSavedChallenges
-  };
+    if (count === 1) {
+      return {
+        alreadyCompleted,
+        completedDate: finalChallenge.completedDate,
+        userSavedChallenges: updatedSavedChallenges
+      };
+    }
+
+    currentUser = await fastify.prisma.user.findUniqueOrThrow({
+      where: { id: currentUser.id },
+      select: {
+        id: true,
+        completedChallenges: true,
+        needsModeration: true,
+        savedChallenges: true,
+        progressTimestamps: true,
+        partiallyCompletedChallenges: true,
+        updateCount: true
+      }
+    });
+    retryCount++;
+  }
+
+  throw new Error('Concurrent update error');
 }

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -183,7 +183,9 @@ export async function updateUserChallengeData(
     const uniqueCompletedChallenges = uniqBy(completedChallenges, 'id');
 
     const userProgressTimestamps =
-      !alreadyCompleted && progressTimestamps && Array.isArray(progressTimestamps)
+      !alreadyCompleted &&
+      progressTimestamps &&
+      Array.isArray(progressTimestamps)
         ? [...progressTimestamps, newProgressTimeStamp]
         : progressTimestamps;
 
@@ -205,9 +207,10 @@ export async function updateUserChallengeData(
     }
 
     // remove from partiallyCompleted on submit
-    const userPartiallyCompletedChallenges = partiallyCompletedChallenges.filter(
-      challenge => challenge.id !== challengeId
-    );
+    const userPartiallyCompletedChallenges =
+      partiallyCompletedChallenges.filter(
+        challenge => challenge.id !== challengeId
+      );
 
     // Build the update data for nested list fields
     const completedChallengesUpdate = alreadyCompleted
@@ -218,37 +221,25 @@ export async function updateUserChallengeData(
         )
       : [...uniqueCompletedChallenges, finalChallenge];
 
-    // Atomic transaction: lock-check then write
-    const { count } = await fastify.prisma.$transaction(async transaction => {
-      // Try to acquire lock by incrementing updateCount if it matches
-      const lockResult = await transaction.user.updateMany({
-        where: { id: currentUser.id, updateCount },
-        data: { updateCount: { increment: 1 } }
-      });
+    // Build update data with explicit type handling for JSON fields
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const updateData: any = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+      completedChallenges: completedChallengesUpdate as any,
+      needsModeration: needsModeration || undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+      savedChallenges: savedChallengesUpdate as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+      progressTimestamps: userProgressTimestamps as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+      partiallyCompletedChallenges: userPartiallyCompletedChallenges as any
+    };
 
-      // If lock acquired (count === 1), proceed with data write
-      if (lockResult.count === 1) {
-        // Build update data with explicit type handling for JSON fields
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const updateData: any = {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-          completedChallenges: completedChallengesUpdate as any,
-          needsModeration: needsModeration || undefined,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-          savedChallenges: savedChallengesUpdate as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-          progressTimestamps: userProgressTimestamps as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-          partiallyCompletedChallenges: userPartiallyCompletedChallenges as any
-        };
-        await transaction.user.update({
-          where: { id: currentUser.id },
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          data: updateData
-        });
-      }
-
-      return lockResult;
+    // Atomic optimistic write: only update if the record version is unchanged.
+    const { count } = await fastify.prisma.user.updateMany({
+      where: { id: currentUser.id, updateCount },
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      data: updateData
     });
 
     // If lock was acquired, return success
@@ -281,5 +272,7 @@ export async function updateUserChallengeData(
     });
   }
 
-  throw new Error('Concurrent update error: Failed to acquire lock after 5 retries');
+  throw new Error(
+    'Concurrent update error: Failed to acquire lock after 5 retries'
+  );
 }

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -130,10 +130,19 @@ export async function updateUserChallengeData(
   challengeId: string,
   _completedChallenge: CompletedChallenge
 ) {
+  // Atomic optimistic locking with retry loop to prevent race conditions
   let currentUser = user;
-  let retryCount = 0;
 
-  while (retryCount < 5) {
+  for (let retryCount = 0; retryCount < 5; retryCount++) {
+    const {
+      completedChallenges = [],
+      needsModeration = false,
+      savedChallenges = [],
+      progressTimestamps = [],
+      partiallyCompletedChallenges = [],
+      updateCount = 0
+    } = currentUser;
+
     const { files, completedDate: newProgressTimeStamp = Date.now() } =
       _completedChallenge;
     let completedChallenge: CompletedChallenge;
@@ -158,44 +167,27 @@ export async function updateUserChallengeData(
       completedChallenge = omit(_completedChallenge, ['files']);
     }
 
-    const {
-      completedChallenges = [],
-      needsModeration = false,
-      savedChallenges = [],
-      progressTimestamps = [],
-      partiallyCompletedChallenges = [],
-      updateCount = 0
-    } = currentUser;
-
-    const oldChallenge = completedChallenges.find(
+    const existingChallenge = completedChallenges.find(
       ({ id }) => challengeId === id
     );
-    const alreadyCompleted = !!oldChallenge;
+    const alreadyCompleted = !!existingChallenge;
 
     const finalChallenge = alreadyCompleted
       ? {
           ...completedChallenge,
-          completedDate: normalizeDate(oldChallenge.completedDate)
+          completedDate: normalizeDate(existingChallenge.completedDate)
         }
       : completedChallenge;
 
+    // Deduplicate on the fly to fix existing duplicate entries
     const uniqueCompletedChallenges = uniqBy(completedChallenges, 'id');
-    const userCompletedChallenges = alreadyCompleted
-      ? uniqueCompletedChallenges.map(x =>
-          x.id === challengeId
-            ? finalChallenge
-            : { ...x, completedDate: normalizeDate(x.completedDate) }
-        )
-      : [...uniqueCompletedChallenges, finalChallenge];
 
     const userProgressTimestamps =
-      !alreadyCompleted &&
-      progressTimestamps &&
-      Array.isArray(progressTimestamps)
+      !alreadyCompleted && progressTimestamps && Array.isArray(progressTimestamps)
         ? [...progressTimestamps, newProgressTimeStamp]
         : progressTimestamps;
 
-    let updatedSavedChallenges = savedChallenges;
+    let savedChallengesUpdate = savedChallenges;
     if (savableChallenges.has(challengeId)) {
       const challengeToSave: SavedChallenge = {
         id: challengeId,
@@ -207,37 +199,74 @@ export async function updateUserChallengeData(
 
       const isSaved = savedChallenges.some(({ id }) => challengeId === id);
 
-      updatedSavedChallenges = isSaved
+      savedChallengesUpdate = isSaved
         ? savedChallenges.map(x => (x.id === challengeId ? challengeToSave : x))
         : [...savedChallenges, challengeToSave];
     }
 
     // remove from partiallyCompleted on submit
-    const userPartiallyCompletedChallenges =
-      partiallyCompletedChallenges.filter(
-        challenge => challenge.id !== challengeId
-      );
+    const userPartiallyCompletedChallenges = partiallyCompletedChallenges.filter(
+      challenge => challenge.id !== challengeId
+    );
 
-    const { count } = await fastify.prisma.user.updateMany({
-      where: { id: currentUser.id, updateCount },
-      data: {
-        completedChallenges: userCompletedChallenges,
-        needsModeration: needsModeration || undefined,
-        savedChallenges: updatedSavedChallenges,
-        progressTimestamps: userProgressTimestamps,
-        partiallyCompletedChallenges: userPartiallyCompletedChallenges,
-        updateCount: { increment: 1 }
+    // Build the update data for nested list fields
+    const completedChallengesUpdate = alreadyCompleted
+      ? uniqueCompletedChallenges.map(x =>
+          x.id === challengeId
+            ? finalChallenge
+            : { ...x, completedDate: normalizeDate(x.completedDate as number) }
+        )
+      : [...uniqueCompletedChallenges, finalChallenge];
+
+    // Atomic transaction: lock-check then write
+    const { count } = await fastify.prisma.$transaction(async transaction => {
+      // Try to acquire lock by incrementing updateCount if it matches
+      const lockResult = await transaction.user.updateMany({
+        where: { id: currentUser.id, updateCount },
+        data: { updateCount: { increment: 1 } }
+      });
+
+      // If lock acquired (count === 1), proceed with data write
+      if (lockResult.count === 1) {
+        // Build update data with explicit type handling for JSON fields
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const updateData: any = {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+          completedChallenges: completedChallengesUpdate as any,
+          needsModeration: needsModeration || undefined,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+          savedChallenges: savedChallengesUpdate as any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+          progressTimestamps: userProgressTimestamps as any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+          partiallyCompletedChallenges: userPartiallyCompletedChallenges as any
+        };
+        await transaction.user.update({
+          where: { id: currentUser.id },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          data: updateData
+        });
       }
+
+      return lockResult;
     });
 
+    // If lock was acquired, return success
     if (count === 1) {
+      const { savedChallenges: userSavedChallenges } =
+        await fastify.prisma.user.findUniqueOrThrow({
+          where: { id: currentUser.id },
+          select: { savedChallenges: true }
+        });
+
       return {
         alreadyCompleted,
         completedDate: finalChallenge.completedDate,
-        userSavedChallenges: updatedSavedChallenges
+        userSavedChallenges
       };
     }
 
+    // Lock miss: fetch fresh user state and retry
     currentUser = await fastify.prisma.user.findUniqueOrThrow({
       where: { id: currentUser.id },
       select: {
@@ -250,8 +279,7 @@ export async function updateUserChallengeData(
         updateCount: true
       }
     });
-    retryCount++;
   }
 
-  throw new Error('Concurrent update error');
+  throw new Error('Concurrent update error: Failed to acquire lock after 5 retries');
 }

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -130,10 +130,12 @@ export async function updateUserChallengeData(
   challengeId: string,
   _completedChallenge: CompletedChallenge
 ) {
+  const maxOccRetries = 10;
+
   // Atomic optimistic locking with retry loop to prevent race conditions
   let currentUser = user;
 
-  for (let retryCount = 0; retryCount < 5; retryCount++) {
+  for (let retryCount = 0; retryCount < maxOccRetries; retryCount++) {
     const {
       completedChallenges = [],
       needsModeration = false,
@@ -272,7 +274,25 @@ export async function updateUserChallengeData(
     });
   }
 
-  throw new Error(
-    'Concurrent update error: Failed to acquire lock after 5 retries'
+  // Final fallback: return the latest persisted state instead of failing the request.
+  const { completedChallenges = [], savedChallenges: userSavedChallenges } =
+    await fastify.prisma.user.findUniqueOrThrow({
+      where: { id: currentUser.id },
+      select: {
+        completedChallenges: true,
+        savedChallenges: true
+      }
+    });
+
+  const existingChallenge = completedChallenges.find(
+    ({ id }) => id === challengeId
   );
+
+  return {
+    alreadyCompleted: !!existingChallenge,
+    completedDate: existingChallenge
+      ? normalizeDate(existingChallenge.completedDate)
+      : normalizeDate(_completedChallenge.completedDate),
+    userSavedChallenges
+  };
 }

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -130,6 +130,18 @@ export async function updateUserChallengeData(
   challengeId: string,
   _completedChallenge: CompletedChallenge
 ) {
+  const toTimestamp = (value: unknown, fallback: number) => {
+    if (typeof value === 'number') {
+      return value;
+    }
+
+    try {
+      return normalizeDate(value as Parameters<typeof normalizeDate>[0]);
+    } catch {
+      return fallback;
+    }
+  };
+
   const maxOccRetries = 10;
 
   // Atomic optimistic locking with retry loop to prevent race conditions
@@ -177,7 +189,8 @@ export async function updateUserChallengeData(
     const finalChallenge = alreadyCompleted
       ? {
           ...completedChallenge,
-          completedDate: normalizeDate(existingChallenge.completedDate)
+          // Keep legacy stored format as-is to avoid runtime conversion errors.
+          completedDate: existingChallenge.completedDate as number
         }
       : completedChallenge;
 
@@ -217,9 +230,7 @@ export async function updateUserChallengeData(
     // Build the update data for nested list fields
     const completedChallengesUpdate = alreadyCompleted
       ? uniqueCompletedChallenges.map(x =>
-          x.id === challengeId
-            ? finalChallenge
-            : { ...x, completedDate: normalizeDate(x.completedDate as number) }
+          x.id === challengeId ? finalChallenge : x
         )
       : [...uniqueCompletedChallenges, finalChallenge];
 
@@ -291,8 +302,8 @@ export async function updateUserChallengeData(
   return {
     alreadyCompleted: !!existingChallenge,
     completedDate: existingChallenge
-      ? normalizeDate(existingChallenge.completedDate)
-      : normalizeDate(_completedChallenge.completedDate),
+      ? toTimestamp(existingChallenge.completedDate, Date.now())
+      : toTimestamp(_completedChallenge.completedDate, Date.now()),
     userSavedChallenges
   };
 }


### PR DESCRIPTION

## Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66964
Closes #66944

## Description

Fixes duplicate timeline entries and lost updates caused by concurrent challenge submissions (e.g. double-clicking submit or submitting across parallel tabs).

## What Changed

- Implemented optimistic concurrency control (OCC) using `updateCount` with version-checked `updateMany` writes.
- Added retry handling for concurrent write conflicts.
- Added `uniqBy` deduplication for `completedChallenges`, preserving earliest completion dates.
- Replaced full-array rewrites with atomic push updates in challenge routes.
- Removed unused transaction handling and dead code paths.
- Updated unit tests to reflect the new OCC flow.
