### PR TITLE
fix(e2e): correct URL assertion in mobile breadcrumb test

### DIFF
--- a/e2e/upper-jaw-scroll-mobile.spec.ts
+++ b/e2e/upper-jaw-scroll-mobile.spec.ts
@@ -195,7 +195,7 @@ test('breadcrumb links and example code dropdown are interactive on mobile', asy
   await mobileBreadcrumb
     .getByRole('link', { name: 'Responsive Web Design Certification' })
     .tap();
-  await expect(page).toHaveURL('/learn/responsive-web-design-v9');
+  await expect(page).toHaveURL('/learn/responsive-web-design-v9/');
 });
 
 test('example code horizontal gesture does not vertically scroll the upper jaw', async ({


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This E2E test is failing in CI:

<img width="784" height="459" alt="Screenshot 2026-05-21 at 18 27 37" src="https://github.com/user-attachments/assets/c154fde3-64af-43bc-b6ba-797c6de145ee" />

https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/26219422556/job/77154817807?pr=67508#step:15:157


<!-- Feel free to add any additional description of changes below this line -->
