### PR TITLE
fix(curriculum): fix trailing space and previous->parent in quiz-bash-commands

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-bash-commands/66f1af4fedf643c78d024c5e.md
+++ b/curriculum/challenges/english/blocks/quiz-bash-commands/66f1af4fedf643c78d024c5e.md
@@ -171,7 +171,7 @@ Which command will rename the 'menlo.font' file to 'menlo.otf'?
 
 #### --text--
 
-Which command can be used to find files or view a file tree ?
+Which command can be used to find files or view a file tree?
 
 #### --distractors--
 
@@ -303,7 +303,7 @@ Which command is used to remove a protected file?
 
 #### --text--
 
-Which command is used to go back to the previous directory?
+Which command is used to go back to the parent directory?
 
 #### --distractors--
 


### PR DESCRIPTION
…-commands

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67714

<!-- Feel free to add any additional description of changes below this line -->
- Removed trailing space before `?` in "Which command can be used to find files or view a file tree ?"
- Changed "previous directory" to "parent directory" since `cd ..` goes to the parent directory, not the previously visited one (that would be `cd -`)
