### PR TITLE
fix(settings): make certification tables full width

### DIFF
--- a/client/src/components/settings/certification.css
+++ b/client/src/components/settings/certification.css
@@ -1,3 +1,8 @@
+.certification-settings table {
+  display: table;
+  width: 100%;
+}
+
 .certification-settings tr {
   height: 57px;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
<!-- Closes #XXXXX -->

<!-- Feel free to add any additional description of changes below this line -->

## What changed

The certification settings tables now explicitly render as full-width tables inside `.certification-settings`.

## Why

The global table styles make tables scrollable inline blocks. In the certification settings view, that allowed shorter certification tables to collapse to their content width, so sections no longer lined up visually.

## Screenshots

Actual local `/settings` screenshots captured from the running app at `http://localhost:8000/settings` with the certified user. The before screenshot applies the previous table display rule to the actual page for comparison.

Before:

![Before: certification tables shrink to content width in the actual settings page](https://gist.githubusercontent.com/Sembauke/534300e394e6950ad23e4abbb0fa2712/raw/0112cde7857dbbe9a0d5a50bbc12839ca683ccf2/before-actual-local-settings.svg)

After:

![After: certification tables use the full content width in the actual settings page](https://gist.githubusercontent.com/Sembauke/534300e394e6950ad23e4abbb0fa2712/raw/e8d13f404455fe1c95ab9355583c8ec419630fdb/after-actual-local-settings.svg)

## Testing

- `pnpm exec stylelint client/src/components/settings/certification.css`
- Captured actual local app screenshots from `/settings`
