### PR TITLE
fix: add missing semicolons in plant nursery catalog step 25

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6737a1a073a0d14c6544d301.md
+++ b/curriculum/challenges/english/blocks/workshop-plant-nursery-catalog/6737a1a073a0d14c6544d301.md
@@ -41,37 +41,37 @@ const ballerina = {
     commonName: "Spanish lavender",
     scientificName: "Lavandula stoechas",
     cultivar: "Ballerina"
-}
+};
 
 const prettyPolly = {
     commonName: "Spanish lavender",
     scientificName: "Lavandula stoechas",
     cultivar: "Pretty Polly"
-}
+};
 
 const willowVale = {
     commonName: "Spanish lavender",
     scientificName: "Lavandula stoechas",
     cultivar: "Willow Vale"
-}
+};
 
 const hidcote = {
     commonName: "English lavender",
     scientificName: "Lavandula angustifolia",
     cultivar: "Hidcote"
-}
+};
 
 const imperialGem = {
     commonName: "English lavender",
     scientificName: "Lavandula angustifolia",
     cultivar: "Imperial Gem"
-}
+};
 
 const royalCrown = {
     commonName: "French lavender",
     scientificName: "Lavandula dentata",
     cultivar: "Royal Crown"
-}
+};
 
 const catalog = new Map();
 catalog.set(ballerina, { small: 20, medium: 15, large: 12 });
@@ -83,14 +83,14 @@ catalog.set(royalCrown, { small: 40, medium: 22, large: 9 });
 
 const sellPlants = (plant, size, potsNo) => {
     if (!catalog.has(plant)) return "Item not found.";
-    const name = `${plant.scientificName} '${plant.cultivar}'`
+    const name = `${plant.scientificName} '${plant.cultivar}'`;
     const pots = catalog.get(plant);
     if (pots[size] - potsNo < 0) {
-        return `Not enough ${size} size pots for ${name}. Only ${pots[size]} left.`
+        return `Not enough ${size} size pots for ${name}. Only ${pots[size]} left.`;
     }
     pots[size] -= potsNo;
-    return `Catalog successfully updated.`
-}
+    return `Catalog successfully updated.`;
+};
 
 const removePlant = plant => catalog.delete(plant);
 
@@ -100,8 +100,8 @@ const displayCatalog = () => {
         catalogString += `${key.scientificName} '${key.cultivar}': ${val.small} S, ${val.medium} M, ${val.large} L
 `
     })
-    return catalogString
-}
+    return catalogString;
+};
 --fcc-editable-region--
 const displayPlantsSet = () => new Set();
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66745

Fix missing semicolons in plant nursery catalog step 25

- Added semicolons to 6 object declarations
- Added semicolons to return statements in sellPlants function
- Added semicolon to return statement in displayCatalog function