### PR TITLE
fix: correct 'in to' typo to 'into' in basic HTML quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-basic-html/66df3b712c41c499e9d31e5b.md
+++ b/curriculum/challenges/english/blocks/quiz-basic-html/66df3b712c41c499e9d31e5b.md
@@ -51,7 +51,7 @@ An element for displaying lists.
 
 ---
 
-An element used for embedding sound in to the document.
+An element used for embedding sound into the document.
 
 #### --answer--
 


### PR DESCRIPTION
Fixed a typo in the basic HTML quiz file.
Changed "in to" to "into" on line 56.

- [x] I have read and followed the contribution guidelines.
- [x] I have read the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally or on GitHub Codespaces.

Closes #67587