### PR TITLE
fix(curriculum): correct capitalization in Task 9 data types challenge

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-use-code-related-concepts-and-terms/6630e609d81a446cd663c521.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-use-code-related-concepts-and-terms/6630e609d81a446cd663c521.md
@@ -12,7 +12,7 @@ lang: en-US
 
 The verb `to store` in programming refers to the act of keeping or saving data so that it can be used later. Choosing the right data types is critical because it influences how information is `stored` and used in a program.
 
-Different data types are suited for different kinds of information, like text, numbers, or boolean values. For example, To `store` text, a programmer might use the data type `string`.
+Different data types are suited for different kinds of information, like text, numbers, or boolean values. For example, to `store` text, a programmer might use the data type `string`.
 
 # --fillInTheBlank--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67571

<!-- Fix capitalization bug: "For example, To store" → "For example, to store" in Task 9 of learn-how-to-use-code-related-concepts-and-terms block -->


