### PR TITLE
fix: correct blockLabel null check logic

### DIFF
--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -134,8 +134,8 @@ async function createProject(projectArgs: CreateProjectArgs) {
   }
 
   if (
-    (chapterBasedSuperBlocks.includes(projectArgs.superBlock) &&
-      projectArgs.blockLabel) == null
+    chapterBasedSuperBlocks.includes(projectArgs.superBlock) &&
+    projectArgs.blockLabel == null
   ) {
     throw new Error(
       'Missing argument: blockLabel when updating intro markdown'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67717 

## Description

This PR fixes an incorrect null check caused by operator precedence in the `blockLabel` validation condition.

### Previous Implementation

```js
if (
  (chapterBasedSuperBlocks.includes(projectArgs.superBlock) &&
    projectArgs.blockLabel) == null
) {
```

In the previous logic, the result of the entire logical expression was being compared against `null`, which could lead to unintended behavior and reduced readability.

### Updated Implementation

```js
if (
  chapterBasedSuperBlocks.includes(projectArgs.superBlock) &&
  projectArgs.blockLabel == null
) {
```

### Changes Made

* Updated the condition in `create-project.ts` (`freeCodeCamp/tools/challenge-helper-scripts`, around lines 137–138)
* Applied the null check directly to `projectArgs.blockLabel`
* Improved readability and maintainability of the condition
* Ensured the logic correctly validates `null` or `undefined` values only when the `superBlock` exists in `chapterBasedSuperBlocks`


