### PR TITLE
fix: fold module progress steps into main button for screen reader accessibility

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -32,6 +32,7 @@
 .super-block-accordion .module-header-wrapper .module-button-main {
   flex: 1;
   min-width: 0;
+  justify-content: space-between;
 }
 
 .super-block-accordion .chapter-header-wrapper .chapter-button-toggle,

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -145,9 +145,9 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    const moduleSteps = within(moduleRight).getByText(
+    // The module-button now contains the progress steps inline
+    const moduleButton = screen.getByTestId('module-button');
+    const moduleSteps = within(moduleButton).getByText(
       /learn\.steps-completed/i
     );
     expect(moduleSteps).toBeInTheDocument();
@@ -184,9 +184,9 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
+    // The module-button now contains the progress steps inline
+    const moduleButton = screen.getByTestId('module-button');
+    expect(within(moduleButton).queryByText(/steps/i)).not.toBeInTheDocument();
   });
 
   // Modules with zero total steps should not display any progress text.
@@ -219,9 +219,9 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
+    // The module-button now contains the progress steps inline
+    const moduleButton = screen.getByTestId('module-button');
+    expect(within(moduleButton).queryByText(/steps/i)).not.toBeInTheDocument();
   });
 
   describe('Reset Button', () => {

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -301,6 +301,7 @@ const Module = ({
           className='module-button module-button-main'
           onClick={toggleOpen}
           type='button'
+          data-testid='module-button'
         >
           <div className='module-button-left'>
             <span className='dropdown-wrap'>
@@ -311,17 +312,6 @@ const Module = ({
             </span>
             {moduleLabel}
           </div>
-        </button>
-        {resetButton}
-        <button
-          aria-controls={panelId}
-          aria-expanded={open}
-          aria-label={`${toggleLabel} ${moduleLabel}`}
-          className='module-button module-button-toggle'
-          data-testid='module-button-right'
-          onClick={toggleOpen}
-          type='button'
-        >
           <div className='module-button-right'>
             {!comingSoon && !!totalSteps && (
               <span className='module-steps'>
@@ -333,6 +323,7 @@ const Module = ({
             )}
           </div>
         </button>
+        {resetButton}
       </div>
       {open && (
         <ul className='module-panel' id={panelId}>


### PR DESCRIPTION
### Description

Fixes #67770

The module progress steps text (e.g. "3 of 101 steps complete") was rendered inside a separate `<button>` element (`module-button-toggle`), which obscured it from screen readers. Screen readers announced this as a standalone button without context from the module name.

**Fix**: Moved the progress steps into the main expand/collapse button (`module-button-main`) and removed the redundant toggle button. Now the progress text is announced in proper context with the module label.

### Changes
- **super-block-accordion.tsx**: Folded `module-steps` content from `module-button-toggle` into `module-button-main`; removed `module-button-toggle`; added `data-testid="module-button"` to the main button
- **super-block-accordion.test.tsx**: Updated 3 tests that referenced `module-button-right` to look at the main button via `module-button` testid

### Testing
- [x] Unit tests pass (updated for the new structure)
- [x] Screen readers will now announce progress in context