### PR TITLE
fix(client): filter challenge nodes by certification to fix progress bar

### DIFF
--- a/client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx
+++ b/client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx
@@ -33,6 +33,7 @@ export function useFetchAllCurriculumData(): void {
         nodes {
           challenge {
             block
+            certification
             id
           }
         }

--- a/client/src/utils/get-completion-percentage.test.ts
+++ b/client/src/utils/get-completion-percentage.test.ts
@@ -274,5 +274,56 @@ describe('get-completion-percentage', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('only counts challenges from the current superblock when a block is shared across superblocks', () => {
+      // This tests the fix for the bug where blocks shared between superblocks
+      // (e.g. javascript-v9 and introduction-to-variables-and-strings-in-javascript)
+      // caused currentBlockIds.length to be doubled, making the progress bar
+      // show 7% instead of 14% for 1/7 challenges.
+      const allChallengesInfo: AllChallengesInfo = {
+        challengeNodes: [
+          // Challenges from the current superblock (javascript-v9)
+          {
+            challenge: {
+              id: 'challenge-1',
+              block: 'workshop-greeting-bot',
+              certification: Certification.JsV9
+            }
+          } as Partial<ChallengeNode> as ChallengeNode,
+          {
+            challenge: {
+              id: 'challenge-2',
+              block: 'workshop-greeting-bot',
+              certification: Certification.JsV9
+            }
+          } as Partial<ChallengeNode> as ChallengeNode,
+          // Same block, but from a different superblock — should be excluded
+          {
+            challenge: {
+              id: 'challenge-1',
+              block: 'workshop-greeting-bot',
+              certification: Certification.RespWebDesignV9
+            }
+          } as Partial<ChallengeNode> as ChallengeNode,
+          {
+            challenge: {
+              id: 'challenge-2',
+              block: 'workshop-greeting-bot',
+              certification: Certification.RespWebDesignV9
+            }
+          } as Partial<ChallengeNode> as ChallengeNode
+        ],
+        certificateNodes: []
+      };
+
+      const result = getCurrentBlockIds(
+        allChallengesInfo,
+        'workshop-greeting-bot',
+        Certification.JsV9,
+        challengeTypes.step
+      );
+
+      expect(result).toEqual(['challenge-1', 'challenge-2']);
+    });
   });
 });

--- a/client/src/utils/get-completion-percentage.ts
+++ b/client/src/utils/get-completion-percentage.ts
@@ -46,7 +46,11 @@ export const getCurrentBlockIds = (
       .filter(node => node.challenge.certification === certification)[0]
       ?.challenge.tests.map(test => test.id) ?? [];
   const currentBlockIds = challengeNodes
-    .filter(node => node.challenge.block === block)
+    .filter(
+      node =>
+        node.challenge.block === block &&
+        node.challenge.certification === certification
+    )
     .map(node => node.challenge.id);
 
   if (isProjectBased(challengeType)) {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67048

## Problem

The progress bar after completing a challenge in the JavaScript v9 curriculum only fills to ~50% maximum (e.g. shows 7% for 1 out of 7 completed challenges instead of 14%).

**Root cause:** 446 block names are shared across multiple superblocks (e.g. `workshop-greeting-bot` exists in both `javascript-v9` and `introduction-to-variables-and-strings-in-javascript`). The `allChallengeNode` GraphQL query returns nodes for **all** superblocks, so `getCurrentBlockIds` was collecting challenge IDs from all superblocks that share the same block name. This doubled `currentBlockIds.length` for shared blocks:

- A 7-challenge block appeared to have 14 IDs → 1/14 = 7% (instead of 1/7 = 14%)
- Completing all 7 visible challenges → 7/14 = 50%

## Fix

1. **`client/src/templates/Challenges/utils/fetch-all-curriculum-data.tsx`** — Added `certification` to the `allChallengeNode` GraphQL query so it's available for filtering.

2. **`client/src/utils/get-completion-percentage.ts`** — Added `certification` to the `challengeNodes` filter in `getCurrentBlockIds`, ensuring only challenges belonging to the current superblock are counted.

3. **`client/src/utils/get-completion-percentage.test.ts`** — Added a regression test covering the shared-block scenario.