### PR TITLE
docs(api): fix typo 'compatability' -> 'compatibility' in test comment

### DIFF
--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -91,7 +91,7 @@ describe('/exam-environment/', () => {
 
         expect(res.body).toStrictEqual({
           code: 'FCC_ERR_EXAM_ENVIRONMENT_EXAM_ATTEMPT',
-          // NOTE: message may not necessarily be a part of the api compatability guarantee.
+          // NOTE: message may not necessarily be a part of the api compatibility guarantee.
           //       That is, it could be changed without requiring a major version bump, because it is just
           //       a human-readable/debug message.
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION

**Repo:** freeCodeCamp/freeCodeCamp (⭐ 443264)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Corrects a misspelling of "compatibility" in a code comment within `api/src/exam-environment/routes/exam-environment.test.ts`. The comment documents an API stability guarantee for the exam-environment endpoint's response shape.

## Why
The misspelled word ("compatability") appeared in a comment that documents non-obvious behavior about which fields of the error response are part of the public API contract vs. which are debug-only. Keeping spelling correct in such notes makes the intent searchable and reads more professionally. A repo-wide search confirmed this was the only occurrence of the misspelling.

## Testing
The change is comment-only inside a test file, so behavior is unchanged. Verified via `git diff` that only the misspelled token in the comment was modified, and via `grep -rIn "compatability" .` (excluding `node_modules`/`.git`) that no further occurrences remain.

## Risk
Low — comment-only change in a single test file; no runtime behavior touched.
