### PR TITLE
fix(curriculum): correct JS review content

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -343,7 +343,7 @@ console.log(text.includes("cat")); // false
 
 :::
 
-- The **`slice()` Method**: This method returns a new array containing a shallow copy of a portion of the original array, specified by start and end indices. The new array contains references to the same elements as the original array (not duplicates). This means that if the elements are primitives (like numbers or strings), the values are copied; but if the elements are objects or arrays, the references are copied, not the objects themselves.
+- The **`slice()` Method**: This method returns a new string containing a portion of the original string, specified by start and end indices.
 
 :::interactive_editor
 
@@ -428,7 +428,7 @@ console.log(text.trimStart()); // "Hello, world!  "
 
 ```js
 const text = " Hello, world! ";
-console.log(text.trimEnd()); // "  Hello, world!"
+console.log(text.trimEnd()); // " Hello, world!"
 ```
 
 :::
@@ -2786,7 +2786,7 @@ console.log(end.test("freecodecamp")); // true
 
 :::
 
-- **`m` Flag**: Anchors look for the beginning and end of the entire string. But you can make a regex handle multiple lines with the `m` flag, or the multi-line modifier.flag, or the multi-line modifier.
+- **`m` Flag**: Anchors look for the beginning and end of the entire string. But you can make a regex handle multiple lines with the `m` flag, or the multi-line modifier.
 
 :::interactive_editor
 
@@ -3076,9 +3076,9 @@ console.log("freecoooooooodecamp".replace(regex, "paid$1world"));
 
 - **`enctype` Attribute**: The `form` element accepts an `enctype` attribute, which represents the encoding type to use for the data. This attribute only accepts three values: `application/x-www-form-urlencoded` (which is the default, sending the data as a URL-encoded form body), `text/plain` (which sends the data in plaintext form, in `name=value` pairs separated by new lines), or `multipart/form-data`, which is specifically for handling forms with a file upload.
 
-## The `date()` Object and Common Methods
+## The `Date()` Object and Common Methods
 
-- **Definition**: The `date()` object is used to create, manipulate, and format dates and times in JavaScript. In the following example, the `new` keyword is used to create a new instance of the `Date` object, and the `Date` object is then assigned to the variable `now`. If you were to log the value of `now` to the console, you would see the current date and time based on the system clock of the computer running the code.
+- **Definition**: The `Date()` object is used to create, manipulate, and format dates and times in JavaScript. In the following example, the `new` keyword is used to create a new instance of the `Date` object, and the `Date` object is then assigned to the variable `now`. If you were to log the value of `now` to the console, you would see the current date and time based on the system clock of the computer running the code.
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist: <!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #67769

<!-- Feel free to add any additional description of changes below this line -->

## Summary

This PR corrects four content issues in the JavaScript Review page:

- updates the string `slice()` description so it refers to returning a new string
- fixes the `trimEnd()` example output comment to preserve the single leading space
- removes duplicated wording in the `m` flag description
- capitalizes `Date()` in the heading and definition

## Testing

- Verified the Markdown diff locally.
- No runtime tests were run because this is a text-only curriculum correction.