### PR TITLE
fix(curriculum): correct inaccurate statement about DOM nodes in DOM lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
@@ -11,7 +11,7 @@ Let's learn about the DOM and why it's so important for web development. DOM sta
 
 With the DOM, you can add, modify, or delete elements on a webpage. You can even make your website interactive by making elements listen to and respond to events.
 
-In the DOM, an HTML document is represented as a tree of nodes. Each node represents an HTML element from the HTML document:
+In the DOM, an HTML document is represented as a tree of nodes. Many of these nodes represent HTML elements, while others represent text, comments, or the document itself:
 
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
Closes #67300

The lesson incorrectly stated "Each node represents an HTML element from the HTML document." 
This is inaccurate because DOM nodes include text nodes, comment nodes, and the document node — not just HTML elements.

Updated to a more accurate description as suggested in issue #67300.