### PR TITLE
fix(curriculum): correct duplicate correct answer in Date object quiz

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -184,7 +184,7 @@ How would you create a `Date` object for July 4, 1776, at 12:00:00 PM?
 
 ### --feedback--
 
-You can provide the date and time in a string format or as separate numeric values.
+Review the example that creates a specific date and time using a date string.
 
 ---
 
@@ -196,11 +196,15 @@ You can provide the date and time in a string format or as separate numeric valu
 
 ### --feedback--
 
-You can provide the date and time in a string format or as separate numeric values.
+Review how the months are numbered when working with the `Date` object.
 
 ---
 
 `const specificDate = new Date(1776, 6, 4);`
+
+### --feedback--
+
+Consider whether this includes the time the question asks for.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67751 

---

The third question in the "How Does the JavaScript Date Object Work" lesson had two answer options without a `--feedback--` block, which marks both of them as correct. By the quiz format only the option selected by `--video-solution--` should be feedback-free.

One of those options, `new Date(1776, 6, 4)`, does not actually answer the question — it omits the time and resolves to `00:00:00`, not `12:00:00 PM`. The option `new Date(1776, 6, 4, 12, 0, 0)` was marked as a distractor even though it is correct, working JavaScript that produces exactly the requested date and time.

This PR keeps the intended string-based answer (`new Date("July 4, 1776 12:00:00")`) as the solution and gives each of the three distractors its own feedback:

- `new Date(1776, 6, 4, 12, 0, 0)` — points the learner back to the string form this lesson teaches.
- `new Date(1776, 7, 4, 12, 0, 0)` — points to the month being zero-based (`7` is August, not July). This also replaces the previous, less specific feedback on this option.
- `new Date(1776, 6, 4)` — prompts the learner to check whether the time is included.

The answer key (`--video-solution--`) is unchanged, so the lesson's intent is preserved. No other questions in the file are affected.