### PR TITLE
fix(curriculum): update raiseTo regex to support return type annotation in step 14

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f4b903bf5427a599f791d.md
+++ b/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f4b903bf5427a599f791d.md
@@ -24,7 +24,7 @@ Your `raiseTo` function should have two parameters, `base` and `exponent`.
 ```js
 assert.match(
   code,
-   /function\s+raiseTo\s*\(\s*base\s*(?::\s*number)?\s*,\s*exponent\s*(?::\s*number)?\s*\)\s*|(?:const|let)\s+raiseTo\s*=\s*\(\s*base\s*(?::\s*number)?\s*,\s*exponent\s*(?::\s*number)?\s*\)\s*=>/
+   /function\s+raiseTo\s*\(\s*base\s*(?::\s*number)?\s*,\s*exponent\s*(?::\s*number)?\s*\)\s*|(?:const|let)\s+raiseTo\s*=\s*\(\s*base\s*(?::\s*number)?\s*,\s*exponent\s*(?::\s*number)?\s*\)\s*(?::\s*\w+\s*)?\s*=>/
 );
 ```
 


### PR DESCRIPTION
…on in step 14

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67362 

<!-- Feel free to add any additional description of changes below this line -->

Updated the regex in the hint for step 14 to account for return type annotations on arrow functions.......so that 
const raiseTo = (base: number, exponent: number): number => { ... } correctly passes the test.
