### PR TITLE
fix: show correct success message after logout

### DIFF
--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -190,7 +190,7 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
 
       void reply.redirectWithMessage(returnURL, {
         type: 'success',
-        content: 'flash.signin-success'
+        content: 'flash.signout-success'
       });
     });
 


### PR DESCRIPTION
## Description

Fixes incorrect flash message shown after logout.

Previously, users saw the sign-in success message after logging out.
This updates the logout flow to use the correct sign-out success flash message.

## Changes

- Updated logout redirect flash message in `api/src/plugins/auth0.ts`
- Replaced `flash.signin-success` with `flash.signout-success`

## Related Issue

Closes #66515