### PR TITLE
fix(curriculum): allow optimized bubble sort in sorting visualizer

### DIFF
--- a/curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
+++ b/curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
@@ -238,7 +238,7 @@ try {
     genBtn.dispatchEvent(new Event("click"));
     sortBtn.dispatchEvent(new Event("click"));
     const container = document.querySelector("#array-container");
-    assert.lengthOf(container.children, 13)
+    assert.isAtLeast(container.children.length, 5);
     Array.from(container.children).forEach(el => {assert.equal(el.tagName, "DIV")})
 } finally {
     randomMocker.restore();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
## Description
The current tests for the Sorting Visualizer lab assume a specific number of steps (13) for an unoptimized Bubble Sort. If a student writes a more efficient version (e.g., stopping when no swaps occur), the test fails even though their code is correct.

This PR changes the `assert.lengthOf` check to `assert.isAtLeast(..., 5)` to allow for optimized implementations while still verifying that the algorithm is working.

## Related Issue
Closes #67100
 
