### PR TITLE
fix: Remove first person language from Tailwind pricing step

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6866740a0f532cc7e9e21877.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6866740a0f532cc7e9e21877.md
@@ -7,7 +7,7 @@ dashedName: step-29
 
 # --description--
 
-Let's move onto the `Most popular` badge. You need to place it in the upper right corner of the card, so you can use some of Tailwind's positioning utility classes to do that.
+Move onto the `Most popular` badge. You need to place it in the upper right corner of the card, so you can use some of Tailwind's positioning utility classes to do that.
 
 Here's how you would use CSS positioning in Tailwind:
 


### PR DESCRIPTION
Updates the Tailwind pricing component workshop step 29 description to remove the first-person phrasing called out in the issue while keeping the instruction and expected learner action unchanged. Verified with a targeted content check for the edited challenge file.
