### PR TITLE
fix: correct typos in accessible-tables-forms lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a539b887ec68c593cdc4b.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a539b887ec68c593cdc4b.md
@@ -13,7 +13,7 @@ For example, let's say we have a table representing our pets. We have two dogs a
 
 As a web developer, you are in charge of creating these associations and structuring your HTML markup in a way that is also easy for screen reader users to interpret.
 
-So, let's see how you can create accessible tables that everyone can understand. The first best practice that we will cover is using table caption. With the `caption` element, you can write the caption (or title) of a table, so users, especially those who use assistive technologies, can quickly understand the table's purpose and content. You should place the `caption` element immediately after the opening tag of the `table` element. This way, screen readers and other assistive technologies can provide more context by announcing the caption before reading the content.
+So, let's see how you can create accessible tables that everyone can understand. The first best practice that we will cover is using a table caption. With the `caption` element, you can write the caption (or title) of a table, so users, especially those who use assistive technologies, can quickly understand the table's purpose and content. You should place the `caption` element immediately after the opening tag of the `table` element. This way, screen readers and other assistive technologies can provide more context by announcing the caption before reading the content.
 
 ```html
 <table>

--- a/curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a53ae8f1ad28c8a1ed0f0.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a53ae8f1ad28c8a1ed0f0.md
@@ -30,7 +30,7 @@ Here's how to associate a `label` with an `input`:
 
 In this example, the `for` attribute of the `label` element is associated with the `id` of the `input` element. This connection allows screen readers to announce the `label` when the `input` is in a focused state, allowing screen reader users to understand the purpose of the `input`.
 
-Associating labels with all input fields also benefits SEO.  With proper labels, search engines will understand the page content better, leading to a positive impact on the page search rankings.
+Associating labels with all input fields also benefits SEO. With proper labels, search engines will understand the page content better, leading to a positive impact on the page search rankings.
 
 But it is important to understand that you're making content for humans, not search engines. So, you should make sure the labels are as clear and descriptive as possible.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67518

Fixes two typos in the accessible-tables-forms block: added missing article 'a' before 'table caption' and removed double space after 'benefits SEO.'