### PR TITLE
fix(client): add language selector to mobile layout for daily coding challenge

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -308,3 +308,35 @@
     padding: 2px 12px;
   }
 }
+
+.mobile-language-selector {
+  display: flex;
+  gap: 3px;
+  padding: 4px 8px;
+  background-color: var(--secondary-background);
+  border-bottom: 1px solid var(--quaternary-color);
+  flex-shrink: 0;
+}
+
+.mobile-language-selector button {
+  padding: 4px 12px;
+  border-width: 3px;
+  border-style: solid;
+  font-size: 0.85em;
+}
+
+.mobile-language-selector button[aria-expanded='true'] {
+  border-color: var(--primary-color);
+  background-color: var(--primary-color);
+  color: var(--secondary-background);
+}
+
+.mobile-language-selector button:hover:not(:disabled) {
+  color: var(--secondary-color);
+  background-color: var(--primary-background);
+}
+
+.mobile-language-selector button[aria-expanded='true']:hover {
+  background-color: var(--quaternary-color);
+  color: var(--secondary-background);
+}

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -308,3 +308,19 @@
     padding: 2px 12px;
   }
 }
+
+.mobile-lang-selector-toggle {
+  background-color: var(--secondary-background);
+  border: 0;
+  border-right: 1px solid var(--quaternary-color);
+  color: var(--primary-color);
+  font-size: 0.8em;
+  height: 100%;
+  padding-left: 0.4rem;
+  padding-right: 0.4rem;
+}
+
+.mobile-lang-selector-toggle:hover {
+  background-color: var(--quaternary-background);
+  color: var(--secondary-color);
+}

--- a/client/src/templates/Challenges/classic/mobile-layout.test.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MobileLayout } from './mobile-layout';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return
+  withTranslation: () => (Component: any) => Component
+}));
+
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string) => key
+  }
+}));
+
+vi.mock('@freecodecamp/shared/config/challenge-types', () => ({
+  challengeTypes: {
+    python: 1,
+    javascript: 2,
+    multifileCertProject: 3,
+    multifilePythonCertProject: 4,
+    lab: 5,
+    jsLab: 6,
+    pyLab: 7,
+    dailyChallengeJs: 8,
+    dailyChallengePy: 9
+  }
+}));
+
+vi.mock('../redux/actions', () => ({
+  removePortalWindow: vi.fn(),
+  setShowPreviewPortal: vi.fn(),
+  setShowPreviewPane: vi.fn(),
+  storePortalWindow: vi.fn()
+}));
+
+vi.mock('../redux/selectors', () => ({
+  portalWindowSelector: vi.fn(),
+  showPreviewPortalSelector: vi.fn(),
+  showPreviewPaneSelector: vi.fn()
+}));
+
+vi.mock('../components/preview-portal', () => ({
+  default: () => <div>Preview Portal</div>
+}));
+
+vi.mock('../components/notes', () => ({
+  default: () => <div>Notes</div>
+}));
+
+vi.mock('./editor-tabs', () => ({
+  default: () => <div>Editor Tabs</div>
+}));
+
+const mockProps = {
+  editor: <div>Editor</div>,
+  hasEditableBoundaries: false,
+  hasPreview: false,
+  instructions: <div>Instructions</div>,
+  notes: '',
+  preview: <div>Preview</div>,
+  onPreviewResize: vi.fn(),
+  windowTitle: 'Test Title',
+  showPreviewPortal: false,
+  showPreviewPane: false,
+  toolPanel: <div>ToolPanel</div>,
+  removePortalWindow: vi.fn(),
+  setShowPreviewPortal: vi.fn(),
+  setShowPreviewPane: vi.fn(),
+  portalWindow: null,
+  updateUsingKeyboardInTablist: vi.fn(),
+  testOutput: <div>Test Output</div>,
+  usesMultifileEditor: false,
+  usesTerminal: false
+};
+
+describe('<MobileLayout />', () => {
+  it('should render language selector when isDailyCodingChallenge is true', () => {
+    render(
+      <MobileLayout
+        {...mockProps}
+        isDailyCodingChallenge={true}
+        dailyCodingChallengeLanguage='javascript'
+      />
+    );
+    expect(screen.getByText('JS')).toBeInTheDocument();
+  });
+
+  it('should not render language selector when isDailyCodingChallenge is false', () => {
+    render(<MobileLayout {...mockProps} isDailyCodingChallenge={false} />);
+    expect(screen.queryByText('JS')).not.toBeInTheDocument();
+    expect(screen.queryByText('PY')).not.toBeInTheDocument();
+  });
+
+  it('should call setDailyCodingChallengeLanguage when a language is selected', () => {
+    const setDailyCodingChallengeLanguage = vi.fn();
+    render(
+      <MobileLayout
+        {...mockProps}
+        isDailyCodingChallenge={true}
+        dailyCodingChallengeLanguage='javascript'
+        setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
+      />
+    );
+
+    // Open dropdown
+    fireEvent.click(screen.getByText('JS'));
+
+    // Click Python option
+    fireEvent.click(screen.getByText('Python'));
+
+    expect(setDailyCodingChallengeLanguage).toHaveBeenCalledWith('python');
+  });
+});

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -4,7 +4,9 @@ import { faWindowRestore } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
+import store from 'store';
 import { Tabs, TabsContent, TabsTrigger, TabsList } from '@freecodecamp/ui';
