### PR TITLE
fix(client): resume AudioContext before playing campfire mode sounds

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -434,7 +434,8 @@ const Editor = (props: EditorProps): JSX.Element => {
       dataRef.current.monaco.model ||
       createModel(
         challengeFile?.contents ?? '',
-        modeMap[challengeFile?.ext ?? 'html']
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        modeMap[(challengeFile?.ext as keyof typeof modeMap) ?? 'html']
       );
     dataRef.current.monaco.model = model;
 
@@ -967,19 +968,33 @@ const Editor = (props: EditorProps): JSX.Element => {
       ? [coveringRange.startLineNumber - 1, coveringRange.endLineNumber + 1]
       : [];
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (player.current.sampler?.loaded && player.current.shouldPlay) {
-      void import('tone').then(tone => {
-        if (tone.context.state !== 'running') void tone.context.resume();
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        player.current.sampler?.triggerAttack(
-          editorNotes[player.current.noteIndex]
-        );
-        player.current.noteIndex++;
-        if (player.current.noteIndex >= editorNotes.length) {
-          player.current.noteIndex = 0;
-        }
-      });
+    if (store.get('fcc-sound')) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (!player.current.sampler) {
+        // Lazily initialize the sampler if sound was enabled after mount.
+        void import('tone').then(tone => {
+          const newSound = new tone.Sampler(editorToneOptions).toDestination();
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          player.current.sampler = newSound;
+
+          const storedVolume = (store.get('soundVolume') as number) ?? 50;
+          const calculateDecibel = -60 * (1 - storedVolume / 100);
+          newSound.volume.value = calculateDecibel;
+        });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      } else if (player.current.sampler?.loaded) {
+        void import('tone').then(tone => {
+          if (tone.context.state !== 'running') void tone.context.resume();
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          player.current.sampler?.triggerAttack(
+            editorNotes[player.current.noteIndex]
+          );
+          player.current.noteIndex++;
+          if (player.current.noteIndex >= editorNotes.length) {
+            player.current.noteIndex = 0;
+          }
+        });
+      }
     }
     updateFile({ fileKey, contents, editableRegionBoundaries });
   };
@@ -1414,7 +1429,9 @@ const Editor = (props: EditorProps): JSX.Element => {
           editorWillUnmount={(editor, monaco) => {
             // Any model we've created has to be manually disposed of to prevent
             // memory leaks.
-            const language = modeMap[challengeFile?.ext ?? 'html'];
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const language =
+              modeMap[(challengeFile?.ext as keyof typeof modeMap) ?? 'html'];
             if (language === 'typescript') {
               teardownTSModels(monaco);
             } else {
@@ -1422,7 +1439,10 @@ const Editor = (props: EditorProps): JSX.Element => {
             }
           }}
           onChange={onChange}
-          language={modeMap[challengeFile?.ext ?? 'html']}
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          language={
+            modeMap[(challengeFile?.ext as keyof typeof modeMap) ?? 'html']
+          }
           options={{ ...options, folding: !hasEditableRegion() }}
           theme={editorTheme}
         />

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -100,6 +100,13 @@ export async function playTone(state: ToneStates): Promise<void> {
   if (playSound && toneUrls[state]) {
     const Tone = await import('tone');
 
+    // Resume the AudioContext if it is suspended (browsers suspend it by
+    // default due to autoplay policies and it must be resumed from within
+    // a user-gesture handler before any sound can be played).
+    if (Tone.getContext().state !== 'running') {
+      await Tone.start();
+    }
+
     const player = new Tone.Player(toneUrls[state]).toDestination();
 
     const storedVolume = (store.get('soundVolume') as number) ?? 50;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67208

<!-- Feel free to add any additional description of changes below this line -->
[
<img width="1920" height="1791" alt="screencapture-localhost-9876-2026-05-02-22_17_35" src="https://github.com/user-attachments/assets/44b93419-b0f9-48be-a324-488ba8aa6b0f" />
](url)

I've fixed the bug where Campfire Mode guitar sounds weren't playing for some users.

What I changed:

-Waking up the audio: Browsers now block sound by default until they see a "user action." I added a fix to make sure the audio engine actually "wakes up" (starts) when you click or type, so the sounds aren't blocked.
-Live typing sounds: Fixed the editor so that if you turn on Campfire Mode after you've already opened a challenge, the guitar sounds will start working immediately. Before, it would stay silent unless you refreshed the page.
-Cleaned up the code: Fixed some small technical errors and updated the sound library calls to the latest version.
-How I tested it: I created a test page that perfectly simulated the silent bug. I confirmed that with these changes, the audio context resumes properly and sounds play every time you type or change the volume.

!! check the attached screenshot of my testing.