### PR TITLE
fix: Remove first person language from discount calculator workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-discount-calculator/68e5293bd00d2fe134f5898a.md
+++ b/curriculum/challenges/english/blocks/workshop-discount-calculator/68e5293bd00d2fe134f5898a.md
@@ -7,7 +7,7 @@ dashedName: step-19
 
 # --description--
 
-Let's test your new discount strategy. After the existing code, create an instance of `FixedAmountDiscount` with an amount of `5` and assign it to a variable named `fixed_discount`. Then apply this discount to the product and print the result.
+You need to test your new discount strategy. After the existing code, create an instance of `FixedAmountDiscount` with an amount of `5` and assign it to a variable named `fixed_discount`. Then apply this discount to the product and print the result.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec5309d.md
+++ b/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec5309d.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-Now let's create a third discount strategy for premium users. Create a class named `PremiumUserDiscount` that inherits from `DiscountStrategy`.
+Now you need to create a third discount strategy for premium users. Create a class named `PremiumUserDiscount` that inherits from `DiscountStrategy`.
 
 Unlike the previous strategies, this one doesn't need an `__init__` method because it doesn't store any configuration. It will apply a fixed 20% discount to all premium users.
 

--- a/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec530a6.md
+++ b/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec530a6.md
@@ -7,7 +7,7 @@ dashedName: step-29
 
 # --description--
 
-Now let's test the complete discount system! Add an `if` statement checking if `__name__ == '__main__'` and move `product = Product('Wireless Mouse', 50.0)` inside it.
+Now you need to test the complete discount system! Add an `if` statement checking if `__name__ == '__main__'` and move `product = Product('Wireless Mouse', 50.0)` inside it.
 
 After that, inside the `if` block, create a variable `user_tier` and set it to the string `Premium`. Then create a variable `strategies` set to a list of strategies containing `PercentageDiscount(10)`, `FixedAmountDiscount(5)`, and `PremiumUserDiscount()`.
 


### PR DESCRIPTION
This updates the three discount calculator workshop steps listed in the issue to avoid first person language by replacing the remaining instances of "let's" with direct learner-facing wording.

Closes #67378

Tested with a targeted content assertion confirming the old phrase is absent and the replacement wording is present in all three updated challenge files.
