### PR TITLE
fix(client): remove forced 1px size on editor screen-reader textarea

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -21,12 +21,6 @@
   z-index: 11;
 }
 
-/* NVDA skips the textarea in browse mode if there is no size */
-textarea.inputarea {
-  width: 1px !important;
-  height: 1px !important;
-}
-
 .editor-container {
   background: var(--editor-background);
 }


### PR DESCRIPTION
## Problem
With NVDA on Windows, pressing Up/Down in the challenge code editor announces
only a single character instead of the current line. Shift+Up/Down (line
selection) works correctly. Reproduced on e.g. the daily coding challenge.

## Root cause
The classic editor uses `wordWrap: 'on'`, so Monaco gives its hidden
screen-reader `textarea.inputarea` the attribute `wrap="on"`. The rule in
`classic/editor.css` forcing that textarea to `width: 1px !important`
overrides Monaco's own sizing, so the soft-wrapping textarea wraps **every
character onto its own line**. NVDA announces "the current line" on a
vertical caret move — and that line is one character.

This is not a Monaco-version issue: a current Monaco build reproduces it too,
and monaco-editor 0.52.2 works fine without this CSS rule.

## Fix
Remove the rule.

The rule was a stale workaround. It was added in May 2022 (#45803) when this
repo shipped **monaco-editor 0.28.1**; the comment "NVDA skips the textarea
in browse mode if there is no size" reflects that older Monaco not giving the
textarea a size. The repo now ships **monaco-editor 0.52.2**, which sizes the
textarea itself:

- On the live site the textarea carries Monaco's own inline style
  `width: 390px; height: 24px` — it only *rendered* at 1px because the
  `!important` rule overrode it.
- Measured in an isolated monaco-editor 0.52.2 build (no rule,
  `accessibilitySupport: 'on'`, `wordWrap: 'on'`): the textarea is
  `755 × 19 px`, `display: block`, `visible`, on-screen.

So removing the rule does not make the textarea zero-size — it gives it
Monaco's natural size, which is far larger than the 1px the rule provided.
The browse-mode skip the rule guarded against is triggered by *zero* size; a
non-zero, visible, on-screen textarea is included in NVDA's virtual buffer.
The lecture "Interactive Editor" (`components/custom-monaco-editor.tsx`)
already ships with no such rule and is reachable/announced normally by NVDA.

## Scope
This was verified to be the only occurrence. freeCodeCamp has exactly two
Monaco editor instances: the classic challenge editor (`classic/editor.tsx`)
and the lecture "Interactive Editor" (`components/custom-monaco-editor.tsx`).
`wordWrap: 'on'` is set in exactly one place repo-wide — `classic/editor.tsx`
— so only that editor's textarea gets `wrap="on"`. The removed
`textarea.inputarea` block was the only CSS rule targeting the Monaco
textarea; no other `.css` file references it. The lecture editor sets neither
ingredient and is unaffected (confirmed working with NVDA).

## Testing
- Reproduced and fixed in an isolated Monaco harness, verified with NVDA in
  Chrome, Edge, and Firefox: `wrap="on"` + 1px textarea fails; removing the
  1px rule passes; the lecture "Interactive Editor" (no such rule) was never
  affected.
- Confirmed the textarea keeps a non-zero, on-screen size once the rule is
  removed (measured `755 × 19 px`).
- prettier and stylelint pass.
