### PR TITLE
fix(curriculum): clarify useMemo explanation in memoization lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-fetching-and-memoization-in-react/67d2f4ddb4a4306fdf5bbaee.md
@@ -124,9 +124,9 @@ function ExpensiveSquare({ num }) {
 export default ExpensiveSquare;
 ```
 
-This will make sure the function is memoized by caching the result, so calculation happens only when the `num` variable changes, not when anything changes in the component it's being used in.
+This will make sure the function is memoized by caching the result. Even though the `ExpensiveSquare` component still re-renders every time the `timer` updates in the parent, the `calculateSquare` computation will only re-run when `num` changes.
 
-The `calculateSquare` function call is not running any time `timer` changes anymore but on the initial render and when `num` changes.
+The `calculateSquare` function call is not running every time `timer` changes, but only on the initial render and when `num` changes.
 
 # --questions--
 


### PR DESCRIPTION
## Description

Fixes #67331

The previous text in the "What Is Memoization and How Does the useMemo Hook Work" lecture contained a conceptually misleading explanation about `useMemo`.

### The Problem:
The phrase *"not when anything changes in the component it's being used in"* incorrectly implied that `useMemo` prevents the `<ExpensiveSquare />` component from re-rendering when the parent's `timer` state updates. This confuses the purpose of `useMemo` with `React.memo`.

### The Fix:
Updated the explanation to accurately describe that:
- The `ExpensiveSquare` component **still re-renders** every time `timer` updates in the parent
- Only the `calculateSquare` computation is cached and skips re-running when `num` has not changed
- `useMemo` prevents unnecessary **recalculation**, not **re-rendering**

### Changes:
**Before:**
> "This will make sure the function is memoized by caching the result, so calculation happens only when the `num` variable changes, not when anything changes in the component it's being used in."

**After:**
> "This will make sure the function is memoized by caching the result. Even though the `ExpensiveSquare` component still re-renders every time the `timer` updates in the parent, the `calculateSquare` computation will only re-run when `num` changes."

## Checklist

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or Gitpod.