### PR TITLE
fix(curriculum): relax step 18 unknown key checks

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
@@ -18,31 +18,29 @@ Finally, use `continue` to skip the rest of the loop body. The `continue` statem
 You should check if `book.year` is equal to `"Unknown"`.
 
 ```js
-assert.match(groupByDecade.toString(), /book\.year\s*===?\s*["']Unknown["']/);
+assert.match(groupByDecade.toString(), /book\.year\s*===?\s*("|')Unknown\1/);
 ```
 
 You should check if `grouped["Unknown"]` doesn't exist yet and initialize it as an empty array.
 
 ```js
-assert.isTrue(
-  /!\s*grouped\s*\[\s*["']Unknown["']\s*\]/.test(groupByDecade.toString()) ||
-    /!\s*Object\.hasOwn\s*\(\s*grouped\s*,\s*["']Unknown["']\s*\)/.test(
-      groupByDecade.toString()
-    ) ||
-    /!\s*grouped\s*\.hasOwnProperty\s*\(\s*["']Unknown["']\s*\)/.test(
-      groupByDecade.toString()
-    ) ||
-    /grouped\s*\[\s*["']Unknown["']\s*\]\s*===?\s*undefined/.test(
-      groupByDecade.toString()
-    )
-);
-assert.match(groupByDecade.toString(), /grouped\s*\[\s*["']Unknown["']\s*\]\s*=\s*\[\s*\]/);
+const code = groupByDecade.toString();
+const existenceChecks = [
+  /!\s*grouped\s*\[\s*(["'])Unknown\1\s*\]/,
+  /!\s*Object\.hasOwn\s*\(\s*grouped\s*,\s*(["'])Unknown\1\s*\)/,
+  /!\s*grouped\s*\.hasOwnProperty\s*\(\s*(["'])Unknown\1\s*\)/,
+  /grouped\s*\[\s*(["'])Unknown\1\s*\]\s*===?\s*undefined/,
+  /!\s*\(\s*(["'])Unknown\1\s*in\s*grouped\s*\)/,
+];
+
+assert.isTrue(existenceChecks.some(re => re.test(code)));
+assert.match(code, /grouped\s*\[\s*("|')Unknown\1\s*\]\s*=\s*\[\s*\]/);
 ```
 
 You should push `book` into `grouped["Unknown"]`.
 
 ```js
-assert.match(groupByDecade.toString(), /grouped\s*\[\s*["']Unknown["']\s*\]\s*\.push\s*\(\s*book\s*\)/);
+assert.match(groupByDecade.toString(), /grouped\s*\[\s*("|')Unknown\1\s*\]\s*\.push\s*\(\s*book\s*\)/);
 ```
 
 You should use `continue` to skip to the next iteration after handling an unknown year.

--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
@@ -26,11 +26,11 @@ You should check if `grouped["Unknown"]` doesn't exist yet and initialize it as 
 ```js
 const code = groupByDecade.toString();
 const existenceChecks = [
-  /!\s*grouped\s*\[\s*(["'])Unknown\1\s*\]/,
-  /!\s*Object\.hasOwn\s*\(\s*grouped\s*,\s*(["'])Unknown\1\s*\)/,
-  /!\s*grouped\s*\.hasOwnProperty\s*\(\s*(["'])Unknown\1\s*\)/,
-  /grouped\s*\[\s*(["'])Unknown\1\s*\]\s*===?\s*undefined/,
-  /!\s*\(\s*(["'])Unknown\1\s*in\s*grouped\s*\)/,
+  /!\s*grouped\s*\[\s*("|')Unknown\1\s*\]/,
+  /!\s*Object\.hasOwn\s*\(\s*grouped\s*,\s*("|')Unknown\1\s*\)/,
+  /!\s*grouped\s*\.hasOwnProperty\s*\(\s*("|')Unknown\1\s*\)/,
+  /grouped\s*\[\s*("|')Unknown\1\s*\]\s*===?\s*undefined/,
+  /!\s*\(\s*("|')Unknown\1\s*in\s*grouped\s*\)/,
 ];
 
 assert.isTrue(existenceChecks.some(re => re.test(code)));

--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de82b435a1310aff57c2.md
@@ -18,20 +18,31 @@ Finally, use `continue` to skip the rest of the loop body. The `continue` statem
 You should check if `book.year` is equal to `"Unknown"`.
 
 ```js
-assert.match(groupByDecade.toString(), /book\.year\s*===?\s*"Unknown"/);
+assert.match(groupByDecade.toString(), /book\.year\s*===?\s*["']Unknown["']/);
 ```
 
 You should check if `grouped["Unknown"]` doesn't exist yet and initialize it as an empty array.
 
 ```js
-assert.match(groupByDecade.toString(), /!\s*grouped\s*\[\s*"Unknown"\s*\]/);
-assert.match(groupByDecade.toString(), /grouped\s*\[\s*"Unknown"\s*\]\s*=\s*\[\s*\]/);
+assert.isTrue(
+  /!\s*grouped\s*\[\s*["']Unknown["']\s*\]/.test(groupByDecade.toString()) ||
+    /!\s*Object\.hasOwn\s*\(\s*grouped\s*,\s*["']Unknown["']\s*\)/.test(
+      groupByDecade.toString()
+    ) ||
+    /!\s*grouped\s*\.hasOwnProperty\s*\(\s*["']Unknown["']\s*\)/.test(
+      groupByDecade.toString()
+    ) ||
+    /grouped\s*\[\s*["']Unknown["']\s*\]\s*===?\s*undefined/.test(
+      groupByDecade.toString()
+    )
+);
+assert.match(groupByDecade.toString(), /grouped\s*\[\s*["']Unknown["']\s*\]\s*=\s*\[\s*\]/);
 ```
 
 You should push `book` into `grouped["Unknown"]`.
 
 ```js
-assert.match(groupByDecade.toString(), /grouped\s*\[\s*"Unknown"\s*\]\s*\.push\s*\(\s*book\s*\)/);
+assert.match(groupByDecade.toString(), /grouped\s*\[\s*["']Unknown["']\s*\]\s*\.push\s*\(\s*book\s*\)/);
 ```
 
 You should use `continue` to skip to the next iteration after handling an unknown year.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67068

This PR relaxes the Step 18 test logic for the Heritage Library workshop to accept multiple valid ways of checking whether the Unknown group exists.

Accepted patterns now include direct negation, Object.hasOwn, hasOwnProperty, and undefined comparison, while still requiring initialization of the Unknown array and pushing the book into it.

It also accepts both single and double quotes around Unknown in the related checks.

Tested locally with curriculum linting for this challenge and english locale.