### PR TITLE
fix(curriculum): allow multiline label in calorie counter step 47

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-calorie-counter/63c2171c1e5b6e3aa51768d0.md
+++ b/curriculum/challenges/english/blocks/workshop-calorie-counter/63c2171c1e5b6e3aa51768d0.md
@@ -14,13 +14,13 @@ Inside your template literal, create a `label` element and give it the text `Ent
 You should have a `label` element inside your template literal.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label>.*<\/label>/);
+assert.match(code, /HTMLString\s*=\s*`\s*\n\s*<label>[\s\S]*?<\/label>\s*`/);
 ```
 
 Your `label` element should have the text `Entry ${entryNumber} Name`.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label>\s*Entry\s\$\{entryNumber\}\sName\s*<\/label>/);
+assert.match(code, /HTMLString\s*=\s*`\s*\n\s*<label>\s*Entry\s\$\{entryNumber\}\sName\s*<\/label>\s*`/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67274

**Description:**
Updates the regex assertions in `63c2171c1e5b6e3aa51768d0.md` (Step 47 of the Calorie Counter workshop) to accept both single-line and multiline template literals for the `HTMLString` variable. 

* Replaced `.*` with `[\s\S]*?` to capture internal line breaks inside the `<label>` tag.
* Added `\s*` near line breaks and backticks to tolerate different indentation styles.