### PR TITLE
fix: Fix inaccurate explanation of DOM nodes in beginner lesson #67300

### DIFF
--- a/curriculum/challenges/english/blocks/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
+++ b/curriculum/challenges/english/blocks/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
@@ -10,7 +10,7 @@ dashedName: lab-debug-camperbots-profile-page
 
 Camperbot is trying to build a profile page. They asked a friend to look over their code and they said it has some errors.
 
-Your job is to fix all of Camperbot's errors so they can continue building their profile page. Complete the items in the user stories below and click "Run the Tests" to see if you fixed all the errors.
+Your job is to fix all of Camperbot's errors so they can continue building their profile page. Complete the items in the user stories below and click "Check Your Code" to see if you fixed all the errors.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
+++ b/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
@@ -10,7 +10,7 @@ dashedName: debug-donation-form
 
 A local charity has built a donation form website, but there are several issues that need to be fixed. The form isn't accessible and has some HTML syntax errors.
 
-Your job is to fix all of the errors so the form works correctly and is accessible to all users. Complete the items in the user stories below and click "Run the Tests" to see if you fixed all the errors.
+Your job is to fix all of the errors so the form works correctly and is accessible to all users. Complete the items in the user stories below and click "Check Your Code" to see if you fixed all the errors.
 
 **User Stories:**
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
@@ -11,7 +11,8 @@ Let's learn about the DOM and why it's so important for web development. DOM sta
 
 With the DOM, you can add, modify, or delete elements on a webpage. You can even make your website interactive by making elements listen to and respond to events.
 
-In the DOM, an HTML document is represented as a tree of nodes. Each node represents an HTML element from the HTML document:
+In the DOM, an HTML document is represented as a tree of different types of nodes. Some of these nodes, called element nodes, represent the HTML elements in the document, while other nodes can represent text, comments, or the document itself.
+
 
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67300 

<!-- Feel free to add any additional description of changes below this line -->
Updated the DOM node explanation to clarify that the DOM contains different types of nodes and that element nodes represent HTML elements. This keeps the lesson beginner-friendly while improving technical accuracy.