### PR TITLE
refactor(challenge-parser): replace var with const

### DIFF
--- a/tools/challenge-parser/parser/plugins/restore-directives.js
+++ b/tools/challenge-parser/parser/plugins/restore-directives.js
@@ -1,5 +1,5 @@
 const directive = require('mdast-util-directive');
-var toMarkdown = require('mdast-util-to-markdown');
+const toMarkdown = require('mdast-util-to-markdown');
 const { matches } = require('unist-util-select');
 const visit = require('unist-util-visit');
 

--- a/tools/challenge-parser/parser/plugins/table-and-strikethrough.js
+++ b/tools/challenge-parser/parser/plugins/table-and-strikethrough.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var strikethroughFromMD = require('mdast-util-gfm-strikethrough/from-markdown');
-var tableFromMD = require('mdast-util-gfm-table/from-markdown');
-var strikethrough = require('micromark-extension-gfm-strikethrough');
-var table = require('micromark-extension-gfm-table');
+const strikethroughFromMD = require('mdast-util-gfm-strikethrough/from-markdown');
+const tableFromMD = require('mdast-util-gfm-table/from-markdown');
+const strikethrough = require('micromark-extension-gfm-strikethrough');
+const table = require('micromark-extension-gfm-table');
 
 module.exports = tableAndStrikethrough;
 
 function tableAndStrikethrough() {
-  var data = this.data();
+  const data = this.data();
 
   add('micromarkExtensions', strikethrough());
   add('micromarkExtensions', table);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## Summary

This PR replaces unnecessary `var` declarations with `const` in challenge parser plugins where the bindings are never reassigned.

No runtime behavior is changed.

## Testing

Ran locally:

```bash
pnpm -F @freecodecamp/challenge-parser lint
pnpm -F @freecodecamp/challenge-parser test

The challenge parser test suite passed successfully:

Test Files  23 passed (23)
Tests       230 passed (230)