### PR TITLE
fix(curriculum): correct typos in css accessibility quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md
+++ b/curriculum/challenges/english/blocks/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md
@@ -61,7 +61,7 @@ WebAIM's Color Contrast Checker
 
 #### --text--
 
-Which of the following tools allows you to pick background and foreground colors from content displayed on your screen and check for their contrast ratio?
+Which of the following tools allows you to pick background and foreground colors from content displayed on your screen and check their contrast ratio?
 
 #### --distractors--
 
@@ -165,7 +165,7 @@ img {
 
 #### --text--
 
-Which of the following `scroll-behavior` value allows a smooth scrolling behavior?
+Which of the following `scroll-behavior` values allows a smooth scrolling behavior?
 
 #### --distractors--
 
@@ -203,7 +203,7 @@ Which of the following features is used to detect the user's animation preferenc
 
 #### --answer--
 
-`prefers-reduce-motion`
+`prefers-reduced-motion`
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67639

<!-- Feel free to add any additional description of changes below this line -->
### What
Fixes grammatical errors, awkward phrasing, and a typo in the CSS Accessibility quiz challenge file (`66ed8fc1f45ce3ece4053ead.md`).

### Why
* **Line 64:** The original phrasing "check for their contrast ratio" is grammatically awkward and inconsistent with parallel questions in the module (like Q2), which correctly use "check their contrast ratio".
* **Line 168:** The question used the singular noun "value" where the plural "values" is grammatically required by the phrasing "Which of the following...".
* **Line 206:** The CSS media feature `prefers-reduce-motion` was misspelled. It needs to be the standard, valid name `prefers-reduced-motion` to ensure technical accuracy and consistency with the rest of the workshop.

### How
* Modified lines 64, 168, and 206 in `curriculum/challenges/english/blocks/quiz-css-accessibility/66ed8fc1f45ce3ece4053ead.md` to implement the required text updates.
* Verified the formatting and changes within the local curriculum structure.
