### PR TITLE
fix: Remove first person wording from the Luhn algorithm lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-luhn-algorithm/68507cadbf36aa089a84ce2d.md
+++ b/curriculum/challenges/english/blocks/lab-luhn-algorithm/68507cadbf36aa089a84ce2d.md
@@ -14,7 +14,7 @@ The Luhn algorithm, also known as the "modulus 10" or "mod 10" algorithm, is a s
 - Take the sum of all the digits including the check digit.
 - If the sum of all the digits is a multiple of `10`, then the number is valid; else it is not valid.
 
-Let's say we have the number `453914881`. The steps to validate it using the Luhn algorithm would be:
+Suppose the number is `453914881`. The steps to validate it using the Luhn algorithm would be:
 
  ```md 
  Account number      4   5   3   9   1   4   8   8   1 


### PR DESCRIPTION
This updates the Luhn algorithm lab copy to avoid first-person wording, replacing the remaining "let's" and "we" phrasing with direct learner-focused language while keeping the instructions and examples unchanged. Closes #67379.
