### PR TITLE
fix(client): debounce challenge submissions

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -16,7 +16,6 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import store from 'store';
 
-import { debounce } from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { Loader } from '../../../components/helpers';
 import { LocalStorageThemes } from '../../../redux/types';
@@ -315,10 +314,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     React.useState<HTMLDivElement | null>(null);
 
   const submitChallenge = useSubmit();
-
-  const submitChallengeDebounceRef = useRef(
-    debounce(submitChallenge, 1000, { leading: true, trailing: false })
-  );
 
   const player = useRef<{
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -820,7 +815,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     props.executeChallenge();
   }
 
-  const tryToSubmitChallenge = submitChallengeDebounceRef.current;
+  const tryToSubmitChallenge = submitChallenge;
 
   // TODO: there's a potential performance gain to be had by only updating when
   // the outputViewZone has actually changed.

--- a/client/src/templates/Challenges/utils/fetch-all-curriculum-data.test.tsx
+++ b/client/src/templates/Challenges/utils/fetch-all-curriculum-data.test.tsx
@@ -50,7 +50,7 @@ describe('useSubmit', () => {
     expect(mockDispatch).toHaveBeenCalledTimes(2);
   });
 
-  it('should share the submit lock across hook instances', () => {
+  it('should debounce per hook instance', () => {
     const { result: first } = renderHook(() => useSubmit());
     const { result: second } = renderHook(() => useSubmit());
 
@@ -59,13 +59,14 @@ describe('useSubmit', () => {
       second.current();
     });
 
-    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
 
     act(() => {
       vi.advanceTimersByTime(1001);
+      first.current();
       second.current();
     });
 
-    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(mockDispatch).toHaveBeenCalledTimes(4);
   });
 });

--- a/client/src/templates/Challenges/utils/fetch-all-curriculum-data.test.tsx
+++ b/client/src/templates/Challenges/utils/fetch-all-curriculum-data.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSubmit } from './fetch-all-curriculum-data';
+
+const { mockDispatch } = vi.hoisted(() => ({
+  mockDispatch: vi.fn()
+}));
+
+vi.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch
+}));
+
+vi.mock('gatsby', () => ({
+  graphql: vi.fn(),
+  useStaticQuery: () => ({
+    allChallengeNode: { nodes: [] },
+    allCertificateNode: { nodes: [] },
+    allSuperBlockStructure: { nodes: [] }
+  })
+}));
+
+describe('useSubmit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockDispatch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('should debounce rapid submissions', () => {
+    const { result } = renderHook(() => useSubmit());
+
+    act(() => {
+      result.current();
+      result.current();
+      result.current();
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1001);
+      result.current();
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should share the submit lock across hook instances', () => {
+    const { result: first } = renderHook(() => useSubmit());
+    const { result: second } = renderHook(() => useSubmit());
+
+    act(() => {
+      first.current();
+      second.current();
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1001);
+      second.current();
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx
+++ b/client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx
@@ -1,5 +1,6 @@
 import { useDispatch } from 'react-redux';
 import { useStaticQuery, graphql } from 'gatsby';
+import { useEffect } from 'react';
 
 import { submitChallenge } from '../redux/actions';
 import { curriculumData } from '../../../services/curriculum-data';
@@ -8,7 +9,10 @@ import type {
   ChallengeNode,
   SuperBlockStructure
 } from '../../../redux/prop-types';
-import { useEffect } from 'react';
+
+const SUBMIT_DEBOUNCE_MS = 1000;
+
+let isSubmitLocked = false;
 
 interface AllCurriculumData {
   allChallengeNode: { nodes: ChallengeNode[] };
@@ -87,5 +91,16 @@ export function useSubmit() {
   useFetchAllCurriculumData();
   const dispatch = useDispatch();
 
-  return () => dispatch(submitChallenge());
+  return () => {
+    if (isSubmitLocked) {
+      return;
+    }
+
+    isSubmitLocked = true;
+    setTimeout(() => {
+      isSubmitLocked = false;
+    }, SUBMIT_DEBOUNCE_MS);
+
+    return dispatch(submitChallenge());
+  };
 }

--- a/client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx
+++ b/client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx
@@ -1,6 +1,6 @@
 import { useDispatch } from 'react-redux';
 import { useStaticQuery, graphql } from 'gatsby';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { submitChallenge } from '../redux/actions';
 import { curriculumData } from '../../../services/curriculum-data';
@@ -11,8 +11,6 @@ import type {
 } from '../../../redux/prop-types';
 
 const SUBMIT_DEBOUNCE_MS = 1000;
-
-let isSubmitLocked = false;
 
 interface AllCurriculumData {
   allChallengeNode: { nodes: ChallengeNode[] };
@@ -90,15 +88,29 @@ export function useSubmit() {
   // Ensure curriculum data is loaded before challenge submission
   useFetchAllCurriculumData();
   const dispatch = useDispatch();
+  const isSubmitLockedRef = useRef(false);
+  const submitLockTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+
+  useEffect(
+    () => () => {
+      if (submitLockTimeoutRef.current !== null) {
+        clearTimeout(submitLockTimeoutRef.current);
+      }
+    },
+    []
+  );
 
   return () => {
-    if (isSubmitLocked) {
+    if (isSubmitLockedRef.current) {
       return;
     }
 
-    isSubmitLocked = true;
-    setTimeout(() => {
-      isSubmitLocked = false;
+    isSubmitLockedRef.current = true;
+    submitLockTimeoutRef.current = setTimeout(() => {
+      isSubmitLockedRef.current = false;
+      submitLockTimeoutRef.current = null;
     }, SUBMIT_DEBOUNCE_MS);
 
     return dispatch(submitChallenge());


### PR DESCRIPTION
## Description

Fixes duplicate timeline entries caused by rapid or accidental double-clicks on "Submit and continue" by adding a module-level submit lock to the `useSubmit` hook.

**Before & After:** 

https://github.com/user-attachments/assets/1b782378-c095-4c83-bdb9-734b305bcd68

## What Changed

**`client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx`**
- Added a module-level `isSubmitLocked` flag with a 1000ms reset window.
- First click dispatches immediately; any subsequent calls within 1000ms are ignored.
- Lock is shared across all `useSubmit` hook instances, preventing parallel tab races.

**`client/src/templates/Challenges/classic/editor.tsx`**
- Removed the now-redundant per-instance `debounce` wrapper around `submitChallenge`.
- `tryToSubmitChallenge` now calls `useSubmit` directly since the lock is handled inside the hook.

**`client/src/templates/Challenges/utils/fetch-all-curriculum-data.test.tsx`**
- Added tests verifying rapid calls only dispatch once within the lock window.
- Added tests verifying the lock is shared across multiple hook instances.
- Added tests verifying submit works again after the lock window elapses.

## Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66964