### PR TITLE
feat: allow solutions in any step

### DIFF
--- a/tools/challenge-parser/parser/plugins/add-solution.js
+++ b/tools/challenge-parser/parser/plugins/add-solution.js
@@ -1,8 +1,6 @@
 const { isEmpty } = require('lodash');
 const { root } = require('mdast-builder');
 const visitChildren = require('unist-util-visit-children');
-const fs = require('fs');
-const path = require('path');
 
 const { editableRegionMarker, isWorkshop } = require('./add-seed');
 const { getSection } = require('./utils/get-section');
@@ -18,52 +16,6 @@ function validateMarkers({ value }) {
     );
 }
 
-function isLastStep(file) {
-  const challengeDir = path.dirname(file.path);
-  const blockName = path.basename(challengeDir);
-
-  let current = challengeDir;
-  let blockJsonPath = null;
-
-  for (let i = 0; i < 10; i++) {
-    current = path.dirname(current);
-    const candidate = path.join(
-      current,
-      'structure',
-      'blocks',
-      `${blockName}.json`
-    );
-    if (fs.existsSync(candidate)) {
-      blockJsonPath = candidate;
-      break;
-    }
-  }
-
-  if (!blockJsonPath) return true;
-
-  try {
-    const blockData = JSON.parse(fs.readFileSync(blockJsonPath, 'utf8'));
-
-    // Upcoming blocks may still contain transitional content that does not yet
-    // follow this invariant.
-    if (blockData.isUpcomingChange) {
-      return true;
-    }
-
-    const challengeOrder = blockData.challengeOrder;
-
-    if (!Array.isArray(challengeOrder) || challengeOrder.length === 0) {
-      return true;
-    }
-
-    const currentId = path.basename(file.path, '.md');
-    const lastId = challengeOrder[challengeOrder.length - 1].id;
-
-    return currentId === lastId;
-  } catch {
-    return true;
-  }
-}
 function createPlugin() {
   return function transformer(tree, file) {
     const solutionArrays = splitOnThematicBreak(
@@ -98,11 +50,6 @@ function createPlugin() {
       if (totalMarkers > 0 && totalMarkers !== 2) {
         throw Error(
           `Workshop challenge ${file.path} must have exactly 2 editable region markers`
-        );
-      }
-      if (solutions.length > 0 && !isLastStep(file)) {
-        throw Error(
-          `Workshop challenge ${file.path} has solutions but is not the last step.`
         );
       }
     }

--- a/tools/challenge-parser/parser/plugins/add-solution.test.js
+++ b/tools/challenge-parser/parser/plugins/add-solution.test.js
@@ -95,20 +95,6 @@ describe('add solution plugin', () => {
     plugin(mockAST, file);
     expect(file.data).toMatchSnapshot();
   });
-  it('should throw if a workshop non-last step has solutions', async () => {
-    expect.assertions(1);
-    const workshopNonLastAST = await parseFixture('with-multiple-solns.md');
-    const workshopFile = {
-      data: {},
-      path: path.join(
-        __dirname,
-        '../__fixtures__/workshop-test-steps/step-1.md'
-      )
-    };
-    expect(() => plugin(workshopNonLastAST, workshopFile)).toThrow(
-      'has solutions but is not the last step'
-    );
-  });
 
   it('should allow solutions in non-last steps for upcoming workshop blocks', async () => {
     expect.assertions(1);


### PR DESCRIPTION
It is occasionally necessary to use solutions for non-final steps.

For example, the new TypeScript lessons need them to provide the
correct tsconfig. Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/67261

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
