### PR TITLE
fix(api): resolve ReferenceError on origin in email subscription endp…

### DIFF
--- a/api/src/routes/public/email-subscription.ts
+++ b/api/src/routes/public/email-subscription.ts
@@ -32,8 +32,8 @@ export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
       }
     },
     async (req, reply) => {
+      const { origin } = getRedirectParams(req);
       try {
-        const { origin } = getRedirectParams(req);
         const { unsubscribeId } = req.params;
         const log = fastify.log.child({ req, unsubscribeId });
 
@@ -104,8 +104,8 @@ export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
       }
     },
     async (req, reply) => {
+      const { origin } = getRedirectParams(req);
       try {
-        const { origin } = getRedirectParams(req);
         const { unsubscribeId } = req.params;
         const log = fastify.log.child({ req, unsubscribeId });
 


### PR DESCRIPTION
Closes #67632
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. -->


<!-- Feel free to add any additional description of changes below this line -->

### Description

This PR fixes a scoping bug in the email subscription routes (`/ue/:unsubscribeId` and `/resubscribe/:unsubscribeId`). 

Previously, `const { origin } = getRedirectParams(req);` was declared inside the `try` block. If a database operation failed, the code would drop into the `catch` block and attempt to use `origin` to send a redirect. However, because `origin` was block-scoped inside the `try`, this caused a `ReferenceError: origin is not defined` at runtime, resulting in a 500 error instead of the intended user-friendly flash message redirect.

By hoisting `const { origin }` outside of the `try` block, it is now safely accessible within the `catch` block.
