### PR TITLE
fix(curriculum): update registration form step 48 to have borderBottomStyle set to none

### DIFF
--- a/curriculum/challenges/english/blocks/learn-html-forms-by-building-a-registration-form/62b30924c5e4ef0daba23b5e.md
+++ b/curriculum/challenges/english/blocks/learn-html-forms-by-building-a-registration-form/62b30924c5e4ef0daba23b5e.md
@@ -26,8 +26,8 @@ assert.exists(new __helpers.CSSHelp(document).getStyle('fieldset:last-of-type'))
 Your `fieldset:last-of-type` should have `border-bottom` set as `none`.
 
 ```js
-const borderBottom = new __helpers.CSSHelp(document).getStyle('fieldset:last-of-type')?.borderBottom;
-assert(borderBottom === 'none' || borderBottom === 'medium none' || borderBottom === 'medium');
+const borderBottomStyle = new __helpers.CSSHelp(document).getStyle('fieldset:last-of-type')?.borderBottomStyle;
+assert.equal(borderBottomStyle, 'none');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66950

<!-- Feel free to add any additional description of changes below this line -->

Updated Registration Form Step 48 to have borderBottomStyle set to none 
