### PR TITLE
fix: add missing semicolons to console.log statements in workshop-linked-list-js

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a012c6224fac85832247dd.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a012c6224fac85832247dd.md
@@ -53,8 +53,8 @@ function add(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a013a86c97dac3784b2636.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a013a86c97dac3784b2636.md
@@ -56,8 +56,8 @@ function add(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a014bd9b1730e94136279f.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a014bd9b1730e94136279f.md
@@ -57,8 +57,8 @@ function add(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a016ac6edea7d8c8020c98.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a016ac6edea7d8c8020c98.md
@@ -52,8 +52,8 @@ function add(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a0179a85b00b6127e0af45.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a0179a85b00b6127e0af45.md
@@ -54,8 +54,8 @@ function add(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a01864d343dc2f2484d131.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a01864d343dc2f2484d131.md
@@ -55,8 +55,8 @@ function add(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a02ee82bbeaee00e44c67d.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a02ee82bbeaee00e44c67d.md
@@ -55,11 +55,11 @@ function add(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 --fcc-editable-region--
 
 --fcc-editable-region--
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a030fbe487f185f55b8627.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a030fbe487f185f55b8627.md
@@ -68,10 +68,10 @@ function add(list, element) {
 --fcc-editable-region--
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a03aaa1e6fe8152788ce6a.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a03aaa1e6fe8152788ce6a.md
@@ -69,10 +69,10 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a03ddce82b0626f329b001.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a03ddce82b0626f329b001.md
@@ -64,10 +64,10 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a03f70b50b4c4d9a0f0113.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a03f70b50b4c4d9a0f0113.md
@@ -70,10 +70,10 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a04088e600bd8074a9852f.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a04088e600bd8074a9852f.md
@@ -74,10 +74,10 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a04466917c66b132323a1b.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a04466917c66b132323a1b.md
@@ -78,10 +78,10 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a045fd236d0d973a59f103.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a045fd236d0d973a59f103.md
@@ -82,10 +82,10 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a046a1a74385bb4be1bb88.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a046a1a74385bb4be1bb88.md
@@ -77,10 +77,10 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 ```

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a04712866a37ea8f38b6bd.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a04712866a37ea8f38b6bd.md
@@ -86,12 +86,12 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 --fcc-editable-region--
 
 --fcc-editable-region--
@@ -154,12 +154,12 @@ function remove(list, element) {
 }
 
 const myList = initList();
-console.log(isEmpty(myList))
+console.log(isEmpty(myList));
 add(myList, 42);
 add(myList, 43);
 add(myList, 44);
-console.log(myList)
-console.log(isEmpty(myList))
+console.log(myList);
+console.log(isEmpty(myList));
 remove(myList, 43);
 console.log(JSON.stringify(myList, null, 2))
 ```


### PR DESCRIPTION
Adds missing semicolons to `console.log` statements in the seed code 
across all steps of the `workshop-linked-list-js` workshop.

The following statements were missing semicolons:
- `console.log(isEmpty(myList))` → `console.log(isEmpty(myList));`
- `console.log(myList)` → `console.log(myList);`

Checklist:
- [x] I have read and followed the contribution guidelines
- [x] I have read and followed the how to open a pull request guide
- [x] My pull request targets the `main` branch of freeCodeCamp
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces

Closes part of #66745