### PR TITLE
fix: correct boolean lecture wording and truthy explanation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/67fe85a3db9bad35f2b6a2bd.md
+++ b/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/67fe85a3db9bad35f2b6a2bd.md
@@ -73,7 +73,7 @@ if age >= 18:
 print('You are an adult') # IndentationError: expected an indented block after 'if' statement on line 3
 ```
 
-Though you can use any number spaces (as long as you are consistent) to determine each level of indentation, the Python style guide recommends using four spaces.
+Though you can use any number of spaces (as long as you are consistent) to determine each level of indentation, the Python style guide recommends using four spaces.
 
 Blocks are also found in loops and functions, which you'll learn about in future lessons.
 

--- a/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/68480f431e8568b2056b140b.md
+++ b/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/68480f431e8568b2056b140b.md
@@ -52,7 +52,7 @@ print(bool(1)) # True
 print(bool('Hello')) # True
 ```
 
-Now that you understand truthy and falsy values, we can take a look at Boolean operators, which are also known as logical operators . These are special operators that allow you to combine multiple expressions to create more complex decision-making logic in your code.
+Now that you understand truthy and falsy values, we can take a look at Boolean operators, which are also known as logical operators. These are special operators that allow you to combine multiple expressions to create more complex decision-making logic in your code.
 
 There are three Boolean operators in Python: `and`, `or`, and `not`.
 
@@ -94,7 +94,7 @@ is_employed = False
 print(age or is_employed) # 19
 ```
 
-The following code will print the number 19 because the first operand `age` is `Truthy`.
+The following code will print the number 19 because the first operand `age` is `truthy`.
 
 If you need to check if one or more expressions is `True`, then you can use the `or` operator in a conditional like this:
 

--- a/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/68480f431e8568b2056b140b.md
+++ b/curriculum/challenges/english/blocks/lecture-booleans-and-conditionals/68480f431e8568b2056b140b.md
@@ -52,7 +52,7 @@ print(bool(1)) # True
 print(bool('Hello')) # True
 ```
 
-Now that you understand truthy and falsy values, we can take a look at Boolean operators, which are also known as logical operators or Boolean operators. These are special operators that allow you to combine multiple expressions to create more complex decision-making logic in your code.
+Now that you understand truthy and falsy values, we can take a look at Boolean operators, which are also known as logical operators . These are special operators that allow you to combine multiple expressions to create more complex decision-making logic in your code.
 
 There are three Boolean operators in Python: `and`, `or`, and `not`.
 
@@ -94,7 +94,7 @@ is_employed = False
 print(age or is_employed) # 19
 ```
 
-The following code will print the number 19 because the first operand `age` is `True`.
+The following code will print the number 19 because the first operand `age` is `Truthy`.
 
 If you need to check if one or more expressions is `True`, then you can use the `or` operator in a conditional like this:
 
@@ -136,7 +136,7 @@ else:
 
 Since `is_admin` is `False`, then `not is_admin` is saying not `False` which is `True`. So the message `Access denied for non-administrators.` will be printed.
 
-Now that you understand truthy and falsy values, the `and`, `or`, and `not` operators, and short-circuiting work, you can write more flexible and readable conditional logic.
+Now that you understand truthy and falsy values, the `and`, `or`, and `not` operators, and how short-circuiting works, you can write more flexible and readable conditional logic.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

* [x] I have read and followed the [[contribution guidelines](https://contribute.freecodecamp.org/)](https://contribute.freecodecamp.org).
* [x] I have read and followed the [[how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes freeCodeCamp/freeCodeCamp#67512

Corrected grammar issues and improved technical accuracy in the lecture-booleans-and-conditionals block.

### Changes made

* Added missing word "of" in indentation explanation
* Removed repeated phrase "or Boolean operators"
* Replaced "True" with "truthy" for technical correctness
* Fixed grammar in short-circuiting sentence