### PR TITLE
fix(curriculum): relax step 28 csv field access

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
@@ -7,7 +7,7 @@ dashedName: step-28
 
 # --description--
 
-Add a `for` loop over `catalog`. Inside the loop, declare `const entry = catalog[i]`. Build a row string with the four fields separated by commas and push it into `rows`.
+Add a `for` loop over `catalog`. Inside the loop, declare `const entry = catalog[i]`. Build a row string with the four fields separated by commas and push it into `rows`. Use either dot notation or bracket notation when reading the string fields.
 
 String fields need literal double-quote characters in the output (e.g. `"King, Stephen"`), so that commas inside values don't break the CSV format. Since `year` is a number, it doesn't need them.
 
@@ -28,7 +28,14 @@ assert.match(exportToCSV.toString(), /rows\.push/);
 String fields should be wrapped in double quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /"\$\{entry\./);
+assert.isTrue(
+  /"\$\{entry\.(?:title|author|location)\}"/.test(
+    __helpers.removeJSComments(code)
+  ) ||
+    /"\$\{entry\[\s*["'](?:title|author|location)["']\s*\]\}"/.test(
+      __helpers.removeJSComments(code)
+    )
+);
 
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67225

This PR relaxes the Step 28 CSV export hint for the Heritage Library workshop so it accepts both dot notation and bracket notation when reading entry fields.

The CSV output requirement remains unchanged: rows still need the four fields separated by commas, and string fields still need to be wrapped in double quotes.

Validated locally with curriculum linting for the affected challenge using the english locale.