### PR TITLE
fix(curriculum): clarify useMemo rerender behavior

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
@@ -124,7 +124,7 @@ function ExpensiveSquare({ num }) {
 export default ExpensiveSquare;
 ```
 
-This caches the result of the `calculateSquare(num)` computation. Even though the `ExpensiveSquare` component still re-renders every time the parent's `timer` state updates, the `calculateSquare` computation only re-runs on the initial render and when `num` changes.
+This will make sure the function is memoized by caching the result. Even though the `ExpensiveSquare` component still re-renders every time the parent's `timer` state updates, the `calculateSquare` computation only re-runs on the initial render and when `num` changes.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
@@ -124,9 +124,7 @@ function ExpensiveSquare({ num }) {
 export default ExpensiveSquare;
 ```
 
-This will make sure the function is memoized by caching the result, so calculation happens only when the `num` variable changes, not when anything changes in the component it's being used in.
-
-The `calculateSquare` function call is not running any time `timer` changes anymore but on the initial render and when `num` changes.
+This caches the result of the `calculateSquare(num)` computation. Even though the `ExpensiveSquare` component still re-renders every time the parent's `timer` state updates, the `calculateSquare` computation only re-runs on the initial render and when `num` changes.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67331

This PR clarifies the useMemo explanation in the memoization lesson.

The updated text now makes it clear that useMemo caches the result of the calculateSquare(num) computation, but does not prevent the ExpensiveSquare component from re-rendering when the parent timer updates.
