### PR TITLE
fix(curriculum): remove first person language

### DIFF
--- a/curriculum/challenges/english/blocks/lab-luhn-algorithm/68507cadbf36aa089a84ce2d.md
+++ b/curriculum/challenges/english/blocks/lab-luhn-algorithm/68507cadbf36aa089a84ce2d.md
@@ -14,7 +14,7 @@ The Luhn algorithm, also known as the "modulus 10" or "mod 10" algorithm, is a s
 - Take the sum of all the digits including the check digit.
 - If the sum of all the digits is a multiple of `10`, then the number is valid; else it is not valid.
 
-Let's say we have the number `453914881`. The steps to validate it using the Luhn algorithm would be:
+For the number `453914881`, the steps to validate it using the Luhn algorithm would be:
 
  ```md 
  Account number      4   5   3   9   1   4   8   8   1 

--- a/curriculum/challenges/english/blocks/workshop-discount-calculator/68e5293bd00d2fe134f5898a.md
+++ b/curriculum/challenges/english/blocks/workshop-discount-calculator/68e5293bd00d2fe134f5898a.md
@@ -7,7 +7,7 @@ dashedName: step-19
 
 # --description--
 
-Let's test your new discount strategy. After the existing code, create an instance of `FixedAmountDiscount` with an amount of `5` and assign it to a variable named `fixed_discount`. Then apply this discount to the product and print the result.
+Test your new discount strategy. After the existing code, create an instance of `FixedAmountDiscount` with an amount of `5` and assign it to a variable named `fixed_discount`. Then apply this discount to the product and print the result.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec5309d.md
+++ b/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec5309d.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-Now let's create a third discount strategy for premium users. Create a class named `PremiumUserDiscount` that inherits from `DiscountStrategy`.
+Now create a third discount strategy for premium users. Create a class named `PremiumUserDiscount` that inherits from `DiscountStrategy`.
 
 Unlike the previous strategies, this one doesn't need an `__init__` method because it doesn't store any configuration. It will apply a fixed 20% discount to all premium users.
 

--- a/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec530a6.md
+++ b/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec530a6.md
@@ -7,7 +7,7 @@ dashedName: step-29
 
 # --description--
 
-Now let's test the complete discount system! Add an `if` statement checking if `__name__ == '__main__'` and move `product = Product('Wireless Mouse', 50.0)` inside it.
+Now test the complete discount system! Add an `if` statement checking if `__name__ == '__main__'` and move `product = Product('Wireless Mouse', 50.0)` inside it.
 
 After that, inside the `if` block, create a variable `user_tier` and set it to the string `Premium`. Then create a variable `strategies` set to a list of strategies containing `PercentageDiscount(10)`, `FixedAmountDiscount(5)`, and `PremiumUserDiscount()`.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contributing guidelines.

Closes #67378
Closes #67379

This updates the Python curriculum wording to remove first-person phrasing from the Luhn algorithm lab and discount calculator workshop steps called out in the linked issues.

No tests were run; copy-only curriculum update.