### PR TITLE
fix(curriculum): relax overly strict tests in heritage library catalog step 18

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
@@ -18,7 +18,7 @@ Finally, use `continue` to skip the rest of the loop body. The `continue` statem
 You should check if `book.year` is equal to `"Unknown"`.
 
 ```js
-assert.match(groupByDecade.toString(), /book\.year\s*===?\s*["']Unknown["']/);
+assert.match(groupByDecade.toString(), /book\.year\s*===?\s*("|')Unknown\1/);
 ```
 
 You should check if `grouped["Unknown"]` doesn't exist yet and initialize it as an empty array.

--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
@@ -26,15 +26,15 @@ You should check if `grouped["Unknown"]` doesn't exist yet and initialize it as 
 ```js
 assert.match(
   groupByDecade.toString(),
-  /(?:!\s*grouped\s*\[\s*["']Unknown["']\s*\]|!\s*Object\.hasOwn\s*\(\s*grouped\s*,\s*["']Unknown["']\s*\)|!\s*grouped\.hasOwnProperty\s*\(\s*["']Unknown["']\s*\)|grouped\s*\[\s*["']Unknown["']\s*\]\s*===\s*undefined)/
+  /(?:!\s*grouped\s*\[\s*("|')Unknown\1\s*\]|!\s*Object\.hasOwn\s*\(\s*grouped\s*,\s*("|')Unknown\2\s*\)|!\s*grouped\.hasOwnProperty\s*\(\s*("|')Unknown\3\s*\)|grouped\s*\[\s*("|')Unknown\4\s*\]\s*===\s*undefined)/
 );
-assert.match(groupByDecade.toString(), /grouped\s*\[\s*["']Unknown["']\s*\]\s*=\s*\[\s*\]/);
+assert.match(groupByDecade.toString(), /grouped\s*\[\s*("|')Unknown\1\s*\]\s*=\s*\[\s*\]/);
 ```
 
 You should push `book` into `grouped["Unknown"]`.
 
 ```js
-assert.match(groupByDecade.toString(), /grouped\s*\[\s*["']Unknown["']\s*\]\s*\.push\s*\(\s*book\s*\)/);
+assert.match(groupByDecade.toString(), /grouped\s*\[\s*("|')Unknown\1\s*\]\s*\.push\s*\(\s*book\s*\)/);
 ```
 
 You should use `continue` to skip to the next iteration after handling an unknown year.

--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
@@ -18,20 +18,23 @@ Finally, use `continue` to skip the rest of the loop body. The `continue` statem
 You should check if `book.year` is equal to `"Unknown"`.
 
 ```js
-assert.match(groupByDecade.toString(), /book\.year\s*===?\s*"Unknown"/);
+assert.match(groupByDecade.toString(), /book\.year\s*===?\s*["']Unknown["']/);
 ```
 
 You should check if `grouped["Unknown"]` doesn't exist yet and initialize it as an empty array.
 
 ```js
-assert.match(groupByDecade.toString(), /!\s*grouped\s*\[\s*"Unknown"\s*\]/);
-assert.match(groupByDecade.toString(), /grouped\s*\[\s*"Unknown"\s*\]\s*=\s*\[\s*\]/);
+assert.match(
+  groupByDecade.toString(),
+  /(?:!\s*grouped\s*\[\s*["']Unknown["']\s*\]|!\s*Object\.hasOwn\s*\(\s*grouped\s*,\s*["']Unknown["']\s*\)|!\s*grouped\.hasOwnProperty\s*\(\s*["']Unknown["']\s*\)|grouped\s*\[\s*["']Unknown["']\s*\]\s*===\s*undefined)/
+);
+assert.match(groupByDecade.toString(), /grouped\s*\[\s*["']Unknown["']\s*\]\s*=\s*\[\s*\]/);
 ```
 
 You should push `book` into `grouped["Unknown"]`.
 
 ```js
-assert.match(groupByDecade.toString(), /grouped\s*\[\s*"Unknown"\s*\]\s*\.push\s*\(\s*book\s*\)/);
+assert.match(groupByDecade.toString(), /grouped\s*\[\s*["']Unknown["']\s*\]\s*\.push\s*\(\s*book\s*\)/);
 ```
 
 You should use `continue` to skip to the next iteration after handling an unknown year.


### PR DESCRIPTION
## Description

Fixes overly strict test assertions in Step 18 of the Heritage Library Catalog workshop that only accepted one specific way to check for property existence and only accepted double quotes, causing valid solutions to fail.

**Demo:**

https://github.com/user-attachments/assets/4b960c0b-ab45-4760-bbb1-d0ba046d2955



## Root Cause

The tests used hardcoded string patterns that only matched `!grouped["Unknown"]` with double quotes. Other semantically correct approaches like `!Object.hasOwn(grouped, "Unknown")`, `!grouped.hasOwnProperty("Unknown")`, `grouped["Unknown"] === undefined`, and single-quote equivalents all failed despite being valid JavaScript.

## What Changed

**`curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md`**
- Updated regex in the property existence check test to accept single or double quotes around `Unknown`.
- Replaced the two-assertion existence check with a single flexible regex that accepts `!grouped['Unknown']`, `!Object.hasOwn(...)`, `!grouped.hasOwnProperty(...)`, and `grouped['Unknown'] === undefined`.
- Updated the array initialization and push assertions to accept both single and double quotes.

## Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67068