### PR TITLE
fix(curriculum): remove repetitive explanations in bill splitter workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/69757cc0faae0152c1418aad.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/69757cc0faae0152c1418aad.md
@@ -9,13 +9,7 @@ dashedName: step-1
 
 In this workshop, you will practice working with numbers and mathematical operations to build a bill splitter. This tool will calculate how much each person owes after adding meal costs and a tip.
 
-To start, you need a way to keep track of the total amount as costs are added. In Python, you can use a variable to store an integer (a whole number) that changes over time.
-
-For example, you might write:
-
-```py
-my_number = 2
-```
+To start, you need a way to keep track of the total amount as costs are added. 
 
 Create a variable named `running_total` and assign it the value `0`.
 

--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
@@ -9,8 +9,6 @@ dashedName: step-6
 
 Now that you have calculated the tip, you need to add it to your `running_total` to find the final bill amount.
 
-In Python, you can use the augmented assignment operator `+=` to add a value to a variable and update that variable at the same time. For example, `total += 5` is a shorthand way of writing `total = total + 5`.
-
 Use the `+=` operator to add the value of `tip` to your `running_total`. Finally, use `print()` to display the string `Total with tip:` followed by a space and the value of `running_total`.
 
 # --hints--

--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/697a7f71ebfcd9e4cacd69c2.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/697a7f71ebfcd9e4cacd69c2.md
@@ -9,7 +9,7 @@ dashedName: step-8
 
 The bill is split, but division often results in long decimal numbers. Since money is typically represented with two decimal places, you should round the final result.
 
-Python provides a built-in `round()` function for this. It takes two arguments: the number you want to round and the number of decimal places to keep. Here's an example:
+In an earlier lesson, you learned about the `round()` function which takes two arguments: the number you want to round and the number of decimal places to keep. Here's an example:
 
 ```py
 num = 4.815162342

--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/6982684f3a25f379e195a5fc.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/6982684f3a25f379e195a5fc.md
@@ -7,9 +7,9 @@ dashedName: step-4
 
 # --description--
 
-Now that you have stored the individual costs, you can calculate the total. In Python, you use the addition operator `+` to sum values together. 
+Now that you have stored the individual costs, you can calculate the total. 
 
-The `+=` operator adds a value to an existing variable and updates it at the same time. For example:
+Recall that the `+=` operator adds a value to an existing variable and updates it at the same time. For example:
 
 ```py
 total = 10


### PR DESCRIPTION
I went through the bill splitter workshop and noticed a few instances where we were introducing the same concepts over and over again.

Here are the changes I made:

- In step 1, I removed the explanation on variable assignments and integers because there were two other workshops before this where this was already taught and practiced. 
- In step 4, I updated the language to mention that `+=` was taught earlier.
- In step 6, I removed the explanation for the `+=` operator because there was already a lesson on that beforehand. And an earlier step where you got to practice that. 
- In step 8, I updated the language to point out that prior lessons first introduced the `round()` function. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
