### PR TITLE
fix(curriculum): replace 'the below code' with 'the following code' in basic CSS lesson

### DIFF
--- a/curriculum/challenges/english/blocks/basic-css/58c383d33e2e3259241f3076.md
+++ b/curriculum/challenges/english/blocks/basic-css/58c383d33e2e3259241f3076.md
@@ -13,7 +13,7 @@ You have been adding `id` or `class` attributes to elements that you wish to spe
 
 Let's bring out CatPhotoApp again to practice using CSS Selectors.
 
-For this challenge, you will use the `[attr=value]` attribute selector to style the checkboxes in CatPhotoApp. This selector matches and styles elements with a specific attribute value. For example, the below code changes the margins of all elements with the attribute `type` and a corresponding value of `radio`:
+For this challenge, you will use the `[attr=value]` attribute selector to style the checkboxes in CatPhotoApp. This selector matches and styles elements with a specific attribute value. For example, the following code changes the margins of all elements with the attribute `type` and a corresponding value of `radio`:
 
 ```css
 [type='radio'] {


### PR DESCRIPTION
The phrase "the below code" is awkward and non-standard English.

The correct and more natural phrasing is "the following code" when referring to code examples that appear after the text.

File: curriculum/challenges/english/blocks/basic-css/58c383d33e2e3259241f3076.md