### PR TITLE
fix(client): open completion modal from mobile lower jaw

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -825,7 +825,9 @@ const Editor = (props: EditorProps): JSX.Element => {
   };
 
   function tryToExecuteChallenge() {
-    props.executeChallenge();
+    props.executeChallenge({
+      showCompletionModal: !props.showIndependentLowerJaw
+    });
   }
 
   const tryToSubmitChallenge = submitChallenge;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

---

## Description

Follow-up to #66552.

Mobile workshop-style challenges use the classic Monaco lower jaw instead of the independent lower jaw. When learners run tests from that lower jaw, the execution path did not request the completion modal, so passing a challenge on mobile did not open it.

This updates the classic lower jaw execution path to request the completion modal only when the independent lower jaw is not active. Desktop independent lower jaw behavior is unchanged.

## Testing

- `pnpm exec prettier --check client/src/templates/Challenges/classic/editor.tsx`
- `pnpm -F @freecodecamp/client exec tsc --noEmit --pretty false`
- `git diff --check`