### PR TITLE
docs: add Chinese (zh-CN) and Traditional Chinese (zh-TW) README translations

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,95 @@
+[![freeCodeCamp 社区横幅](https://cdn.freecodecamp.org/platform/universal/fcc_banner_new.png)](https://www.freecodecamp.org/)
+
+[![新手友好](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://www.firsttimersonly.com/)
+[![Discord](https://img.shields.io/discord/692816967895220344?logo=discord&label=Discord&color=5865F2)](https://discord.gg/PRyKn3Vbay)
+[![LFX 活跃贡献者](https://insights.linuxfoundation.org/api/badge/active-contributors?project=freecodecamp&repos=https://github.com/freeCodeCamp/freeCodeCamp)](https://insights.linuxfoundation.org/project/freecodecamp/repository/freecodecamp-freecodecamp)
+
+## freeCodeCamp.org 的开源代码库与课程
+
+[freeCodeCamp.org](https://www.freecodecamp.org) 是一个友好的社区，在这里你可以免费学习编程。它由一个[捐赠支持的 501(c)(3) 慈善组织](https://www.freecodecamp.org/donate)运营，旨在帮助数百万忙碌的成年人转行进入科技行业。我们的社区已经帮助超过 100,000 人获得了他们的第一份开发工作。
+
+我们的全栈 Web 开发和机器学习课程完全免费且可自定进度。我们拥有数千个交互式编程挑战，帮助你拓展技能。
+
+## 目录
+
+- [认证](#认证)
+- [学习平台](#学习平台)
+- [报告错误和问题](#报告错误和问题)
+- [报告安全问题和负责任披露](#报告安全问题和负责任披露)
+- [贡献](#贡献)
+- [平台、构建和部署状态](#平台构建和部署状态)
+- [许可证](#许可证)
+
+### 认证
+
+freeCodeCamp.org 提供多个免费的开发者认证，这些认证构成了[全栈开发者课程](https://www.freecodecamp.org/learn/full-stack-developer-v9/)：
+
+- [响应式 Web 设计](https://www.freecodecamp.org/learn/responsive-web-design-v9/)
+- [JavaScript](https://www.freecodecamp.org/learn/javascript-v9/)
+- [前端开发库](https://www.freecodecamp.org/learn/front-end-development-libraries-v9/)
+- [Python](https://www.freecodecamp.org/learn/python-v9/)
+- [关系型数据库](https://www.freecodecamp.org/learn/relational-databases-v9/)
+- [后端开发与 API](https://www.freecodecamp.org/learn/back-end-development-and-apis-v9/)
+
+每个认证都包含交互式课程、工作坊、实验、复习和测验。在整个认证过程中，你需要完成 5 个必修项目才能获得考试资格。通过考试后，即可领取认证。
+
+freeCodeCamp.org 还提供围绕国际公认语言水平等级设计的免费语言认证：
+
+- [A2 开发者英语（测试版）](https://www.freecodecamp.org/learn/a2-english-for-developers/)
+- [B1 开发者英语（测试版）](https://www.freecodecamp.org/learn/b1-english-for-developers/)
+- [A1 专业西班牙语（测试版）](https://www.freecodecamp.org/learn/a1-professional-spanish/)
+- [A1 专业中文（测试版）](https://www.freecodecamp.org/learn/a1-professional-chinese/)
+
+每个语言认证按模块组织，包含热身练习、课程、实践练习、复习页面和测验，确保你在进入下一模块前充分掌握内容。你需要完成所有测验，才能获得认证结业考试的资格。
+
+一旦获得认证，它将永久有效。你可以随时将其链接到你的 LinkedIn 或简历中。当潜在雇主或自由职业客户点击该链接时，他们将看到一份专属于你的已验证认证。
+
+唯一的例外是如果我们发现违反[学术诚信政策](https://www.freecodecamp.org/news/academic-honesty-policy/)的行为。当我们发现有人明确抄袭（未经引用将他人的代码或项目作为自己的提交）时，我们会像所有严谨的学习机构一样——撤销其认证并禁止相关人员。
+
+此外，为了帮助准备求职面试，freeCodeCamp.org 还包含 The Odin Project（freeCodeCamp 改编版）、编程面试准备、Project Euler 和 Rosetta Code。
+
+还提供免费的 Microsoft 基础 C# 专业认证。
+
+### 学习平台
+
+此代码在 [freeCodeCamp.org](https://www.freecodecamp.org) 上实时运行。
+
+我们的社区还拥有：
+
+- 一个[论坛](https://forum.freecodecamp.org)，你通常可以在数小时内获得编程帮助或项目反馈。
+- 一个 [YouTube 频道](https://youtube.com/freecodecamp)，提供 Python、SQL、Android 等各种技术的免费课程。
+- 一个[技术出版物](https://www.freecodecamp.org/news)，包含数千篇关于编程、数学和计算机科学的教程与文章。
+- 一个 [Discord 服务器](https://discord.gg/Z7Fm39aNtZ)，你可以在这里与开发者和其他学习编程的人交流和聊天。
+
+> #### [点击此处加入社区](https://www.freecodecamp.org/signin)。
+
+### 报告错误和问题
+
+如果你认为发现了 bug，请先阅读[如何报告 bug](https://forum.freecodecamp.org/t/how-to-report-a-bug/19543) 文章并按其说明操作。
+
+如果你确认这是一个新的 bug，并且确认其他人也遇到了相同的问题，请创建新的 GitHub issue。请务必包含尽可能多的信息，以便我们复现该 bug。
+
+### 报告安全问题和负责任披露
+
+我们感谢对可能影响平台和用户完整性的漏洞进行负责任披露。
+
+> #### [阅读我们的安全政策并按照以下步骤报告漏洞](https://contribute.freecodecamp.org/#/security)。
+
+### 贡献
+
+freeCodeCamp.org 社区的存在离不开成千上万像你这样热心的志愿者。我们欢迎对社区的各种贡献，并期待你的加入。
+
+> #### [请按照以下步骤进行贡献](https://contribute.freecodecamp.org)。
+
+近期贡献：
+
+![Alt](https://repobeats.axiom.co/api/embed/89be0a1a1c8f641c54f9234a7423e7755352c746.svg 'Repobeats 分析图')
+
+### 许可证
+
+版权所有 © 2014 freeCodeCamp.org
+
+本仓库的内容受以下许可证约束：
+
+- 计算机软件基于 [BSD-3-Clause](LICENSE.md) 许可证。
+- [`/curriculum`](/curriculum) 目录中的学习资源及其子目录版权所有 © 2014 freeCodeCamp.org

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,95 @@
+[![freeCodeCamp 社群橫幅](https://cdn.freecodecamp.org/platform/universal/fcc_banner_new.png)](https://www.freecodecamp.org/)
+
+[![新手友善](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://www.firsttimersonly.com/)
+[![Discord](https://img.shields.io/discord/692816967895220344?logo=discord&label=Discord&color=5865F2)](https://discord.gg/PRyKn3Vbay)
+[![LFX 活躍貢獻者](https://insights.linuxfoundation.org/api/badge/active-contributors?project=freecodecamp&repos=https://github.com/freeCodeCamp/freeCodeCamp)](https://insights.linuxfoundation.org/project/freecodecamp/repository/freecodecamp-freecodecamp)
+
+## freeCodeCamp.org 的開放原始碼程式庫與課程
+
+[freeCodeCamp.org](https://www.freecodecamp.org) 是一個友善的社群，在這裡你可以免費學習程式設計。它由一個[捐贈支持的 501(c)(3) 慈善組織](https://www.freecodecamp.org/donate)營運，旨在幫助數百萬忙碌的成年人轉行進入科技產業。我們的社群已經幫助超過 100,000 人獲得了他們的第一份開發工作。
+
+我們的全端 Web 開發和機器學習課程完全免費且可自訂進度。我們擁有數千個互動式程式設計挑戰，幫助你拓展技能。
+
+## 目錄
+
+- [認證](#認證)
+- [學習平台](#學習平台)
+- [回報錯誤和問題](#回報錯誤和問題)
+- [回報安全問題和負責任揭露](#回報安全問題和負責任揭露)
+- [貢獻](#貢獻)
+- [平台、建置和部署狀態](#平台建置和部署狀態)
+- [授權條款](#授權條款)
+
+### 認證
+
+freeCodeCamp.org 提供多個免費的開發者認證，這些認證構成了[全端開發者課程](https://www.freecodecamp.org/learn/full-stack-developer-v9/)：
+
+- [回應式 Web 設計](https://www.freecodecamp.org/learn/responsive-web-design-v9/)
+- [JavaScript](https://www.freecodecamp.org/learn/javascript-v9/)
+- [前端開發函式庫](https://www.freecodecamp.org/learn/front-end-development-libraries-v9/)
+- [Python](https://www.freecodecamp.org/learn/python-v9/)
+- [關聯式資料庫](https://www.freecodecamp.org/learn/relational-databases-v9/)
+- [後端開發與 API](https://www.freecodecamp.org/learn/back-end-development-and-apis-v9/)
+
+每個認證都包含互動式課程、工作坊、實驗、複習和測驗。在整個認證過程中，你需要完成 5 個必修專案才能獲得考試資格。通過考試後，即可領取認證。
+
+freeCodeCamp.org 還提供圍繞國際公認語言水準等級設計的免費語言認證：
+
+- [A2 開發者英語（測試版）](https://www.freecodecamp.org/learn/a2-english-for-developers/)
+- [B1 開發者英語（測試版）](https://www.freecodecamp.org/learn/b1-english-for-developers/)
+- [A1 專業西班牙語（測試版）](https://www.freecodecamp.org/learn/a1-professional-spanish/)
+- [A1 專業中文（測試版）](https://www.freecodecamp.org/learn/a1-professional-chinese/)
+
+每個語言認證按模組組織，包含暖身練習、課程、實作練習、複習頁面和測驗，確保你在進入下一個模組前充分掌握內容。你需要完成所有測驗，才能獲得認證結業考試的資格。
+
+一旦獲得認證，它將永久有效。你可以隨時將其連結到你的 LinkedIn 或履歷中。當潛在雇主或自由接案客戶點擊該連結時，他們將看到一份專屬於你的已驗證認證。
+
+唯一的例外是如果我們發現違反[學術誠信政策](https://www.freecodecamp.org/news/academic-honesty-policy/)的行為。當我們發現有人明確抄襲（未經引用將他人的程式碼或專案作為自己的提交）時，我們會像所有嚴謹的學習機構一樣——撤銷其認證並禁止相關人員。
+
+此外，為了幫助準備求職面試，freeCodeCamp.org 還包含 The Odin Project（freeCodeCamp 改編版）、程式設計面試準備、Project Euler 和 Rosetta Code。
+
+還提供免費的 Microsoft 基礎 C# 專業認證。
+
+### 學習平台
+
+此程式碼在 [freeCodeCamp.org](https://www.freecodecamp.org) 上即時執行。
+
+我們的社群還擁有：
+
+- 一個[論壇](https://forum.freecodecamp.org)，你通常可以在數小時內獲得程式設計幫助或專案回饋。
+- 一個 [YouTube 頻道](https://youtube.com/freecodecamp)，提供 Python、SQL、Android 等各種技術的免費課程。
+- 一個[技術出版物](https://www.freecodecamp.org/news)，包含數千篇關於程式設計、數學和電腦科學的教學與文章。
+- 一個 [Discord 伺服器](https://discord.gg/Z7Fm39aNtZ)，你可以在這裡與開發者和其他學習程式設計的人交流和聊天。
+
+> #### [點擊此處加入社群](https://www.freecodecamp.org/signin)。
+
+### 回報錯誤和問題
+
+如果你認為發現了 bug，請先閱讀[如何回報 bug](https://forum.freecodecamp.org/t/how-to-report-a-bug/19543) 文章並按其說明操作。
+
+如果你確認這是一個新的 bug，並且確認其他人也遇到了相同的問題，請建立新的 GitHub issue。請務必包含盡可能多的資訊，以便我們重現該 bug。
+
+### 回報安全問題和負責任揭露
+
+我們感謝對可能影響平台和使用者完整性的漏洞進行負責任揭露。
+
+> #### [閱讀我們的安全政策並按照以下步驟回報漏洞](https://contribute.freecodecamp.org/#/security)。
+
+### 貢獻
+
+freeCodeCamp.org 社群的存在離不開成千上萬像你這樣熱心的志工。我們歡迎對社群的各種貢獻，並期待你的加入。
+
+> #### [請按照以下步驟進行貢獻](https://contribute.freecodecamp.org)。
+
+近期貢獻：
+
+![Alt](https://repobeats.axiom.co/api/embed/89be0a1a1c8f641c54f9234a7423e7755352c746.svg 'Repobeats 分析圖')
+
+### 授權條款
+
+版權所有 © 2014 freeCodeCamp.org
+
+本倉庫的內容受以下授權條款約束：
+
+- 電腦軟體基於 [BSD-3-Clause](LICENSE.md) 授權條款。
+- [`/curriculum`](/curriculum) 目錄中的學習資源及其子目錄版權所有 © 2014 freeCodeCamp.org


### PR DESCRIPTION
## Description

This PR adds Simplified Chinese (README.zh-CN.md) and Traditional Chinese (README.zh-TW.md) translations of the README, making the project more accessible to millions of Chinese-speaking developers.

All original links, badges, and markdown formatting are preserved. No code changes — only two new translation files.

## Testing

- [x] I tested these changes locally
- [x] These changes are documentation-only and do not affect functionality

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67630