### PR TITLE
fix(curriculum): correct fCC authors page typo

### DIFF
--- a/curriculum/challenges/english/blocks/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
+++ b/curriculum/challenges/english/blocks/learn-fetch-and-promises-by-building-an-fcc-authors-page/641daae5e18eae4b562633e4.md
@@ -7,7 +7,7 @@ dashedName: step-28
 
 # --description--
 
-Finally, what if there's an error and the author data fail to load? Then we need to show an error in the UI. That's exactly what the `.catch()` method is for – handling errors.
+Finally, what if there's an error and the author data fails to load? Then we need to show an error in the UI. That's exactly what the `.catch()` method is for – handling errors.
 
 Inside the `.catch()`, remove the `console.error()` and set the `innerHTML` of the `authorContainer` to a `p` element with the `class` `"error-msg"` and text `"There was an error loading the authors"`.
 

--- a/curriculum/challenges/english/blocks/workshop-fcc-authors-page/641daae5e18eae4b562633e4.md
+++ b/curriculum/challenges/english/blocks/workshop-fcc-authors-page/641daae5e18eae4b562633e4.md
@@ -7,7 +7,7 @@ dashedName: step-23
 
 # --description--
 
-Finally, what if there's an error and the author data fail to load? Then you need to show an error in the UI. That's exactly what the `.catch()` method is for – handling errors.
+Finally, what if there's an error and the author data fails to load? Then you need to show an error in the UI. That's exactly what the `.catch()` method is for – handling errors.
 
 Inside the `.catch()`, remove the `console.error()` and set the `innerHTML` of the `authorContainer` to a `p` element with a `class` attribute of `"error-msg"` and text `"There was an error loading the authors"`.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67412

<!-- Feel free to add any additional description of changes below this line -->

This PR corrects a subject-verb agreement typo in two fCC authors page curriculum challenge descriptions.