### PR TITLE
fix: Teach modern hsl syntax in CSS lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md
@@ -25,6 +25,14 @@ element {
 }
 ```
 
+Modern CSS also supports a space-separated syntax:
+
+```css
+element {
+  color: hsl(hue saturation lightness);
+}
+```
+
 Let's break this down with an example:
 
 :::interactive_editor
@@ -46,7 +54,7 @@ p {
 
 :::
 
-In this case, the hue is `120` degrees, which corresponds to green. The saturation is `100%`, so the green will be fully vivid. The lightness is `50%`, so it's at its normal tone — neither too dark nor too light. As a result, the text color of the paragraph will be a bright green.
+In this case, the hue is `120` degrees, which corresponds to green. The saturation is `100%`, so the green will be fully vivid. The lightness is `50%`, so it's at its normal tone — neither too dark nor too light. As a result, the text color of the paragraph will be a bright green. This can also be written as `hsl(120 100% 50%)`.
 
 One of the main advantages of the HSL color model is its intuitive nature. It makes it easy to adjust a color’s vibrancy or lightness by tweaking the saturation and lightness values without having to alter the core color (hue). 
 
@@ -83,6 +91,14 @@ element {
 }
 ```
 
+You can also add alpha transparency to the modern `hsl()` syntax by placing a slash before the alpha value:
+
+```css
+element {
+  background-color: hsl(hue saturation lightness / alpha);
+}
+```
+
 Let's take a look at an example:
 
 :::interactive_editor
@@ -100,7 +116,7 @@ div {
 
 :::
 
-This code would give the `div` a semi-transparent red background, where the hue is set to `0` degrees (red), saturation is `100%`, lightness is `50%`, and alpha is `0.5` (50% opacity). You can also specify the alpha as a percentage — for example, `hsla(0, 100%, 50%, 50%)` is equivalent to `hsla(0, 100%, 50%, 0.5)`.
+This code would give the `div` a semi-transparent red background, where the hue is set to `0` degrees (red), saturation is `100%`, lightness is `50%`, and alpha is `0.5` (50% opacity). You can also specify the alpha as a percentage — for example, `hsla(0, 100%, 50%, 50%)` is equivalent to `hsla(0, 100%, 50%, 0.5)`. In modern syntax, the same color can be written as `hsl(0 100% 50% / 0.5)`.
 
 The HSL color model is particularly useful when you need to create color schemes and adjust shades or tints easily. 
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67219

Updates the HSL color model lecture to mention modern space-separated `hsl()` syntax and the slash alpha form, while keeping the existing comma-separated examples intact.

Local verification:

- `git diff --check`

Note: this fresh filtered clone does not have `node_modules`, so I did not run the full curriculum content test locally.