### PR TITLE
fix(curriculum): correct grammar in Fetch API lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407be6af21d6766ed4b96.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407be6af21d6766ed4b96.md
@@ -7,7 +7,7 @@ dashedName: how-does-the-fetch-api-work-with-common-http-methods-and-res-json
 
 # --description--
 
-In the previous lesson, we saw what the Fetch API is and how to use it. In this lesson, we will discuss about the `GET`, `POST`, `PUT` and `DELETE` HTTP methods of Fetch API.
+In the previous lesson, we saw what the Fetch API is and how to use it. In this lesson, we will discuss the `GET`, `POST`, `PUT`, and `DELETE` HTTP methods of Fetch API.
 
 Let's start with the most common HTTP method which is the `GET` method. This is used to retrieve data from a server. When you use `fetch()` without specifying a method, it defaults to `GET`.
 
@@ -15,7 +15,7 @@ Let's start with the most common HTTP method which is the `GET` method. This is 
 fetch('https://api.example.com/data')
 ```
 
-In this code, we're making a `GET` request to `https://api.example.com/data`. Now, please note that you cannot use this data directly, you have to convert the response to a JSON format. Only then you can use it anywhere you want in your project. Here’s an example of how to do it:
+In this code, we're making a `GET` request to `https://api.example.com/data`. Now, please note that you cannot use this data directly. You have to convert the response to a JSON format. Only then you can use it anywhere you want in your project. Here’s an example of how to do it:
 
 ```js
 fetch('https://api.example.com/data')
@@ -27,7 +27,7 @@ In this code, the response coming from the Fetch API is a promise, and we are us
 
 The value of a promise is not known when the promise is created. It’s only known when the asynchronous process is completed. When we chain the two `.then` handlers to the fetch call, this is something called promise chaining which will be taught in the next lesson.
 
-So far we have been retrieving resources from a server. But, did you know that we can also send data to the server? The `POST` method is used to send data to a server to create a resource. Here’s an example of a `POST` method which is used to create data into the server: 
+So far we have been retrieving resources from a server. But, did you know that we can also send data to the server? The `POST` method is used to send data to a server to create a resource. Here’s an example of a `POST` method which is used to create a resource on the server: 
 
 ```js
 fetch('https://api.example.com/users', {
@@ -59,7 +59,7 @@ fetch('https://api.example.com/users/45', {
 })
 ```
 
-In this example, look carefully at the URL, you can see a `45` at the end. This is typically used as a unique ID to identify the data we are trying to update. We used the `PUT` method on the code and also specified the data as the `body` which will be used to update the identified data. 
+In this example, look carefully at the URL, you can see a `45` at the end. This is typically used as a unique ID to identify the data we are trying to update. We used the `PUT` method in the code and also specified the data as the `body` which will be used to update the identified data. 
 
 The `DELETE` method is used to delete a resource from the server. Here’s an example:
 
@@ -69,7 +69,7 @@ fetch('https://api.example.com/users/45', {
 })
 ```
 
-In this code, we are including the `DELETE` method and an ID at the end of the url to identify the data which needs to be deleted. 
+In this code, we are including the `DELETE` method and an ID at the end of the URL to identify the data which needs to be deleted. 
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x  ] My pull request targets the `main` branch of freeCodeCamp.
- [  x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67470 

<!-- Feel free to add any additional description of changes below this line -->

Hi,

As a first-time contributor, I’ve addressed the grammar errors mentioned in this issue to improve the lecture's clarity. I corrected the sentence structure, fixed the comma splice, and updated the "URL" casing as requested.

Happy to make further adjustments if needed.

Closes #67470
