### PR TITLE
fix: Fix mislabelled warn log for non-CSRF request errors

### DIFF
--- a/api/src/plugins/error-handling.ts
+++ b/api/src/plugins/error-handling.ts
@@ -41,7 +41,7 @@ const errorHandling: FastifyPluginCallback = (fastify, _options, done) => {
       if (reply.statusCode >= 500) {
         logger.error(error, 'Error in request');
       } else {
-        logger.warn(error, 'CSRF error in request');
+        logger.warn(error, 'Error in request');
       }
     }
 


### PR DESCRIPTION
## Bug

The api error-handling plugin logs non-CSRF request errors with the
message `'CSRF error in request'`, so log collectors that filter on
that string see *non-CSRF* errors instead of CSRF ones, and actual
CSRF errors (which this branch already excludes) never match.

## Root cause

```typescript
const isCSRFError =
  error.code === 'FST_CSRF_INVALID_TOKEN' ||
  error.code === 'FST_CSRF_MISSING_SECRET';

if (!isCSRFError) {
  if (reply.statusCode >= 500) {
    logger.error(error, 'Error in request');
  } else {
    logger.warn(error, 'CSRF error in request');
  }
}
```

The outer guard is `!isCSRFError`, so anything reaching either inner
branch is by definition *not* a CSRF error. The `logger.error` branch
uses the correct label `'Error in request'`, but the sibling
`logger.warn` branch carries a stale `'CSRF error in request'` label -
almost certainly left over from a refactor that moved the CSRF
handling out of this block.

Net effect: every non-CSRF, <500 request error is reported in the logs
as a CSRF error, and any CSRF-specific log searches produce
false positives while missing the real CSRF events.

## Why the fix is correct

- Uses the same `'Error in request'` message as the immediately
  preceding `logger.error` branch, accurately describing what both
  branches actually handle.
- Only the log message changes; the `!isCSRFError` gate, the 500
  split, and the error payload passed to the logger are untouched.
- CSRF errors continue to be intentionally not logged here, matching
  the existing design (they're user-driven).

## Change

`api/src/plugins/error-handling.ts`: `logger.warn(error, 'CSRF error in request')`
→ `logger.warn(error, 'Error in request')`. One-line fix.