### PR TITLE
fix(e2e): address potential race condition in editor test

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -168,20 +168,20 @@ test.describe('Editor theme if the system theme is light', () => {
     }) => {
       await setTheme(request, 'default');
       await page.goto(testPage);
+      const editorContent = getEditors(page);
+      // Wait for the editor's mount-time autofocus
+      // so it cannot steal focus from the menu after we open it.
+      await expect(editorContent).toBeFocused();
+
       // Open the nav menu and toggle the theme
       const menuButton = page.getByRole('button', { name: 'Menu' });
       await menuButton.click();
       const menu = page.getByRole('list', { name: 'Menu' });
       await expect(menu).toBeVisible();
 
-      const toggle = page.getByRole('button', { name: 'Night Mode' });
+      const toggle = menu.getByRole('button', { name: 'Night Mode' });
       await expect(toggle).toBeVisible();
-
-      const listItem = page.getByRole('listitem').filter({ has: toggle });
-
-      // The button's click event is intercepted by the `li`,
-      // so we need to click on the `li` to trigger the theme change action.
-      await listItem.click();
+      await toggle.click();
 
       // Ensure that the action is completed before checking the editor.
       await expect(page.getByText('We have updated your theme')).toBeVisible();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This test case is still flaky after my previous attempt (#66565): 

> [chromium] › editor.spec.ts:169:9 › Editor theme if the system theme is light › If the user is signed in › should switch the editor theme when the user toggles the theme

Log: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/24877334643/job/72838226710?pr=67087#step:15:215

---

I think the test has a race condition because:
- The editor is auto-focused on mount
  - https://github.com/freeCodeCamp/freeCodeCamp/blob/495b0666201d90bc3d13e4f131c5a45672a7fe19/client/src/templates/Challenges/classic/editor.tsx#L1121
- While the dropdown menu closes if the Menu button blurs and the focus moves outside dropdown
  - https://github.com/freeCodeCamp/freeCodeCamp/blob/495b0666201d90bc3d13e4f131c5a45672a7fe19/client/src/components/Header/components/menu-button.tsx#L23-L32

From the log, the test was able to locate and click the Menu button, but couldn't find the dropdown menu. So the likely sequence is:
- Playwright finds and clicks the Menu button immediately after page load.
- The editor finishes mounting later and steals focus from the Menu button. 
- The Menu button now blurs and the dropdown is hidden, so the test can't find it.
 
 The fix is to wait for the editor to mount and receive focus first, then interact with the menu.

<!-- Feel free to add any additional description of changes below this line -->
