### PR TITLE
fix(curriculum): replace incorrect 'comprised of' with 'composed of' in HTML foundations

### DIFF
--- a/curriculum/challenges/english/blocks/top-learn-html-foundations/637f4e0e72c65bc8e73dfe1e.md
+++ b/curriculum/challenges/english/blocks/top-learn-html-foundations/637f4e0e72c65bc8e73dfe1e.md
@@ -9,7 +9,7 @@ dashedName: html-foundations-lesson-a
 
 Almost all elements on an HTML page are just pieces of content wrapped in opening and closing HTML tags.
 
-Opening tags tell the browser this is the start of an HTML element. They are comprised of a keyword enclosed in angle brackets `<>`. For example, an opening paragraph tag looks like this: `<p>`.
+Opening tags tell the browser this is the start of an HTML element. They are composed of a keyword enclosed in angle brackets `<>`. For example, an opening paragraph tag looks like this: `<p>`.
 
 Closing tags tell the browser where an element ends. They are almost the same as opening tags; the only difference is that they have a forward slash before the keyword. For example, a closing paragraph tag looks like this: `</p>`.
 


### PR DESCRIPTION
The lesson used the grammatically incorrect phrase "comprised of" which should be "composed of".

"Comprise" means to include or contain, so "comprised of" is redundant. The correct phrase is "composed of".