### PR TITLE
fix(curriculum): clarify useMemo re-render behavior

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
@@ -124,7 +124,7 @@ function ExpensiveSquare({ num }) {
 export default ExpensiveSquare;
 ```
 
-This will make sure the function is memoized by caching the result, so calculation happens only when the `num` variable changes, not when anything changes in the component it's being used in.
+This will make sure the function is memoized by caching the result. Even though the `ExpensiveSquare` component still re-renders every time the `timer` updates in the parent, the `calculateSquare` computation will only re-run when `num` changes.
 
 The `calculateSquare` function call is not running any time `timer` changes anymore but on the initial render and when `num` changes.
 


### PR DESCRIPTION
Closes #67331\n\n- Clarifies that useMemo caches the computed value\n- Removes the misleading implication that it stops component re-renders\n\nValidation:\n- Sanity-checked the updated lesson text locally