### PR TITLE
fix: Add unit tests for stripeCardErrorHandler authentication error path

### DIFF
--- a/client/src/redux/donation-saga.test.js
+++ b/client/src/redux/donation-saga.test.js
@@ -3,7 +3,7 @@
 /* eslint-disable vitest/expect-expect */
 // @vitest-environment jsdom
 import { expectSaga } from 'redux-saga-test-plan';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   postChargeStripe,
   postChargeStripeCard,
@@ -219,5 +219,75 @@ describe('donation-saga', () => {
       .call(updateStripeCard)
       .put(updateCardError())
       .run();
+  });
+
+  it('calls handleAuthentication with clientSecret and paymentMethodId on UserActionRequired error', () => {
+    const handleAuthentication = vi.fn().mockResolvedValue({
+      paymentIntent: { status: 'succeeded' }
+    });
+
+    const stripeCardDataMock = {
+      payload: {
+        ...postChargeDataMock.payload,
+        paymentProvider: 'stripe card',
+        handleAuthentication
+      }
+    };
+
+    const { paymentMethodId, amount, duration } = stripeCardDataMock.payload;
+    const optimizedPayload = { paymentMethodId, amount, duration };
+
+    postChargeStripeCard.mockResolvedValue({
+      data: {
+        error: {
+          type: 'UserActionRequired',
+          client_secret: 'sec_test_123'
+        }
+      }
+    });
+
+    return expectSaga(postChargeSaga, stripeCardDataMock)
+      .withState(signedInStoreMock)
+      .call(postChargeStripeCard, optimizedPayload)
+      .run()
+      .then(() => {
+        expect(handleAuthentication).toHaveBeenCalledTimes(1);
+        expect(handleAuthentication).toHaveBeenCalledWith(
+          'sec_test_123',
+          '123456'
+        );
+      });
+  });
+
+  it('does not call handleAuthentication when error type is not UserActionRequired', () => {
+    const handleAuthentication = vi.fn();
+
+    const stripeCardDataMock = {
+      payload: {
+        ...postChargeDataMock.payload,
+        paymentProvider: 'stripe card',
+        handleAuthentication
+      }
+    };
+
+    const { paymentMethodId, amount, duration } = stripeCardDataMock.payload;
+    const optimizedPayload = { paymentMethodId, amount, duration };
+
+    postChargeStripeCard.mockResolvedValue({
+      data: {
+        error: {
+          type: 'card_declined',
+          client_secret: null
+        }
+      }
+    });
+
+    return expectSaga(postChargeSaga, stripeCardDataMock)
+      .withState(signedInStoreMock)
+      .call(postChargeStripeCard, optimizedPayload)
+      .run()
+      .then(() => {
+        expect(handleAuthentication).not.toHaveBeenCalled();
+      });
   });
 });


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ X ] My pull request targets the `main` branch of freeCodeCamp.
- [ X ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67666

<!-- Feel free to add any additional description of changes below this line -->

This PR adds two test cases to client/src/redux/donation-saga.test.js covering the stripeCardErrorHandler authentication error path, which was previously untested. The new tests exercise the saga branch triggered when postChargeStripeCard returns a UserActionRequired error.