### PR TITLE
fix(client): disable Save on privacy revert

### DIFF
--- a/client/src/components/profile/components/profile-privacy.test.tsx
+++ b/client/src/components/profile/components/profile-privacy.test.tsx
@@ -151,4 +151,54 @@ describe('<ProfilePrivacy />', () => {
     await user.click(saveButton);
     expect(saveButton).toHaveAttribute('aria-disabled', 'true');
   });
+
+  it('save button becomes aria-disabled when a toggle is reverted to its original value', async () => {
+    const user = userEvent.setup();
+    render(
+      <Provider store={makeStore({ isLocked: true })}>
+        <ProfilePrivacy />
+      </Provider>
+    );
+    const saveButton = screen.getByRole('button', { name: SAVE_BTN_NAME });
+    const radioById = (id: string): HTMLElement => {
+      const found = screen.getAllByRole('radio').find(r => r.id === id);
+      if (!found) throw new Error(`radio ${id} not found`);
+      return found;
+    };
+
+    // isLocked starts as `true` (private radio checked).
+    await user.click(radioById('radioBisLocked'));
+    expect(saveButton).not.toHaveAttribute('aria-disabled', 'true');
+
+    await user.click(radioById('radioAisLocked'));
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('save button stays enabled while any change differs from the original', async () => {
+    const user = userEvent.setup();
+    render(
+      <Provider store={makeStore({ isLocked: true })}>
+        <ProfilePrivacy />
+      </Provider>
+    );
+    const saveButton = screen.getByRole('button', { name: SAVE_BTN_NAME });
+    const radioById = (id: string): HTMLElement => {
+      const found = screen.getAllByRole('radio').find(r => r.id === id);
+      if (!found) throw new Error(`radio ${id} not found`);
+      return found;
+    };
+
+    // Flip both isLocked (true -> false) and showName (true -> false).
+    await user.click(radioById('radioBisLocked'));
+    await user.click(radioById('radioAname'));
+    expect(saveButton).not.toHaveAttribute('aria-disabled', 'true');
+
+    // Revert showName only; isLocked is still off.
+    await user.click(radioById('radioBname'));
+    expect(saveButton).not.toHaveAttribute('aria-disabled', 'true');
+
+    // Revert isLocked too; now both match the original.
+    await user.click(radioById('radioAisLocked'));
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+  });
 });

--- a/client/src/components/profile/components/profile-privacy.tsx
+++ b/client/src/components/profile/components/profile-privacy.tsx
@@ -33,20 +33,23 @@ function ProfilePrivacyComponent({
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(user.profileUI.isLocked);
   const [privacyValues, setPrivacyValues] = useState({ ...user.profileUI });
-  const [madeChanges, setMadeChanges] = useState(false);
+  const [savedValues, setSavedValues] = useState({ ...user.profileUI });
+
+  const hasChanges = (Object.keys(privacyValues) as (keyof ProfileUI)[]).some(
+    key => privacyValues[key] !== savedValues[key]
+  );
 
   function toggleFlag(flag: keyof ProfileUI): () => void {
     return () => {
-      setMadeChanges(true);
       setPrivacyValues({ ...privacyValues, [flag]: !privacyValues[flag] });
     };
   }
 
   function submitNewProfileSettings(e: React.FormEvent) {
     e.preventDefault();
-    if (!madeChanges) return;
+    if (!hasChanges) return;
     submitProfileUI(privacyValues);
-    setMadeChanges(false);
+    setSavedValues(privacyValues);
   }
 
   return (
@@ -172,8 +175,8 @@ function ProfilePrivacyComponent({
                 size='large'
                 variant='primary'
                 block={true}
-                disabled={!madeChanges}
-                {...(!madeChanges && { tabIndex: -1 })}
+                disabled={!hasChanges}
+                {...(!hasChanges && { tabIndex: -1 })}
               >
                 {t('buttons.save')}{' '}
                 <span className='sr-only'>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67200

## What

On the user profile **Privacy** settings, toggling a preference enabled the Save button — but reverting that toggle back to its original value left the button **enabled**. Submitting then dispatched a `submitProfileUI` action and showed the "We have updated your privacy settings" banner even though nothing had actually changed.

## Why

The component tracked a one-way `madeChanges` flag that was set to `true` on every toggle and only reset on save. It never compared the current draft to the loaded state, so a "no-op" cycle of two toggles still looked like a change.

## How

`profile-privacy.tsx`:

- Removed the `madeChanges` state.
- Added a `savedValues` baseline (initialized from `user.profileUI`).
- Derived `hasChanges` by comparing every key of `privacyValues` against `savedValues`.
- On submit, dispatch `submitProfileUI(privacyValues)` and update the baseline so subsequent renders reflect the new clean state.
- The Save `Button` now reads `disabled={!hasChanges}` (and the conditional `tabIndex` follows the same flag), so reverting to the original disables it again.

## Tests

`profile-privacy.test.tsx` adds two regression tests on top of the existing eight:

- **Revert single toggle** — flipping `isLocked` and flipping it back leaves the Save button `aria-disabled="true"`.
- **Multi-toggle partial revert** — with `isLocked` and `showName` both flipped, reverting only `showName` keeps Save enabled (because `isLocked` still differs); reverting `isLocked` too disables it.

Local verification:

```
pnpm vitest run profile-privacy.test.tsx   # 11 passed
pnpm type-check                            # clean
pnpm lint <touched files>                  # clean
```

## Reproduction (before this PR)

1. Go to Profile → Privacy.
2. Click any **Public/Private** button to flip its current value — Save becomes enabled.
3. Click it again to restore the original value — Save **stays enabled**.
4. Click Save — the "settings updated" banner appears even though no setting actually changed.

After this PR, step 3 disables Save again and step 4's no-op submit is impossible.