### PR TITLE
fix: Return 1 from getPoints when progressTimestamps is an empty array

### DIFF
--- a/api/src/utils/progress.ts
+++ b/api/src/utils/progress.ts
@@ -32,5 +32,5 @@ export const getCalendar = (
 export const getPoints = (
   progressTimestamps: ProgressTimestamp[] | null
 ): number => {
-  return progressTimestamps?.length ?? 1;
+  return progressTimestamps?.length || 1;
 };


### PR DESCRIPTION
## Bug

`getPoints` in `api/src/utils/progress.ts` returns `0` when the user's
`progressTimestamps` field is an empty array, disagreeing with the
existing behaviour for `null` (`1`) and the test's own description:
*"should return 1 if there are no progressTimestamps"*.

## Root cause

```typescript
export const getPoints = (
  progressTimestamps: ProgressTimestamp[] | null
): number => {
  return progressTimestamps?.length ?? 1;
};
```

The nullish-coalescing operator `??` only substitutes when the left
operand is `null` or `undefined`. For an empty array,
`progressTimestamps?.length` is `0` — a valid number, so `??` keeps it
and `getPoints([]) === 0`. Only the `null` input takes the intended
fallback path because optional chaining short-circuits to `undefined`.

The unit test `'should return 1 if there are no progressTimestamps'`
(`progress.test.ts:33–35`) covers only the `null` case but its
description treats "no progressTimestamps" as a single condition — and
callers in `routes/public/user.ts:192` and
`routes/protected/challenge.ts:158`,`216` display the returned value
as the user's point total, so a user whose timestamps field is `[]`
(a plausible persisted value for a newly-registered account) would
render with `0` points instead of the intended starting `1`.

## Why the fix is correct

- `progressTimestamps?.length || 1` returns `1` for `null`, `undefined`
  **and** empty array — matching the test's stated contract.
- Non-empty arrays still return their length (`3 || 1 === 3`), so
  the `getPoints([0, 1, 2]) === 3` test continues to pass.
- Only the `[] → 0` behaviour changes to `[] → 1`; every other input
  is unaffected.

## Change

`api/src/utils/progress.ts`: `?? 1` → `|| 1` in `getPoints`.