### PR TITLE
fix(curriculum): fix CSS colors quiz typos

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
+++ b/curriculum/challenges/english/blocks/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
@@ -259,7 +259,7 @@ At least 2.
 
 #### --text--
 
-Which is NOT a valid way to apply a linear-gradient?
+Which is NOT a valid way to apply a `linear-gradient`?
 
 #### --distractors--
 
@@ -803,7 +803,7 @@ What’s the fourth value in the `hsla()` function?
 
 #### --distractors--
 
-Absorbtion
+Absorption
 
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67707 

<!-- Feel free to add any additional description of changes below this line -->


This PR fixes two small text issues in the CSS Colors quiz:

- Wrapped `linear-gradient` in backticks so it is formatted as a CSS function reference.
- Corrected the misspelling `Absorbtion` to `Absorption`.

## Testing

I checked the affected quiz markdown file locally and confirmed the text updates are applied.