### PR TITLE
fix(curriculum): replace awkward 'The below' with 'The following' in array data structure lesson

### DIFF
--- a/curriculum/challenges/english/blocks/basic-data-structures/587d7b7e367417b2b2512b20.md
+++ b/curriculum/challenges/english/blocks/basic-data-structures/587d7b7e367417b2b2512b20.md
@@ -8,7 +8,7 @@ dashedName: use-an-array-to-store-a-collection-of-data
 
 # --description--
 
-The below is an example of the simplest implementation of an array data structure. This is known as a <dfn>one-dimensional array</dfn>, meaning it only has one level, or that it does not have any other arrays nested within it. Notice it contains <dfn>booleans</dfn>, <dfn>strings</dfn>, and <dfn>numbers</dfn>, among other valid JavaScript data types:
+The following is an example of the simplest implementation of an array data structure. This is known as a <dfn>one-dimensional array</dfn>, meaning it only has one level, or that it does not have any other arrays nested within it. Notice it contains <dfn>booleans</dfn>, <dfn>strings</dfn>, and <dfn>numbers</dfn>, among other valid JavaScript data types:
 
 ```js
 let simpleArray = ['one', 2, 'three', true, false, undefined, null];


### PR DESCRIPTION
The phrase "The below is an example" is awkward and non-standard English.

The correct and more natural phrasing is "The following is an example".

File: curriculum/challenges/english/blocks/basic-data-structures/587d7b7e367417b2b2512b20.md