### PR TITLE
fix(curriculum): remove duplicate word 'the' in links and images lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
@@ -11,7 +11,7 @@ Let's learn about the DOM and why it's so important for web development. DOM sta
 
 With the DOM, you can add, modify, or delete elements on a webpage. You can even make your website interactive by making elements listen to and respond to events.
 
-In the DOM, an HTML document is represented as a tree of nodes. Each node represents an HTML element from the HTML document:
+In the DOM, an HTML document is represented as a tree of nodes. Many of these nodes represent HTML elements, while others represent text, comments, or the document itself:
 
 ```html
 <!DOCTYPE html>

--- a/curriculum/challenges/english/blocks/top-links-and-images/637f700b72c65bc8e73dfe2f.md
+++ b/curriculum/challenges/english/blocks/top-links-and-images/637f700b72c65bc8e73dfe2f.md
@@ -66,7 +66,7 @@ Besides the `src` attribute, every image element should also have an `alt` (alte
 
 The `alt` attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 
-This is how the The Odin Project logo example you used earlier looks with an alt attribute included:
+This is how The Odin Project logo example you used earlier looks with an alt attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
 # --assignment--


### PR DESCRIPTION
The lesson contained a duplicate word error: "This is how the The Odin Project logo example..."

Fixed by removing the extra "the" so it reads: "This is how The Odin Project logo example..."