### PR TITLE
feat: add anchor links to curriculum chapter and module headings

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo } from 'react';
+import React, { ReactNode, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 // TODO: Add this component to freecodecamp/ui and remove this dependency
 import { Disclosure } from '@headlessui/react';
@@ -138,7 +138,7 @@ const Chapter = ({
   }
 
   return (
-    <Disclosure as='li' className='chapter' defaultOpen={isExpanded}>
+    <Disclosure as='li' className='chapter' defaultOpen={isExpanded} id={dashedName}>
       <Disclosure.Button
         className='chapter-button'
         data-playwright-test-label='chapter-button'
@@ -175,7 +175,7 @@ const Module = ({
   const showModuleContent = !(comingSoon && !showUpcomingChanges);
 
   return (
-    <Disclosure as='li' defaultOpen={isExpanded}>
+    <Disclosure as='li' defaultOpen={isExpanded} id={dashedName}>
       <Disclosure.Button className='module-button'>
         <div className='module-button-left'>
           <span className='dropdown-wrap'>
@@ -322,6 +322,17 @@ export const SuperBlockAccordion = ({
   const expandedChapter = blockToChapterMap.get(chosenBlock);
   const expandedModule = blockToModuleMap.get(chosenBlock);
   const accordion = true;
+
+  // Scroll to the element matching the URL hash on mount
+  useEffect(() => {
+    const hash = window.location.hash.slice(1);
+    if (hash) {
+      const el = document.getElementById(hash);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  }, []);
 
   return (
     <ul className='super-block-accordion'>


### PR DESCRIPTION
Closes #62555

## Summary
Adds anchor link support to curriculum chapter and module headings, allowing users to share direct links to specific sections.

## Changes
- Added `id` attributes (using `dashedName`) to Chapter and Module disclosure elements
- Added `useEffect` to scroll to the target element when a URL hash is present on page load
- Example: `https://www.freecodecamp.org/learn/full-stack-developer#python-basics` will scroll to the Python Basics section

## Test plan
- Navigate to a curriculum super block page
- Append `#<chapter-dashed-name>` to the URL
- Verify the page scrolls to the correct chapter section
- Verify chapter and module elements have correct `id` attributes in the DOM

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #62555