### PR TITLE
fix(curriculum): allow bracket notation in CSV test

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
@@ -28,7 +28,7 @@ assert.match(exportToCSV.toString(), /rows\.push/);
 String fields should be wrapped in double quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /"\$\{entry\./);
+assert.match(__helpers.removeJSComments(code), /"\$\{entry(?:\.\w+|\[\s*["']\w+["']\s*\])/);
 
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67225

This updates the Step 28 hint for the Heritage Library Catalog workshop so the CSV row check accepts both dot notation and bracket notation when accessing entry fields. The previous regex only matched template expressions beginning with entry., even though entry["title"] and entry.title produce the same output for this exercise.

Verification:
- Confirmed the updated regex accepts dot notation, double-quoted bracket notation, and single-quoted bracket notation with a local Node check.
- Ran git diff --check.
