### PR TITLE
fix(curriculum): clarify DOM element node wording

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/67336894ae148431a870694d.md
@@ -11,7 +11,7 @@ Let's learn about the DOM and why it's so important for web development. DOM sta
 
 With the DOM, you can add, modify, or delete elements on a webpage. You can even make your website interactive by making elements listen to and respond to events.
 
-In the DOM, an HTML document is represented as a tree of nodes. Each node represents an HTML element from the HTML document:
+In the DOM, an HTML document is represented as a tree of nodes. Each element node represents an HTML element from the HTML document:
 
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67300

This updates the DOM lesson wording from "Each node represents an HTML element" to "Each element node represents an HTML element". That keeps the beginner-friendly explanation intact while avoiding the inaccurate implication that every DOM node is an HTML element.

Verification:
- Ran git diff --check.
