### PR TITLE
test(curriculum): add coverage for file-handler config helpers

### DIFF
--- a/curriculum/src/file-handler.test.ts
+++ b/curriculum/src/file-handler.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getContentConfig, getLanguageConfig } from './file-handler';
+
+vi.mock('fs', () => ({ existsSync: vi.fn(() => true) }));
+
+describe('file-handler', () => {
+  describe('getContentConfig', () => {
+    it('returns expected directory structure for English', () => {
+      const result = getContentConfig('english');
+      expect(result).toHaveProperty('contentDir');
+      expect(result).toHaveProperty('i18nContentDir');
+      expect(result).toHaveProperty('blockContentDir');
+      expect(result).toHaveProperty('dictionariesDir');
+    });
+
+    it('accepts custom baseDir and i18nBaseDir overrides', () => {
+      const result = getContentConfig('english', {
+        baseDir: '/custom/base',
+        i18nBaseDir: '/custom/i18n'
+      });
+      expect(result.contentDir).toContain('/custom/base');
+    });
+  });
+
+  describe('getLanguageConfig', () => {
+    it('returns the same directory structure as getContentConfig for same inputs', () => {
+      const contentResult = getContentConfig('english');
+      const languageResult = getLanguageConfig('english');
+      expect(contentResult).toEqual(languageResult);
+    });
+
+    it('returns expected directory structure for non-English language', () => {
+      const result = getLanguageConfig('portuguese');
+      expect(result).toHaveProperty('i18nContentDir');
+      expect(result.i18nContentDir).toContain('portuguese');
+    });
+  });
+});


### PR DESCRIPTION
Checklist:

* [x] I have read and followed the contribution guidelines.
* [x] I have read and followed the how to open a pull request guide.
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67667

## Description

This PR adds unit test coverage for `getContentConfig()` and `getLanguageConfig()` in `curriculum/src/file-handler.ts`.

### Added test coverage for:

* English directory configuration generation
* Non-English language configuration generation
* Custom `baseDir` and `i18nBaseDir` overrides
* Behavioral equivalence between:

  * `getContentConfig()`
  * `getLanguageConfig()`
