### PR TITLE
fix: move origin extraction outside try block in email subscription handlers

### DIFF
--- a/api/src/routes/public/email-subscription.ts
+++ b/api/src/routes/public/email-subscription.ts
@@ -32,8 +32,8 @@ export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
       }
     },
     async (req, reply) => {
+      const { origin } = getRedirectParams(req);
       try {
-        const { origin } = getRedirectParams(req);
         const { unsubscribeId } = req.params;
         const log = fastify.log.child({ req, unsubscribeId });
 
@@ -104,8 +104,8 @@ export const emailSubscribtionRoutes: FastifyPluginCallbackTypebox = (
       }
     },
     async (req, reply) => {
+      const { origin } = getRedirectParams(req);
       try {
-        const { origin } = getRedirectParams(req);
         const { unsubscribeId } = req.params;
         const log = fastify.log.child({ req, unsubscribeId });
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67623

## Description

Moved `getRedirectParams(req)` call before the `try` block in both `/ue/:unsubscribeId` and `/resubscribe/:unsubscribeId` handlers so that `origin` is accessible in the `catch` block.

### Problem

`origin` was declared inside `try` with `const`, making it block-scoped and inaccessible in `catch`. If an error occurred (e.g. a Prisma connection failure), the catch block would throw a `ReferenceError: origin is not defined` instead of gracefully redirecting with an error message, resulting in a 500 response.

### Fix

Moved `const { origin } = getRedirectParams(req);` one line above the `try` block in both handlers. This ensures `origin` is in scope for the entire handler function, including the `catch` block. No other logic was changed.