### PR TITLE
fix(curriculum): add demoType to cafe-menu step 1

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f33294a6af5e9188dbdb8f3.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f33294a6af5e9188dbdb8f3.md
@@ -3,6 +3,7 @@ id: 5f33294a6af5e9188dbdb8f3
 title: Step 1
 challengeType: 0
 dashedName: step-1
+demoType: onLoad
 ---
 
 # --description--


### PR DESCRIPTION
Added missing `demoType: onLoad` field to step 1 of the cafe-menu workshop.

File: curriculum/challenges/english/blocks/workshop-cafe-menu/5f33294a6af5e9188dbdb8f3.md

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67522