### PR TITLE
fix(curriculum): allow typed raiseTo arrow functions

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f4b903bf5427a599f791d.md
+++ b/curriculum/challenges/english/blocks/workshop-type-safe-math-toolkit/699f4b903bf5427a599f791d.md
@@ -24,7 +24,7 @@ Your `raiseTo` function should have two parameters, `base` and `exponent`.
 ```js
 assert.match(
   code,
-   /function\s+raiseTo\s*\(\s*base\s*(?::\s*number)?\s*,\s*exponent\s*(?::\s*number)?\s*\)\s*|(?:const|let)\s+raiseTo\s*=\s*\(\s*base\s*(?::\s*number)?\s*,\s*exponent\s*(?::\s*number)?\s*\)\s*=>/
+  /function\s+raiseTo\s*\(\s*base\s*(?::\s*number)?\s*,\s*exponent\s*(?::\s*number)?\s*\)\s*|(?:const|let)\s+raiseTo\s*=\s*\(\s*base\s*(?::\s*number)?\s*,\s*exponent\s*(?::\s*number)?\s*\)\s*(?::\s*number)?\s*=>/
 );
 ```
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contributing guidelines.

Closes #67362

This updates the Step 14 `raiseTo` parameter-name assertion so arrow function declarations with a `: number` return type annotation are accepted.

Verification:
- Ran a local Node regex check for function declarations, typed arrow functions, untyped arrow functions, and an incorrect parameter name.