### PR TITLE
fix(api): resolve timeline race condition on rapid submission

### DIFF
--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -58,7 +58,8 @@ const userChallengeSelect = {
   partiallyCompletedChallenges: true,
   progressTimestamps: true,
   needsModeration: true,
-  savedChallenges: true
+  savedChallenges: true,
+  updateCount: true
 };
 
 /**

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -125,6 +125,7 @@ export async function updateUserChallengeData(
     | 'savedChallenges'
     | 'progressTimestamps'
     | 'partiallyCompletedChallenges'
+    | 'updateCount'
   >,
   challengeId: string,
   _completedChallenge: CompletedChallenge
@@ -215,22 +216,42 @@ export async function updateUserChallengeData(
     challenge => challenge.id !== challengeId
   );
 
-  const { savedChallenges: userSavedChallenges } =
-    await fastify.prisma.user.update({
+  const updateResult = await fastify.prisma.user.updateMany({
+    where: { id: user.id, updateCount: user.updateCount },
+    data: {
+      completedChallenges: userCompletedChallenges,
+      // TODO: `needsModeration` should be handled closer to source, because it exists in 3 states: true, false, undefined/null
+      //       `undefined` in Prisma is a no-op
+      needsModeration: needsModeration || undefined,
+      savedChallenges: savedChallengesUpdate,
+      progressTimestamps: userProgressTimestamps,
+      partiallyCompletedChallenges: userPartiallyCompletedChallenges,
+      updateCount: { increment: 1 }
+    }
+  });
+
+  let userSavedChallenges;
+  if (updateResult.count === 0) {
+    // A concurrent request updated the user record first.
+    // Silently succeed as the challenge should have already been recorded.
+    const updatedUser = await fastify.prisma.user.findUniqueOrThrow({
       where: { id: user.id },
-      data: {
-        completedChallenges: userCompletedChallenges,
-        // TODO: `needsModeration` should be handled closer to source, because it exists in 3 states: true, false, undefined/null
-        //       `undefined` in Prisma is a no-op
-        needsModeration: needsModeration || undefined,
-        savedChallenges: savedChallengesUpdate,
-        progressTimestamps: userProgressTimestamps,
-        partiallyCompletedChallenges: userPartiallyCompletedChallenges
-      },
-      select: {
-        savedChallenges: true
-      }
+      select: { savedChallenges: true }
     });
+    userSavedChallenges = updatedUser.savedChallenges;
+  } else {
+    // If we succeeded in the updateMany, fetch the updated savedChallenges
+    // since updateMany doesn't return the updated record.
+    if (savableChallenges.has(challengeId)) {
+      const updatedUser = await fastify.prisma.user.findUniqueOrThrow({
+        where: { id: user.id },
+        select: { savedChallenges: true }
+      });
+      userSavedChallenges = updatedUser.savedChallenges;
+    } else {
+      userSavedChallenges = savedChallenges;
+    }
+  }
 
   return {
     alreadyCompleted,

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -8,7 +8,8 @@ import {
   retry,
   switchMap,
   tap,
-  mergeMap
+  mergeMap,
+  exhaustMap
 } from 'rxjs/operators';
 import { createFlashMessage } from '../../../components/Flash/redux';
 import {
@@ -247,7 +248,7 @@ function submitMsTrophy(type, state) {
 export default function completionEpic(action$, state$) {
   return action$.pipe(
     ofType(actionTypes.submitChallenge),
-    switchMap(({ type }) => {
+    exhaustMap(({ type }) => {
       const state = state$.value;
 
       const {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66954

### Description

This PR resolves a race condition where rapid successive clicks on the "Submit and continue" button result in duplicate timeline entries for a single challenge.

**Architectural Approach:**

1. **Frontend (Redux):** Implemented `exhaustMap` (or the equivalent debounce/throttle) in the Redux epic for `submitChallenge`. This ensures that while a submission dispatch is actively pending, any subsequent rapid dispatches are ignored at the state management level.
2. **Backend (Optimistic Concurrency Control):** Updated the `updateUserChallengeState` function to utilize Prisma's `updateMany` filtering by the user's current `updateCount`. If a concurrent request attempts to write after the `updateCount` has incremented, the database safely skips the redundant write.

**Note on Idempotency:** The backend is configured to silently succeed (return 200 OK) when a concurrent update is caught, ensuring the client UI remains uninterrupted since the target end-state (challenge completion) is successfully achieved.