### PR TITLE
feat(client): handle exam awaiting challenges

### DIFF
--- a/client/src/templates/Challenges/exam-download/attempts.tsx
+++ b/client/src/templates/Challenges/exam-download/attempts.tsx
@@ -58,8 +58,9 @@ export function Attempts({ examChallengeId }: AttemptsProps) {
       case 'InProgress':
         return t('exam.in-progress');
       case 'PendingModeration':
-        return t('exam.pending');
+      case 'AwaitingChallenges':
       case 'Expired':
+      default:
         return t('exam.pending');
     }
   }
@@ -75,8 +76,9 @@ export function Attempts({ examChallengeId }: AttemptsProps) {
       case 'InProgress':
         return t('exam.in-progress');
       case 'PendingModeration':
-        return t('exam.pending');
+      case 'AwaitingChallenges':
       case 'Expired':
+      default:
         return t('exam.pending');
     }
   }

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -229,7 +229,12 @@ export type Attempt = {
 } & (
   | {
       result: null;
-      status: 'InProgress' | 'Expired' | 'PendingModeration' | 'Denied';
+      status:
+        | 'InProgress'
+        | 'Expired'
+        | 'PendingModeration'
+        | 'Denied'
+        | 'AwaitingChallenges';
     }
   | {
       status: 'Approved';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

To go in before: https://github.com/freeCodeCamp/freeCodeCamp/pull/64692

---

Why does the `default` case get lumped with the other cases?

a. I wanted to keep the fully-typed out cases written down (explicit)
b. TS cannot do the nice thing of:

```ts
export type Attempt = {
  id: string;
  examId: string;
  // ISO 8601 string
  startTime: string;
  questionSets: unknown[];
} & (
  | {
      result: null;
      status:
        | 'InProgress'
        | 'Expired'
        | 'PendingModeration'
        | 'Denied'
        | 'AwaitingChallenges'; // OR `| string` OR `| (string & {})`
    }
  | {
      result: null;
      status: Omit<string, 'Approved'>; // Not a thing
    }
  | {
      status: 'Approved';
      result: { // This is no longer type narrowed
        passingPercent: number;
        score: number;
      };
    }
);
```

In short, there is no way to handle non-exhaustive variants whilst getting the benefits of strong typing.