### PR TITLE
fix(client): switch languages on mobile layout

### DIFF
--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -20,6 +20,7 @@ import { TOOL_PANEL_HEIGHT } from '../../../../config/misc';
 import PreviewPortal from '../components/preview-portal';
 import Notes from '../components/notes';
 import EditorTabs from './editor-tabs';
+import { DailyCodingChallengeLanguages } from '../../../redux/prop-types';
 
 interface MobileLayoutProps {
   editor: JSX.Element | null;
@@ -41,6 +42,11 @@ interface MobileLayoutProps {
   testOutput: JSX.Element;
   usesMultifileEditor: boolean;
   usesTerminal: boolean;
+  isDailyCodingChallenge: boolean;
+  dailyCodingChallengeLanguage: DailyCodingChallengeLanguages;
+  setDailyCodingChallengeLanguage: (
+    language: DailyCodingChallengeLanguages
+  ) => void;
 }
 
 const tabs = {
@@ -48,7 +54,9 @@ const tabs = {
   preview: 'preview',
   console: 'console',
   notes: 'notes',
-  instructions: 'instructions'
+  instructions: 'instructions',
+  python: 'python',
+  javascript: 'javascript'
 } as const;
 
 type Tab = keyof typeof tabs;
@@ -94,6 +102,14 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     this.setState({
       currentTab: tab as Tab
     });
+    if(tab == tabs.python)
+    {
+      this.props.setDailyCodingChallengeLanguage("python")
+    }
+    else if(tab == tabs.javascript)
+    {
+      this.props.setDailyCodingChallengeLanguage("javascript")
+    }
   };
 
   // Keep the tool panel visible when mobile address bar and/or keyboard are in view.
@@ -166,7 +182,8 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       portalWindow,
       windowTitle,
       usesMultifileEditor,
-      usesTerminal
+      usesTerminal,
+      isDailyCodingChallenge
     } = this.props;
 
     const displayPreviewPane = hasPreview && showPreviewPane;
@@ -233,9 +250,18 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
                 {i18next.t('learn.editor-tabs.instructions')}
               </TabsTrigger>
             )}
-            <TabsTrigger value={tabs.editor}>
+            {isDailyCodingChallenge && ( <TabsTrigger value={tabs.javascript}>
+              JavaScript
+            </TabsTrigger>
+            )}
+            {isDailyCodingChallenge && ( <TabsTrigger value={tabs.python}>
+              Python
+            </TabsTrigger>
+            )}
+             {!isDailyCodingChallenge && ( <TabsTrigger value={tabs.editor}>
               {i18next.t('learn.editor-tabs.code')}
             </TabsTrigger>
+            )}
             {!!notes && usesMultifileEditor && (
               <TabsTrigger value={tabs.notes}>
                 {i18next.t('learn.editor-tabs.notes')}
@@ -251,7 +277,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             )}
           </TabsList>
 
-          <TabsContent
+          {!isDailyCodingChallenge && (<TabsContent
             tabIndex={-1}
             className='tab-content'
             value={tabs.editor}
@@ -259,6 +285,27 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             {usesMultifileEditor && <EditorTabs />}
             {editor}
           </TabsContent>
+          )}
+
+          {isDailyCodingChallenge && <TabsContent
+            tabIndex={-1}
+            className='tab-content'
+            value={tabs.javascript}
+          >
+            {usesMultifileEditor && <EditorTabs />}
+            {editor}
+          </TabsContent>
+          }
+           {isDailyCodingChallenge && <TabsContent
+            tabIndex={-1}
+            className='tab-content'
+            value={tabs.python}
+          >
+            {usesMultifileEditor && <EditorTabs />}
+            {editor}
+          </TabsContent>
+          }
+
           {!hasEditableBoundaries && (
             <TabsContent
               tabIndex={-1}

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -102,13 +102,10 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     this.setState({
       currentTab: tab as Tab
     });
-    if(tab == tabs.python)
-    {
-      this.props.setDailyCodingChallengeLanguage("python")
-    }
-    else if(tab == tabs.javascript)
-    {
-      this.props.setDailyCodingChallengeLanguage("javascript")
+    if (tab == tabs.python) {
+      this.props.setDailyCodingChallengeLanguage('python');
+    } else if (tab == tabs.javascript) {
+      this.props.setDailyCodingChallengeLanguage('javascript');
     }
   };
 
@@ -250,17 +247,16 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
                 {i18next.t('learn.editor-tabs.instructions')}
               </TabsTrigger>
             )}
