### PR TITLE
fix(curriculum): allow multiline label in calorie counter step 47

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-calorie-counter/63c2171c1e5b6e3aa51768d0.md
+++ b/curriculum/challenges/english/blocks/workshop-calorie-counter/63c2171c1e5b6e3aa51768d0.md
@@ -14,7 +14,7 @@ Inside your template literal, create a `label` element and give it the text `Ent
 You should have a `label` element inside your template literal.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label>.*<\/label>/);
+assert.match(code, /HTMLString\s*=\s*`\n\s*<label>[\s\S]*<\/label>/);
 ```
 
 Your `label` element should have the text `Entry ${entryNumber} Name`.

--- a/curriculum/challenges/english/blocks/workshop-calorie-counter/63c2171c1e5b6e3aa51768d0.md
+++ b/curriculum/challenges/english/blocks/workshop-calorie-counter/63c2171c1e5b6e3aa51768d0.md
@@ -14,7 +14,7 @@ Inside your template literal, create a `label` element and give it the text `Ent
 You should have a `label` element inside your template literal.
 
 ```js
-assert.match(code, /HTMLString\s*=\s*`\n\s*<label>[\s\S]*<\/label>/);
+assert.match(code, /HTMLString\s*=\s*`\s*<label>[\s\S]*?<\/label>/);
 ```
 
 Your `label` element should have the text `Entry ${entryNumber} Name`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67274

<!-- Feel free to add any additional description of changes below this line -->

The test in step 47 was rejecting valid multiline template literals. 

The issue was with the regex using `.*` which doesn't match newlines 
in JS by default....so if a learner wrote the label element 
across multiple lines...the test would fail

Changed `.*` to `[\s\S]*` which matches any character including 
newlines...so the test now accepts both single-line n multiline 
versions of the label...
