### PR TITLE
fix(curriculum): add backticks to linear-gradient and fix Absorption typo in CSS Colors quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
+++ b/curriculum/challenges/english/blocks/quiz-css-colors/66ed8fe1f45ce3ece4053eb1.md
@@ -259,7 +259,7 @@ At least 2.
 
 #### --text--
 
-Which is NOT a valid way to apply a linear-gradient?
+Which is NOT a valid way to apply a `linear-gradient`?
 
 #### --distractors--
 
@@ -803,7 +803,7 @@ What’s the fourth value in the `hsla()` function?
 
 #### --distractors--
 
-Absorbtion
+Absorption
 
 ---
 


### PR DESCRIPTION
## Description
- Wrap `linear-gradient` in backticks per quiz contribution guidelines (line 262)
- Fix misspelling: Absorbtion → Absorption (line 806)

## Related Issue
Closes #67707