### PR TITLE
fix(client): defer MobileAppModal rendering until after first browser paint

### DIFF
--- a/client/src/templates/Challenges/components/mobile-app-modal.test.tsx
+++ b/client/src/templates/Challenges/components/mobile-app-modal.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { renderToString } from 'react-dom/server';
 import { render, screen, fireEvent } from '@testing-library/react';
 import {
   describe,
@@ -73,6 +74,14 @@ describe('MobileAppModal', () => {
   it('renders the modal on mobile for a public superblock', () => {
     render(<MobileAppModal superBlock={MOBILE_SUPERBLOCK} />);
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('does not render before mount', () => {
+    // useEffect does not run during server-side rendering, so the 'mounted'
+    // flag stays false and the component should produce no output.
+    expect(
+      renderToString(<MobileAppModal superBlock={MOBILE_SUPERBLOCK} />)
+    ).toBe('');
   });
 
   it('does not render on a desktop OS', () => {

--- a/client/src/templates/Challenges/components/mobile-app-modal.tsx
+++ b/client/src/templates/Challenges/components/mobile-app-modal.tsx
@@ -58,6 +58,20 @@ function MobileAppModal({
   const os = detectOS();
   const [dismissed, setDismissed] = useState(isDismissedFor30Days);
 
+  // Defer rendering until after the first browser paint. On a direct page
+  // load the component hydrates before the browser has computed layout, so
+  // document.documentElement.clientWidth is 0. The Modal's scroll-lock
+  // utility calculates the scrollbar compensation as
+  // window.innerWidth - clientWidth, which produces window.innerWidth when
+  // clientWidth is 0, and stamps that value as padding-right on <html>,
+  // breaking the layout. Waiting for useEffect guarantees that layout has
+  // been computed before the modal (and its scroll-lock) opens.
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   useEffect(() => {
     if (isProjectPreviewOpen) setDismissed(true);
   }, [isProjectPreviewOpen]);
@@ -73,7 +87,13 @@ function MobileAppModal({
   const storeName =
     os === 'ios' ? t('mobile-app-modal.ios') : t('mobile-app-modal.android');
 
-  if (os === 'other' || !isAvailable || isProjectPreviewOpen || dismissed)
+  if (
+    !mounted ||
+    os === 'other' ||
+    !isAvailable ||
+    isProjectPreviewOpen ||
+    dismissed
+  )
     return null;
 
   return (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR fixes an issue on direct page load, where `MobileAppModal` opens during React hydration before layout and paint are complete, causing the UI to break.

The issue does not happen if we navigate to the challenge via Gatsby's client-side router, because the page is already painted and layout computed when the component mounts.

Steps to test:
- Switch the browser to mobile view
- Go directly to a challenge where the modal would show up, or just refresh a challenge page
  - Example: /learn/python-v9/lecture-introduction-to-python-strings/what-are-strings-and-what-is-string-immutability

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/5b1a294b-0542-4680-ba12-4403330f06a2

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/bd8c7a2b-71cb-4963-8972-54ce7f34e043

</details>

<!-- Feel free to add any additional description of changes below this line -->
