### PR TITLE
fix(curriculum): add seed data and refine description in smart pantry lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
+++ b/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
@@ -13,15 +13,7 @@ You will simulate receiving a shipment of pantry items, deciding what to do with
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
-The `rawData` array contains pipe-separated strings with the format `sku|name|qty|expires|zone`, where `zone` is optional. For example:
-
-```js
-const rawData = [
-  "A10|Tomatoes|5|2027-01-01",        // no zone field
-  "B21|Bananas|10|2027-01-01|fridge", // zone: "fridge"
-  "C32|Eggs|3|2027-01-01|pantry",     // zone: "pantry"
-];
-```
+The `rawData` array contains pipe-separated strings with the format `sku|name|qty|expires|zone`, where `zone` is optional.
 
 **User Stories:**
 
@@ -260,7 +252,19 @@ assert.isOk(groupedLog, "Log the grouped actions object to the console.");
 ## --seed-contents--
 
 ```js
+const pantry = [
+  { sku: "A10", name: "Tomatoes", qty: 4, expires: "2027-01-01", zone: "fridge" },
+  { sku: "D43", name: "Pineapples", qty: 2, expires: "2020-01-01", zone: "general" }
+];
 
+const rawData = [
+  "A10|Tomatoes|5|2027-01-01",
+  "B21|Bananas|10|2027-01-01",
+  "C32|Eggs|3|2027-01-01|fridge",
+  "C32|Eggs|3|2027-01-01",
+  "D43|Pineapples|0|2027-01-01",
+  "E54|Peppers|-1|2027-01-01|fridge"
+];
 ```
 
 # --solutions--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67720

Added the missing standard arrays (`pantry` and `rawData`) to the `## --seed-contents--` block under `# --seed--` of the "Build a Smart Pantry Restocker" lab.
Also, removed the redundant `rawData` example code block from the `# --description--` section to keep the instructions concise.
