### PR TITLE
fix(curriculum): remove mention of loops in introduction to variables script

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe8597975ea634042cad8f.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe8597975ea634042cad8f.md
@@ -55,9 +55,7 @@ Another convention is to avoid using single-letter variable names. This is very 
 x = 56 # What do you mean by x?
 ```
 
-This is different if you are in a loop or something similar, as variable names like `i`, `j`, `k`, and so on are common and acceptable.
-
-Also, the pound symbol (`#`) and the text that follows in the example above is called a comment. You might already be familiar with comments, so let's go over them quickly and explain how they work.
+The pound symbol (`#`) and the text that follows in the example above is called a comment. You might already be familiar with comments, so let's go over them quickly and explain how they work.
 
 In Python, comments start with a pound symbol (`#`), and the language ignores everything after the `#` symbol on that line:
 


### PR DESCRIPTION
The original script mentions that using single letter variable names is fine when in the context of loops. 

However, loops haven't been taught yet. So beginners won't understand what this fully means. So it is best to leave that sentence out. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


