### PR TITLE
fix(curriculum): remove mentions of bin, oct, hex functions from review pages

### DIFF
--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -478,30 +478,6 @@ num = -13
 print(abs(num)) # 13
 ```
 
-- **`bin()` Function**: This is used to convert an integer to its binary representation as a string:
-
-```py
-num = 56
-
-print(bin(num))  # 0b111000
-```
-
-- **`oct()` Function**: This is used to convert an integer to its octal representation as a string:
-
-```py
-num = 56
-
-print(oct(num))  # 0o70
-```
-
-- **`hex()` Function**: This is used to convert an integer to its hexadecimal representation as a string:
-
-```py
-num = 56
-
-print(hex(num))  # 0x38
-```
-
 - **`pow()` Function**: This is used to raise a number to the power of another:
 
 ```py

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -478,30 +478,6 @@ num = -13
 print(abs(num)) # 13
 ```
 
-- **`bin()` Function**: This is used to convert an integer to its binary representation as a string:
-
-```py
-num = 56
-
-print(bin(num))  # 0b111000
-```
-
-- **`oct()` Function**: This is used to convert an integer to its octal representation as a string:
-
-```py
-num = 56
-
-print(oct(num))  # 0o70
-```
-
-- **`hex()` Function**: This is used to convert an integer to its hexadecimal representation as a string:
-
-```py
-num = 56
-
-print(hex(num))  # 0x38
-```
-
 - **`pow()` Function**: This is used to raise a number to the power of another:
 
 ```py


### PR DESCRIPTION
The `hex()`, `bin()` and `oct()` functions used to be taught inside the numbers lessons.
But that content was removed in this PR here 
https://github.com/freeCodeCamp/freeCodeCamp/pull/64700

So I removed mentions of those functions from the review pages. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


