### PR TITLE
fix: fix broken feedback sentences for raise lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
@@ -185,7 +185,7 @@ It raises a generic `Exception`.
 
 ### --feedback--
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
 ---
 
@@ -193,7 +193,7 @@ It does nothing.
 
 ### --feedback--
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
 ---
 
@@ -204,8 +204,8 @@ It re-raises the current exception.
 It raises a `TypeError`.
 
 ### --feedback--
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67469

<!-- Feel free to add any additional description of changes below this line -->
Fixed broken feedback sentences in the "What Is the Raise Statement and How Does It Work?" lecture by correcting sentence structure for all three incorrect answer feedback strings.