### PR TITLE
fix: update instruction text to match button label

### DIFF
--- a/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
+++ b/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
@@ -10,7 +10,7 @@ dashedName: debug-donation-form
 
 A local charity has built a donation form website, but there are several issues that need to be fixed. The form isn't accessible and has some HTML syntax errors.
 
-Your job is to fix all of the errors so the form works correctly and is accessible to all users. Complete the items in the user stories below and click "Run the Tests" to see if you fixed all the errors.
+Your job is to fix all of the errors so the form works correctly and is accessible to all users. Complete the items in the user stories below and click "Check Your Code" to see if you fixed all the errors.
 
 **User Stories:**
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the 67276below with the issue number.-->

Closes #67276

<!-- Feel free to add any additional description of changes below this line -->

There are no other changes committed except the three texts from the Codespaces instruction has been changed which is matching the text or run button given.

Changed:
"Run the Tests"

to:
"Check Your Code"

Closes #67284

