### PR TITLE
fix(curriculum): use borderStyle instead of getPropVal in step 35

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3a06c6adde47584e2721.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3a06c6adde47584e2721.md
@@ -44,7 +44,7 @@ Set the `border` property to `none`.
 
 ```js
 const style = new __helpers.CSSHelp(document).getStyle('.submit-btn');
-assert.oneOf(style?.getPropVal('border'), ['none', 'medium', 'medium none']);
+assert.equal(style?.borderStyle, 'none');
 ```
 
 Set the `border-radius` property to `6px`.


### PR DESCRIPTION
Changes the border validation in Parent Teacher Conference Form - Step 35 to check borderStyle directly, avoiding intermittent failures from getPropVal returning unexpected values in some browser environments.

Closes #66939