### PR TITLE
fix(gha): correct playwright reporter path

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -186,5 +186,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-${{ matrix.browsers }}
-          path: playwright/reporter
+          path: e2e/playwright/reporter
           retention-days: 7

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -162,5 +162,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-${{ matrix.browsers }}
-          path: playwright/reporter
+          path: e2e/playwright/reporter
           retention-days: 7


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Playwright artifacts are currently not uploaded:

<details>
  <summary>Screenshot</summary>

<img width="862" height="105" alt="Screenshot 2026-04-25 at 06 38 07" src="https://github.com/user-attachments/assets/0b7b6bc7-b7e4-42dd-8d36-ede657b34968" />
</details>

Log: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/24877334643/job/72838226710?pr=67087#step:16:56

---

This is because the path is wrong. Playwright resolves `outputFolder` relative to where the test process runs:

https://github.com/freeCodeCamp/freeCodeCamp/blob/647f8b09ffb00864f1d9e7273c471b9363ba10a7/e2e/playwright.config.ts#L27

<!-- Feel free to add any additional description of changes below this line -->
