### PR TITLE
feat(gha): re-enable korean deploys

### DIFF
--- a/.github/workflows/curriculum-i18n-submodule.yml
+++ b/.github/workflows/curriculum-i18n-submodule.yml
@@ -26,6 +26,7 @@ jobs:
           - 'japanese'
           - 'german'
           - 'swahili'
+          - 'korean'
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -18,6 +18,7 @@ on:
           - japanese
           - german
           - swahili
+          - korean
         default: all
       show_upcoming_changes:
         description: 'Show upcoming changes (enables upcoming certifications and challenges)'
@@ -102,7 +103,8 @@ jobs:
               'ukrainian': 'ukr',
               'japanese': 'jpn',
               'german': 'ger',
-              'swahili': 'swa'
+              'swahili': 'swa',
+              'korean': 'kor'
             };
 
             const allLanguages = Object.keys(languageMap);


### PR DESCRIPTION
We added Korean back to the menu: https://github.com/freeCodeCamp/freeCodeCamp/pull/67080 - but it isn't working. This and the related PR should fix it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Related to: https://github.com/freeCodeCamp/nginx-config/pull/121

<!-- Feel free to add any additional description of changes below this line -->
