### PR TITLE
feat(curriculum): add language settings lecture for RDB workshops

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-the-command-line-and-working-with-bash/6a11c700b647dbc444d1f0ef.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-command-line-and-working-with-bash/6a11c700b647dbc444d1f0ef.md
@@ -1,0 +1,167 @@
+---
+id: 6a11c700b647dbc444d1f0ef
+title: How Do You Set Your System Language for Bash and PostgreSQL Workshops?
+challengeType: 19
+dashedName: how-do-you-set-your-system-language-for-bash-and-postgresql-workshops
+---
+
+# --description--
+
+Let's learn why your keyboard language setting matters for Bash and PostgreSQL workshops.
+
+Tools like `psql` and Bash expect commands to use standard English (US) characters. If your operating system uses a non-English keyboard layout, some special characters may not be sent as expected. For example, typing a semicolon (`;`) might produce a different character entirely, which means a command like `CREATE DATABASE videogames;` will never execute — and `psql` will give no error, making it very hard to debug.
+
+This affects users on all operating systems when a non-English language is set as the active keyboard layout.
+
+GitHub Codespaces uses your local machine's keyboard layout, so if your computer is set to a non-English layout, the same encoding issues will occur inside Codespaces.
+
+**On Windows:**
+
+1. Open **Settings → Time & Language → Language & Region**
+2. Under **Preferred languages**, add **English (United States)** if not already present
+3. Click on it → **Options → Add a keyboard** → select **US QWERTY**
+4. Use the language switcher in the taskbar (or press `Win + Space`) to make US the active layout
+
+**On macOS:**
+
+1. Open **System Settings → Keyboard → Input Sources → Edit**
+2. Click **+** and add **English → US**
+3. Select **US** as the active input source from the menu bar
+
+**On Linux (GUI):**
+
+1. Open your system's keyboard or input settings
+2. Add **English (US)** as a keyboard layout
+3. Move it to the top of the list or set it as the default
+
+**On Linux (terminal):**
+
+First check your current layout:
+
+```bash
+setxkbmap -query
+```
+
+Then switch to US:
+
+```bash
+setxkbmap us
+```
+
+**Verifying your layout:**
+
+After switching, use your operating system's on-screen keyboard (search for "On-Screen Keyboard" on Windows or macOS) to confirm that the key you press for `;` maps to the semicolon symbol in the US layout. This approach works regardless of the physical keyboard or layout you use.
+
+Also watch out for **dead keys** — some non-English layouts treat characters like `"` or `'` as dead keys that wait for a follow-up keystroke. After switching to US, these should type immediately without requiring a second keypress.
+
+Once you have finished the workshops, you can switch back to your original keyboard layout.
+
+# --questions--
+
+## --text--
+
+What problem can a non-English keyboard layout cause when working in `psql`?
+
+## --answers--
+
+The terminal window fails to open.
+
+### --feedback--
+
+Think about what happens when `psql` receives characters it does not expect.
+
+---
+
+Special characters like the semicolon may not be sent correctly, so commands never execute.
+
+---
+
+The database gets deleted automatically.
+
+### --feedback--
+
+Think about what happens when `psql` receives characters it does not expect.
+
+---
+
+The username and password fields are skipped.
+
+### --feedback--
+
+Think about what happens when `psql` receives characters it does not expect.
+
+## --video-solution--
+
+2
+
+## --text--
+
+Which command immediately switches the keyboard layout to US English on Linux?
+
+## --answers--
+
+`setlocale us`
+
+### --feedback--
+
+Look at the terminal section above for the exact command.
+
+---
+
+`keyboard --set us`
+
+### --feedback--
+
+Look at the terminal section above for the exact command.
+
+---
+
+`setxkbmap us`
+
+---
+
+`export LANG=en_US`
+
+### --feedback--
+
+Look at the terminal section above for the exact command.
+
+## --video-solution--
+
+3
+
+## --text--
+
+What is the recommended way to verify your keyboard layout is correctly set to US, regardless of your physical keyboard?
+
+## --answers--
+
+Type every key on the physical keyboard and check each character.
+
+### --feedback--
+
+This approach gives different results depending on the physical keyboard layout.
+
+---
+
+Use the operating system's on-screen keyboard to confirm key mappings.
+
+---
+
+Restart the computer and check the boot screen.
+
+### --feedback--
+
+Restarting does not verify keyboard layout mapping.
+
+---
+
+Run `echo test` in the terminal.
+
+### --feedback--
+
+This does not verify any keyboard layout mapping.
+
+## --video-solution--
+
+2

--- a/curriculum/structure/blocks/lecture-understanding-the-command-line-and-working-with-bash.json
+++ b/curriculum/structure/blocks/lecture-understanding-the-command-line-and-working-with-bash.json
@@ -20,6 +20,10 @@
     {
       "id": "687e947ae3ea7d2867c3d0e1",
       "title": "What Are Some Command Options and Flags?"
+    },
+    {
+      "id": "6a11c700b647dbc444d1f0ef",
+      "title": "How Do You Set Your System Language for Bash and PostgreSQL Workshops?"
     }
   ]
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67263

<!-- Feel free to add any additional description of changes below this line -->

## Summary

Adds a theory lecture explaining how to configure keyboard layout to English (US) before starting Bash and PostgreSQL workshops. Non-English layouts cause \`psql\` to silently drop commands (semicolons not recognized), which is hard to debug.

The lesson covers:
  - Why non-English keyboard layouts break \`psql\` and Bash commands
  - GitHub Codespaces inherits local keyboard layout
  - Per-OS setup: Windows, macOS, Linux (GUI + \`setxkbmap\`)
  - \`setxkbmap -query\` to check layout before switching
  - Layout-agnostic verification using OS on-screen keyboard
  - Dead keys explanation
  - Note to switch back after workshops