### PR TITLE
fix(curriculum): clarify optional parameter order

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-typescript/698f515e99f9a25a3462f97f.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-typescript/698f515e99f9a25a3462f97f.md
@@ -76,6 +76,8 @@ function area(radius: number, height?: number): number {
 }
 ```
 
+Optional parameters must always come after required parameters.
+
 The conditional check inside of the function is there in case the `height` argument is not provided. 
 
 If you want to type your return values, you can add return type annotations like this:

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-typescript/698f515e99f9a25a3462f97f.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-typescript/698f515e99f9a25a3462f97f.md
@@ -76,7 +76,7 @@ function area(radius: number, height?: number): number {
 }
 ```
 
-Optional parameters must always come after required parameters.
+Keep in mind that optional parameters must always come after required parameters. Placing a required parameter after an optional one will result in a TypeScript error.
 
 The conditional check inside of the function is there in case the `height` argument is not provided. 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67363

<!-- Feel free to add any additional description of changes below this line -->

This PR adds a brief clarification to the TypeScript lesson on function types. It explicitly states that optional parameters must come after required parameters, helping prevent beginner confusion and avoiding the `TS1016` error when a required parameter is placed after an optional one.