### PR TITLE
fix: prose issues in Review Asynchronous JavaScript lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lab-flashcard-quiz-app/69b868127999e97f1903f8e1.md
+++ b/curriculum/challenges/english/blocks/lab-flashcard-quiz-app/69b868127999e97f1903f8e1.md
@@ -3,6 +3,7 @@ id: 69b868127999e97f1903f8e1
 title: Build a Flashcard Quiz App
 challengeType: 25
 dashedName: lab-flashcard-quiz-app
+demoType: onClick
 saveSubmissionToDB: true
 ---
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
@@ -185,7 +185,7 @@ It raises a generic `Exception`.
 
 ### --feedback--
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
 ---
 
@@ -193,7 +193,7 @@ It does nothing.
 
 ### --feedback--
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
 ---
 
@@ -205,7 +205,7 @@ It raises a `TypeError`.
 
 ### --feedback--
 
-Refer back to the section about `raise`. understand how it behaves without arguments.
+Refer back to the section about `raise` to understand how it behaves without arguments.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
@@ -185,7 +185,7 @@ It raises a generic `Exception`.
 
 ### --feedback--
 
-Refer back to the section about `raise` to understand how it behaves without arguments.
+Refer back to the section about `raise`. understand how it behaves without arguments.
 
 ---
 
@@ -193,7 +193,7 @@ It does nothing.
 
 ### --feedback--
 
-Refer back to the section about `raise` to understand how it behaves without arguments.
+Refer back to the section about `raise`. understand how it behaves without arguments.
 
 ---
 
@@ -205,7 +205,7 @@ It raises a `TypeError`.
 
 ### --feedback--
 
-Refer back to the section about `raise` to understand how it behaves without arguments.
+Refer back to the section about `raise`. understand how it behaves without arguments.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/review-asynchronous-javascript/6723d35bb07d1bd220d0f28d.md
+++ b/curriculum/challenges/english/blocks/review-asynchronous-javascript/6723d35bb07d1bd220d0f28d.md
@@ -14,7 +14,7 @@ dashedName: review-asynchronous-javascript
 
 ## The JavaScript engine and JavaScript runtime
 
-- The **JavaScript engine** is a program that executes JavaScript code in a web browser. It works like a converter that takes your code, turns it into instructions that the computer can understand and work accordingly. 
+- The **JavaScript engine** is a program that executes JavaScript code in a web browser. It works like a converter that takes your code, turns it into instructions that the computer can understand and work accordingly.
 - V8 is an example of a JavaScript engine developed by Google.
 - The **JavaScript runtime** is the environment in which JavaScript code is executed. It includes the JavaScript engine which processes and executes the code, and additional features like a web browser or Node.js.
 
@@ -41,7 +41,7 @@ fetch('https://api.example.com/data')
   .then(data => console.log(data))
 ```
 
-In this code, the response coming from the Fetch API is a promise and the `.then` handler is converting the response to a JSON format.
+In this code, `fetch()` returns a Promise, and the `.then()` handler converts the resolved response to JSON format.
 
 - **POST**: Used to send data to the server. The `POST` method is used to create new resources on the server.
 
@@ -75,7 +75,7 @@ fetch('https://api.example.com/users/45', {
 })
 ```
 
-In this example, we are updating the ID `45` that is specified at the end of the URL. We have used the `PUT` method on the code and also specified the data as the body which will be used to update the identified data. 
+In this example, we are updating the ID `45` that is specified at the end of the URL. We have used the `PUT` method on the code and also specified the data as the body which will be used to update the identified data.
 
 - **DELETE**: Used to delete data on the server. The `DELETE` method is used to delete resources on the server.
 
@@ -89,7 +89,7 @@ In this example, we're sending a `DELETE` request to remove a user with the ID `
 
 ## Promise and promise chaining
 
