### PR TITLE
fix(client): privacy save button state

### DIFF
--- a/client/src/components/profile/components/profile-privacy.tsx
+++ b/client/src/components/profile/components/profile-privacy.tsx
@@ -32,12 +32,14 @@ function ProfilePrivacyComponent({
 }: ProfilePrivacyProps): JSX.Element {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(user.profileUI.isLocked);
-  const [privacyValues, setPrivacyValues] = useState({ ...user.profileUI });
-  const [madeChanges, setMadeChanges] = useState(false);
+  // Snapshot of the original values to detect unsaved changes
+const [initialPrivacyValues, setInitialPrivacyValues] = useState({ ...user.profileUI });
+const [privacyValues, setPrivacyValues] = useState({ ...user.profileUI });
+const madeChanges = JSON.stringify(privacyValues) !== JSON.stringify(initialPrivacyValues);
 
   function toggleFlag(flag: keyof ProfileUI): () => void {
     return () => {
-      setMadeChanges(true);
+      
       setPrivacyValues({ ...privacyValues, [flag]: !privacyValues[flag] });
     };
   }
@@ -46,7 +48,7 @@ function ProfilePrivacyComponent({
     e.preventDefault();
     if (!madeChanges) return;
     submitProfileUI(privacyValues);
-    setMadeChanges(false);
+    setInitialPrivacyValues({ ...privacyValues }); // reset baseline after saving
   }
 
   return (
@@ -188,6 +190,7 @@ function ProfilePrivacyComponent({
     </FullWidthRow>
   );
 }
+
 
 ProfilePrivacyComponent.displayName = 'ProfilePrivacy';
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67200

## What changed
Replaced the simple `madeChanges` boolean flag with a derived comparison 
between `privacyValues` and `initialPrivacyValues`. The save button now 
correctly disables when settings are reverted to their original state.

## Screenshots

### Bug: Save button stays enabled after reverting changes
<img width="1624" height="999" alt="preference changed to original state, save button remains enabled" src="https://github.com/user-attachments/assets/572b45db-c16d-4fba-bbf5-af7b09308f27" />

### Fix: Save button disables when no changes exist
<img width="1624" height="999" alt="first preference changed, save button enabled" src="https://github.com/user-attachments/assets/261444ad-b2b1-4c8a-8c92-7d4cc95af586" />