### PR TITLE
fix(curriculum): enable event bubbling in lab-product-showcase tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-product-showcase/696920c0c98a1ed58eb86293.md
+++ b/curriculum/challenges/english/blocks/lab-product-showcase/696920c0c98a1ed58eb86293.md
@@ -422,8 +422,8 @@ Clicking the `#all` button should display all the products in the `#output` elem
 ```js
 const len = products.items.length;
 assert.isAtLeast(len, 3);
-books.dispatchEvent(new Event("click"));
-all.dispatchEvent(new Event("click"));
+books.dispatchEvent(new Event("click", { bubbles: true }));
+all.dispatchEvent(new Event("click", { bubbles: true }));
 assert.lengthOf(output.querySelectorAll(".item"), len);
 ```
 
@@ -438,8 +438,8 @@ products.items.forEach(i => {
     count++;
   }
 });
-clothing.dispatchEvent(new Event("click"));
-books.dispatchEvent(new Event("click"));
+clothing.dispatchEvent(new Event("click", { bubbles: true }));
+books.dispatchEvent(new Event("click", { bubbles: true }));
 assert.lengthOf(output.querySelectorAll(".item"), count);
 ```
 
@@ -454,8 +454,8 @@ products.items.forEach(i => {
     count++;
   }
 });
-clothing.dispatchEvent(new Event("click"));
-electronics.dispatchEvent(new Event("click"));
+clothing.dispatchEvent(new Event("click", { bubbles: true }));
+electronics.dispatchEvent(new Event("click", { bubbles: true }));
 assert.lengthOf(output.querySelectorAll(".item"), count);
 ```
 
@@ -470,8 +470,8 @@ products.items.forEach(i => {
     count++;
   }
 });
-books.dispatchEvent(new Event("click"));
-clothing.dispatchEvent(new Event("click"));
+books.dispatchEvent(new Event("click", { bubbles: true }));
+clothing.dispatchEvent(new Event("click", { bubbles: true }));
 assert.lengthOf(output.querySelectorAll(".item"), count);
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67726


<!-- Feel free to add any additional description of changes below this line -->
Updated the Product Showcase lab tests to dispatch bubbling click events (`{ bubbles: true }`).

The lab implementation uses event delegation by attaching a click listener to the parent `.buttons` container. The previous tests dispatched non-bubbling events, preventing the delegated listener from being triggered in the test environment. This change aligns the tests with actual browser click behavior and resolves the failing assertions.