### PR TITLE
fix(curriculum): clarify .toFixed() explanation and examples

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-numbers-and-common-number-methods/673280a1c29d0a0b17316e56.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-numbers-and-common-number-methods/673280a1c29d0a0b17316e56.md
@@ -9,18 +9,29 @@ dashedName: what-is-the-tofixed-method-and-how-does-it-work
 
 The `.toFixed()` method is a built-in JavaScript function that formats a number using fixed-point notation. It's particularly useful when you need to control the number of decimal places in a number, especially for displaying currency values or when working with precise measurements. 
 
-The `.toFixed()` method is called on a number and takes one optional argument, which is the number of digits to appear after the decimal point. It returns a string representation of the number with the specified number of decimal places. Here's a basic example of how `.toFixed()` works:
+The `.toFixed()` method is called on a number and takes one optional argument, which specifies how many digits should appear after the decimal point. It returns a string representation of the number with the specified number of decimal places.
+
+If you call `.toFixed()` without an argument, it defaults to 0 decimal places.
+
+Here are two basic examples of how .toFixed() works:
 
 :::interactive_editor
 
 ```js
+// Without argument
+let num = 3.14159;
+console.log(num.toFixed()); // "3"
+
+// With argument
 let num = 3.14159;
 console.log(num.toFixed(2)); // "3.14"
 ```
 
 :::
 
-In this case, we're limiting the number of decimal places to two. So, `3.14159` becomes `3.14`. It's important to note that `.toFixed()` returns a string, not a number. This is because the method is primarily intended for formatting numbers for display, not for further calculations.
+In this case, we're limiting the number of decimal places to zero and two. So, `3.14159` becomes `3` when no argument is provided, and `3.14` when a value is specified.
+
+It's important to note that `.toFixed()` returns a string, not a number. This is because the method is primarily intended for formatting numbers for display, rather than for further calculations. It's important to note that `.toFixed()` returns a string, not a number. This is because the method is primarily intended for formatting numbers for display, not for further calculations.
 
 The `.toFixed()` method rounds the number to the nearest value that can be represented with the specified number of decimal places. This rounding behavior is important to understand:
 
@@ -34,7 +45,7 @@ console.log((3.14550).toFixed(3));  // "3.146"
 
 :::
 
-As you can see, `.toFixed()` rounds up when the next digit is `5` or greater, and rounds down otherwise. If you call `.toFixed()` without arguments, it defaults to `0` decimal places:
+As you can see, `.toFixed()` rounds up when the next digit is `5` or greater, and rounds down otherwise.
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66991

<!-- Feel free to add any additional description of changes below this line -->
 
Further clarify explanation of how .toFixed() acts when no argument is provided. 
To accomplish this i moved the example as for when no argument is provided further up and also altered the explanation of it

I have tested the change on my local setup of ffc

### Before
<img width="778" height="715" alt="image" src="https://github.com/user-attachments/assets/24962d92-a89a-493e-84d9-cb9350a4cf94" />

### After

<img width="1622" height="1018" alt="Screenshot 2026-04-19 at 02-04-17 Working with Numbers and Common Number Methods - What Is the toFixed() Method and How Does It Work Learn freeCodeCamp org" src="https://github.com/user-attachments/assets/313a8b05-4d9c-4d3a-8fe1-50279b4ad821" />
