### PR TITLE
fix(curriculum): remove first person language from email simulator workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-email-simulator/6852f06fdde1b4634a263f03.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/6852f06fdde1b4634a263f03.md
@@ -7,7 +7,7 @@ dashedName: step-4
 
 # --description--
 
-Now let's test the `Email` class by creating an email object and checking that it stores information correctly. You'll print a couple of attributes to verify everything works.
+Now test the `Email` class by creating an email object and checking that it stores information correctly. You'll print a couple of attributes to verify everything works.
 
 Create an email object named `email_obj` with `alice@example.com` as the sender, `bob@example.com` as the receiver, `Hello` as the subject, and `Hi Bob!` as the body. Then print the `sender` and `subject` attributes as separate print statements to verify they are stored correctly.
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/6852f0c3fcedb964ab959921.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/6852f0c3fcedb964ab959921.md
@@ -7,7 +7,7 @@ dashedName: step-6
 
 # --description--
 
-Now let's test that the `read` attribute was added correctly to your `Email` class. Since you already have an email object from the previous steps, print the `read` attribute to see that it's now `False` by default.
+Now test that the `read` attribute was added correctly to your `Email` class. Since you already have an email object from the previous steps, print the `read` attribute to see that it's now `False` by default.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/6853f2da9b8ed891e9fdc5fc.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/6853f2da9b8ed891e9fdc5fc.md
@@ -7,7 +7,7 @@ dashedName: step-23
 
 # --description--
 
-Now let's display the sender and receiver information. To show who sent and received the email, add two print statements to the `display_full_email` method in this format:
+Now display the sender and receiver information. To show who sent and received the email, add two print statements to the `display_full_email` method in this format:
 
 - `From: sender` where `sender` is replaced with the sender's name 
 - `To: receiver` where `receiver` is replaced with the receiver's name

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/6853f34ff93594934f6636d9.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/6853f34ff93594934f6636d9.md
@@ -7,7 +7,7 @@ dashedName: step-27
 
 # --description--
 
-Let's add a string representation to our `Email` class so we can display brief email summaries.
+Add a string representation to the `Email` class to display brief email summaries.
 
 Add a `__str__` method to the `Email` class that takes `self` as a parameter.
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/6853f553d90a2f9874ff9d0e.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/6853f553d90a2f9874ff9d0e.md
@@ -7,7 +7,7 @@ dashedName: step-39
 
 # --description--
 
-Now we're ready to add timestamps to our emails to track when they were sent and received.
+Now you're ready to add timestamps to the emails to track when they were sent and received.
 
 First, import the `datetime` module at the top of your file.
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/6853f68dd3affa9adb2e6d99.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/6853f68dd3affa9adb2e6d99.md
@@ -7,7 +7,7 @@ dashedName: step-41
 
 # --description--
 
-Great! Now that you've practiced datetime formatting, remove the `current_time` variable and the print statement from the bottom of your code. We'll integrate timestamps into the `Email` class in the next step.
+Great! Now that you've practiced datetime formatting, remove the `current_time` variable and the print statement from the bottom of your code. You'll integrate timestamps into the `Email` class in the next step.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/6853f70470f45d9c280af659.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/6853f70470f45d9c280af659.md
@@ -7,7 +7,7 @@ dashedName: step-43
 
 # --description--
 
-Now let's show the timestamp when displaying the full email.
+Now show the timestamp when displaying the full email.
 
 Below the subject, print the received timestamp using `strftime` to format it as `'%Y-%m-%d %H:%M'`. Use the following format:
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/685941422c30cd3dc41b1d0a.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/685941422c30cd3dc41b1d0a.md
@@ -7,7 +7,7 @@ dashedName: step-22
 
 # --description--
 
-Now let's add a header to the email display. In the `display_full_email` method, after calling `mark_as_read()`, print `\n--- Email ---` to start the email display with a clear header.
+Now add a header to the email display. In the `display_full_email` method, after calling `mark_as_read()`, print `\n--- Email ---` to start the email display with a clear header.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/6859523c793377706e19e9a0.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/6859523c793377706e19e9a0.md
@@ -7,7 +7,7 @@ dashedName: step-42
 
 # --description--
 
