### PR TITLE
fix(curriculum): replace 'the below user stories' with 'the following user stories' in data visualization projects

### DIFF
--- a/curriculum/challenges/english/blocks/data-visualization-projects/587d7fa6367417b2b2512bbf.md
+++ b/curriculum/challenges/english/blocks/data-visualization-projects/587d7fa6367417b2b2512bbf.md
@@ -10,7 +10,7 @@ dashedName: visualize-data-with-a-choropleth-map
 
 **Objective:** Build an app that is functionally similar to this: <a href="https://choropleth-map.freecodecamp.rocks" target="_blank" rel="noopener noreferrer nofollow">https://choropleth-map.freecodecamp.rocks</a>.
 
-Fulfill the below user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
+Fulfill the following user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
 
 You can use HTML, JavaScript, CSS, and the D3 svg-based visualization library. Required DOM elements are queried on the moment of each test. If you use a front-end framework (like Vue for example), the test results may be inaccurate for dynamic content. We hope to accommodate them eventually, but these frameworks are not currently supported for D3 projects.
 

--- a/curriculum/challenges/english/blocks/data-visualization-projects/587d7fa6367417b2b2512bc0.md
+++ b/curriculum/challenges/english/blocks/data-visualization-projects/587d7fa6367417b2b2512bc0.md
@@ -10,7 +10,7 @@ dashedName: visualize-data-with-a-treemap-diagram
 
 **Objective:** Build an app that is functionally similar to this: <a href="https://treemap-diagram.freecodecamp.rocks" target="_blank" rel="noopener noreferrer nofollow">https://treemap-diagram.freecodecamp.rocks</a>.
 
-Fulfill the below user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
+Fulfill the following user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
 
 You can use HTML, JavaScript, CSS, and the D3 svg-based visualization library. The tests require axes to be generated using the D3 axis property, which automatically generates ticks along the axis. These ticks are required for passing the D3 tests because their positions are used to determine alignment of graphed elements. You will find information about generating axes at <https://d3js.org/d3-axis>. Required DOM elements are queried on the moment of each test. If you use a front-end framework (like Vue for example), the test results may be inaccurate for dynamic content. We hope to accommodate them eventually, but these frameworks are not currently supported for D3 projects.
 

--- a/curriculum/challenges/english/blocks/data-visualization-projects/bd7168d8c242eddfaeb5bd13.md
+++ b/curriculum/challenges/english/blocks/data-visualization-projects/bd7168d8c242eddfaeb5bd13.md
@@ -10,7 +10,7 @@ dashedName: visualize-data-with-a-bar-chart
 
 **Objective:** Build an app that is functionally similar to this: <a href="https://bar-chart.freecodecamp.rocks" target="_blank" rel="noopener noreferrer nofollow">https://bar-chart.freecodecamp.rocks</a>.
 
-Fulfill the below user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
+Fulfill the following user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
 
 You can use HTML, JavaScript, CSS, and the D3 svg-based visualization library. The tests require axes to be generated using the D3 axis property, which automatically generates ticks along the axis. These ticks are required for passing the D3 tests because their positions are used to determine alignment of graphed elements. You will find information about generating axes at <https://d3js.org/d3-axis>. Required DOM elements are queried on the moment of each test. If you use a front-end framework (like Vue for example), the test results may be inaccurate for dynamic content. We hope to accommodate them eventually, but these frameworks are not currently supported for D3 projects.
 

--- a/curriculum/challenges/english/blocks/data-visualization-projects/bd7178d8c242eddfaeb5bd13.md
+++ b/curriculum/challenges/english/blocks/data-visualization-projects/bd7178d8c242eddfaeb5bd13.md
@@ -10,7 +10,7 @@ dashedName: visualize-data-with-a-scatterplot-graph
 
 **Objective:** Build an app that is functionally similar to this: <a href="https://scatterplot-graph.freecodecamp.rocks" target="_blank" rel="noopener noreferrer nofollow">https://scatterplot-graph.freecodecamp.rocks</a>.
 
-Fulfill the below user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
+Fulfill the following user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
 
 You can use HTML, JavaScript, CSS, and the D3 svg-based visualization library. The tests require axes to be generated using the D3 axis property, which automatically generates ticks along the axis. These ticks are required for passing the D3 tests because their positions are used to determine alignment of graphed elements. You will find information about generating axes at <https://d3js.org/d3-axis>. Required DOM elements are queried on the moment of each test. If you use a front-end framework (like Vue for example), the test results may be inaccurate for dynamic content. We hope to accommodate them eventually, but these frameworks are not currently supported for D3 projects.
 

--- a/curriculum/challenges/english/blocks/data-visualization-projects/bd7188d8c242eddfaeb5bd13.md
+++ b/curriculum/challenges/english/blocks/data-visualization-projects/bd7188d8c242eddfaeb5bd13.md
@@ -10,7 +10,7 @@ dashedName: visualize-data-with-a-heat-map
 
 **Objective:** Build an app that is functionally similar to this: <a href="https://heat-map.freecodecamp.rocks" target="_blank" rel="noopener noreferrer nofollow">https://heat-map.freecodecamp.rocks</a>.
 
-Fulfill the below user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
+Fulfill the following user stories and get all of the tests to pass. Use whichever libraries or APIs you need. Give it your own personal style.
 
 You can use HTML, JavaScript, CSS, and the D3 svg-based visualization library. Required DOM elements are queried on the moment of each test. If you use a front-end framework (like Vue for example), the test results may be inaccurate for dynamic content. We hope to accommodate them eventually, but these frameworks are not currently supported for D3 projects.
 


### PR DESCRIPTION
The phrase "Fulfill the below user stories" is awkward and non-standard English.

The correct phrasing is "Fulfill the following user stories".

This fix applies to 5 files in the data-visualization-projects folder.