### PR TITLE
fix(curriculum): avoid parent/child terminology in travel agency page hints

### DIFF
--- a/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -198,7 +198,7 @@ You should have at least three `figure` elements.
 assert.isAtLeast(document.querySelectorAll('figure').length, 3);
 ```
 
-Each `figure` element should contain an anchor element as its first child.
+Each `figure` element should contain an anchor element as its first nested element.
 
 ```js
 const figures = document.querySelectorAll('figure');
@@ -208,7 +208,7 @@ for (let figure of figures) {
 }
 ```
 
-Each `figure` element should contain a `figcaption` element as its second child.
+Each `figure` element should contain a `figcaption` element as its second nested element.
 
 ```js
 const figures = document.querySelectorAll('figure');
@@ -226,7 +226,7 @@ assert.isNotEmpty(figcaptionEls);
 figcaptionEls.forEach((figcaption => assert.isNotEmpty(figcaption.innerText)));
 ```
 
-Each of the `a` elements that are children of your `figure` elements should contain an image.
+Each of the `a` elements nested in your `figure` elements should contain an image.
 
 ```js
 const anchors = document.querySelectorAll('figure > a');


### PR DESCRIPTION
### Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/#/).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67561

### Description:
This PR updates the wording of the test descriptions in the "Travel Agency Page" lab to avoid the use of parent/child/children terminology, as requested by the reviewer. Specifically, references to first/second child are changed to first/second nested elements, and references to anchor children of figures are changed to anchors nested in figures.