### PR TITLE
fix(api): remove legacy get-session-user endpoint

### DIFF
--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -187,7 +187,7 @@ const lockedProfileUI = {
 };
 
 // These are not part of the schema, but are added to the user object by
-// get-session-user's handler
+// session-user's handler
 const computedProperties = {
   calendar: {},
   completedChallengeCount: 0,
@@ -198,7 +198,7 @@ const computedProperties = {
   profileUI: lockedProfileUI
 };
 
-// The following appears in get-session-user responses, but not
+// The following appears in session-user responses, but not
 // get-public-profile
 const sessionOnlyData = {
   currentChallengeId: testUserData.currentChallengeId,
@@ -1632,16 +1632,6 @@ Thanks and regards,
     describe('/user/session-user', () => {
       test('GET returns 200 with empty user object for unauthenticated users', async () => {
         const response = await superRequest('/user/session-user', {
-          method: 'GET',
-          setCookies
-        });
-
-        expect(response.statusCode).toBe(200);
-        expect(response.body).toStrictEqual({ user: {}, result: '' });
-      });
-
-      test('GET legacy endpoint returns 200 with empty user object for unauthenticated users', async () => {
-        const response = await superRequest('/user/get-session-user', {
           method: 'GET',
           setCookies
         });

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -838,14 +838,6 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
   };
 
   fastify.get(
-    '/user/get-session-user',
-    {
-      schema: schemas.getSessionUser
-    },
-    getSessionUserHandler
-  );
-
-  fastify.get(
     '/user/session-user',
     {
       schema: schemas.getSessionUser

--- a/api/src/routes/public/user.test.ts
+++ b/api/src/routes/public/user.test.ts
@@ -391,7 +391,7 @@ describe('userRoutes', () => {
           expect(response.statusCode).toBe(200);
         });
         // TODO: create a list of public properties like the api-server and use that
-        // to restrict the output of this and get-session-user.
+        // to restrict the output of this and session-user.
         test('returns 200 status code with public user object', async () => {
           const testUser =
             await fastifyTestInstance.prisma.user.findFirstOrThrow({


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Save to remove, the client uses the latest endpoint and is deployed.

Closes #50734