### PR TITLE
fix(curriculum): correct grammar in lecture-accessible-media-elements

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55b5c0c14493328fe36e.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55b5c0c14493328fe36e.md
@@ -72,7 +72,7 @@ You should write something like this instead, where the `alt` text describes wha
 
 Only images that convey important information should have `alt` text. If an image is only used for decorative purposes, it should have `null` (empty) `alt` text, so it can be ignored by screen readers and other assistive technologies.
 
-Here is an example of an empty `alt` attribute is empty:
+Here is an example of an empty `alt` attribute:
 
 ```html
 <img src="decorative_image.jpg" alt="" />

--- a/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55dd1d86bc939606e204.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55dd1d86bc939606e204.md
@@ -44,7 +44,7 @@ Now, here is an example of good link text:
 
 This link text gives users context about the content they will find, making it easier to decide whether they want to click on it. It reduces ambiguity by specifying that the link is related to a webinar.
 
-Here is an another example linking to a post in a blog:
+Here is another example linking to a post in a blog:
 
 ```html
 <a href="/blog-post-link">Read more</a>

--- a/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55eb7791559421ff0cd3.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55eb7791559421ff0cd3.md
@@ -17,7 +17,7 @@ A video is not just about visuals but also audio, so the first thing you should 
 
 Captions provide the text version of spoken words and important non-verbal sounds, like music or laughter, synchronized with the video. 
 
-Subtitles on the other hand are essential for people who don't understand the language you're speaking. This helps not only people who are deaf or hard of hearing but also those watching videos in noisy or quiet environments.
+Subtitles, on the other hand, are essential for people who don't understand the language you're speaking. This helps not only people who are deaf or hard of hearing but also those watching videos in noisy or quiet environments.
 
 To add captions or subtitles to your video or audio content, you can use the `track` element inside your `video` or `audio` element:
 

--- a/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55fbc2d95a9453151caf.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55fbc2d95a9453151caf.md
@@ -14,7 +14,7 @@ Let's look at some practical techniques you can employ to make web applications 
 
 Many users rely on the `Tab` key to move through interactive elements on a webpage. By default, browsers let users tab through elements like links, buttons, and form fields in the order they appear in the HTML. This is called the natural tab order.
 
-Sometimes, you may want to adjust which elements are focusable or change their focus order. The `tabindex` attribute allows you do this.
+Sometimes, you may want to adjust which elements are focusable or change their focus order. The `tabindex` attribute allows you to do this.
 
 Here is the basic syntax:
 


### PR DESCRIPTION
## Summary

Fix 4 grammar errors in the `lecture-accessible-media-elements` block:

1. **Redundant phrase** in `672a55b5c0c14493328fe36e.md` (line 75): Removed duplicate "is empty" — `"Here is an example of an empty alt attribute is empty:"` → `"Here is an example of an empty alt attribute:"`
2. **"an another"** in `672a55dd1d86bc939606e204.md` (line 47): Fixed article — `"Here is an another example"` → `"Here is another example"`
3. **Missing commas** in `672a55eb7791559421ff0cd3.md` (line 20): Added commas around parenthetical phrase — `"Subtitles on the other hand are essential"` → `"Subtitles, on the other hand, are essential"`
4. **Missing "to"** in `672a55fbc2d95a9453151caf.md` (line 17): Added missing infinitive marker — `"allows you do this"` → `"allows you to do this"`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #67503

<!-- Feel free to add any additional description of changes below this line -->
