### PR TITLE
fix(curriculum): correct misplaced adverb in quiz classes and objects

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-classes-and-objects/67f413038f0f8c452c660dc5.md
+++ b/curriculum/challenges/english/blocks/quiz-classes-and-objects/67f413038f0f8c452c660dc5.md
@@ -85,7 +85,7 @@ Instance attributes are set within the `__init__` method; class attributes are s
 
 ---
 
-Instance attributes can be directly accessed from the class; class attributes can be only accessed from an actual instance of the class.
+Instance attributes can be directly accessed from the class; class attributes can only be accessed from an actual instance of the class.
 
 #### --answer--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67659

<!-- Feel free to add any additional description of changes below this line --> 

## Description

Corrected a misplaced adverb in the quiz classes-and-objects lesson.

Changed:

"class attributes can be only accessed..."

to:

"class attributes can only be accessed..."