### PR TITLE
fix(curriculum): remove first person language from Tailwind pricing component

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6866740a0f532cc7e9e21877.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6866740a0f532cc7e9e21877.md
@@ -7,7 +7,7 @@ dashedName: step-29
 
 # --description--
 
-Let's move onto the `Most popular` badge. You need to place it in the upper right corner of the card, so you can use some of Tailwind's positioning utility classes to do that.
+Now move onto the `Most popular` badge. You need to place it in the upper right corner of the card, so you can use some of Tailwind's positioning utility classes to do that.
 
 Here's how you would use CSS positioning in Tailwind:
 


### PR DESCRIPTION
…omponent workshop

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67381 

<!-- Feel free to add any additional description of changes below this line -->

Replaced "Let's" with "Now" in Step 29 to remove first person language.