### PR TITLE
fix: allow bracket notation in Step 28 exportToCSV test

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
@@ -28,8 +28,7 @@ assert.match(exportToCSV.toString(), /rows\.push/);
 String fields should be wrapped in double quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /"\$\{entry\./);
-
+assert.match(__helpers.removeJSComments(code), /"\$\{entry[.[]/);
 ```
 
 # --seed--


### PR DESCRIPTION
## Description
The test in Step 28 of the Heritage Library Catalog only accepted 
dot notation (entry.title) but rejected valid bracket notation 
(entry["title"]), even though both produce identical output.

## Changes Made
Updated the hint regex to accept both dot and bracket notation 
for accessing entry fields in the exportToCSV function.

## Related Issue
Closes #67225

## Type of Change
- [x] Bug fix