### PR TITLE
fix(curriculum): use output test for bill splitter step 4 print hint

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/6982684f3a25f379e195a5fc.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/6982684f3a25f379e195a5fc.md
@@ -43,9 +43,16 @@ You should print the string `Total bill so far:` followed by a space and the val
 ```js
 ({
     test: () => runPython(`
-    sol1 = "print('Total bill so far:', running_total)"
-    sol2 = "print(f'Total bill so far: {running_total}')"
-    assert _Node(_code).has_call(sol1) or _Node(_code).has_call(sol2)`)
+import io, contextlib
+
+_expected = f"Total bill so far: {37.89 + 57.34 + 39.39 + 64.21}"
+
+buffer = io.StringIO()
+with contextlib.redirect_stdout(buffer):
+    exec(_code)
+
+assert _expected in buffer.getvalue()
+`)
 })
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/67442

<!-- Feel free to add any additional description of changes below this line -->

It's not the most intuitive approach, so I just opened this.

This should be able to allow all outputs if correct independently on how the `print` is written