### PR TITLE
Add unit tests for the search redux reducer 

### DIFF
--- a/client/src/components/search/redux/index.test.js
+++ b/client/src/components/search/redux/index.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reducer,
+  toggleSearchFocused,
+  toggleSearchDropdown,
+  updateSearchQuery
+} from './index';
+
+const initialState = {
+  query: '',
+  indexName: 'news',
+  isSearchDropdownEnabled: true,
+  isSearchBarFocused: false
+};
+
+describe('search reducer', () => {
+  describe('toggleSearchDropdown', () => {
+    it('sets dropdown to false when payload is false', () => {
+      const result = reducer(initialState, toggleSearchDropdown(false));
+      expect(result.isSearchDropdownEnabled).toBe(false);
+    });
+
+    it('toggles dropdown when payload is not a boolean', () => {
+      const result = reducer(initialState, toggleSearchDropdown(undefined));
+      expect(result.isSearchDropdownEnabled).toBe(false);
+    });
+  });
+
+  describe('toggleSearchFocused', () => {
+    it('updates isSearchBarFocused when payload differs from current state', () => {
+      const result = reducer(initialState, toggleSearchFocused(true));
+      expect(result.isSearchBarFocused).toBe(true);
+    });
+
+    it('returns same state reference when payload matches current state', () => {
+      const result = reducer(initialState, toggleSearchFocused(false));
+      expect(result).toBe(initialState);
+    });
+
+    it('does not deduplicate when non-boolean truthy payload is passed', () => {
+      const focusedState = { ...initialState, isSearchBarFocused: true };
+      const result = reducer(focusedState, toggleSearchFocused(1));
+      expect(result).toBe(focusedState);
+    });
+  });
+
+  describe('updateSearchQuery', () => {
+    it('updates the query string', () => {
+      const result = reducer(initialState, updateSearchQuery('javascript'));
+      expect(result.query).toBe('javascript');
+    });
+
+    it('resets query to empty string', () => {
+      const state = { ...initialState, query: 'react' };
+      const result = reducer(state, updateSearchQuery(''));
+      expect(result.query).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ X ] My pull request targets the `main` branch of freeCodeCamp.
- [ X ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67662

<!-- Feel free to add any additional description of changes below this line -->

This PR adds a unit test suite for the search redux reducer (client/src/components/search/redux/index.js), which previously had no test coverage. The reducer handles three actions used across the /learn search bar flow and is a pure function, making it straightforward to test without mocks or async setup.