### PR TITLE
fix: allow bracket notation in step 28 CSV export test

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
@@ -28,7 +28,7 @@ assert.match(exportToCSV.toString(), /rows\.push/);
 String fields should be wrapped in double quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /"\$\{entry\./);
+assert.match(__helpers.removeJSComments(code), /"\$\{entry[\.\[]/);
 
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67243

<!-- Feel free to add any additional description of changes below this line -->

The test in Step 28 only accepted dot notation (`entry.title`) but rejected 
bracket notation (`entry["title"]`), even though both produce identical output.

Changed the regex from `/"\$\{entry\./` to `/"\$\{entry[\.\ []/` to accept both 
dot and bracket notation.

Closes #67243
