### PR TITLE
fix(curriculum): clarify validateForm keys for conditional descriptio…

### DIFF
--- a/curriculum/challenges/english/blocks/lab-customer-complaint-form/67279fe50237291f80eed8b8.md
+++ b/curriculum/challenges/english/blocks/lab-customer-complaint-form/67279fe50237291f80eed8b8.md
@@ -24,7 +24,7 @@ For this lab, you have been provided with all the HTML and CSS. You will use Jav
     - `#complaint-description` contains at least twenty characters if the `Other` checkbox is checked.
     - a radio button from `#solutions-group` is selected.
     - `#solution-description` contains at least twenty characters if the `Other` radio button is selected.
-1. You should have a function named `validateForm` that returns an object containing the following keys: `full-name`, `email`, `order-no`, `product-code`, `quantity`, `complaints-group`, `complaint-description`, `solutions-group`, and `solution-description`. The value of each key should be `true` if the corresponding form field is correctly filled and `false` otherwise.
+1. You should have a function named `validateForm` that returns an object containing the following keys: `full-name`, `email`, `order-no`, `product-code`, `quantity`, `complaints-group`, `complaint-description`, `solutions-group`, and `solution-description`. The value of each key should be `true` if the corresponding form field is correctly filled and `false` otherwise. The conditional description fields should be `true` when they are not required, and otherwise validated based on whether they contain at least twenty characters.
 1. You should have a function named `isValid` that takes the object returned by `validateForm` as argument and returns `true` if every form field is correctly filled and `false` otherwise.
 1. If a change event is triggered on a form field and it has a valid value, you should set its border color to `green`. In case of checkbox and radio button groups, you should set the border color of the parent `fieldset`.
 1. If a change event is triggered on a form field and it has an invalid value, you should set its border color to `red`. In case of checkbox and radio button groups, you should set the border color of the parent `fieldset`.
@@ -198,6 +198,13 @@ const fieldset = document.getElementById("complaints-group");
 assert.equal(fieldset.style.borderColor, "red");
 ```
 
+When `#other-complaint` is not checked, `validateForm()["complaint-description"]` should be `true`.
+
+```js
+document.getElementById("other-complaint").checked = false;
+assert.isTrue(validateForm()["complaint-description"]);
+```
+
 When `#other-complaint` is checked and `#complaint-description` contains at least twenty characters, `validateForm()["complaint-description"]` should be `true`.
 
 ```js
@@ -274,6 +281,13 @@ exchangeRadioBtn.checked = false;
 exchangeRadioBtn.dispatchEvent(new Event("change", { bubbles: true }));
 const fieldset = document.getElementById("solutions-group");
 assert.equal(fieldset.style.borderColor, "red");
+```
+
+When `#other-solution` is not checked, `validateForm()["solution-description"]` should be `true`.
+
+```js
+document.getElementById("other-solution").checked = false;
+assert.isTrue(validateForm()["solution-description"]);
 ```
 
 When `#other-solution` is checked and `#solution-description` contains at least twenty characters, `validateForm()["solution-description"]` should be `true`.
@@ -799,9 +813,9 @@ const validateForm = () => {
         "product-code": /[A-Z]{2}\d{2}-[A-Z]\d{3}-[A-Z]{2}\d/i.test(productCode.value.trim()),
         "quantity": Number(quantity.value.trim()) > 0,
         "complaints-group": complaintsArr.some(i => i),
-        "complaint-description": null,
+        "complaint-description": true,
         "solutions-group": solutionsArr.some(i => i),
-        "solution-description": null
+        "solution-description": true
     }
 
     if (complaintsArr[3]) {
@@ -826,8 +840,6 @@ const validateForm = () => {
     } else {
         solutionTextAreaDiv.style.display = "none";
     }
-    if (validationObject["complaint-description"] === null) delete validationObject["complaint-description"];
-    if (validationObject["solution-description"] === null) delete validationObject["solution-description"];
 
     return validationObject;
 }


### PR DESCRIPTION
…n fields

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #59167
<!-- Feel free to add any additional description of changes below this line -->
Summary
This updates the Build a Customer Complaint Form lab so validateForm() behavior for the conditional description fields matches what [@Sembauke described after triage](https://github.com/freeCodeCamp/freeCodeCamp/issues/59167): learners should see one clear rule instead of an undefined edge case.

Problem
#complaint-description and #solution-description are only required when Other complaint / Other solution are selected. The original copy did not spell out what validateForm() should return when those options are off, which made isValid(validateForm()) hard to reason about and confused campers who treated short text in hidden fields as invalid.

Approach (aligned with Sembauke’s comment)

validateForm() always returns the same keys, each a boolean.
When a conditional description field is not required, its value is true.
When it is required, it is validated with length ≥ 20 as before.
The user story, hints, and reference solution in the lab markdown were updated together so instructions and tests match.