### PR TITLE
fix: disable privacy save button when no changes are made

### DIFF
--- a/client/src/components/settings/privacy.tsx
+++ b/client/src/components/settings/privacy.tsx
@@ -36,21 +36,24 @@ function PrivacySettings({ submitProfileUI, user }: PrivacyProps): JSX.Element {
     ...user.profileUI
   });
 
-  const [madeChanges, setMadeChanges] = useState(false);
-
   function toggleFlag(flag: keyof ProfileUI): () => void {
     return () => {
-      setMadeChanges(true);
-      setPrivacyValues({ ...privacyValues, [flag]: !privacyValues[flag] });
+      const newValues = { ...privacyValues, [flag]: !privacyValues[flag] };
+      setPrivacyValues(newValues);
     };
   }
 
   function submitNewProfileSettings(e: React.FormEvent) {
     e.preventDefault();
-    if (!madeChanges) return;
+    if (!hasChanges) return;
     submitProfileUI(privacyValues);
-    setMadeChanges(false);
   }
+
+  const hasChanges = Object.keys(privacyValues).some(
+    key =>
+      privacyValues[key as keyof ProfileUI] !==
+      user.profileUI[key as keyof ProfileUI]
+  );
 
   return (
     <div className='privacy-settings' id='privacy-settings'>
@@ -157,8 +160,8 @@ function PrivacySettings({ submitProfileUI, user }: PrivacyProps): JSX.Element {
             size='large'
             variant='primary'
             block={true}
-            disabled={!madeChanges}
-            {...(!madeChanges && { tabIndex: -1 })}
+            disabled={!hasChanges}
+            {...(!hasChanges && { tabIndex: -1 })}
           >
             {t('buttons.save')}{' '}
             <span className='sr-only'>{t('settings.headings.privacy')}</span>


### PR DESCRIPTION
Fixes the privacy settings save button remaining enabled after toggling a setting back to its original value. Replaced the `madeChanges` boolean with a `hasChanges` derived value that compares current toggle states against the original `profileUI` values from the server.

Related forum thread: https://forum.freecodecamp.org/t/small-bug-issue-to-fix-in-privacy-settings/787468

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67265