-            {isDailyCodingChallenge && ( <TabsTrigger value={tabs.javascript}>
-              JavaScript
-            </TabsTrigger>
+            {isDailyCodingChallenge && (
+              <TabsTrigger value={tabs.javascript}>JavaScript</TabsTrigger>
             )}
-            {isDailyCodingChallenge && ( <TabsTrigger value={tabs.python}>
-              Python
-            </TabsTrigger>
+            {isDailyCodingChallenge && (
+              <TabsTrigger value={tabs.python}>Python</TabsTrigger>
             )}
-             {!isDailyCodingChallenge && ( <TabsTrigger value={tabs.editor}>
-              {i18next.t('learn.editor-tabs.code')}
-            </TabsTrigger>
+            {!isDailyCodingChallenge && (
+              <TabsTrigger value={tabs.editor}>
+                {i18next.t('learn.editor-tabs.code')}
+              </TabsTrigger>
             )}
             {!!notes && usesMultifileEditor && (
               <TabsTrigger value={tabs.notes}>
@@ -277,34 +273,37 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             )}
           </TabsList>
 
-          {!isDailyCodingChallenge && (<TabsContent
-            tabIndex={-1}
-            className='tab-content'
-            value={tabs.editor}
-          >
-            {usesMultifileEditor && <EditorTabs />}
-            {editor}
-          </TabsContent>
+          {!isDailyCodingChallenge && (
+            <TabsContent
+              tabIndex={-1}
+              className='tab-content'
+              value={tabs.editor}
+            >
+              {usesMultifileEditor && <EditorTabs />}
+              {editor}
+            </TabsContent>
           )}
 
-          {isDailyCodingChallenge && <TabsContent
-            tabIndex={-1}
-            className='tab-content'
-            value={tabs.javascript}
-          >
-            {usesMultifileEditor && <EditorTabs />}
-            {editor}
-          </TabsContent>
-          }
-           {isDailyCodingChallenge && <TabsContent
-            tabIndex={-1}
-            className='tab-content'
-            value={tabs.python}
-          >
-            {usesMultifileEditor && <EditorTabs />}
-            {editor}
-          </TabsContent>
-          }
+          {isDailyCodingChallenge && (
+            <TabsContent
+              tabIndex={-1}
+              className='tab-content'
+              value={tabs.javascript}
+            >
+              {usesMultifileEditor && <EditorTabs />}
+              {editor}
+            </TabsContent>
+          )}
+          {isDailyCodingChallenge && (
+            <TabsContent
+              tabIndex={-1}
+              className='tab-content'
+              value={tabs.python}
+            >
+              {usesMultifileEditor && <EditorTabs />}
+              {editor}
+            </TabsContent>
+          )}
 
           {!hasEditableBoundaries && (
             <TabsContent

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -484,9 +484,9 @@ function ShowClassic({
         <Helmet title={windowTitle} />
         {isMobile ? (
           <MobileLayout
-          dailyCodingChallengeLanguage={dailyCodingChallengeLanguage}
-          isDailyCodingChallenge={isDailyCodingChallenge}
-          setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
+            dailyCodingChallengeLanguage={dailyCodingChallengeLanguage}
+            isDailyCodingChallenge={isDailyCodingChallenge}
+            setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
             editor={renderEditor({
               isMobileLayout: true,
               isUsingKeyboardInTablist: usingKeyboardInTablist

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -484,6 +484,9 @@ function ShowClassic({
         <Helmet title={windowTitle} />
         {isMobile ? (
           <MobileLayout
+          dailyCodingChallengeLanguage={dailyCodingChallengeLanguage}
+          isDailyCodingChallenge={isDailyCodingChallenge}
+          setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
             editor={renderEditor({
               isMobileLayout: true,
               isUsingKeyboardInTablist: usingKeyboardInTablist


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66361

<!-- Feel free to add any additional description of changes below this line -->
It was not exactly a clean split. I made it so if it was a daily coding challenge two different tabs would appear; Python and Javascript. Along with the tabs; I added two other tab contents. When the tabs switch; I then change the programming language. 

I did check to see if the tabs appear and they do; as the do the code contents change. The only thing I haven't really tested yet is how the tests themselves respond to the new editor. 