### PR TITLE
fix(curriculum): add missing period in placeholder text solution

### DIFF
--- a/curriculum/challenges/english/blocks/basic-html-and-html5/bad87fee1348bd9aedf08833.md
+++ b/curriculum/challenges/english/blocks/basic-html-and-html5/bad87fee1348bd9aedf08833.md
@@ -46,5 +46,5 @@ assert.match(document.querySelector('p').textContent,/Kitty(\s)+ipsum/gi);
 
 <h2>CatPhotoApp</h2>
 
-<p>Kitty ipsum dolor sit amet, shed everywhere shed everywhere stretching attack your ankles chase the red dot, hairball run catnip eat the grass sniff</p>
+<p>Kitty ipsum dolor sit amet, shed everywhere shed everywhere stretching attack your ankles chase the red dot, hairball run catnip eat the grass sniff.</p>
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67677

In the "Fill in the Blank with Placeholder Text" challenge (`basic-html-and-html5/bad87fee1348bd9aedf08833.md`), the instructions ask the camper to use the kitty ipsum text ending in a period (`...eat the grass sniff.`), but the solution block drops the trailing period.

This is the only place in the block where that sentence is missing it: the same kitty ipsum line appears 31 times across the Basic HTML and HTML5 challenges, and the other 30 all end with `sniff.`. This change adds the period back so the solution matches both the instructions and the rest of the block.
