### PR TITLE
fix(deps): update monaco-editor to v0.52.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -89,7 +89,7 @@
     "lodash": "4.17.21",
     "lodash-es": "4.17.21",
     "micromark": "4.0.2",
-    "monaco-editor": "0.33.0",
+    "monaco-editor": "0.52.2",
     "nanoid": "3.3.11",
     "normalize-url": "6.1.0",
     "path-browserify": "1.0.1",

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -381,7 +381,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         : 4,
     dragAndDrop: true,
     lightbulb: {
-      enabled: false
+      enabled: 'off' as editor.ShowLightbulbIconMode
     },
     hover: {
       enabled: false
@@ -577,14 +577,14 @@ const Editor = (props: EditorProps): JSX.Element => {
     // @ts-ignore
     editor._standaloneKeybindingService.addDynamicKeybinding(
       '-editor.action.triggerSuggest',
-      null,
+      0,
       () => {}
     );
     const newLine = editor.getAction('editor.action.insertLineAfter');
     // @ts-ignore
     editor._standaloneKeybindingService.addDynamicKeybinding(
       '-editor.action.insertLineAfter',
-      null,
+      0,
       () => {}
     );
     // @ts-ignore
@@ -592,13 +592,13 @@ const Editor = (props: EditorProps): JSX.Element => {
       'editor.action.insertLineAfter',
       monaco.KeyMod.Alt | monaco.KeyCode.Enter,
       () => {
-        newLine.run();
+        void newLine?.run();
       }
     );
     // @ts-ignore
     editor._standaloneKeybindingService.addDynamicKeybinding(
       '-actions.find',
-      null,
+      0,
       () => {}
     );
     // Make toggle tab setting in editor permanent
@@ -1422,6 +1422,7 @@ const Editor = (props: EditorProps): JSX.Element => {
             }
           }}
           onChange={onChange}
+          language={modeMap[challengeFile?.ext ?? 'html']}
           options={{ ...options, folding: !hasEditableRegion() }}
           theme={editorTheme}
         />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,8 +400,8 @@ importers:
         specifier: 4.0.2
         version: 4.0.2
       monaco-editor:
-        specifier: 0.33.0
-        version: 0.33.0
+        specifier: 0.52.2
+        version: 0.52.2
       nanoid:
         specifier: 3.3.11
         version: 3.3.11
@@ -464,7 +464,7 @@ importers:
         version: 7.29.0(algoliasearch@4.27.0)(react@18.3.1)
       react-monaco-editor:
         specifier: 0.59.0
-        version: 0.59.0(monaco-editor@0.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.59.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-redux:
         specifier: 8.1.3
         version: 8.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)
@@ -660,7 +660,7 @@ importers:
         version: 4.1.0
       monaco-editor-webpack-plugin:
         specifier: 7.1.1
-        version: 7.1.1(monaco-editor@0.33.0)(webpack@5.106.2)
+        version: 7.1.1(monaco-editor@0.52.2)(webpack@5.106.2)
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -9567,8 +9567,8 @@ packages:
       monaco-editor: '>= 0.31.0'
       webpack: ^4.5.0 || 5.x
 
-  monaco-editor@0.33.0:
-    resolution: {integrity: sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw==}
+  monaco-editor@0.52.2:
+    resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
 
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
@@ -24490,13 +24490,13 @@ snapshots:
 
   moment@2.30.1: {}
 
-  monaco-editor-webpack-plugin@7.1.1(monaco-editor@0.33.0)(webpack@5.106.2):
+  monaco-editor-webpack-plugin@7.1.1(monaco-editor@0.52.2)(webpack@5.106.2):
     dependencies:
       loader-utils: 2.0.4
-      monaco-editor: 0.33.0
+      monaco-editor: 0.52.2
       webpack: 5.106.2(webpack-cli@4.10.0)
 
-  monaco-editor@0.33.0: {}
+  monaco-editor@0.52.2: {}
 
   mongodb-connection-string-url@3.0.2:
     dependencies:
@@ -25847,9 +25847,9 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resize-observer-polyfill: 1.5.1
 
-  react-monaco-editor@0.59.0(monaco-editor@0.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-monaco-editor@0.59.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      monaco-editor: 0.33.0
+      monaco-editor: 0.52.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67139

<!-- Feel free to add any additional description of changes below this line -->

Updates `monaco-editor` to match the `react-monaco-editor` peer dependency range. This also adjusts the classic challenge editor for Monaco 0.52 API changes and passes the active file language to prevent valid HTML/CSS from being diagnosed as JavaScript.

Tested with:

- `pnpm --filter @freecodecamp/client exec tsc --noEmit --pretty false`
- Local Playwright check on `/learn/responsive-web-design-v9/workshop-colored-markers/step-9/` confirmed no Monaco squiggle decorations.
