### PR TITLE
fix(api): improve missing curriculum error

### DIFF
--- a/api/src/utils/get-challenges.ts
+++ b/api/src/utils/get-challenges.ts
@@ -3,15 +3,23 @@
 // redirectToCurrentChallenge and, instead, only report the current challenge id
 // via the user object, then we should *not* store this so it can be garbage
 // collected.
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'path';
 
 const CURRICULUM_PATH = '../../../curriculum/generated/curriculum.json';
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const curriculumPath = join(__dirname, CURRICULUM_PATH);
+
+if (!existsSync(curriculumPath)) {
+  throw new Error(
+    'Missing curriculum/generated/curriculum.json. Generate the curriculum before starting the API.'
+  );
+}
+
 // Curriculum is read using fs, because it is too large for VSCode's LSP to handle type inference which causes annoying behavior.
 const curriculum = JSON.parse(
-  readFileSync(join(__dirname, CURRICULUM_PATH), 'utf-8')
+  readFileSync(curriculumPath, 'utf-8')
 ) as Curriculum;
 
 interface Challenge {


### PR DESCRIPTION
Checklist:

* [x] I have read and followed the [[contribution guidelines](https://contribute.freecodecamp.org/)](https://contribute.freecodecamp.org).
* [x] I have read and followed the [[how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67656

This PR improves the error message in `api/src/utils/get-challenges.ts` when `curriculum/generated/curriculum.json` is missing.

Instead of calling `readFileSync` directly with the joined path, the code now resolves the curriculum file path once, checks whether the file exists, and throws a clearer error message if it does not.

Changes included:

* Import `existsSync` from `fs`
* Add a `curriculumPath` variable
* Check whether the generated curriculum file exists before calling `readFileSync`
* Throw a clearer error message when the generated curriculum file is missing

Testing:

* Not run locally. Docker Engine was not running in my Windows environment.
* Verified the change by reviewing the updated path handling and missing-file check in `api/src/utils/get-challenges.ts`.