### PR TITLE
fix(curriculum): remove response.redirected check from URL shortener test

### DIFF
--- a/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/bd7158d8c443edefaeb5bd0e.md
+++ b/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/bd7158d8c443edefaeb5bd0e.md
@@ -71,8 +71,7 @@ When you visit `/api/shorturl/<short_url>`, you will be redirected to the origin
     url + '/api/shorturl/' + shortenedUrlVariable
   );
   if (getResponse) {
-    const { redirected, url } = getResponse;
-    assert.isTrue(redirected);
+    const { url } = getResponse;
     assert.strictEqual(url,fullUrl);
   } else {
     throw new Error(`${getResponse.status} ${getResponse.statusText}`);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67199

## Describe the changes
This pull request addresses an issue where Test 3 of the URL Shortener Microservice project would fail even when the user provided a correct implementation.

The issue stems from the `proxy fetch` polyfill in the browser's test evaluator (`dom-test-evaluator.js`). This custom fetch proxy does not implement the `.redirected` property. As a result, when the test attempted to destructure `const { redirected, url } = getResponse` and verify `assert.isTrue(redirected)`, it would throw a `redirected is not implemented yet` error.

Since the `fetch` proxy transparently follows redirects and correctly assigns the final destination URL to the `.url` property, we can safely remove the `redirected` assertion. This PR updates the test to rely solely on `assert.strictEqual(url, fullUrl)` to verify that the redirect occurred successfully without triggering the environment error.