-Now let's add timestamps to our emails. In the Email class `__init__` method, create a `timestamp` attribute and assign the current time to it to automatically set a timestamp for when the email was created.
+Now add timestamps to the emails. In the Email class `__init__` method, create a `timestamp` attribute and assign the current time to it to automatically set a timestamp for when the email was created.
 
 This is helpful for tracking when messages were sent and received.
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/685c1eba966c6396850736ea.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/685c1eba966c6396850736ea.md
@@ -7,7 +7,7 @@ dashedName: step-13
 
 # --description--
 
-While users can send emails and have inboxes, we need a dedicated class to manage inbox operations efficiently. 
+While users can send emails and have inboxes, a dedicated class is needed to manage inbox operations efficiently. 
 
 The `Inbox` class will store a list of emails and provide methods to add new emails, list all emails, and manage them.
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/685d2fd1f309b9191f257c55.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/685d2fd1f309b9191f257c55.md
@@ -7,7 +7,7 @@ dashedName: step-40
 
 # --description--
 
-Before integrating timestamps into our email system, let's practice working with datetime formatting. The `datetime.datetime.now()` function gives us the current date and time, and we can use the `strftime()` method to format it in different ways.
+Before integrating timestamps into the email system, practice working with datetime formatting. The `datetime.datetime.now()` function gives the current date and time, and you can use the `strftime()` method to format it in different ways.
 
 Here's how `strftime()` works with format codes:
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/685d53b5e4f5784562a12d1b.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/685d53b5e4f5784562a12d1b.md
@@ -7,7 +7,7 @@ dashedName: step-45
 
 # --description--
 
-Users should get confirmation when they successfully send an email. Let's improve the user experience by adding feedback to the `send_email` method.
+Users should get confirmation when they successfully send an email. Improve the user experience by adding feedback to the `send_email` method.
 
 In the `send_email` method of the `User` class, add a `print` statement after the email is sent that shows confirmation. The message should be `Email sent from [sender_name] to [receiver_name]!\n`, where `[sender_name]` is replaced by the sender's name and `[receiver_name]` is replaced by the receiver's name.
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/685d53ec88a16a4643c2437b.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/685d53ec88a16a4643c2437b.md
@@ -7,7 +7,7 @@ dashedName: step-44
 
 # --description--
 
-Now let's also show timestamps in the email listing. Update the `__str__` method in the `Email` class to include the timestamp after the subject.
+Now also show timestamps in the email listing. Update the `__str__` method in the `Email` class to include the timestamp after the subject.
 
 Modify the return statement to include the timestamp formatted as `'%Y-%m-%d %H:%M'` at the end, separated by ` | Time: `.
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/688754f3494b17e0b352d67d.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/688754f3494b17e0b352d67d.md
@@ -7,7 +7,7 @@ dashedName: step-17
 
 # --description--
 
-Now it's time to test our complete email system! Let's create some users and see the email functionality in action.
+Now it's time to test the complete email system! Create two users and see the email functionality in action.
 
 Create two User objects: `alice` with name `"Alice"` and `bob` with name `"Bob"`. This will demonstrate how users can be created and interact with each other.
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/68875521efc1a4e3f0c570e3.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/68875521efc1a4e3f0c570e3.md
@@ -7,7 +7,7 @@ dashedName: step-19
 
 # --description--
 
-Now let's verify that the email was delivered successfully by printing the length of Bob's inbox emails.
+Now verify that the email was delivered successfully by printing the length of Bob's inbox emails.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-email-simulator/68879d0a2aeb368e26559635.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/68879d0a2aeb368e26559635.md
@@ -7,7 +7,7 @@ dashedName: step-26
 
 # --description--
 
-Finally, let's add a footer to complete the email display format. Add a final print statement: `print('------------\n')` to close off the email display with a nice separator line.
+Finally, add a footer to complete the email display format. Add a final print statement: `print('------------\n')` to close off the email display with a nice separator line.
 
 # --hints--
 


### PR DESCRIPTION
…rkshop

Replaces first person language (let's, we, our, we're, we'll) with second person (you, your, imperative) across 16 steps in the email simulator workshop, following the curriculum writing guidelines at https://contribute.freecodecamp.org/how-to-work-on-coding-challenges/#challenge-descriptionsinstructions

Steps updated: 4, 6, 13, 17, 19, 22, 23, 26, 27, 39, 40, 41, 42, 43, 44, 45

Fixes #67359

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67359

<!-- Feel free to add any additional description of changes below this line -->
