### PR TITLE
fix: correct factual and grammatical errors in async programming lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/6733b072bd8f5b06ccdbd9e2.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/6733b072bd8f5b06ccdbd9e2.md
@@ -29,7 +29,7 @@ The concept of threads is very important. A thread is a unit of execution within
 
 In synchronous programming, threads execute sequentially, one after the other. If a thread is blocked, like waiting for user input, the entire process is blocked until the thread is completed.
 
-In asynchronous programming, threads can be executed concurrently, running multiple threads at the same time. This way, the program can continue running multiple tasks simultaneously without making the main program unresponsive, even if one of the threads is blocked.
+JavaScript is single-threaded, so it does not run multiple threads concurrently. Asynchronous behavior is handled by the event loop, not by spawning threads. This way, the program can continue running multiple tasks simultaneously without making the main program unresponsive, even if one of the threads is blocked.
 
 Asynchronous programming often involves callbacks, promises, or async/await to handle non-blocking operations.
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/67340798c2c1776709d8a5fe.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/67340798c2c1776709d8a5fe.md
@@ -25,7 +25,7 @@ Let's start with the `async` attribute:
 
 By adding the `async` attribute to a `script` tag, the browser will continue parsing the HTML while the script is being downloaded. Once the script is fully downloaded, the browser will pause HTML parsing, execute the script, and then resume parsing the HTML. This can significantly speed up page loading.
 
-It's important to note that async scripts are executed as soon as they're downloaded, which means they might not run in the correct order which we desire. This is where the `defer` attribute comes in for the rescue. Let's look at how the `defer` attribute looks like:
+It's important to note that async scripts are executed as soon as they're downloaded, which means they might not run in the correct order which we desire. This is where the `defer` attribute comes to the rescue. Let's look at what the `defer` attribute looks like:
 
 ```js
 <script src="example.js" defer></script>

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407a223891b6734563c89.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407a223891b6734563c89.md
@@ -13,13 +13,13 @@ The Fetch API allows web apps to make network requests, typically to retrieve or
 fetch('https://api.example.com/data')
 ```
 
-In this example, we're making a `GET` request to `https://api.example.com/data`. This will then return us some data that we need to convert to JSON format and can use anywhere we want to. 
+In this example, we're making a `GET` request to `https://api.example.com/data`. This returns data that must be converted to JSON format before it can be used.
 
 By default, the Fetch API uses the `GET` method to retrieve data. This will be covered in the next lesson, along with other common HTTP request methods.
 
 Now, let's discuss some common types of resources that are fetched from the network.
 
-In our web apps, we need some common data like weather data, professions list data, country names list, country code or country flag icons/images. Using these data we can make our app more informative and interactive. Thanks to Fetch API, we can get these resources from the network.
+In our web apps, we need some common data like weather data, professions list data, country names list, country code or country flag icons/images. Using this data we can make our app more informative and interactive. Thanks to Fetch API, we can get these resources from the network.
 
 Images are some frequently fetched resources. You might use fetch to load images statically or dynamically based on user actions, and display them on your web app.
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407ca21117a67cf9521ca.md
@@ -31,7 +31,7 @@ aPromise.then((result) => {
 });
 ```
 
-In this code, or instructions of what to do when the promise is fulfilled, the function passed to `.then()` will be called with the resolved value of the promise. If an error occurs, the function passed to `.catch()` will be called instead.
+In this code, the function passed to `.then()` will be called with the resolved value of the promise. If an error occurs, the function passed to `.catch()` will be called instead.
 
 Now, let's talk about promise chaining. One of the powerful features of promises is that we can chain multiple asynchronous operations together. Each `.then()` can return a new promise, allowing you to perform a sequence of asynchronous operations one after the other. Here’s an example: 
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407d56c3dce67fa97969b.md
@@ -100,7 +100,7 @@ Consider the restrictions on where `await` can be placed.
 
 ---
 
-At very beginning of your code.
+At the very beginning of your code.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407e02bcf0d682b9a49a9.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407e02bcf0d682b9a49a9.md
@@ -7,7 +7,7 @@ dashedName: how-does-the-javascript-engine-work-and-what-is-a-javascript-runtime
 
 # --description--
 
-The JavaScript engine has the ability to read, understand, and execute your code. It works like a converter that takes your code, turns it into instructions that the computer can understand and work accordingly. 
+The JavaScript engine has the ability to read, understand, and execute your code. It works like a converter that takes your code, turns it into instructions that the computer can understand and execute.
 
 One of the most well-known JavaScript engines is V8, developed by Google, used in Chrome and Node.js. The JavaScript engine works in a few steps. First, it parses your code, reading it line by line to make sure there’s no mistake in the JavaScript code. Then, it converts this code into bytecode, which is a simpler, intermediate version of your code that’s easier for the computer to understand and execute. Finally, it runs this bytecode to execute your program's instructions. Here's an example of JavaScript code:
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407eb10ca9d68634e81d9.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-asynchronous-programming/673407eb10ca9d68634e81d9.md
@@ -29,9 +29,9 @@ If there is an issue with getting the position, then the error will be logged to
 
 The `getCurrentPosition` method uses GPS, Wi-Fi networks, or IP address geolocation, depending on the device and its settings. Once the location is found, the success callback function is called with a position object.
 
-The position object contains various properties, where the most commonly used are `latitude` and `longitude`, but it can also include `altitude`, `accuracy`, `speed`, and `heading`, and so on.
+The position object contains various properties, where the most commonly used are `latitude` and `longitude`, but it can also include `altitude`, `accuracy`, `speed`,  `heading`, and so on.
 
-One important consideration when using geolocation is user privacy. Explain to your users why you need their location data and how you'll use it.
+One important consideration when using geolocation is user privacy. Be sure to explain to your users why you need their location data and how you'll use it.
 
 # --questions--
 


### PR DESCRIPTION
This PR fixes factual inaccuracies, grammar issues, and idiom errors in the asynchronous programming lecture.

Changes include:
- Corrected JavaScript thread model explanation
- Fixed subject-verb agreement (these data → this data)
- Corrected common idioms (comes in for the rescue → comes to the rescue)
- Fixed article usage errors
- Improved sentence clarity and readability

Closes #67491

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->