### PR TITLE
fix: add missing backticks to get_balance method

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-object-oriented-programming-and-encapsulation/68420be9af9d89620af7944a.md
@@ -88,7 +88,7 @@ account = Wallet(500)
 print(account.__balance) # AttributeError: 'Wallet' object has no attribute '__balance'
 ```
 
-To get the current value of `__balance`, you can define a get_balance method. For example:
+To get the current value of `__balance`, you can define a `get_balance` method. For example:
 
 ```py
 class Wallet:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67465

Added missing backticks around `get_balance` in the OOP lesson.
