### PR TITLE
fix(curriculum): remove solutions from non-last steps in math toolkit ws

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f3cb8d057f29954205d7d.md
+++ b/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f3cb8d057f29954205d7d.md
@@ -53,22 +53,3 @@ console.log(result);
 }
 ```
 
-# --solutions--
-
-```ts
-function square(num: number) {
-  return num * num;
-}
-
-const result = square("something");
-
-console.log(result);
-```
-
-```json
-{
-  "compilerOptions": {
-    "noCheck": true
-  }
-}
-```

--- a/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f3f636aa840b7201aa37c.md
+++ b/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f3f636aa840b7201aa37c.md
@@ -41,3 +41,10 @@ const result = square("something");
 console.log(result);
 ```
 
+```json
+{
+  "compilerOptions": {
+    "noCheck": true
+  }
+}
+```

--- a/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f412114c87221f16a99e3.md
+++ b/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f412114c87221f16a99e3.md
@@ -45,22 +45,3 @@ console.log(result);
 }
 ```
 
-# --solutions--
-
-```ts
-function square(num: number) {
-  return num * num;
-}
-
-const result = square(5, 10);
-
-console.log(result);
-```
-
-```json
-{
-  "compilerOptions": {
-    "noCheck": true
-  }
-}
-```

--- a/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f41b8da20f816b5c7dece.md
+++ b/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f41b8da20f816b5c7dece.md
@@ -39,3 +39,10 @@ const result = square(5, 10);
 console.log(result);
 ```
 
+```json
+{
+  "compilerOptions": {
+    "noCheck": true
+  }
+}
+```

--- a/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f49669ea51a31d2ba89d8.md
+++ b/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f49669ea51a31d2ba89d8.md
@@ -62,31 +62,3 @@ console.log(avgResult);
 }
 ```
 
-# --solutions--
-
-```ts
-function square(num: number) {
-  return num * num;
-}
-
-const result = square(5);
-
-console.log(result);
-
-function getAverage(numbers: number[]): number {
-  const sum = numbers.reduce((acc, n) => acc + n, 0);
-  return "something";
-}
-
-const avgResult = getAverage([2, 14, 26, 8]);
-
-console.log(avgResult);
-```
-
-```json
-{
-  "compilerOptions": {
-    "noCheck": true
-  }
-}
-```

--- a/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f4a3e7b4c6bfa538cc4f7.md
+++ b/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f4a3e7b4c6bfa538cc4f7.md
@@ -56,3 +56,10 @@ const avgResult = getAverage([2, 14, 26, 8]);
 console.log(avgResult);
 ```
 
+```json
+{
+  "compilerOptions": {
+    "noCheck": true
+  }
+}
+```


### PR DESCRIPTION
…where needed

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The backstory for this is that we had to add solution markers to some steps in the math toolkit workshop so those steps could pass with errors. Now we don't need to do that anymore, so we need to remove those solution markers before releasing the TS module, as multiple CIs are failing due to that.

Check https://github.com/freeCodeCamp/freeCodeCamp/pull/67261