+import { DailyCodingChallengeLanguages } from '../../../redux/prop-types';
 
 import {
   removePortalWindow,
@@ -26,6 +28,11 @@ interface MobileLayoutProps {
   hasEditableBoundaries: boolean;
   hasPreview: boolean;
   instructions: JSX.Element;
+  isDailyCodingChallenge?: boolean;
+  dailyCodingChallengeLanguage?: DailyCodingChallengeLanguages;
+  setDailyCodingChallengeLanguage?: (
+    language: DailyCodingChallengeLanguages
+  ) => void;
   notes: string;
   preview: JSX.Element;
   onPreviewResize: () => void;
@@ -166,8 +173,20 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       portalWindow,
       windowTitle,
       usesMultifileEditor,
-      usesTerminal
+      usesTerminal,
+      isDailyCodingChallenge,
+      dailyCodingChallengeLanguage,
+      setDailyCodingChallengeLanguage
     } = this.props;
+
+    const handleLanguageChange = (
+      language: DailyCodingChallengeLanguages
+    ): void => {
+      store.set('dailyCodingChallengeLanguage', language);
+      if (setDailyCodingChallengeLanguage) {
+        setDailyCodingChallengeLanguage(language);
+      }
+    };
 
     const displayPreviewPane = hasPreview && showPreviewPane;
     const displayPreviewPortal = hasPreview && showPreviewPortal;
@@ -256,6 +275,26 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             className='tab-content'
             value={tabs.editor}
           >
+            {isDailyCodingChallenge && (
+              <div className='mobile-language-selector'>
+                <button
+                  aria-expanded={
+                    dailyCodingChallengeLanguage === 'javascript'
+                  }
+                  disabled={dailyCodingChallengeLanguage === 'javascript'}
+                  onClick={() => handleLanguageChange('javascript')}
+                >
+                  JavaScript
+                </button>
+                <button
+                  aria-expanded={dailyCodingChallengeLanguage === 'python'}
+                  disabled={dailyCodingChallengeLanguage === 'python'}
+                  onClick={() => handleLanguageChange('python')}
+                >
+                  Python
+                </button>
+              </div>
+            )}
             {usesMultifileEditor && <EditorTabs />}
             {editor}
           </TabsContent>

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -4,7 +4,16 @@ import { faWindowRestore } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
-import { Tabs, TabsContent, TabsTrigger, TabsList } from '@freecodecamp/ui';
+import store from 'store';
+import {
+  Tabs,
+  TabsContent,
+  TabsTrigger,
+  TabsList,
+  Dropdown,
+  MenuItem
+} from '@freecodecamp/ui';
+import { DailyCodingChallengeLanguages } from '../../../redux/prop-types';
 
 import {
   removePortalWindow,
@@ -26,6 +35,11 @@ interface MobileLayoutProps {
   hasEditableBoundaries: boolean;
   hasPreview: boolean;
   instructions: JSX.Element;
+  isDailyCodingChallenge?: boolean;
+  dailyCodingChallengeLanguage?: DailyCodingChallengeLanguages;
+  setDailyCodingChallengeLanguage?: (
+    language: DailyCodingChallengeLanguages
+  ) => void;
   notes: string;
   preview: JSX.Element;
   onPreviewResize: () => void;
@@ -79,7 +93,10 @@ const mapStateToProps = createSelector(
   })
 );
 
-class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
+export class MobileLayout extends Component<
+  MobileLayoutProps,
+  MobileLayoutState
+> {
   static displayName: string;
 
   #toolPanelGroup!: HTMLElement;
@@ -166,8 +183,20 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       portalWindow,
       windowTitle,
       usesMultifileEditor,
-      usesTerminal
+      usesTerminal,
+      isDailyCodingChallenge,
+      dailyCodingChallengeLanguage,
+      setDailyCodingChallengeLanguage
     } = this.props;
+
+    const handleLanguageChange = (
+      language: DailyCodingChallengeLanguages
+    ): void => {
+      store.set('dailyCodingChallengeLanguage', language);
+      if (setDailyCodingChallengeLanguage) {
+        setDailyCodingChallengeLanguage(language);
+      }
+    };
 
     const displayPreviewPane = hasPreview && showPreviewPane;
     const displayPreviewPortal = hasPreview && showPreviewPortal;
@@ -228,6 +257,26 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
           {...(hasPreview && { 'data-haspreview': 'true' })}
         >
           <TabsList className='nav-lists'>
+            {isDailyCodingChallenge && (
+              <Dropdown>
+                <Dropdown.Toggle
+                  className='mobile-lang-selector-toggle'
+                  id='mobile-language-selector'
+                >
+                  {dailyCodingChallengeLanguage === 'javascript'
+                    ? 'JS'
+                    : 'PY'}{' '}
+                </Dropdown.Toggle>
+                <Dropdown.Menu>
+                  <MenuItem onClick={() => handleLanguageChange('javascript')}>
+                    JavaScript
+                  </MenuItem>
+                  <MenuItem onClick={() => handleLanguageChange('python')}>
+                    Python
+                  </MenuItem>
+                </Dropdown.Menu>
+              </Dropdown>
+            )}
             {!hasEditableBoundaries && (
               <TabsTrigger value={tabs.instructions}>
                 {i18next.t('learn.editor-tabs.instructions')}

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -490,6 +490,9 @@ function ShowClassic({
             })}
             hasEditableBoundaries={hasEditableBoundaries}
             hasPreview={hasPreview}
+            isDailyCodingChallenge={isDailyCodingChallenge}
+            dailyCodingChallengeLanguage={dailyCodingChallengeLanguage}
+            setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
             instructions={renderInstructionsPanel({
               toolPanel: null,
               hasDemo: demoType === 'onClick'

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -325,7 +325,10 @@ function ShowClassic({
   // Show test
 
   useEffect(() => {
-    if (isPreFetchEnabled && envData.clientLocale === 'espanol') {
+    if (
+      isPreFetchEnabled &&
+      (envData as { clientLocale: string }).clientLocale === 'espanol'
+    ) {
       preloadPage(nextChallengePath);
     }
   }, [nextChallengePath, isPreFetchEnabled]);
@@ -493,6 +496,9 @@ function ShowClassic({
             })}
             hasEditableBoundaries={hasEditableBoundaries}
             hasPreview={hasPreview}
+            isDailyCodingChallenge={isDailyCodingChallenge}
+            dailyCodingChallengeLanguage={dailyCodingChallengeLanguage}
+            setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
             instructions={renderInstructionsPanel({
               toolPanel: null,
               hasDemo: demoType === 'onClick'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66361

<!-- Feel free to add any additional description of changes below this line -->

## Problem
On screens narrower than ~765px, freeCodeCamp switches to `MobileLayout`. The JavaScript/Python language selector for daily coding challenges only existed in `ActionRow`, which is only rendered in the "desktop" layout — so the selector was completely invisible on small screens.

## Changes
- mobile-layout.tsx: Added optional props "isDailyCodingChallenge", "dailyCodingChallengeLanguage", and "setDailyCodingChallengeLanguage" When on a daily coding challenge, a "[JavaScript] [Python]" selector is rendered inside the Code tab content area.
- show.tsx: Passed the three daily challenge props to "MobileLayout" (previously they were only forwarded to "DesktopLayout").
- classic.css: Added ".mobile-language-selector" styles matching the desktop button appearance.

## Behaviour
The language selector appears below the tab bar when the "Code tab" is active on mobile/small screens. Switching language saves to "localStorage" and dispatches the Redux action — identical to the desktop version in "action-row.tsx".