-- **Promises** are objects that represent the eventual completion or failure of an asynchronous operation and its resulting value. The value of the promise is known only when the `async` operation is completed.
+- **Promises** are objects that represent the eventual completion or failure of an asynchronous operation and its resulting value. The value of the promise is known only when the asynchronous operation is completed.
 - Here is an example to create a simple promise:
 
 ```js
@@ -134,13 +134,13 @@ fetch('https://api.example.com/data')
   });
 ```
 
-In the above example, we first fetch data from one URL, then fetch data from another URL based on the first response, and finally log the second data received. 
+In the above example, we first fetch data from one URL, then fetch data from another URL based on the first response, and finally log the second data received.
 
 The `catch` method would handle any errors that occur during the process. This means you don't need to add error handling to each step, which can greatly simplify your code.
 
 ## Using `async/await` to handle promises
 
-Async/await makes writing & reading asynchronous code easier which is built on top of Promises.
+`Async`/`await` makes writing and reading asynchronous code easier, which is built on top of Promises.
 
 - **async**: The `async` keyword is used to define an asynchronous function. An `async` function returns a Promise, which resolves with the value returned by the `async` function.
 - **await**: The `await` keyword is used inside an `async` function to pause the execution of the function until the Promise is resolved. It can only be used inside an `async` function.
@@ -179,24 +179,24 @@ In the above example, the `try` block contains the code that might throw an erro
 
 ## The `async` attribute
 
-- The `async` attribute tells the browser to download the script file asynchronously while continuing to parse the HTML document. 
+- The `async` attribute tells the browser to download the script file asynchronously while continuing to parse the HTML document.
 - Once the script is downloaded, the HTML parsing is paused, the script is executed, and then HTML parsing resumes.
-- You should use `async` for independent scripts where the order of execution doesn't matter
+- You should use `async` for independent scripts where the order of execution doesn't matter.
 
 ## The `defer` attribute
 
-- The `defer` attribute also downloads the script asynchronously, but it defers the execution of the script until after the HTML document has been fully parsed. 
+- The `defer` attribute also downloads the script asynchronously, but it defers the execution of the script until after the HTML document has been fully parsed.
 - The `defer` scripts maintain the order of execution as they appear in the HTML document.
 
 - It's important to note that both `async` and `defer` attributes are ignored for inline scripts and only work for external script files.
 
 - When both `async` and `defer` attributes are present, the `async` attribute takes precedence.
 
-## Geolocation API 
+## Geolocation API
 
 - The Geolocation API provides a way for websites to request the user's location.
 
-- The example below demonstrates the API's  `getCurrentPosition()` method which is used to get the user's current location.
+- The example below demonstrates the API's `getCurrentPosition()` method which is used to get the user's current location.
 
 ```js
 navigator.geolocation.getCurrentPosition(
@@ -210,11 +210,11 @@ navigator.geolocation.getCurrentPosition(
 );
 ```
 
-In this code, we're calling `getCurrentPosition` and passing it a function which will be called when the position is successfully obtained. 
+In this code, we're calling `getCurrentPosition` and passing it a function which will be called when the position is successfully obtained.
 
 The `position` object contains a variety of information, but here we have selected `latitude` and `longitude` only.
 
-If there is an issue with getting the `position`, then the error will be logged to the console. 
+If there is an issue with getting the `position`, then the error will be logged to the console.
 
 - It is important to respect the user's privacy and only request their location when necessary.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## Description of Changes
Fixed prose issues in the Review Asynchronous JavaScript lecture:

- Removed trailing whitespace on lines 17, 78, 137, 182, 188, 195, 213, 217
- Line 44: Updated `.then` to `.then()` and rewrote sentence for accuracy
- Line 92: Changed `async` operation (backtick) to asynchronous operation (plain text)
- Line 143: Replaced `&` with `and`, added backticks to `Async`/`await`, added missing comma before `which`
- Line 184: Added missing terminal period
- Line 199: Removed double space before `getCurrentPosition()`

Closes #67641