### PR TITLE
fix: Clarify optional parameter placement in TypeScript lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-typescript/698f515e99f9a25a3462f97f.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-typescript/698f515e99f9a25a3462f97f.md
@@ -76,7 +76,7 @@ function area(radius: number, height?: number): number {
 }
 ```
 
-The conditional check inside of the function is there in case the `height` argument is not provided. 
+The conditional check inside of the function is there in case the `height` argument is not provided. Optional parameters must come after all required parameters in the parameter list.
 
 If you want to type your return values, you can add return type annotations like this:
 


### PR DESCRIPTION
Adds a brief note to the TypeScript function types lesson explaining that optional parameters must be placed after required parameters, matching the example and helping learners avoid the TS1016 error when experimenting with parameter order.
