### PR TITLE
fix(curriculum): add missing demoType to flashcard quiz app

### DIFF
--- a/curriculum/challenges/english/blocks/lab-flashcard-quiz-app/69b868127999e97f1903f8e1.md
+++ b/curriculum/challenges/english/blocks/lab-flashcard-quiz-app/69b868127999e97f1903f8e1.md
@@ -3,6 +3,7 @@ id: 69b868127999e97f1903f8e1
 title: Build a Flashcard Quiz App
 challengeType: 25
 dashedName: lab-flashcard-quiz-app
+demoType: onClick
 saveSubmissionToDB: true
 ---
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
@@ -185,7 +185,7 @@ It raises a generic `Exception`.
 
 ### --feedback--
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
 ---
 
@@ -193,7 +193,7 @@ It does nothing.
 
 ### --feedback--
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
 ---
 
@@ -205,7 +205,7 @@ It raises a `TypeError`.
 
 ### --feedback--
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
@@ -185,7 +185,7 @@ It raises a generic `Exception`.
 
 ### --feedback--
 
-Refer back to the section about `raise` to understand how it behaves without arguments.
+Refer back to the section about `raise`. understand how it behaves without arguments.
 
 ---
 
@@ -193,7 +193,7 @@ It does nothing.
 
 ### --feedback--
 
-Refer back to the section about `raise` to understand how it behaves without arguments.
+Refer back to the section about `raise`. understand how it behaves without arguments.
 
 ---
 
@@ -205,7 +205,7 @@ It raises a `TypeError`.
 
 ### --feedback--
 
-Refer back to the section about `raise` to understand how it behaves without arguments.
+Refer back to the section about `raise`. understand how it behaves without arguments.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67480

Added missing demoType: onClick field to flashcard quiz app lab frontmatter.