### PR TITLE
fix: add missing semicolons in workshop-loan-qualification-checker

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4b2.md
+++ b/curriculum/challenges/english/blocks/workshop-loan-qualification-checker/66c8ba975ee7230e29f6c4b2.md
@@ -111,14 +111,14 @@ const minIncomeForCar = 30000;
 const minCreditScoreForCar = 650;
 
 function getLoanMessage(annualIncome, creditScore) {
-  if(creditScore >= minCreditScoreForDuplex && annualIncome >= minIncomeForDuplex) {
-    return "You qualify for a duplex, condo, and car loan."
+  if (creditScore >= minCreditScoreForDuplex && annualIncome >= minIncomeForDuplex) {
+    return "You qualify for a duplex, condo, and car loan.";
   } else if (annualIncome >= minIncomeForCondo && creditScore >= minCreditScoreForCondo) {
-    return "You qualify for a condo and car loan."
+    return "You qualify for a condo and car loan.";
   } else if (annualIncome >= minIncomeForCar && creditScore >= minCreditScoreForCar) {
-    return "You qualify for a car loan."
+    return "You qualify for a car loan.";
   } else {
-    return "You don't qualify for any loans."
+    return "You don't qualify for any loans.";
   }
 }
 
@@ -140,26 +140,26 @@ const minIncomeForCar = 30000;
 const minCreditScoreForCar = 650;
 
 function getLoanMessage(annualIncome, creditScore) {
-  if(creditScore >= minCreditScoreForDuplex && annualIncome >= minIncomeForDuplex) {
-    return "You qualify for a duplex, condo, and car loan."
+  if (creditScore >= minCreditScoreForDuplex && annualIncome >= minIncomeForDuplex) {
+    return "You qualify for a duplex, condo, and car loan.";
   } else if (annualIncome >= minIncomeForCondo && creditScore >= minCreditScoreForCondo) {
-    return "You qualify for a condo and car loan."
+    return "You qualify for a condo and car loan.";
   } else if (annualIncome >= minIncomeForCar && creditScore >= minCreditScoreForCar) {
-    return "You qualify for a car loan."
+    return "You qualify for a car loan.";
   } else {
-    return "You don't qualify for any loans."
+    return "You don't qualify for any loans.";
   }
 }
 
-const duplexLoanMsg = getLoanMessage(85000, 850)
-console.log(duplexLoanMsg)
+const duplexLoanMsg = getLoanMessage(85000, 850);
+console.log(duplexLoanMsg);
 
-const condoLoanMsg = getLoanMessage(65000, 690)
-console.log(condoLoanMsg)
+const condoLoanMsg = getLoanMessage(65000, 690);
+console.log(condoLoanMsg);
 
-const carLoanMsg = getLoanMessage(45000, 660)
-console.log(carLoanMsg)
+const carLoanMsg = getLoanMessage(45000, 660);
+console.log(carLoanMsg);
 
-const noLoanMsg = getLoanMessage(25000, 550)
-console.log(noLoanMsg)
+const noLoanMsg = getLoanMessage(25000, 550);
+console.log(noLoanMsg);
 ```


### PR DESCRIPTION
Adds missing semicolons to the seed code and solution code in `workshop-loan-qualification-checker` Step 7.

The following were missing semicolons:
- All four `return` statements inside `getLoanMessage` in both seed and solution
- Variable declarations: `duplexLoanMsg`, `condoLoanMsg`, `carLoanMsg`, `noLoanMsg`
- All four `console.log()` calls in the solution

Also improved indentation consistency inside the `getLoanMessage` function to match freeCodeCamp style guidelines.

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes part of #66745