### PR TITLE
fix: add missing User Stories header in lab-travel-weather-planner

### DIFF
--- a/curriculum/challenges/english/blocks/lab-travel-weather-planner/694acade1d4afdbce71e5840.md
+++ b/curriculum/challenges/english/blocks/lab-travel-weather-planner/694acade1d4afdbce71e5840.md
@@ -11,6 +11,8 @@ For this lab, you will use conditional statements to determine whether commuting
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
+**User Stories:**
+
 1. You should create the following variables:
    * `distance_mi` (a number representing the distance to travel in miles)
    * `is_raining` (a boolean representing if the user is currently experiencing rainy weather)


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67318