### PR TITLE
fix: salary tracker step 32 misleading hint

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-salary-tracker/68ca758f8160b11757f877ae.md
+++ b/curriculum/challenges/english/blocks/workshop-salary-tracker/68ca758f8160b11757f877ae.md
@@ -22,6 +22,12 @@ You should have a fourth `if` statement inside your `level` setter.
 Your `if` statement should use `hasattr(self, '_level')` to check if `_level` exists before comparing.
 
 ```js
+({ test: () => assert(runPython(`"hasattr(self, '_level')" in str(_Node(_code).find_class("Employee").find_functions("level")[1].find_ifs()[3].find_conditions()[0])`)) })
+```
+
+Your `if` statement should compare `Employee._base_salaries[new_level]` against `Employee._base_salaries[self.level]` to check if the new level has a lower base salary.
+
+```js
 ({ test: () => assert(runPython(`_Node(_code).find_class("Employee").find_functions("level")[1].find_ifs()[3].find_conditions()[0].is_equivalent("hasattr(self, '_level') and Employee._base_salaries[new_level] < Employee._base_salaries[self.level]")`)) })
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-salary-tracker/68ca758f8160b11757f877ae.md
+++ b/curriculum/challenges/english/blocks/workshop-salary-tracker/68ca758f8160b11757f877ae.md
@@ -28,7 +28,10 @@ Your `if` statement should use `hasattr(self, '_level')` to check if `_level` ex
 Your `if` statement should compare `Employee._base_salaries[new_level]` against `Employee._base_salaries[self.level]` to check if the new level has a lower base salary.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_class("Employee").find_functions("level")[1].find_ifs()[3].find_conditions()[0].is_equivalent("hasattr(self, '_level') and Employee._base_salaries[new_level] < Employee._base_salaries[self.level]")`)) })
+({ test: () => assert(runPython(`
+cond = _Node(_code).find_class("Employee").find_functions("level")[1].find_ifs()[3].find_conditions()[0]
+cond.is_equivalent("hasattr(self, '_level') and Employee._base_salaries[new_level] < Employee._base_salaries[self.level]") or cond.is_equivalent("hasattr(self, '_level') and Employee._base_salaries[self.level] > Employee._base_salaries[new_level]")
+`)) })
 ```
 
 When `new_level` is lower than `self.level`, you should raise a `ValueError` with the message `Cannot change to lower level.`


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Errors in the second part of the condition would result in the `hasattr` hint, now it should give a useful hint