### PR TITLE
fix(curriculum): correct factual and grammar errors in asynchronous programming block

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
@@ -31,7 +31,7 @@ aPromise.then((result) => {
 });
 ```
 
-In this code, or instructions of what to do when the promise is fulfilled, the function passed to `.then()` will be called with the resolved value of the promise. If an error occurs, the function passed to `.catch()` will be called instead.
+In this code, the function passed to `.then()` will be called with the resolved value of the promise. If an error occurs, the function passed to `.catch()` will be called instead.
 
 Now, let's talk about promise chaining. One of the powerful features of promises is that we can chain multiple asynchronous operations together. Each `.then()` can return a new promise, allowing you to perform a sequence of asynchronous operations one after the other. Here’s an example: 
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
@@ -100,7 +100,7 @@ Consider the restrictions on where `await` can be placed.
 
 ---
 
-At very beginning of your code.
+At the very beginning of your code.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407e02bcf0d682b9a49a9.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407e02bcf0d682b9a49a9.md
@@ -7,7 +7,7 @@ dashedName: how-does-the-javascript-engine-work-and-what-is-a-javascript-runtime
 
 # --description--
 
-The JavaScript engine has the ability to read, understand, and execute your code. It works like a converter that takes your code, turns it into instructions that the computer can understand and work accordingly. 
+The JavaScript engine has the ability to read, understand, and execute your code. It works like a converter that takes your code, turns it into instructions that the computer can understand and execute.
 
 One of the most well-known JavaScript engines is V8, developed by Google, used in Chrome and Node.js. The JavaScript engine works in a few steps. First, it parses your code, reading it line by line to make sure there’s no mistake in the JavaScript code. Then, it converts this code into bytecode, which is a simpler, intermediate version of your code that’s easier for the computer to understand and execute. Finally, it runs this bytecode to execute your program's instructions. Here's an example of JavaScript code:
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407eb10ca9d68634e81d9.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407eb10ca9d68634e81d9.md
@@ -29,9 +29,9 @@ If there is an issue with getting the position, then the error will be logged to
 
 The `getCurrentPosition` method uses GPS, Wi-Fi networks, or IP address geolocation, depending on the device and its settings. Once the location is found, the success callback function is called with a position object.
 
-The position object contains various properties, where the most commonly used are `latitude` and `longitude`, but it can also include `altitude`, `accuracy`, `speed`, and `heading`, and so on.
+The position object contains various properties, where the most commonly used are `latitude` and `longitude`, but it can also include `altitude`, `accuracy`, `speed`, `heading`, and so on.
 
-One important consideration when using geolocation is user privacy. Explain to your users why you need their location data and how you'll use it.
+One important consideration when using geolocation is user privacy. Be sure to explain to your users why you need their location data and how you'll use it.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67491

<!-- Feel free to add any additional description of changes below this line -->

This is a continuation of #67526 to apply the requested grammatical and phrasing updates.

### Changes:
- Addressed factual, phrasing, list formatting, and grammatical errors in 4 curriculum files under the asynchronous programming block:
  - `673407ca21117a67cf9521ca.md`
  - `673407d56c3dce67fa97969b.md`
  - `673407e02bcf0d682b9a49a9.md`
  - `673407eb10ca9d68634e81d9.md`