### PR TITLE
fix(curriculum): add missing colons to User Stories headers

### DIFF
--- a/curriculum/challenges/english/blocks/lab-element-skipper/a5deed1811a43193f9f1c841.md
+++ b/curriculum/challenges/english/blocks/lab-element-skipper/a5deed1811a43193f9f1c841.md
@@ -13,7 +13,7 @@ For example, for an array like `[1, 1, 1, 2, 1, 1, 1]` and a test function `func
 
 **Objective**: Fulfill the user stories below and get all the tests to pass to complete the lab.
 
-**User Stories**
+**User Stories:**
 
 1. You should have a `dropElements` function that accepts an array (`arr`) and a function (`func`) as arguments.
 1. The `dropElements` function should iterate through the array and remove elements starting from the first one until `func` returns `true` for an element.

--- a/curriculum/challenges/english/blocks/lab-linked-list-operations/69708d59833ceded7d00541f.md
+++ b/curriculum/challenges/english/blocks/lab-linked-list-operations/69708d59833ceded7d00541f.md
@@ -11,7 +11,7 @@ In this lab, you will implement additional operations for a linked list data str
 
 **Objective**: Fulfill the user stories below and get all the tests to pass to complete the lab.
 
-**User Stories**
+**User Stories:**
 
 1. You should have a `contains` function that accepts a linked list and an element. It should return `true` if the specified element exists in the linked list, and `false` otherwise.
 1. You should have a `getAt` function that accepts a linked list and an index. It should return the element at the given index in the linked list. If the index is out of bounds, it should return `undefined`.

--- a/curriculum/challenges/english/blocks/lab-odd-fibonacci-sum-calculator/a5229172f011153519423690.md
+++ b/curriculum/challenges/english/blocks/lab-odd-fibonacci-sum-calculator/a5229172f011153519423690.md
@@ -11,7 +11,7 @@ In this lab you will build an odd Fibonacci sum calculator that computes the sum
 
 **Objective**: Fulfill the user stories below and get all the tests to pass to complete the lab.
 
-**User Stories**
+**User Stories:**
 
 1. You should have a `sumFibs` function that accepts a number as an argument.
 1. The `sumFibs` function should return the sum of all odd Fibonacci numbers that are less than or equal to the given number.

--- a/curriculum/challenges/english/blocks/lab-pricing-plans-layout/68e45a2b4ab9b2f48b1cc6df.md
+++ b/curriculum/challenges/english/blocks/lab-pricing-plans-layout/68e45a2b4ab9b2f48b1cc6df.md
@@ -10,7 +10,7 @@ demoType: onClick
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
-**User Stories**
+**User Stories:**
 
 1. Your page should have an `h1` element with the text `Pricing Plans`.
 2. Your page should have a `div` element with the class `pricing-container` below the `h1` element.

--- a/curriculum/challenges/english/blocks/lab-range-based-lcm-calculator/ae9defd7acaf69703ab432ea.md
+++ b/curriculum/challenges/english/blocks/lab-range-based-lcm-calculator/ae9defd7acaf69703ab432ea.md
@@ -11,7 +11,7 @@ In this lab, you will create a function that takes an array of two numbers and r
 
 **Objective**: Fulfill the user stories below and get all the tests to pass to complete the lab.
 
-**User Stories**
+**User Stories:**
 
 1. You should have a `smallestCommons` function that accepts an array of two numbers as an argument.
 1. The `smallestCommons` function should return the smallest common multiple that is evenly divisible by both numbers and all sequential numbers in the range between them.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or in cGitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67319 

<!-- Feel free to add any additional description of changes below this line -->

## Description

This PR adds missing colons to the `User Stories:` headers in 5 lab challenge markdown files for consistency with the formatting used across the curriculum.

### Files Updated

* `lab-element-skipper`
* `lab-linked-list-operations`
* `lab-odd-fibonacci-sum-calculator`
* `lab-range-based-lcm-calculator`
* `lab-pricing-plans-layout`
