### PR TITLE
refactor(client): modernize rxjs usage in epics

### DIFF
--- a/client/src/redux/failed-updates-epic.js
+++ b/client/src/redux/failed-updates-epic.js
@@ -1,10 +1,11 @@
 import { ofType } from 'redux-observable';
-import { empty, merge } from 'rxjs';
+import { EMPTY, from } from 'rxjs';
 import {
   catchError,
   filter,
   ignoreElements,
   map,
+  mergeAll,
   switchMap,
   tap
 } from 'rxjs/operators';
@@ -20,7 +21,7 @@ import { isServerOnlineSelector, isSignedInSelector } from './selectors';
 
 const key = 'fcc-failed-updates';
 
-function delay(time = 0, fn) {
+function delay(fn, time = 0) {
   return setTimeout(fn, time);
 }
 
@@ -28,6 +29,32 @@ function delay(time = 0, fn) {
 const isSubmitable = failure =>
   failure.payload.challengeType !== challengeTypes.backEndProject ||
   failure.payload.solution;
+
+function handleUpdateSuccess(update) {
+  console.info(`${update.id} succeeded`);
+  const failures = store.get(key) || [];
+  const newFailures = failures.filter(x => x.id !== update.id);
+  store.set(key, newFailures);
+}
+
+function runUpdate(update) {
+  return new Promise((resolve, reject) => {
+    postUpdate$(update)
+      .pipe(
+        switchMap(({ response, data }) => {
+          if (data?.message || isGoodXHRStatus(response?.status)) {
+            handleUpdateSuccess(update);
+          }
+          return EMPTY;
+        }),
+        catchError(() => EMPTY)
+      )
+      .subscribe({
+        complete: resolve,
+        error: reject
+      });
+  });
+}
 
 function failedUpdateEpic(action$, state$) {
   const storeUpdates = action$.pipe(
@@ -70,23 +97,7 @@ function failedUpdateEpic(action$, state$) {
         // 6th: 1600ms delay
         // and so-on
         delayTime += 100 * i;
-        return delay(delayTime, () =>
-          postUpdate$(update)
-            .pipe(
-              switchMap(({ response, data }) => {
-                if (data?.message || isGoodXHRStatus(response?.status)) {
-                  console.info(`${update.id} succeeded`);
-                  // the request completed successfully
-                  const failures = store.get(key) || [];
-                  const newFailures = failures.filter(x => x.id !== update.id);
-                  store.set(key, newFailures);
-                }
-                return empty();
-              }),
-              catchError(() => empty())
-            )
-            .toPromise()
-        );
+        return delay(() => runUpdate(update), delayTime);
       });
       Promise.all(batch)
         .then(() => console.info('progress updates processed where possible'))
@@ -97,7 +108,7 @@ function failedUpdateEpic(action$, state$) {
     ignoreElements()
   );
 
-  return merge(storeUpdates, flushUpdates);
+  return from([storeUpdates, flushUpdates]).pipe(mergeAll());
 }
 
 export default failedUpdateEpic;

--- a/client/src/redux/failed-updates-epic.test.js
+++ b/client/src/redux/failed-updates-epic.test.js
@@ -19,7 +19,9 @@ describe('failed-updates-epic', () => {
     const state$ = new StateObservable(new Subject(), initialState);
     const epic$ = failedUpdatesEpic(action$, state$);
 
-    await epic$.toPromise();
+    await new Promise(resolve => {
+      epic$.subscribe({ complete: resolve });
+    });
 
     expect(store.get(key)).toEqual(submitableChallenges);
   });

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -1,15 +1,8 @@
 import { navigate } from 'gatsby';
 import { omit } from 'lodash-es';
 import { ofType } from 'redux-observable';
-import { empty, of } from 'rxjs';
-import {
-  catchError,
-  concat,
-  retry,
-  switchMap,
-  tap,
-  mergeMap
-} from 'rxjs/operators';
+import { EMPTY, of, concat } from 'rxjs';
+import { catchError, retry, switchMap, tap, mergeMap } from 'rxjs/operators';
 import { createFlashMessage } from '../../../components/Flash/redux';
 import {
   standardErrorMessage,
@@ -157,12 +150,12 @@ function submitModern(type, state) {
       return postChallenge(update);
     }
   }
-  return empty();
+  return EMPTY;
 }
 
 function submitProject(type, state) {
   if (type === actionTypes.checkChallenge) {
-    return empty();
+    return EMPTY;
   }
 
   const { solution, githubLink } = projectFormValuesSelector(state);
@@ -177,8 +170,9 @@ function submitProject(type, state) {
     endpoint: '/project-completed',
     payload: challengeInfo
   };
-  return postChallenge(update, username).pipe(
-    concat(of(updateSolutionFormValues({})))
+  return concat(
+    postChallenge(update, username),
+    of(updateSolutionFormValues({}))
   );
 }
 
@@ -199,7 +193,7 @@ function submitBackendChallenge(type, state) {
       return postChallenge(update);
     }
   }
-  return empty();
+  return EMPTY;
 }
 
 const submitters = {
@@ -226,7 +220,7 @@ function submitExam(type, state) {
     };
     return postChallenge(update, username);
   }
-  return empty();
+  return EMPTY;
 }
 
 function submitMsTrophy(type, state) {
@@ -241,7 +235,7 @@ function submitMsTrophy(type, state) {
     };
     return postChallenge(update);
   }
-  return empty();
+  return EMPTY;
 }
 
 export default function completionEpic(action$, state$) {
@@ -303,25 +297,25 @@ export default function completionEpic(action$, state$) {
         return donationData ? allowSectionDonationRequests(donationData) : null;
       };
 
-      return submitter(type, state).pipe(
-        concat(
-          of(setIsAdvancing(!isLastChallengeInBlock), setIsProcessing(false))
-        ),
-        mergeMap(x => {
-          const donationAction = canAllowDonationRequest(state, x);
-          return donationAction ? of(x, donationAction) : of(x);
-        }),
-        mergeMap(x => of(x, setRenderStartTime(Date.now()))),
-        tap(res => {
-          if (res.type !== submitActionTypes.updateFailed) {
-            if (challengeType !== challengeTypes.exam) {
-              navigate(pathToNavigateTo);
+      return concat(
+        submitter(type, state).pipe(
+          mergeMap(x => {
+            const donationAction = canAllowDonationRequest(state, x);
+            return donationAction ? of(x, donationAction) : of(x);
+          }),
+          mergeMap(x => of(x, setRenderStartTime(Date.now()))),
+          tap(res => {
+            if (res.type !== submitActionTypes.updateFailed) {
+              if (challengeType !== challengeTypes.exam) {
+                navigate(pathToNavigateTo);
+              }
+            } else {
+              createFlashMessage(standardErrorMessage);
             }
-          } else {
-            createFlashMessage(standardErrorMessage);
-          }
-        }),
-        concat(of(closeModal('completion')))
+          })
+        ),
+        of(setIsAdvancing(!isLastChallengeInBlock), setIsProcessing(false)),
+        of(closeModal('completion'))
       );
     })
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67496

<!-- Feel free to add any additional description of changes below this line -->

Summary:
- Modernize deprecated RxJS APIs in challenge epics and related test.
- Remove deprecated patterns flagged by Sonar and reduce nesting.

Testing:
- pnpm --filter client test