### PR TITLE
fix(client,curriculum): mark inputType as required for Chinese FITB challenges

### DIFF
--- a/client/schema.gql
+++ b/client/schema.gql
@@ -540,7 +540,6 @@ type ChallengeNodeChallengeSceneCommandsPosition {
 type ChallengeNodeChallengeFillInTheBlank @derivedTypes {
   sentence: String
   blanks: [ChallengeNodeChallengeFillInTheBlankBlanks]
-  inputType: String
 }
 
 type ChallengeNodeChallengeFillInTheBlankBlanks {

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -43,8 +43,9 @@ export type Question = {
 export type FillInTheBlank = {
   sentence: string;
   blanks: MultipleChoiceAnswer[];
-  inputType?: 'pinyin-tone' | 'pinyin-to-hanzi';
 };
+
+export type FillInTheBlankInputType = 'pinyin-tone' | 'pinyin-to-hanzi';
 
 export type Fields = {
   slug: string;
@@ -216,6 +217,7 @@ export type ChallengeNode = {
     helpCategory: string;
     hooks?: Hooks;
     id: string;
+    inputType?: FillInTheBlankInputType;
     lang?: ChallengeLang;
     instructions: string;
     internal?: {

--- a/client/src/templates/Challenges/components/fill-in-the-blanks.tsx
+++ b/client/src/templates/Challenges/components/fill-in-the-blanks.tsx
@@ -4,13 +4,17 @@ import { Spacer } from '@freecodecamp/ui';
 
 import { parseBlanks, parseAnswer } from '../fill-in-the-blank/parse-blanks';
 import PrismFormatted from '../components/prism-formatted';
-import { FillInTheBlank } from '../../../redux/prop-types';
+import {
+  FillInTheBlankInputType,
+  FillInTheBlank
+} from '../../../redux/prop-types';
 import ChallengeHeading from './challenge-heading';
 import PinyinToHanziInput from './pinyin-to-hanzi-input';
 import PinyinToneInput from './pinyin-tone-input';
 
 type FillInTheBlankProps = {
   fillInTheBlank: FillInTheBlank;
+  inputType?: FillInTheBlankInputType;
   answersCorrect: (boolean | null)[];
   showFeedback: boolean;
   feedback: string | null;
@@ -103,7 +107,8 @@ const BlankInput = ({
 };
 
 function FillInTheBlanks({
-  fillInTheBlank: { sentence, blanks, inputType },
+  fillInTheBlank: { sentence, blanks },
+  inputType,
   answersCorrect,
   showFeedback,
   feedback,

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -92,6 +92,7 @@ const ShowFillInTheBlank = ({
         translationPending,
         challengeType,
         fillInTheBlank,
+        inputType,
         helpCategory,
         scene,
         tests,
@@ -181,7 +182,7 @@ const ShowFillInTheBlank = ({
       const answer = blankAnswers[i];
       const normalizedUserAnswer = userAnswer.trim().toLowerCase();
 
-      if (fillInTheBlank.inputType === 'pinyin-to-hanzi') {
+      if (inputType === 'pinyin-to-hanzi') {
         const pairs = parseHanziPinyinPairs(answer);
         if (pairs.length === 1) {
           const hanziPinyin = pairs[0];
@@ -191,7 +192,7 @@ const ShowFillInTheBlank = ({
             hanzi.replace(/\s+/g, '')
           );
         }
-      } else if (fillInTheBlank.inputType === 'pinyin-tone') {
+      } else if (inputType === 'pinyin-tone') {
         // Ignore spaces to allow both syllable formats:
         // spaced (e.g., 'nǐ hǎo') and unspaced (e.g., 'nǐhǎo').
         return (
@@ -302,6 +303,7 @@ const ShowFillInTheBlank = ({
               <ObserveKeys only={['ctrl', 'cmd', 'enter']}>
                 <FillInTheBlanks
                   fillInTheBlank={fillInTheBlank}
+                  inputType={inputType}
                   answersCorrect={answersCorrect}
                   showFeedback={showFeedback}
                   feedback={feedback}
@@ -371,8 +373,8 @@ export const query = graphql`
             answer
             feedback
           }
-          inputType
         }
+        inputType
         tests {
           text
           testString

--- a/curriculum/schema/__snapshots__/challenge-schema.test.mjs.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.mjs.snap
@@ -476,17 +476,6 @@ exports[`challenge schema > should not be changed without informing the mobile t
           ],
           "type": "array",
         },
-        "inputType": {
-          "allow": [
-            "pinyin-tone",
-            "pinyin-to-hanzi",
-          ],
-          "flags": {
-            "only": true,
-            "presence": "optional",
-          },
-          "type": "string",
-        },
         "sentence": {
           "flags": {
             "presence": "required",
@@ -629,7 +618,7 @@ exports[`challenge schema > should not be changed without informing the mobile t
                   ],
                   "flags": {
                     "only": true,
-                    "presence": "optional",
+                    "presence": "required",
                   },
                   "type": "string",
                 },

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -248,8 +248,7 @@ export const schema = Joi.object().keys({
           feedback: Joi.string().allow(null)
         })
       )
-      .required(),
-    inputType: Joi.string().valid('pinyin-tone', 'pinyin-to-hanzi').optional()
+      .required()
   }),
   forumTopicId: Joi.number(),
   id: Joi.objectId().required(),
@@ -262,7 +261,7 @@ export const schema = Joi.object().keys({
     is: challengeTypes.fillInTheBlank,
     then: Joi.when('superBlock', {
       is: Joi.valid(SuperBlocks.A1Chinese, SuperBlocks.A2Chinese),
-      then: Joi.string().valid('pinyin-tone', 'pinyin-to-hanzi').optional(),
+      then: Joi.string().valid('pinyin-tone', 'pinyin-to-hanzi').required(),
       otherwise: Joi.forbidden()
     }),
     otherwise: Joi.forbidden()

--- a/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js
+++ b/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js
@@ -107,7 +107,7 @@ function plugin() {
           }
         }
 
-        return { sentence, blanks, ...(inputType && { inputType }) };
+        return { sentence, blanks };
       }
 
       function getBlanks(blanksNodes) {

--- a/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.test.js
+++ b/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.test.js
@@ -198,7 +198,7 @@ Example of good formatting:
     plugin(mockChineseFillInTheBlankAST, file);
     const testObject = file.data.fillInTheBlank;
 
-    expect(testObject.inputType).toBe('pinyin-to-hanzi');
+    expect(file.data.inputType).toBe('pinyin-to-hanzi');
 
     expect(testObject.sentence).toBe(
       '<p>BLANK BLANK，BLANK <ruby>是王华<rp>(</rp><rt>shì Wang Hua</rt><rp>)</rp></ruby>，<ruby>请问你<rp>(</rp><rt>qǐng wèn nǐ</rt><rp>)</rp></ruby> BLANK <ruby>什么名字<rp>(</rp><rt>shén me míng zi</rt><rp>)</rp></ruby>？</p>'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Consolidates `inputType` in challenge data so we have a single source of truth 
- Marks `inputType` as required for Chinese fill-in-the-blank challenges (ref #67198)
- Does not break the mobile app as Chinese curriculum isn't supported there yet

<!-- Feel free to add any additional description of changes below this line -->
