### PR TITLE
fix(curriculum): Fix Redundant phrasing and missing hyphen in the Common Design Tools lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-common-design-tools/672aa7005c24e45bbd53b20d.md
+++ b/curriculum/challenges/english/blocks/lecture-common-design-tools/672aa7005c24e45bbd53b20d.md
@@ -31,7 +31,7 @@ Without clearly defining project scope, things can get out of hand and go over b
 
 One of the challenging aspects about project design is the timescale and budget. It is important to be realistic about what can be achieved within the given timeframe and budget. So, having a design brief that outlines these constraints is important.
 
-Once all of these details have been discussed and documented, the design brief should be reviewed and approved by all stakeholders before the project begins. At that point, that is when the designers can get started with their work.
+Once all of these details have been discussed and documented, the design brief should be reviewed and approved by all stakeholders before the project begins. At that point, the designers can get started with their work.
 
 So, what is the developer's role in all of this? The developer's role is to take the designs, understand the project requirements, and turn them into a working product.
 
@@ -41,7 +41,7 @@ Oftentimes, developers will work in teams where the work is split up between mul
 
 There will also usually be a project manager who will be responsible for coordinating the work and making sure that the project stays on track.
 
-So, while you might not be involved in the design and initial decision making process as a developer, it is still important to understand the design brief and how it will impact your work.
+So, while you might not be involved in the design and initial decision-making process as a developer, it is still important to understand the design brief and how it will impact your work.
 
 # --questions--
 


### PR DESCRIPTION
…mon Design Tools lecture

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67706 

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes two wording issues in the Common Design Tools lecture:

Changed line 34 from:

“At that point, that is when the designers can get started with their work.”

to:

“At that point, the designers can get started with their work.”

Changed line 44 from:

“decision making process”

to:

“decision-making process”