### PR TITLE
fix(curriculum): correct duplicate correct answer in Date object quiz

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -180,7 +180,7 @@ How would you create a `Date` object for July 4, 1776, at 12:00:00 PM?
 
 ## --answers--
 
-`const specificDate = new Date(1776, 6, 4, 12, 0, 0);`
+`const specificDate = new Date(1776, 6, 4, 0, 0, 0);`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -184,7 +184,7 @@ How would you create a `Date` object for July 4, 1776, at 12:00:00 PM?
 
 ### --feedback--
 
-You can provide the date and time in a string format or as separate numeric values.
+Review the example that creates a specific date and time using a date string.
 
 ---
 
@@ -196,11 +196,15 @@ You can provide the date and time in a string format or as separate numeric valu
 
 ### --feedback--
 
-You can provide the date and time in a string format or as separate numeric values.
+Review how the months are numbered when working with the `Date` object.
 
 ---
 
 `const specificDate = new Date(1776, 6, 4);`
+
+### --feedback--
+
+Consider whether this includes the time the question asks for.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -184,7 +184,7 @@ How would you create a `Date` object for July 4, 1776, at 12:00:00 PM?
 
 ### --feedback--
 
-Review the example that creates a specific date and time using a date string.
+You can provide the date and time in a string format or as separate numeric values.
 
 ---
 
@@ -196,7 +196,7 @@ Review the example that creates a specific date and time using a date string.
 
 ### --feedback--
 
-Review how the months are numbered when working with the `Date` object.
+You can provide the date and time in a string format or as separate numeric values.
 
 ---
 
@@ -204,7 +204,7 @@ Review how the months are numbered when working with the `Date` object.
 
 ### --feedback--
 
-Consider whether this includes the time the question asks for.
+You can provide the date and time in a string format or as separate numeric values.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67751

The third question in the "How Does the JavaScript Date Object Work" lesson asks how to create a Date for July 4, 1776, at 12:00:00 PM. It had two issues:

1. A second correct answer was marked wrong. new Date(1776, 6, 4, 12, 0, 0) is valid JavaScript that produces exactly July 4, 1776 at 12:00:00 (month 6 is July, since months are zero-based), so it was just as correct as the intended answer new Date("July 4, 1776 12:00:00") — yet it was listed as a distractor.
2. A distractor was missing its --feedback-- block. new Date(1776, 6, 4) had no feedback, which is inconsistent with the quiz format.

This PR fixes both:

- new Date(1776, 6, 4, 12, 0, 0) → new Date(1776, 6, 4, 0, 0, 0) — now resolves to midnight instead of noon, so it no longer matches the requested time and is a genuine distractor.
- Added the missing --feedback-- block to new Date(1776, 6, 4), using the same feedback as the other two wrong answers so that all three distractors for this question share one consistent message, following the format used by the other questions in this file.

The intended answer new Date("July 4, 1776 12:00:00") and the answer key (--video-solution--) are unchanged.