### PR TITLE
fix(curriculum): update focus style instructions and add outline test in job application form lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md
+++ b/curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md
@@ -22,7 +22,7 @@ demoType: onClick
 1. You should have a `textarea` element with the id `message` for entering a message.
 1. You should associate every `input` element with a `label` element. 
 1. You should have a `button` element with the type `submit` for submitting the form.
-1. Add a `:focus` pseudo-class to the `input` and `textarea` elements to change their border color when focused.
+1. Add a `:focus` pseudo-class to the `input` and `textarea` elements to change their border color and remove the default outline when focused.
 1. The `input`, `select` and `textarea` elements should have an `:invalid` pseudo-class that changes the border color to red when invalid input is detected.
 1. The `input`, `select` and `textarea` elements should have a `:valid` pseudo-class that changes the border color to green when valid input is entered.
 1. The `button` element should have a `:hover` pseudo-class that changes the background color when hovered over.
@@ -102,10 +102,11 @@ You should have a `button` element with the type `submit` for submitting the for
 assert.isNotEmpty(document.querySelectorAll("div.container > form button[type='submit']"));
 ```
 
-You should add a `:focus` pseudo-class to the `input` and `textarea` elements to change their border color when focused. Use a list selector in the given order.
+You should add a `:focus` pseudo-class to the `input` and `textarea` elements to change their border color and remove the default outline when focused. Use a list selector in the given order.
 
 ```js
-assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('input:focus, textarea:focus').getPropertyValue('border-color'))
+assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('input:focus, textarea:focus').getPropertyValue('border-color'));
+assert.equal(new __helpers.CSSHelp(document).getStyle('input:focus, textarea:focus').getPropertyValue('outline'), 'none');
 ```
 
 The `input`, `select` and `textarea` elements should have an `:invalid` pseudo-class that changes the border color to red when invalid input is detected. Use a list selector in the given order.

--- a/curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md
+++ b/curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md
@@ -102,10 +102,15 @@ You should have a `button` element with the type `submit` for submitting the for
 assert.isNotEmpty(document.querySelectorAll("div.container > form button[type='submit']"));
 ```
 
-You should add a `:focus` pseudo-class to the `input` and `textarea` elements to change their border color and remove the default outline when focused. Use a list selector in the given order.
+You should add a `:focus` pseudo-class to the `input` and `textarea` elements to change their border color when focused. Use a list selector in the given order.
 
 ```js
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('input:focus, textarea:focus').getPropertyValue('border-color'));
+```
+
+You should add a `:focus` pseudo-class to the `input` and `textarea` elements to remove the default outline when focused.
+
+```js
 assert.equal(new __helpers.CSSHelp(document).getStyle('input:focus, textarea:focus').getPropertyValue('outline'), 'none');
 ```
 

--- a/curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md
+++ b/curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md
@@ -108,7 +108,7 @@ You should add a `:focus` pseudo-class to the `input` and `textarea` elements to
 assert.isNotEmpty(new __helpers.CSSHelp(document).getStyle('input:focus, textarea:focus').getPropertyValue('border-color'));
 ```
 
-You should add a `:focus` pseudo-class to the `input` and `textarea` elements to remove the default outline when focused.
+You should use the selector for the `:focus` pseudo-class for `input` and `textarea` to also remove the default outline when focused.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyle('input:focus, textarea:focus').getPropertyValue('outline'), 'none');


### PR DESCRIPTION
## Description

Fixes a confusing user story in the Job Application Form lab where the required border on focused `input` and `textarea` elements was hidden beneath the browser's default outline, making it invisible unless the border was very thick.

## Root Cause

The `:focus` user story only asked students to change the border color when focused, but the browser's default `outline` renders on top of the border, hiding it entirely. Since `outline` hasn't been introduced in the curriculum at this point, the fix is to update the user story to also require removing the default outline.

## What Changed

**`curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md`**
- Updated user story text to include "and remove the default outline when focused".
- Updated the test description to match.
- Added `assert.equal(...getPropertyValue('outline'), 'none')` to verify the outline is removed.
- Fixed missing semicolon on the existing `border-color` assertion.

## Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #64786