### PR TITLE
fix(curriculum): add missing demoType to flashcard quiz app

### DIFF
--- a/curriculum/challenges/english/blocks/lab-flashcard-quiz-app/69b868127999e97f1903f8e1.md
+++ b/curriculum/challenges/english/blocks/lab-flashcard-quiz-app/69b868127999e97f1903f8e1.md
@@ -3,6 +3,7 @@ id: 69b868127999e97f1903f8e1
 title: Build a Flashcard Quiz App
 challengeType: 25
 dashedName: lab-flashcard-quiz-app
+demoType: onClick
 saveSubmissionToDB: true
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67480

Adds the missing `demoType: onClick` field to the flashcard quiz app lab frontmatter.