### PR TITLE
fix(ci): flaky puppeteer installs

### DIFF
--- a/.github/workflows/curriculum-i18n-submodule.yml
+++ b/.github/workflows/curriculum-i18n-submodule.yml
@@ -64,8 +64,15 @@ jobs:
         env:
           CURRICULUM_LOCALE: ${{ matrix.locale }}
           CLIENT_LOCALE: ${{ matrix.locale }}
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           pnpm run build
+
+      - name: Setup cache for puppeteer browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/puppeteer/
+          key: ${{ runner.os }}-puppeteer-${{ hashFiles('curriculum/package.json') }}
 
       - name: Install Chrome for Puppeteer
         run: pnpm -F=curriculum install-puppeteer

--- a/.github/workflows/curriculum-i18n-submodule.yml
+++ b/.github/workflows/curriculum-i18n-submodule.yml
@@ -64,18 +64,8 @@ jobs:
         env:
           CURRICULUM_LOCALE: ${{ matrix.locale }}
           CLIENT_LOCALE: ${{ matrix.locale }}
-          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           pnpm run build
-
-      - name: Setup cache for puppeteer browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/puppeteer/
-          key: ${{ runner.os }}-puppeteer-${{ hashFiles('curriculum/package.json') }}
-
-      - name: Install Chrome for Puppeteer
-        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         env:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -181,6 +181,13 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+      - name: Setup cache for puppeteer browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/puppeteer/
+          key: ${{ runner.os }}-puppeteer-${{ hashFiles('curriculum/package.json') }}
 
       - name: Install Chrome for Puppeteer
         run: pnpm -F=curriculum install-puppeteer
@@ -234,6 +241,14 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+
+      - name: Setup cache for puppeteer browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/puppeteer/
+          key: ${{ runner.os }}-puppeteer-${{ hashFiles('curriculum/package.json') }}
 
       - name: Install Chrome for Puppeteer
         run: pnpm -F=curriculum install-puppeteer
@@ -293,9 +308,15 @@ jobs:
         env:
           CURRICULUM_LOCALE: ${{ matrix.locale }}
           CLIENT_LOCALE: ${{ matrix.locale }}
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+      - name: Setup cache for puppeteer browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/puppeteer/
+          key: ${{ runner.os }}-puppeteer-${{ hashFiles('curriculum/package.json') }}
 
       # DONT REMOVE THIS STEP.
       # TODO: Refactor and use re-usable workflow and shared artifacts

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -181,16 +181,6 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: true
-      - name: Setup cache for puppeteer browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/puppeteer/
-          key: ${{ runner.os }}-puppeteer-${{ hashFiles('curriculum/package.json') }}
-
-      - name: Install Chrome for Puppeteer
-        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         run: pnpm test
@@ -241,17 +231,6 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: true
-
-      - name: Setup cache for puppeteer browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/puppeteer/
-          key: ${{ runner.os }}-puppeteer-${{ hashFiles('curriculum/package.json') }}
-
-      - name: Install Chrome for Puppeteer
-        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         run: pnpm test
@@ -308,15 +287,9 @@ jobs:
         env:
           CURRICULUM_LOCALE: ${{ matrix.locale }}
           CLIENT_LOCALE: ${{ matrix.locale }}
-          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
-      - name: Setup cache for puppeteer browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/puppeteer/
-          key: ${{ runner.os }}-puppeteer-${{ hashFiles('curriculum/package.json') }}
 
       # DONT REMOVE THIS STEP.
       # TODO: Refactor and use re-usable workflow and shared artifacts
@@ -326,9 +299,6 @@ jobs:
           CLIENT_LOCALE: ${{ matrix.locale }}
         run: |
           pnpm run build
-
-      - name: Install Chrome for Puppeteer
-        run: pnpm -F=curriculum install-puppeteer
 
       - name: Run Tests
         env:


### PR DESCRIPTION
It's unclear exactly why puppeteer is creating partial installs, but hopefully this fixes it.

The idea is to cache the download whenever curriculum/package.json changes (the only place we use puppeteer) and try to ensure that pnpm install doesn't attempt to install the browser.

It may prove necessary to set PUPPETEER_SKIP_DOWNLOAD globally, but hopefully not.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
