### PR TITLE
Clarify optional parameter placement in TypeScript lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-typescript/698f515e99f9a25a3462f97f.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-typescript/698f515e99f9a25a3462f97f.md
@@ -76,7 +76,7 @@ function area(radius: number, height?: number): number {
 }
 ```
 
-The conditional check inside of the function is there in case the `height` argument is not provided. 
+The conditional check inside of the function is there in case the `height` argument is not provided. Optional parameters must come after required parameters, or TypeScript will report an error.
 
 If you want to type your return values, you can add return type annotations like this:
 


### PR DESCRIPTION
This adds a short note after the optional parameter example explaining that optional parameters must be placed after required parameters. The wording keeps the lesson flow intact while clarifying the TypeScript rule that otherwise produces an error when a required parameter follows an optional one.

Closes #67363
