### PR TITLE
fix(curriculum): correct format errors in error handling lecture block

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c8ef26f3cad09f36b95b9.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c8ef26f3cad09f36b95b9.md
@@ -13,7 +13,7 @@ Debugging is the process of identifying and resolving errors or bugs in your cod
 
 In this lesson, we'll go over common debugging techniques you can use in your next Python project.
 
-## Using the print function and f-strings
+## Using the Print Function and F-Strings
 
 First, using the `print()` function and f-strings at various points in your code can help you understand the flow and state of variables. For example:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67517

<!-- Feel free to add any additional description of changes below this line -->

This is a continuation of #67538 to apply the requested formatting fixes.

### Changes:
- Capitalized the heading `## Using the print function and f-strings` to `## Using the Print Function and F-Strings` in `688c8ef26f3cad09f36b95b9.md` to conform to title case guidelines.