### PR TITLE
fix(curriculum): add example data structure to forum leaderboard lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-fcc-forum-leaderboard/673c91f0b934834bc4a3ecc2.md
+++ b/curriculum/challenges/english/blocks/lab-fcc-forum-leaderboard/673c91f0b934834bc4a3ecc2.md
@@ -35,6 +35,7 @@ In this lab, you will build a freeCodeCamp forum leaderboard that displays the l
   }
   
 }
+```
 
 **User Stories:**
 
@@ -49,13 +50,13 @@ In this lab, you will build a freeCodeCamp forum leaderboard that displays the l
 1. The `forumCategory` function should verify that the selected category id is a property of the `allCategories` object and should return a string containing an anchor element with:
    - the text of the `category` key of the selected category.
    - a class of `category` followed by the `className` property of the selected category.
-   - an `href` with the value of `<forumCategoryUrl>/<className>/<id>`, where `<className>` is the `className` property of the selected category and `id` is the argument passed to `forumCategory`.
+   - an `href` formed by appending `<className>/<id>` to `forumCategoryUrl` without adding an extra `/`, where `<className>` is the `className` property of the selected category and `id` is the argument passed to `forumCategory`.
 1. If the `allCategories` object does not have the selected category id as its property, `category` should be indicated as `General` and `className` should be indicated as `general`.
 1. You should have a function named `avatars` that takes two arrays representing posters and users, respectively.
 1. The `avatars` function should return a string made by joining `img` elements, one for each `user_id` in the `posters` array. Find the `img` URL by looking up the `user_id` property in the `posters` array and find the matching `id` property in the `users` array.
-1. The `avatars` function should set each avatar's size by accessing the `avatar_template` property and replacing `{size}` with `30`.
+1. The `avatars` function should set each avatar's size. Each object in the `users` array contains an `avatar_template` string where `{size}` is a placeholder that should be replaced with `30`.
 1. Each image element should have an alt text with the value of the `name` property of the poster.
-1. Each image element should have a source with the value of the `avatar_template` property of the poster. In case `avatar_template` contains a relative path, you should set the source to `<avatarUrl>/<avatar_template>`.
+1. Each image element should have a source derived from the `avatar_template` property of the poster. If `avatar_template` starts with `/`, prepend `avatarUrl` without adding an extra `/`.
 1. You should have a function named `showLatestPosts` that takes a single parameter.
 1. The `showLatestPosts` should extract the `users` and `topic_list` properties from the object passed as argument. Also, it should process the following properties of the objects from the `topics` array, which is contained in `topic_list`:
    - `id`: the id of the post

--- a/curriculum/challenges/english/blocks/lab-fcc-forum-leaderboard/673c91f0b934834bc4a3ecc2.md
+++ b/curriculum/challenges/english/blocks/lab-fcc-forum-leaderboard/673c91f0b934834bc4a3ecc2.md
@@ -12,6 +12,30 @@ In this lab, you will build a freeCodeCamp forum leaderboard that displays the l
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
+### Example Data Structure
+
+```json
+{
+  "users": [
+    {
+      "id": 6,
+      "name": "Quincy Larson",
+      "avatar_template": "/user_avatar/QuincyLarson_{size}.png"
+    }
+  ],
+  "topic_list": {
+    "topics": [
+      {
+        "id": 684569,
+        "title": "Example title",
+        "posters": [{ "user_id": 6 }],
+        "category_id": 1
+      }
+    ]
+  }
+  
+}
+
 **User Stories:**
 
 1. You should have a function named `timeAgo` that takes a timestamp in the ISO 8601 format as the argument.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66891

<!-- Feel free to add any additional description of changes below this line -->

Adds an example JSON data structure to the Forum Leaderboard lab.

Previously, learners had to infer the structure of the `users` and `topic_list` objects, which could lead to confusion—especially around properties like `avatar_template` and how data is mapped between posters and users.

This change provides a clear reference so learners can:
- understand the structure of the API response
- correctly work with `users`, `topics`, and `posters`
- better implement functions like `avatars` and `showLatestPosts`

This improves clarity and reduces guesswork without altering any existing functionality or tests.