### PR TITLE
fix: add language selector to mobile layout for daily coding challenge

### DIFF
--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -5,6 +5,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import { Tabs, TabsContent, TabsTrigger, TabsList } from '@freecodecamp/ui';
+import store from 'store';
+import { DailyCodingChallengeLanguages } from '../../../redux/prop-types';
 
 import {
   removePortalWindow,
@@ -41,6 +43,11 @@ interface MobileLayoutProps {
   testOutput: JSX.Element;
   usesMultifileEditor: boolean;
   usesTerminal: boolean;
+  isDailyCodingChallenge: boolean;
+  dailyCodingChallengeLanguage: DailyCodingChallengeLanguages;
+  setDailyCodingChallengeLanguage: (
+    language: DailyCodingChallengeLanguages
+  ) => void;
 }
 
 const tabs = {
@@ -166,8 +173,16 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       portalWindow,
       windowTitle,
       usesMultifileEditor,
-      usesTerminal
+      usesTerminal,
+      isDailyCodingChallenge,
+      dailyCodingChallengeLanguage,
+      setDailyCodingChallengeLanguage
     } = this.props;
+
+    const handleLanguageChange = (language: DailyCodingChallengeLanguages) => {
+      store.set('dailyCodingChallengeLanguage', language);
+      setDailyCodingChallengeLanguage(language);
+    };
 
     const displayPreviewPane = hasPreview && showPreviewPane;
     const displayPreviewPortal = hasPreview && showPreviewPortal;
@@ -236,6 +251,26 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             <TabsTrigger value={tabs.editor}>
               {i18next.t('learn.editor-tabs.code')}
             </TabsTrigger>
+            {isDailyCodingChallenge && (
+              <>
+                <TabsTrigger
+                  value='javascript-lang'
+                  aria-expanded={dailyCodingChallengeLanguage === 'javascript'}
+                  disabled={dailyCodingChallengeLanguage === 'javascript'}
+                  onClick={() => handleLanguageChange('javascript')}
+                >
+                  JavaScript
+                </TabsTrigger>
+                <TabsTrigger
+                  value='python-lang'
+                  aria-expanded={dailyCodingChallengeLanguage === 'python'}
+                  disabled={dailyCodingChallengeLanguage === 'python'}
+                  onClick={() => handleLanguageChange('python')}
+                >
+                  Python
+                </TabsTrigger>
+              </>
+            )}
             {!!notes && usesMultifileEditor && (
               <TabsTrigger value={tabs.notes}>
                 {i18next.t('learn.editor-tabs.notes')}

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -517,6 +517,9 @@ function ShowClassic({
             updateUsingKeyboardInTablist={updateUsingKeyboardInTablist}
             usesMultifileEditor={usesMultifileEditor}
             usesTerminal={usesTerminal}
+            isDailyCodingChallenge={isDailyCodingChallenge}
+            dailyCodingChallengeLanguage={dailyCodingChallengeLanguage}
+            setDailyCodingChallengeLanguage={setDailyCodingChallengeLanguage}
           />
         ) : (
           <DesktopLayout


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66361

## Problem
The JavaScript/Python language selector was missing on mobile/small window views of the daily coding challenge.

The desktop layout passes `isDailyCodingChallenge`, `dailyCodingChallengeLanguage`, and `setDailyCodingChallengeLanguage` to `ActionRow` which renders the selector, but `MobileLayout` had no equivalent — the props were never passed and the buttons were never rendered on mobile.

## Fix
- Added the three language-related props to `MobileLayoutProps` interface
- Destructured and wired them in `render()`
- Rendered JavaScript/Python `TabsTrigger` buttons in the `TabsList` when `isDailyCodingChallenge` is true
- Passed the three props from `show.tsx` to `<MobileLayout>`