### PR TITLE
test(search): add reducer unit tests for search state

### DIFF
--- a/client/src/components/search/redux/index.test.js
+++ b/client/src/components/search/redux/index.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  reducer,
+  toggleSearchDropdown,
+  toggleSearchFocused,
+  updateSearchQuery
+} from './index';
+
+describe('search redux reducer', () => {
+  const initialState = reducer(undefined, { type: '@@INIT' });
+
+  it('returns the initial state', () => {
+    expect(initialState).toEqual({
+      query: '',
+      indexName: 'news',
+      isSearchDropdownEnabled: true,
+      isSearchBarFocused: false
+    });
+  });
+
+  describe('toggleSearchDropdown', () => {
+    it('sets isSearchDropdownEnabled from a boolean payload', () => {
+      const state = reducer(initialState, toggleSearchDropdown(false));
+
+      expect(state).toEqual({
+        ...initialState,
+        isSearchDropdownEnabled: false
+      });
+    });
+
+    it('toggles isSearchDropdownEnabled when payload is undefined', () => {
+      const state = reducer(initialState, toggleSearchDropdown());
+
+      expect(state).toEqual({
+        ...initialState,
+        isSearchDropdownEnabled: false
+      });
+    });
+
+    it('toggles isSearchDropdownEnabled when payload is not a boolean', () => {
+      const state = reducer(initialState, toggleSearchDropdown('invalid'));
+
+      expect(state).toEqual({
+        ...initialState,
+        isSearchDropdownEnabled: false
+      });
+    });
+  });
+
+  describe('toggleSearchFocused', () => {
+    it('sets isSearchBarFocused to true', () => {
+      const state = reducer(initialState, toggleSearchFocused(true));
+
+      expect(state).toEqual({
+        ...initialState,
+        isSearchBarFocused: true
+      });
+    });
+
+    it('sets isSearchBarFocused to false', () => {
+      const focusedState = {
+        ...initialState,
+        isSearchBarFocused: true
+      };
+
+      const state = reducer(focusedState, toggleSearchFocused(false));
+
+      expect(state).toEqual({
+        ...initialState,
+        isSearchBarFocused: false
+      });
+    });
+
+    it('returns the same state when payload matches the current focus state', () => {
+      const state = reducer(initialState, toggleSearchFocused(false));
+
+      expect(state).toBe(initialState);
+    });
+
+    it('stores a non-boolean payload as-is', () => {
+      const state = reducer(initialState, toggleSearchFocused('focused'));
+
+      expect(state).toEqual({
+        ...initialState,
+        isSearchBarFocused: 'focused'
+      });
+    });
+  });
+
+  describe('updateSearchQuery', () => {
+    it('updates query from the payload', () => {
+      const state = reducer(initialState, updateSearchQuery('javascript'));
+
+      expect(state).toEqual({
+        ...initialState,
+        query: 'javascript'
+      });
+    });
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67662 

<!-- Feel free to add any additional description of changes below this line -->

## Summary 
Add unit tests for the search Redux reducer in `client/src/components/search/redux/index.js`.

## Changes

- adds test coverage for the intial state
- covers `toggleSearchDropdown`
- covers `toggleSearchFocused`
- covers `updateSearchQuery`
- documents the current non-boolean payload behavior in `toggleSearchFocused`

