### PR TITLE
fix(curriculum): add overlapping phrases test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-proofreading-tool/69dd63d1dcdeccb7b39ba4c3.md
+++ b/curriculum/challenges/english/blocks/lab-proofreading-tool/69dd63d1dcdeccb7b39ba4c3.md
@@ -100,6 +100,12 @@ assert.sameDeepOrderedMembers(findRepeatedPhrases(["the"], 2), []);
 assert.sameDeepOrderedMembers(findRepeatedPhrases(["the", "cat", "sat", "the", "cat"], 2), [0, 3]);
 ```
 
+`findRepeatedPhrases` should return all start indices for overlapping repeated phrases.
+
+```js
+assert.sameDeepOrderedMembers(findRepeatedPhrases(["ba", "ba", "ba"], 2), [0, 1]);
+```
+
 `analyzeTexts` should be a function.
 
 ```js

--- a/curriculum/challenges/english/blocks/lab-proofreading-tool/69dd63d1dcdeccb7b39ba4c3.md
+++ b/curriculum/challenges/english/blocks/lab-proofreading-tool/69dd63d1dcdeccb7b39ba4c3.md
@@ -21,7 +21,7 @@ A phrase is a sequence of consecutive words. For example, in `["the", "cat", "sa
 
 2. You should define a function named `findPalindromeBreaks` that takes a `words` array as its argument. It should return an array of indices of words that are not palindromes. It should return an empty array if the input is empty.
 
-3. You should define a function named `findRepeatedPhrases` that takes a `words` array and a `phraseLength` number as arguments. It should return an array of all start indices where a sequence of `phraseLength` consecutive words appears more than once in the array — including the index of the first occurrence. It should return an empty array if `phraseLength` is greater than or equal to the length of `words`.
+3. You should define a function named `findRepeatedPhrases` that takes a `words` array and a `phraseLength` number as arguments. It should return an array of all start indices where a sequence of `phraseLength` consecutive words appears more than once in the array — including the index of the first occurrence. It should return an empty array if `phraseLength` is greater than or equal to the length of `words`. Overlapping sequences should also be counted.
 
 4. You should define a function named `analyzeTexts` that takes a `texts` array and a `phraseLength` number as arguments. It should process each element of `texts` (each an array of words) and return an array of objects, each with `repeatedPhrases` and `palindromeBreaks` properties. It should return an empty array if `texts` is empty.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67545 

<!-- Feel free to add any additional description of changes below this line -->
## Description

The `findRepeatedPhrases` hints didn't have a test case covering overlapping phrases, so implementations that only checked non-overlapping windows (by starting the inner loop at `j = i + phraseLength` instead of `j = i + 1`) were passing all tests incorrectly.

Added a test with `["ba", "ba", "ba"]` and `phraseLength = 2`, which expects `[0, 1]`. Both index 0 and index 1 start a phrase `["ba", "ba"]` that appears more than once, so both should be returned. The existing solution already handles this correctly - only the test coverage was missing.