### PR TITLE
fix(curriculum): remove trailing spaces and fix HTTP formatting

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-asynchronous-javascript/66edd630f7666cfa54b404d0.md
+++ b/curriculum/challenges/english/blocks/quiz-asynchronous-javascript/66edd630f7666cfa54b404d0.md
@@ -29,7 +29,7 @@ A technique to handle errors in your code.
 
 ---
 
-A way to make network requests, typically to retrieve or send data to the server. 
+A way to make network requests, typically to retrieve or send data to the server.
 
 #### --answer--
 
@@ -43,7 +43,7 @@ What is a thread?
 
 #### --distractors--
 
-A function used to retrieve data from the server. 
+A function used to retrieve data from the server.
 
 ---
 
@@ -83,7 +83,7 @@ To make network requests to servers.
 
 #### --text--
 
-Which `HTTP` method is used to send data to a server for processing?
+Which HTTP method is used to send data to a server for processing?
 
 #### --distractors--
 
@@ -341,7 +341,7 @@ Which of the following attributes downloads the script asynchronously but waits 
 
 #### --text--
 
-What will the following code return? 
+What will the following code return?
 
 ```js
 fetch('https://api.example.com/data')


### PR DESCRIPTION
Fixes:
- Removed trailing spaces from distractor options
- Removed unnecessary backticks around HTTP
- Removed trailing whitespace in question text

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67640