### PR TITLE
fix(tools): add HTTP and GraphQL error handling in queryGraphQL

### DIFF
--- a/tools/daily-challenges/helpers.ts
+++ b/tools/daily-challenges/helpers.ts
@@ -13,7 +13,26 @@ export async function queryGraphQL(query: string) {
     body: JSON.stringify({ query })
   });
 
-  const json = (await response.json()) as QueryResult;
+  // response.ok is false for any non-2xx status (4xx client errors, 5xx server errors).
+  // Note: network-level failures (unreachable host) throw before reaching this point.
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `GraphQL HTTP error ${response.status} ${response.statusText}: ${errorBody}`
+    );
+  }
+
+  const json = (await response.json()) as QueryResult & {
+    errors?: Array<{ message: string }>;
+  };
+
+  // GraphQL can return HTTP 200 with errors in the response body.
+  // This check catches query validation errors, resolver failures, etc.
+  // without being masked by misleading parsing errors downstream.
+  if (json.errors) {
+    const errorMessages = json.errors.map(e => e.message).join('; ');
+    throw new Error(`GraphQL error: ${errorMessages}`);
+  }
 
   if (!json?.data?.allChallengeNode?.edges?.length) {
     throw new Error(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67645 

<!-- Feel free to add any additional description of changes below this line -->
---

## Description

### Problem
The `queryGraphQL` function in `tools/daily-challenges/helpers.ts` lacks comprehensive error handling for HTTP and GraphQL-level failures, leading to misleading error messages.

**Specific Issues:**
1. **Missing HTTP validation**: If the server returns 4xx/5xx, `response.json()` may still succeed with an error body, causing confusing downstream errors instead of surfacing the actual HTTP error.
2. **No GraphQL error checking**: GraphQL endpoints return HTTP 200 with errors in the response body's `errors` field. These are currently missed, allowing query validation and resolver failures to go undetected.

### Solution
Added comprehensive error handling that:
- Validates HTTP response status using `response.ok`
- Checks for GraphQL-level errors in the response body
- Provides clear, descriptive error messages distinguishing between HTTP and GraphQL errors
- Includes professional comments explaining the error handling logic

### Changes
- Added HTTP-level error validation after `fetch()`
- Added GraphQL-level error validation after `response.json()`
- Extended inline type to include optional `errors` field
- Added detailed comments explaining each validation check

### Testing
- Verified the fix handles 4xx/5xx HTTP errors correctly
- Verified GraphQL error responses with status 200 are caught
- Confirmed error messages are clear and actionable
- Tested locally with the daily challenges seeding script

### Benefits
- Errors are surfaced clearly without being masked by misleading messages
- Easier debugging when the GraphQL endpoint fails
- Better error messages help developers quickly identify issues
- Follows best practices for HTTP error handling in Node.js scripts

