### PR TITLE
fix(curriculum): correct misleading 'Int Division:' label in Python v9 curriculum

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-numbers-and-mathematical-operations/67fe859e9d3b3635197781c8.md
+++ b/curriculum/challenges/english/blocks/lecture-numbers-and-mathematical-operations/67fe859e9d3b3635197781c8.md
@@ -61,7 +61,7 @@ my_int_2 = 12
 
 # Division
 div_ints = my_int_1 / my_int_2
-print('Integer Division:', div_ints) # Integer Division: 4.666666666666667
+print('Division:', div_ints) # Division: 4.666666666666667
 ```
 
 Floats are positive or negative numbers with decimal points, like `3.14`, `-0.5`, or `0.0`.

--- a/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
+++ b/curriculum/challenges/english/blocks/review-python-basics/67f39b40deaec81a3e40e0c5.md
@@ -404,7 +404,7 @@ print('Float Multiplication:', float_2 * float_1) # Float Multiplication: 64.800
 
 # Division
 
-print('Int Division:', int_1 / int_2) # Int Division: 4.666666666666667
+print('Division:', int_1 / int_2) # Division: 4.666666666666667
 print('Float Division:', float_2 / float_1) # Float Division: 2.222222222222222
 ```
 

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -404,7 +404,7 @@ print('Float Multiplication:', float_2 * float_1) # Float Multiplication: 64.800
 
 # Division
 
-print('Int Division:', int_1 / int_2) # Int Division: 4.666666666666667
+print('Division:', int_1 / int_2) # Division: 4.666666666666667
 print('Float Division:', float_2 / float_1) # Float Division: 2.222222222222222
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67394

## Description

Three Python curriculum lessons labeled the result of the `/` operator as "Integer Division" or "Int Division". This is misleading because `/` performs true division and returns a `float`, while `//` is Python's integer (floor) division operator.

## What changed

- Renamed the print labels from "Integer Division" / "Int Division" to "Division" in the three affected lesson files.