### PR TITLE
fix(curriculum): accept bracket notation in CSV step

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
@@ -28,7 +28,7 @@ assert.match(exportToCSV.toString(), /rows\.push/);
 String fields should be wrapped in double quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /"\$\{entry\./);
+assert.match(__helpers.removeJSComments(code), /"\$\{entry(?:\.|\[\s*["'])/);
 
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67225

This updates the Step 28 CSV assertion to accept bracket notation in addition to dot notation when accessing entry fields in template literals.

Verification:
- Ran a local Node regex check for dot notation, double-quoted bracket notation, single-quoted bracket notation, and an unquoted CSV template case.
