### PR TITLE
fix(curriculum): remove repetitive explanations from movie ticket workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-movie-ticket-booking-calculator/694a9ff65d4472dd451d8255.md
+++ b/curriculum/challenges/english/blocks/workshop-movie-ticket-booking-calculator/694a9ff65d4472dd451d8255.md
@@ -11,13 +11,6 @@ In this workshop, you will practice how to use booleans and conditional statemen
 
 Begin by declaring variables that store information about the user and the movie show.
 
-As you learned in previous lessons, variables are assigned using the assignment operator (`=`) this way:
-
-```py
-# Assigns the value 10 to variable x
-x = 10
-```
-
 Create a variable named `base_price` to store the base price of the movie ticket and set its value to `15`. Create another variable named `age` to store the user's age and set its value to `21`.
 
 # --hints--

--- a/curriculum/challenges/english/blocks/workshop-movie-ticket-booking-calculator/694cc1b515976889afd4cded.md
+++ b/curriculum/challenges/english/blocks/workshop-movie-ticket-booking-calculator/694cc1b515976889afd4cded.md
@@ -7,15 +7,9 @@ dashedName: step-2
 
 # --description--
 
-Now you need to store some string values about the movie ticket. You can store strings in Python this way:
-
-```py
-name = 'Alice'
-```
+Now you need to store some string values about the movie ticket. 
 
 Create a variable named `seat_type` to store the type of seat the user has selected and set its value to the string `Gold`. Create another variable named `show_time` to store the show time of the movie and set its value to the string `Evening`.
-
-Remember to surround both values with either single or double quotes.
 
 # --hints--
 


### PR DESCRIPTION
I was going through the movie ticket workshop and noticed a couple of times where there were explanations on how to use the assignment operator and assigning strings. But there have already been a few workshops where you practiced those concepts. So the explanations aren't necessary. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


