### PR TITLE
fix(curriculum): teach modern space-separated hsl() syntax

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md
@@ -17,13 +17,15 @@ Saturation refers to the intensity or purity of the color. It is measured as a p
 
 Lightness determines how light or dark the color is, again measured as a percentage. A lightness value of `0%` will produce black, `50%` will give you the normal tone of the hue, and `100%` will result in white.
 
-In CSS, the `hsl()` function is used to define colors using the HSL color model. Here is the basic syntax:
+In CSS, the `hsl()` function is used to define colors using the HSL color model. The modern syntax separates the values with spaces:
 
 ```css
 element {
-  color: hsl(hue, saturation, lightness);
+  color: hsl(hue saturation lightness);
 }
 ```
+
+You may still encounter the older comma-separated form (`hsl(hue, saturation, lightness)`) in existing code. Both forms are supported, but the space-separated syntax is the current standard.
 
 Let's break this down with an example:
 
@@ -36,11 +38,11 @@ Let's break this down with an example:
 
 ```css
 body {
-  background-color: hsla(0, 0%, 1%, 1.00);
+  background-color: hsl(0 0% 1% / 1);
 }
 
 p {
-  color: hsl(120, 100%, 50%);
+  color: hsl(120 100% 50%);
 }
 ```
 
@@ -62,12 +64,12 @@ For instance, if you want to create different shades or tints of the same color,
 
 ```css
 div.light {
-  background-color: hsl(240, 100%, 80%);
+  background-color: hsl(240 100% 80%);
 }
 
 div.dark {
-  background-color: hsl(240, 100%, 20%);
-  color: hsl(0, 0%, 100%);
+  background-color: hsl(240 100% 20%);
+  color: hsl(0 0% 100%);
 }
 ```
 
@@ -75,11 +77,11 @@ div.dark {
 
 Here, both `div` elements are using the same hue (`240` degrees, which is blue), but one has a lightness of `80%` (a lighter shade of blue), and the other has a lightness of `20%` (a darker shade of blue).
 
-Just like the RGB model has an `rgba()` function to include transparency, the HSL model has an `hsla()` function. The fourth parameter in this function represents the alpha value, which controls the opacity of the color. Here is the basic syntax:
+The `hsl()` function also supports an optional alpha value, which controls the opacity of the color. The alpha is added after a forward slash. Here is the basic syntax:
 
 ```css
 element {
-  background-color: hsla(hue, saturation, lightness, alpha);
+  background-color: hsl(hue saturation lightness / alpha);
 }
 ```
 
@@ -94,13 +96,13 @@ Let's take a look at an example:
 
 ```css
 div {
-  background-color: hsla(0, 100%, 50%, 0.5);
+  background-color: hsl(0 100% 50% / 0.5);
 }
 ```
 
 :::
 
-This code would give the `div` a semi-transparent red background, where the hue is set to `0` degrees (red), saturation is `100%`, lightness is `50%`, and alpha is `0.5` (50% opacity). You can also specify the alpha as a percentage — for example, `hsla(0, 100%, 50%, 50%)` is equivalent to `hsla(0, 100%, 50%, 0.5)`.
+This code would give the `div` a semi-transparent red background, where the hue is set to `0` degrees (red), saturation is `100%`, lightness is `50%`, and alpha is `0.5` (50% opacity). You can also specify the alpha as a percentage — for example, `hsl(0 100% 50% / 50%)` is equivalent to `hsl(0 100% 50% / 0.5)`. The older `hsla()` function uses comma-separated values (for example, `hsla(0, 100%, 50%, 0.5)`) and continues to work as an alias for `hsl()` with an alpha value.
 
 The HSL color model is particularly useful when you need to create color schemes and adjust shades or tints easily. 
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67219

## Summary

The HSL color model lecture taught the legacy comma-separated `hsl(120, 100%, 50%)` form. CSS Color Level 4 standardised the space-separated `hsl(120 100% 50%)` form, with optional alpha provided after a forward slash (`hsl(120 100% 50% / 0.5)`). MDN now documents the space-separated form as the primary syntax.

This PR updates only the lecture that explains the syntax, in line with @Sembauke's comment on the issue (we are intentionally not touching the ~400 occurrences in labs and workshops). The lecture is rewritten to teach the modern syntax, while still acknowledging that learners will encounter the comma-separated form (and `hsla()`) in existing code.

## Files changed

- `curriculum/challenges/english/blocks/lecture-working-with-colors-in-css/672bc523324694be91d90d96.md` — *What Is the HSL Color Model, and How Does the HSL Function Work in CSS?*

## Before / after

Syntax description:

```diff
-element { color: hsl(hue, saturation, lightness); }
+element { color: hsl(hue saturation lightness); }
```

Interactive examples:

```diff
-body { background-color: hsla(0, 0%, 1%, 1.00); }
-p    { color: hsl(120, 100%, 50%); }
+body { background-color: hsl(0 0% 1% / 1); }
+p    { color: hsl(120 100% 50%); }
```

```diff
-div.light { background-color: hsl(240, 100%, 80%); }
-div.dark  { background-color: hsl(240, 100%, 20%);
-            color: hsl(0, 0%, 100%); }
+div.light { background-color: hsl(240 100% 80%); }
+div.dark  { background-color: hsl(240 100% 20%);
+            color: hsl(0 0% 100%); }
```

```diff
-element { background-color: hsla(hue, saturation, lightness, alpha); }
-div     { background-color: hsla(0, 100%, 50%, 0.5); }
+element { background-color: hsl(hue saturation lightness / alpha); }
+div     { background-color: hsl(0 100% 50% / 0.5); }
```

A short sentence is added after the syntax block noting the older comma-separated form is still supported, and the alpha section keeps a note that `hsla()` continues to work as an alias for `hsl()` with alpha.

## Notes

- **Scope**: lecture text and interactive examples only. The three quiz questions and their correct answers (including the answer that mentions `hsla()`) are left untouched — the answer is still factually correct, and changing the answer key risks affecting user-facing answer validation.
- **Translations**: only the English file is updated. Per the usual freeCodeCamp convention, the Crowdin pipeline will pick this up; translations are not edited directly here.
- **Other lectures**: the gradients lecture in this block does not use `hsl()`. The named-colors lecture has a single `hsl(120, 100%, 50%)` reference inside a multiple-choice answer (it is the *wrong* answer demonstrating that named colors are not numerical codes), and is best left as-is for the same reason as the quiz answers above.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -F=@freecodecamp/shared build && pnpm -F=@freecodecamp/challenge-linter build`
- `cd curriculum && pnpm lint-challenges` — passes.
- `cd curriculum && pnpm test-gen` — block test file generated successfully (challenge frontmatter + sections parse cleanly).