### PR TITLE
fix: fix incorrect alt text for D3 lecture images

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-data-visualization/695b9093a0c45b36932dcbcb.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-data-visualization/695b9093a0c45b36932dcbcb.md
@@ -11,7 +11,7 @@ In the prior lessons, you were introduced to data visualization which is the pro
 
 The D3 library is a free and open source library you can use to create compelling and effective data visualizations in JavaScript.
 
-<img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/what-is-the-d3-library-used-for-1.png" alt="A graph with four nodes labeled A, B, C, and D. Node A connects to B, C, and D. Node B connects to A and D. Node C connects to A. Node D connects to A and B. It's the same image as before.">
+<img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/what-is-the-d3-library-used-for-1.png" alt="A green choropleth map of the United States showing county-level data, with a color scale ranging from light green (~3%) to dark green (60%+).">
 
 
 The name D3 is an abbreviation for data-driven documents, referring to how it dynamically binds data to elements in the Document Object Model (DOM). This library is flexible and works naturally with the web. Instead of having to learn a whole new graphical representation, you can build data visualizations with `svg` and `canvas` elements.
@@ -26,7 +26,7 @@ For example, if you want to create a bar chart using D3, you can do the followin
     
 * Create the SVG container with the bars and labels
     
-<img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/what-is-the-d3-library-used-for-2.png" alt="A graph with four nodes labeled A, B, C, and D. Node A connects to B, C, and D. Node B connects to A and D. Node C connects to A. Node D connects to A and B. It's the same image as before.">
+<img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/what-is-the-d3-library-used-for-2.png" alt="A bar chart titled United States GDP showing Gross Domestic Product from 1947 to 2015, with values rising from near zero to approximately 18,000.">
 
 So what are some other reasons to learn D3 over other visualization tools like Chart.js, Plotly, or Tableau?
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67468

<!-- Feel free to add any additional description of changes below this line -->

Fixed incorrect alt text for both images in the "What Is the D3 Library Used For?" lecture by updating the descriptions to accurately match the displayed visuals.