### PR TITLE
test: add unit tests for search reducer

### DIFF
--- a/client/src/components/search/redux/index.test.js
+++ b/client/src/components/search/redux/index.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  reducer,
+  toggleSearchDropdown,
+  toggleSearchFocused,
+  updateSearchQuery
+} from './index';
+
+describe('search reducer', () => {
+  it('toggles search dropdown when payload is undefined', () => {
+    const state = reducer(undefined, toggleSearchDropdown());
+    expect(state.isSearchDropdownEnabled).toBe(false);
+  });
+
+  it('sets dropdown when boolean payload is provided', () => {
+    const state = reducer(undefined, toggleSearchDropdown(false));
+    expect(state.isSearchDropdownEnabled).toBe(false);
+  });
+
+  it('updates search query', () => {
+    const state = reducer(undefined, updateSearchQuery('react'));
+    expect(state.query).toBe('react');
+  });
+
+  it('updates focus state', () => {
+    const state = reducer(undefined, toggleSearchFocused(true));
+    expect(state.isSearchBarFocused).toBe(true);
+  });
+
+  it('supports non-boolean focus payload', () => {
+    const state = reducer(undefined, toggleSearchFocused('banana'));
+    expect(state.isSearchBarFocused).toBe('banana');
+  });
+
+  it('returns same state when focus value does not change', () => {
+    const first = reducer(undefined, toggleSearchFocused(false));
+    const second = reducer(first, toggleSearchFocused(false));
+
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67662

## Description of changes

This PR adds unit tests for the search Redux reducer located in `client/src/components/search/redux/index.js`.

The new test file covers the following behavior:

- `toggleSearchDropdown`:
  - Toggles the dropdown when no payload is provided
  - Sets explicit boolean values correctly when provided

- `toggleSearchFocused`:
  - Updates focus state when payload changes
  - Supports non-boolean payload values as expected by reducer behavior
  - Ensures state is not mutated when the value does not change

- `updateSearchQuery`:
  - Correctly updates the search query state

These tests help ensure regression safety for search-related UI state management and validate edge cases already present in the reducer logic.
