### PR TITLE
feat: aria-live attribute feedback

### DIFF
--- a/client/src/templates/Challenges/components/independent-lower-jaw.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.tsx
@@ -203,6 +203,7 @@ export function IndependentLowerJaw({
           </div>
           <div
             className='hint-body'
+            aria-live='polite'
             dangerouslySetInnerHTML={{
               __html: sanitizeHtml(hint, {
                 allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
@@ -267,7 +268,7 @@ export function IndependentLowerJaw({
               <span className='tooltiptext'> {t('buttons.close')}</span>
             </button>
           </div>
-          <b>{t('learn.congratulations-code-passes')}</b>
+          <b aria-live='polite'>{t('learn.congratulations-code-passes')}</b>
           <div className='progress-bar-container'>
             <Progress minified={true} />
           </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #67296

<!-- Feel free to add any additional description of changes below this line -->
I did set up the aria-live attributes and tested using my headphones while the NVDA software was running. It seemed to work. I've not tested it with other screen-readers and have not checked for other languages than English. 