### PR TITLE
fix(curriculum): add missing inputType to zh-a1 task-17

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-learn-numbers-20-to-99/69884da53311674ed527537f.md
+++ b/curriculum/challenges/english/blocks/zh-a1-learn-numbers-20-to-99/69884da53311674ed527537f.md
@@ -4,6 +4,7 @@ title: Task 17
 challengeType: 22
 dashedName: task-17
 lang: zh-CN
+inputType: pinyin-to-hanzi
 ---
 
 # --description--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #XXXXX

Task 17 in the `zh-a1-learn-numbers-20-to-99` block was missing `inputType: pinyin-to-hanzi` in its frontmatter. Without it, the challenge parser does not include an `inputType` in the output, so the UI renders a plain text input instead of the pinyin-to-hanzi converter. Evaluation then falls through to a direct string comparison against the full answer string (e.g. `七十二 (qī shí èr)`), making the challenge impossible to complete as intended.

All other `challengeType: 22` challenges in the block already have `inputType: pinyin-to-hanzi` set. This adds the missing field to Task 17.