### PR TITLE
docs(README): add missing C# Microsoft Certification link (#67239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The one exception to this is if we discover violations of our [Academic Honesty 
 
 In addition, to help prepare for job interviews, freeCodeCamp.org includes The Odin Project (freeCodeCamp Remix), Coding Interview Prep, Project Euler, and Rosetta Code.
 
-A free, professional Foundational C# with Microsoft Certification is also available.
+A free, professional [Foundational C# with Microsoft Certification](https://www.freecodecamp.org/learn/foundational-c-sharp-with-microsoft/) is also available.
 
 ### The Learning Platform
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67239

### Change

The line mentioning the Foundational C# with Microsoft Certification was plain text. This wraps the certification name in a markdown link to the corresponding curriculum page, matching the link style used for the other certifications listed earlier in the section.

Before:

```
A free, professional Foundational C# with Microsoft Certification is also available.
```

After:

```
A free, professional [Foundational C# with Microsoft Certification](https://www.freecodecamp.org/learn/foundational-c-sharp-with-microsoft/) is also available.
```

### Target URL

`https://www.freecodecamp.org/learn/foundational-c-sharp-with-microsoft/` resolves with HTTP 200 and matches the trailing-slash convention used by the other certification links in the same section (e.g. `responsive-web-design-v9/`, `javascript-v9/`).

The diff is one line, no surrounding text reflowed.