### PR TITLE
fix: accept single quotes for user_tier in workshop-discount-calculat…

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec530a6.md
+++ b/curriculum/challenges/english/blocks/workshop-discount-calculator/68e52994bc7ea2e3dec530a6.md
@@ -33,7 +33,7 @@ You should set `user_tier` to the string `Premium` within the `if` block.
 
 ```js
 ({
-  test: () => runPython(`assert _Node(_code).find_ifs()[0].has_stmt('user_tier = "Premium"')`)
+  test: () => runPython(`assert _Node(_code).find_ifs()[0].has_stmt('user_tier = "Premium"') or _Node(_code).find_ifs()[0].has_stmt("user_tier = 'Premium'")`)
 })
 ```
 


### PR DESCRIPTION
…or step 29

The test previously only accepted double quotes for the user_tier string assignment, causing learners who used single quotes (also valid Python) to fail the test. Updated the assertion to accept both quote styles.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67500

<!-- Feel free to add any additional description of changes below this line -->
