### PR TITLE
fix: correct misleading useMemo explanation in lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
@@ -124,7 +124,7 @@ function ExpensiveSquare({ num }) {
 export default ExpensiveSquare;
 ```
 
-This will make sure the function is memoized by caching the result, so calculation happens only when the `num` variable changes, not when anything changes in the component it's being used in.
+This will make sure the function is memoized by caching the result. Even though the `ExpensiveSquare` component still re-renders every time the timer updates in the parent, the `calculateSquare` computation will only re-run when `num` changes.
 
 The `calculateSquare` function call is not running any time `timer` changes anymore but on the initial render and when `num` changes.
 


### PR DESCRIPTION
Checklist:

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67343

<!-- Feel free to add any additional description of changes below this line -->

Fixes the misleading explanation of the `useMemo` hook in the lecture on memoization. The old text implied that `useMemo` prevents the component from re-rendering, which is incorrect — that is the job of `React.memo`. The corrected text clarifies that `useMemo` only prevents the `calculateSquare` computation from re-running on every render, while the component itself still re-renders when the parent timer updates.



