### PR TITLE
fix: Remove first person language from shopping list step

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-list-app/67fe694ebcafe94ab7451a8f.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-list-app/67fe694ebcafe94ab7451a8f.md
@@ -11,7 +11,7 @@ Your app works! Go ahead and test it out.
 
 However, it's not as efficient as it could be. While React is already very performant, there are some cases where it can be better to cache the results of potentially expensive calculations, or to ensure that functions are not recreated on every render.
 
-We'll improve the performance of your app over the following steps. But first, let's add some logging so you can see the lifecycle of this component more clearly.
+The performance of your app will be improved over the following steps. But first, add some logging to show the lifecycle of this component more clearly.
 
 Above `filteredItems`, add a `console.log()` statement that logs the string `Filtering items...` to the console.
 


### PR DESCRIPTION
This updates the shopping list app workshop step mentioned in #67380 to avoid first person wording while keeping the instruction and expected learner action the same. I verified the targeted text no longer contains the listed first person phrases.
