### PR TITLE
fix(curriculum): capitalize TV in media catalogue workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-media-catalogue/68b99289c744bffa96807d04.md
+++ b/curriculum/challenges/english/blocks/workshop-media-catalogue/68b99289c744bffa96807d04.md
@@ -7,7 +7,7 @@ dashedName: step-37
 
 # --description--
 
-Currently, both movies and tv series are displayed all together when you print the catalogue. In the next steps, you'll take care of filtering the items in two categories to display separately.
+Currently, both movies and TV series are displayed all together when you print the catalogue. In the next steps, you'll take care of filtering the items in two categories to display separately.
 
 Inside the `MediaCatalogue` class, create a method named `get_movies` and make it return a list containing only instances of the parent class `Movie` that can be found in `self.items`.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67407

<!-- Feel free to add any additional description of changes below this line -->

Capitalized "TV" in the curriculum description for consistency.