### PR TITLE
fix(curriculum): update misleading explanation on interfaces

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-type-composition/698f5a3a492176259d1afcf9.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-type-composition/698f5a3a492176259d1afcf9.md
@@ -31,7 +31,7 @@ interface User {
 }
 ```
 
-`type` and `interface` are similar but one key difference is that interfaces use the `extends` keyword to build on other interfaces, while `type` aliases use intersection types (`&`) to combine types.
+`type` and `interface` are similar but one key difference is that interfaces use the `extends` keyword to build on other interfaces or types, while `type` aliases use intersection types (`&`) to combine types.
 
 Let's look at some examples:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67448

<!-- Feel free to add any additional description of changes below this line -->

Fixed the misleading sentence as proposed:

Previous:
"...interfaces use the extends keyword to build on other interfaces, while type aliases..."

Updated: 
"...interfaces use the extends keyword to build on other interfaces or types, while type aliases..."

