### PR TITLE
fix(curriculum): add missing word to dialogue transcript

### DIFF
--- a/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6660a2dc899b426da432d83b.md
+++ b/curriculum/challenges/english/blocks/learn-determiners-and-advanced-use-of-articles/6660a2dc899b426da432d83b.md
@@ -171,7 +171,7 @@ Watch the video.
       "startTime": 83.94,
       "finishTime": 91.4,
       "dialogue": {
-        "text": "Thanks, Jake. Keep me updated on the test's progress and prepare a detailed comparison. We should go over it together to make a final choice.",
+        "text": "Thanks, Jake. Keep me updated on the test's progress and prepare a detailed comparison report. We should go over it together to make a final choice.",
         "align": "right"
       }
     },


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The word "report" is present in the audio dialogue, but is missing from the captions.
https://www.freecodecamp.org/learn/b1-english-for-developers/learn-determiners-and-advanced-use-of-articles/dialogue-1-choosing-the-right-cloud-storage-solution