### PR TITLE
fix(curriculum): make Step 35 border test more robust

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3a06c6adde47584e2721.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3a06c6adde47584e2721.md
@@ -44,7 +44,7 @@ Set the `border` property to `none`.
 
 ```js
 const style = new __helpers.CSSHelp(document).getStyle('.submit-btn');
-assert.include(style?.getPropVal('border'), 'none');
+assert.strictEqual(style?.borderBottomStyle, 'none');
 ```
 
 Set the `border-radius` property to `6px`.

--- a/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3a06c6adde47584e2721.md
+++ b/curriculum/challenges/english/blocks/workshop-parent-teacher-conference-form/68eb3a06c6adde47584e2721.md
@@ -44,7 +44,7 @@ Set the `border` property to `none`.
 
 ```js
 const style = new __helpers.CSSHelp(document).getStyle('.submit-btn');
-assert.oneOf(style?.getPropVal('border'), ['none', 'medium', 'medium none']);
+assert.include(style?.getPropVal('border'), 'none');
 ```
 
 Set the `border-radius` property to `6px`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66939

<!-- Feel free to add any additional description of changes below this line -->

Fixes inconsistent failures in Step 35 of the Parent Teacher Conference Form workshop.

* Updates the border assertion to handle cross-browser differences in computed styles
* Ensures `border: none` is correctly validated across environments
* Minimal change that preserves the original learning intent
