### PR TITLE
fix: preserve challenge source file boundaries

### DIFF
--- a/packages/challenge-builder/src/build.test.ts
+++ b/packages/challenge-builder/src/build.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from 'vitest';
-import { getTSConfig } from './build';
-import { ChallengeFile } from '@freecodecamp/shared/utils/polyvinyl';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
+import type { ChallengeFile } from '@freecodecamp/shared/utils/polyvinyl';
+import { buildChallenge, getTSConfig } from './build';
+
+vi.mock('./typescript-worker-handler.js', () => ({
+  compileTypeScriptCode: () => Promise.resolve('const compiled = true;'),
+  setupTSCompiler: () => Promise.resolve(true)
+}));
 
 describe('getTSConfig', () => {
   it("should return the tsconfig file's contents if it exists", () => {
@@ -31,6 +41,54 @@ describe('getTSConfig', () => {
 
     expect(() => getTSConfig(challengeFiles)).toThrow(
       'TypeScript challenge must include only one tsconfig.json file'
+    );
+  });
+});
+
+describe('buildChallenge', () => {
+  it('separates source files when building the test runner source map', async () => {
+    const challengeFiles = [
+      {
+        name: 'index',
+        ext: 'html',
+        contents:
+          '<!doctype html><html><head><link rel="stylesheet" href="styles.css"></head><body><script src="index.ts"></script></body></html>',
+        fileKey: 'indexhtml',
+        history: ['index.html']
+      },
+      {
+        name: 'styles',
+        ext: 'css',
+        contents: '',
+        fileKey: 'stylescss',
+        history: ['styles.css']
+      },
+      {
+        name: 'index',
+        ext: 'ts',
+        contents: 'interface FlashCard {}',
+        fileKey: 'indexts',
+        history: ['index.ts']
+      }
+    ] as ChallengeFile[];
+
+    const result = await buildChallenge(
+      {
+        challengeType: challengeTypes.lab,
+        challengeFiles,
+        required: [],
+        template: '',
+        url: ''
+      },
+      {
+        preview: false,
+        disableLoopProtectTests: true,
+        disableLoopProtectPreview: true
+      }
+    );
+
+    expect(result.sources?.contents).toContain(
+      '</html>\n\ninterface FlashCard {}'
     );
   });
 });

--- a/packages/challenge-builder/src/build.ts
+++ b/packages/challenge-builder/src/build.ts
@@ -54,20 +54,29 @@ const applyFunction =
 const composeFunctions = (...fns: ApplyFunctionProps[]) =>
   fns.map(applyFunction).reduce((f, g) => x => f(x).then(g));
 
+// Test helpers parse sources.contents across all files. Without this boundary,
+// an index.ts first-line declaration can be concatenated onto empty/no-newline
+// HTML or CSS, so AST checks fail.
+const joinWithFileBoundaries = (contents: string[]) => contents.join('\n');
+
 function buildSourceMap(challengeFiles: ChallengeFile[]): Source | undefined {
   // TODO: rename sources.index to sources.contents.
-  const source: Source | undefined = challengeFiles?.reduce(
-    (sources, challengeFile) => {
-      sources.index += challengeFile.source || '';
-      sources.contents = sources.index;
-      sources.editableContents += challengeFile.editableContents || '';
-      return sources;
-    },
-    {
-      index: '',
-      editableContents: ''
-    } as Source
+  const index = joinWithFileBoundaries(
+    challengeFiles.map(challengeFile => challengeFile.source ?? '')
   );
+  const editableContents = joinWithFileBoundaries(
+    challengeFiles.map(challengeFile => challengeFile.editableContents ?? '')
+  );
+  const source: Source | undefined = challengeFiles.length
+    ? {
+        index,
+        contents: index,
+        editableContents
+      }
+    : {
+        index,
+        editableContents
+      };
   return source;
 }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67439

This updates the challenge builder source map logic to keep a newline boundary between each file's original source. Without that boundary, AST-based test helpers can see the first line of `index.ts` as part of an empty or no-newline HTML/CSS file, which makes interface declarations disappear from tests.

Added a regression test for a multi-file lab with empty `styles.css` and a first-line `interface FlashCard {}` declaration in `index.ts`.

Tested with:

```bash
pnpm --dir packages/challenge-builder test build.test.ts
```