### PR TITLE
test: improve generateExam coverage

### DIFF
--- a/api/src/exam-environment/utils/exam-environment.test.ts
+++ b/api/src/exam-environment/utils/exam-environment.test.ts
@@ -198,6 +198,71 @@ describe('Exam Environment mocked Math.random', () => {
       };
       expect(() => generateExam(invalidExam)).toThrow();
     });
+
+    it('should throw when no question set config exists', () => {
+      const invalidExam = {
+        ...exam,
+        config: {
+          ...exam.config,
+          questionSets: []
+        }
+      };
+
+      expect(() => generateExam(invalidExam)).toThrow(
+        'Invalid exam config - no question sets config.'
+      );
+    });
+
+    it('should throw when there are not enough questions for a question type', () => {
+      const invalidExam = structuredClone(exam);
+
+      invalidExam.config.questionSets[0]!.numberOfQuestions = 999;
+
+      expect(() => generateExam(invalidExam)).toThrow(
+        'Not enough questions for question type'
+      );
+    });
+
+    it('should generate questions with the configured number of answers', () => {
+      const generated = generateExam(exam);
+
+      generated.questionSets.forEach(gqs => {
+        const originalQuestionSet = exam.questionSets.find(
+          qs => qs.id === gqs.id
+        );
+
+        expect(originalQuestionSet).toBeDefined();
+
+        const config = exam.config.questionSets.find(
+          c => c.type === originalQuestionSet!.type
+        );
+
+        expect(config).toBeDefined();
+
+        gqs.questions.forEach(gq => {
+          const originalQuestion = originalQuestionSet!.questions.find(
+            q => q.id === gq.id
+          );
+
+          expect(originalQuestion).toBeDefined();
+
+          const generatedAnswers = originalQuestion!.answers.filter(a =>
+            gq.answers.includes(a.id)
+          );
+
+          const correctAnswers = generatedAnswers.filter(a => a.isCorrect);
+          const incorrectAnswers = generatedAnswers.filter(a => !a.isCorrect);
+
+          expect(correctAnswers.length).toBeGreaterThanOrEqual(
+            config!.numberOfCorrectAnswers
+          );
+
+          expect(incorrectAnswers.length).toBeGreaterThanOrEqual(
+            config!.numberOfIncorrectAnswers
+          );
+        });
+      });
+    });
   });
 
   describe('validateAttempt()', () => {


### PR DESCRIPTION
Checklist:

* [x] I have read and followed the contribution guidelines.
* [x] I have read and followed the how to open a pull request guide.
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67663

## Description

This PR improves unit test coverage for `generateExam()` in `exam-environment.ts`.

### Added test coverage for:

* Empty `questionSets` configuration
* Insufficient questions available for a question type
* Validation of generated answer constraints:

  * `numberOfCorrectAnswers`
  * `numberOfIncorrectAnswers`

### Purpose

The `generateExam()` function contains multiple exceptional execution paths and business-rule constraints that were not fully covered by the existing test suite.

These additional tests improve:

* regression protection
* validation of edge cases
* reliability of the exam generation algorithm
* confidence during future refactoring

No production logic was modified as part of this change.
