### PR TITLE
fix(curriculum): correct acronym spacing and remove trailing whitespace in computer basics review

### DIFF
--- a/curriculum/challenges/english/blocks/review-computer-basics/671a87e6dcef5b5bd765e5ed.md
+++ b/curriculum/challenges/english/blocks/review-computer-basics/671a87e6dcef5b5bd765e5ed.md
@@ -10,16 +10,16 @@ dashedName: review-computer-basics
 ## Understanding Computer, Internet and Developer Tooling Basics
 
 - **Motherboard**: holds all of the memory, connectors, and hard drives that are needed to run the computer. It serves as the main circuit board for the computer.
-- **Central Processing Unit(CPU)**: a processor that is responsible for executing instructions and performing calculations. 
-- **Random Access Memory(RAM)**: a temporary storage location for the computer's CPU.
-- **Hard Disk Drive(HDD)**: a permanent storage location that is used to store data even when the computer is turned off.
-- **Solid State Drive(SSD)**: non-volatile flash memory and can be used in place of a hard drive.
-- **Power Supply Unit(PSU)**: responsible for converting the electricity from the wall outlet into a form that the computer can use.
-- **Graphics Processing Unit(GPU)**: responsible for rendering visuals on the computer screen.
+- **Central Processing Unit (CPU)**: a processor that is responsible for executing instructions and performing calculations.
+- **Random Access Memory (RAM)**: a temporary storage location for the computer's CPU.
+- **Hard Disk Drive (HDD)**: a permanent storage location that is used to store data even when the computer is turned off.
+- **Solid State Drive (SSD)**: non-volatile flash memory and can be used in place of a hard drive.
+- **Power Supply Unit (PSU)**: responsible for converting the electricity from the wall outlet into a form that the computer can use.
+- **Graphics Processing Unit (GPU)**: responsible for rendering visuals on the computer screen.
 - **Different Types of Internet Service Providers**: An Internet Service Provider (ISP) is a company that provides access to the internet. There are different types of ISPs, including dial-up, DSL, cable, fiber-optic, and satellite.
 - **Safe Ways to Sign Into Your Computer**: Examples of safe ways to sign into your computer include using a strong password, enabling two-factor authentication, and using a password manager.
-- **Integrated Development Environment (IDE)**: a tool that helps developers write, test and debug code in an efficient manner. 
-- **Code Editor**: a tool that developers use to write and debug code. 
+- **Integrated Development Environment (IDE)**: a tool that helps developers write, test, and debug code in an efficient manner.
+- **Code Editor**: a tool that developers use to write and debug code.
 - **Git**: a popular version control system that allows developers to track changes in their code and collaborate with others.
 - **Cloud-based Hosting Services for repositories**: A repository is a storage location for project files and version history. Popular cloud-based hosting services for repositories include GitHub, GitLab, and Bitbucket.
 - **Package Managers**: tools that help developers simplify the process of adding, updating, and removing libraries and project dependencies. Examples include npm, pip, and Maven.
@@ -37,7 +37,7 @@ dashedName: review-computer-basics
 - **Common Image and Graphic Formats**: `JPEG` and `PNG` are common image file formats. `GIF` is another common image file format that supports animation. `SVG` is a file format for vector graphics.
 - **Common Audio and Video Formats**: The `MP3` format is commonly used for audio files. The `MP4` format is commonly used for video files. The `MOV` format was developed by Apple and is commonly used for video files.
 - **Common Font Formats**: The `TTF` format is commonly used for TrueType fonts. The `WOFF` format is commonly used for web fonts. The successor to WOFF is `WOFF2`, which provides better compression.
-- **ZIP**: a file format that is used to compress files and folders. 
+- **ZIP**: a file format that is used to compress files and folders.
 
 ## Browsing the Web Effectively
 


### PR DESCRIPTION
## Summary
Closes #67747

Fixes formatting issues in the Computer Basics review block.

## Changes
- Added missing spaces before acronyms: CPU, RAM, HDD, SSD, PSU, GPU
- Removed trailing whitespace after 'manner.' and 'code.'
- Ensured consistent formatting throughout the review

## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67747