### PR TITLE
fix(settings): update margins for settings disclaimer

### DIFF
--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -185,7 +185,11 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
               >
                 {t('settings.for', { username: username })}
               </h1>
-              <Trans i18nKey='settings.profile-note'>
+              <Trans
+                i18nKey='settings.profile-note'
+                parent='p'
+                className='text-center'
+              >
                 <a href={`/${username}`}>your profile</a>
               </Trans>
             </ScrollElement>

--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -9,7 +9,7 @@ import store from 'store';
 import { scroller, Element as ScrollElement } from 'react-scroll';
 import envData from '../../config/env.json';
 import { createFlashMessage } from '../components/Flash/redux';
-import { Loader } from '../components/helpers';
+import { FullWidthRow, Loader } from '../components/helpers';
 import Certification from '../components/settings/certification';
 import Account from '../components/settings/account';
 import DangerZone from '../components/settings/danger-zone';
@@ -175,19 +175,21 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
         <SettingsSidebarNav userToken={userToken} />
         <main className='settings-main'>
           <Spacer size='l' />
-          <ScrollElement name='username'>
-            <h1
-              id='content-start'
-              className='text-center'
-              style={{ overflowWrap: 'break-word' }}
-              data-playwright-test-label='settings-heading'
-            >
-              {t('settings.for', { username: username })}
-            </h1>
-            <Trans i18nKey='settings.profile-note'>
-              <a href={`/${username}`}>your profile</a>
-            </Trans>
-          </ScrollElement>
+          <FullWidthRow>
+            <ScrollElement name='username'>
+              <h1
+                id='content-start'
+                className='text-center'
+                style={{ overflowWrap: 'break-word' }}
+                data-playwright-test-label='settings-heading'
+              >
+                {t('settings.for', { username: username })}
+              </h1>
+              <Trans i18nKey='settings.profile-note'>
+                <a href={`/${username}`}>your profile</a>
+              </Trans>
+            </ScrollElement>
+          </FullWidthRow>
           <Spacer size='l' />
           <ScrollElement name='personal'>
             <About


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67181

<!-- Feel free to add any additional description of changes below this line -->

Wraps the top disclaimer text ("You can go to [your profile](https://www.freecodecamp.org/fcc-ef7b8ea2-1a21-4533-a885-cb02ea21876c) to update your personal information.") in a `<FullWidthRow>` component to ensure this text has the same margins as other section descriptions in `show-settings.tsx`. Also centers the text with a class name to align it more properly. The margins for this disclaimer text more closely now match the rows in other component blocks like `components/settings/privacy.tsx`.

PREVIOUS UI:
<img width="1512" height="684" alt="Screenshot 2026-04-29 at 11 31 55 PM" src="https://github.com/user-attachments/assets/4bb77e0e-ba5a-442c-b5af-e086c598043f" />

UPDATED UI:
<img width="1512" height="718" alt="Screenshot 2026-04-30 at 12 34 15 AM" src="https://github.com/user-attachments/assets/829203e5-49b1-4a38-8439-33a043b048a8" />
