### PR TITLE
fix(curriculum): allow bracket notation in step 28 test

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/69a9de8abda299f753b1afe4.md
@@ -28,7 +28,7 @@ assert.match(exportToCSV.toString(), /rows\.push/);
 String fields should be wrapped in double quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /"\$\{entry\./);
+assert.match(__helpers.removeJSComments(code), /"\$\{entry(?:\.\w+|\[['"]\w+['"]\])/);
 
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67225

<!-- Feel free to add any additional description of changes below this line -->
This PR updates the Step 28 test regex to allow both dot notation and bracket notation when accessing entry properties in the CSV export challenge.

Previously, the test only accepted dot notation even though bracket notation produces the same valid output.