### PR TITLE
fix(curriculum): remove introductory examples from caesar cipher workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a3d4c065557260de2ff33.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a3d4c065557260de2ff33.md
@@ -7,13 +7,9 @@ dashedName: step-1
 
 # --description--
 
-As you may recall from previous lessons, in Python, you declare a variable by writing the variable name on the left side of the assignment operator (`=`) and the value to assign on the right side:
+In this workshop, you will create a program called caesar cipher which is an encryption method that shifts letters in the alphabet to encode messages.
 
-```py
-variable_name = value
-```
-
-Create a variable called `shift` and assign the value `5` to your new variable.
+Start by creating a variable called `shift` and assign the value `5` to your new variable.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a41ef5bfdc059cfd9d4b5.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a41ef5bfdc059cfd9d4b5.md
@@ -7,13 +7,6 @@ dashedName: step-2
 
 # --description--
 
-In previous lessons, you learned about different data types you can store in a variable. You just assigned an integer value. Now you need to assign a string, which is a sequence of characters enclosed by either single or double quotes:
-
-```py
-string_1 = 'I am a string'
-string_2 = "I am also a string"
-```
-
 Declare another variable called `alphabet` and assign the string `abcdefghijklmnopqrstuvwxyz` to this variable.
 
 # --hints--

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/680a549f60f5a3fedfc0edd9.md
@@ -7,15 +7,7 @@ dashedName: step-4
 
 # --description--
 
-As you can see from the output, the shifted alphabet starts at the letter `f` because `shift` has the value `5`. But now the first five letters of the alphabet – `a`, `b`, `c`, `d` and `e` – are missing from the shifted alphabet, so you'll need to add them at the end of the shifted alphabet.
-
-The `+` operator is used to combine two or more strings together in a process called concatenation like this:
-
-```py
-greeting = 'Hello' + ' ' + 'World'
-print(greeting) # Hello World
-
-```
+As you can see from the output, the shifted alphabet starts at the letter `f` because `shift` has the value `5`. But now the first five letters of the alphabet – `a`, `b`, `c`, `d` and `e` – are missing from the shifted alphabet, so you'll need to add them at the end of the shifted alphabet. You can use the `+` operator to concatenate the missing portion of the alphabet.
 
 Modify the existing assignment of the `shifted_alphabet` variable: use the slicing syntax to extract the missing first portion of `alphabet` and concatenate it to `alphabet[shift:]`.
 

--- a/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819bc0637b80256a33adccc.md
+++ b/curriculum/challenges/english/blocks/workshop-caesar-cipher/6819bc0637b80256a33adccc.md
@@ -7,12 +7,7 @@ dashedName: step-16
 
 # --description--
 
-Now that you've implemented the basic functionalities of the cipher, it's time to add some validation. For that, you'll need an `if` statement. Here's a reminder of the syntax for an `if` statement:
-
-```py
-if condition:
-    # code to run when condition is true
-```
+Now that you've implemented the basic functionalities of the cipher, it's time to add some validation. For that, you'll need an `if` statement. 
 
 At the beginning of your function body, create an `if` statement. For now, use `True` as the condition, and within the `if` statement body return the string `Shift must be an integer value.`
 


### PR DESCRIPTION
This used to be the first workshop in the Python certification. 
But then we added more workshops and labs before it. So the introductory examples around variables, working with strings, can be removed. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

