### PR TITLE
fix(curriculum): audit editable regions for workshop-calculator

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc0a9e06e00b75d6782be9.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc0a9e06e00b75d6782be9.md
@@ -46,6 +46,7 @@ assert.match(code, /console\.log\(\s*addTwoAndSeven\(\s*\)\s*\)/);
 function addTwoAndSeven() {
   return 2 + 7;
 }
+
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc1ccfefdd727e18c2ab20.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc1ccfefdd727e18c2ab20.md
@@ -53,7 +53,6 @@ function calculateQuotient(num1, num2) {
 }
 
 console.log(calculateQuotient(7, 11));
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc1deb1f04647f2aabee2b.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc1deb1f04647f2aabee2b.md
@@ -58,11 +58,11 @@ function calculateProduct(num1, num2) {
 
 console.log(calculateProduct(13, 5));
 
---fcc-editable-region--
 function calculateQuotient(num1, num2) {
-  return num1 / num2;
-}
 --fcc-editable-region--
+  return num1 / num2;
+--fcc-editable-region--
+}
 
 console.log(calculateQuotient(7, 11));
 console.log(calculateQuotient(3, 0));

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cdf76685e4cb5a8726e27b.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cdf76685e4cb5a8726e27b.md
@@ -37,7 +37,6 @@ function calculateSum(num1, num2) {
 }
 
 console.log(calculateSum(2, 5));
-
 --fcc-editable-region--
 
 --fcc-editable-region--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Part of #67721

<!-- Feel free to add any additional description of changes below this line -->

This PR completes the editable-region audit for workshop-calculator.

Changes:

In Step 3, the editable region begins immediately under the function declaration. I added one blank line above the editable region to improve readability and match the spacing used in other steps.

In Steps 9 and 14, I moved the editable region up one line so it sits directly under the previous console.log. This improves readability and keeps the spacing consistent with the rest of the workshop.

In Step 15, the editable region wraps the entire function definition, including the opening and closing braces. I updated it so the editable region includes only the function body, since that is the part the camper must modify.