### PR TITLE
fix(curriculum): explain callable() in dynamic attributes lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-classes-and-objects/6908d38f7cccc31602743340.md
+++ b/curriculum/challenges/english/blocks/lecture-classes-and-objects/6908d38f7cccc31602743340.md
@@ -97,6 +97,8 @@ for attr in dir(person):
 # name: John Doe
 ```
 
+In the loop above, `callable()` is a built-in function that returns `True` if the object passed to it can be called like a function or method, and `False` otherwise. By checking `not callable(getattr(person, attr))`, the loop skips over methods and only prints the data attributes like `name` and `age`.
+
 The `setattr()` function lets you create a new attribute or update an existing one dynamically. The syntax looks like this: 
 
 ```python


### PR DESCRIPTION
Fixes #67358
The "How to Handle Object Attributes Dynamically" lesson used callable() in the dir() loop examples without explaining what it does or why it is needed. Learners had no context for understanding how callable() filters out methods and keeps only data attributes.

Added a sentence after the first dir() code block explaining that callable() returns True if an object can be called like a function or method, and that not callable(...) is used to skip over methods and print only data attributes such as name and age.

Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67358

<!-- Feel free to add any additional description of changes below this line -->
