### PR TITLE
fix: separate duplicate erms validation in insertErms

### DIFF
--- a/tools/challenge-helper-scripts/helpers/insert-erms.ts
+++ b/tools/challenge-helper-scripts/helpers/insert-erms.ts
@@ -1,6 +1,6 @@
 // Update given value with markers (labels)
 const insertErms = (seedCode: string, erms: number[]): string => {
-  if (!erms || erms.length <= 1) {
+  if (!erms) {
     throw Error('erms should be provided');
   }
 

--- a/tools/challenge-helper-scripts/helpers/insert-erms.ts
+++ b/tools/challenge-helper-scripts/helpers/insert-erms.ts
@@ -1,9 +1,5 @@
 // Update given value with markers (labels)
 const insertErms = (seedCode: string, erms: number[]): string => {
-  if (!erms) {
-    throw Error('erms should be provided');
-  }
-
   if (erms.length <= 1) {
     throw Error('erms should contain 2 elements');
   }


### PR DESCRIPTION
Checklist:

## Description

This PR fixes a logic error in the `insertErms` function where duplicate error checks prevented the second validation from ever being reached.

**What changed:**
- Split the combined condition `if (!erms || erms.length <= 1)` into two separate checks
- First check validates that `erms` is provided
- Second check validates that `erms` contains at least 2 elements

**Why:**
The original code had the second error check as unreachable dead code because the first condition would throw if `erms.length <= 1`, so the second check could never execute.

---

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67427 

