### PR TITLE
fix(curriculum): clarify useMemo re-render behavior

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
@@ -124,7 +124,7 @@ function ExpensiveSquare({ num }) {
 export default ExpensiveSquare;
 ```
 
-This will make sure the function is memoized by caching the result, so calculation happens only when the `num` variable changes, not when anything changes in the component it's being used in.
+This will make sure the function is memoized by caching the result. Even though the `ExpensiveSquare` component still re-renders every time the timer updates in the parent, the `calculateSquare` computation will only re-run when `num` changes.
 
 The `calculateSquare` function call is not running any time `timer` changes anymore but on the initial render and when `num` changes.
 


### PR DESCRIPTION
Clarified memoization explanation for calculateSquare function.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #67331

<!-- Feel free to add any additional description of changes below this line -->
