### PR TITLE
feat(curriculum): add error handling JavaScript review page

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -5319,6 +5319,13 @@
           "In this lab, you'll debug a random background color changer and fix the errors to make it work properly."
         ]
       },
+      "review-javascript-error-handling": {
+        "title": "Error Handling JavaScript Review",
+        "intro": [
+          "Before you continue, you should review what you've learned about error handling.",
+          "Open up this page to review concepts including custom error classes, error propagation, <code>error.cause</code> and handling errors in asynchronous code."
+        ]
+      },
       "review-debugging-javascript": {
         "title": "Debugging JavaScript Review",
         "intro": [

--- a/curriculum/challenges/english/blocks/review-javascript-error-handling/6a202f39453c840520c40802.md
+++ b/curriculum/challenges/english/blocks/review-javascript-error-handling/6a202f39453c840520c40802.md
@@ -1,0 +1,211 @@
+---
+id: 6a202f39453c840520c40802
+title: Error Handling JavaScript Review
+challengeType: 31
+dashedName: review-javascript-error-handling
+---
+
+# --interactive--
+
+## The `Error` Object
+
+When something goes wrong, JavaScript creates an `Error` object. Every error you can catch has a few useful properties:
+
+- **`name`**: the type of the error, such as `"TypeError"` or `"RangeError"`.
+- **`message`**: a human-readable description of what went wrong.
+- **`stack`**: a string showing the call stack at the moment the error was created, which is useful for tracing where the problem started.
+
+JavaScript ships with several built-in error types (`SyntaxError`, `ReferenceError`, `TypeError`, `RangeError` and more). You reviewed how these are triggered in the Debugging review; here the focus is on how to *handle* them.
+
+:::interactive_editor
+
+```js
+const error = new TypeError("Something went wrong");
+
+console.log(error.name);    // TypeError
+console.log(error.message); // Something went wrong
+console.log(error instanceof Error); // true
+```
+
+:::
+
+## Throwing Errors
+
+- **Definition**: The `throw` statement raises an exception, immediately stopping the current function and passing control to the nearest error handler.
+
+Always throw an `Error` instance (or a subclass) rather than a plain string. An `Error` object carries a `name`, `message`, and `stack`, while a thrown string gives you none of that context.
+
+:::interactive_editor
+
+```js
+function getDiscount(price) {
+  if (typeof price !== "number") {
+    throw new TypeError("price must be a number");
+  }
+  return price * 0.9;
+}
+
+console.log(getDiscount("free")); // TypeError: price must be a number
+```
+
+:::
+
+## `try...catch...finally`
+
+- **`try`**: wraps the code that might throw.
+- **`catch`**: receives the thrown error and decides how to recover.
+- **`finally`**: always runs afterward, whether or not an error was thrown — ideal for cleanup such as closing connections or releasing resources.
+
+Be careful with `return` inside `finally`: a value returned from `finally` overrides any value returned or error thrown in `try`/`catch`, which can hide bugs.
+
+:::interactive_editor
+
+```js
+function readConfig(raw) {
+  try {
+    console.log("Parsing config...");
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error("Could not parse config:", error.message);
+    return {};
+  } finally {
+    console.log("Done attempting to parse.");
+  }
+}
+
+console.log(readConfig('{ "debug": true }')); // { debug: true }
+console.log(readConfig("not json"));          // {}
+```
+
+:::
+
+## Error Propagation and Re-throwing
+
+If a `catch` block can't fully handle an error, it can inspect it and `throw` again so a higher-level handler deals with it. Use `instanceof` to handle only the error types you understand and re-throw the rest.
+
+:::interactive_editor
+
+```js
+function parseUser(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      // Add context, then let it keep propagating.
+      throw new Error("Invalid user JSON: " + error.message);
+    }
+    throw error; // re-throw anything we didn't expect
+  }
+}
+
+try {
+  parseUser("{ broken");
+} catch (error) {
+  console.error("Top-level handler:", error.message);
+}
+```
+
+:::
+
+## Custom Error Classes
+
+For domain-specific errors, extend the built-in `Error` class. Call `super(message)` to set the message, and set `this.name` so the error reports its own type. You can then branch on the error with `instanceof`.
+
+:::interactive_editor
+
+```js
+class ValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+function setAge(age) {
+  if (age < 0) {
+    throw new ValidationError("age cannot be negative");
+  }
+  return age;
+}
+
+try {
+  setAge(-5);
+} catch (error) {
+  if (error instanceof ValidationError) {
+    console.error(error.name + ": " + error.message);
+  } else {
+    throw error;
+  }
+}
+```
+
+:::
+
+## Chaining Errors with `error.cause`
+
+When you catch a low-level error and throw a higher-level one, pass the original error as the `cause` so the root problem isn't lost.
+
+:::interactive_editor
+
+```js
+function loadSettings(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error("Failed to load settings", { cause: error });
+  }
+}
+
+try {
+  loadSettings("oops");
+} catch (error) {
+  console.error(error.message);        // Failed to load settings
+  console.error(error.cause.name);     // SyntaxError
+}
+```
+
+:::
+
+## Handling Errors in Asynchronous Code
+
+- **`async`/`await`**: wrap awaited calls in `try...catch`, just like synchronous code.
+- **Promises**: handle rejections with `.catch()`, and use `.finally()` for cleanup.
+- **`unhandledrejection`**: a rejected promise with no handler triggers this global event, which is useful as a last-resort safety net.
+
+:::interactive_editor
+
+```js
+function fetchData(shouldFail) {
+  return new Promise((resolve, reject) => {
+    if (shouldFail) {
+      reject(new Error("Network request failed"));
+    } else {
+      resolve("data");
+    }
+  });
+}
+
+async function load() {
+  try {
+    const result = await fetchData(true);
+    console.log(result);
+  } catch (error) {
+    console.error("Caught:", error.message); // Caught: Network request failed
+  }
+}
+
+load();
+```
+
+:::
+
+## Best Practices
+
+- **Fail fast**: validate inputs early and throw a clear error instead of letting bad data spread.
+- **Never swallow errors**: an empty `catch {}` hides bugs. At minimum, log the error.
+- **Catch what you can handle**: only catch error types you know how to recover from, and re-throw the rest.
+- **Write meaningful messages**: a good `message` plus the `stack` makes debugging far easier.
+
+# --assignment--
+
+Review the error handling topics and concepts.

--- a/curriculum/structure/blocks/review-javascript-error-handling.json
+++ b/curriculum/structure/blocks/review-javascript-error-handling.json
@@ -1,0 +1,10 @@
+{
+  "blockLabel": "review",
+  "blockLayout": "link",
+  "isUpcomingChange": false,
+  "dashedName": "review-javascript-error-handling",
+  "challengeOrder": [
+    { "id": "6a202f39453c840520c40802", "title": "Error Handling JavaScript Review" }
+  ],
+  "helpCategory": "JavaScript"
+}

--- a/curriculum/structure/superblocks/javascript-v9.json
+++ b/curriculum/structure/superblocks/javascript-v9.json
@@ -196,6 +196,7 @@
           "blocks": [
             "lecture-debugging-techniques",
             "lab-random-background-color-changer",
+            "review-javascript-error-handling",
             "review-debugging-javascript",
             "quiz-debugging-javascript"
           ]


### PR DESCRIPTION
Adds a new review block `review-javascript-error-handling` to the
  Debugging module of the JavaScript v9 certification. Covers topics
  not addressed in the existing debugging review: custom error classes,
  error propagation and re-throwing, error.cause chaining, and handling
  errors in asynchronous code (async/await and Promises).

  Checklist:

  - [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
  - [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

  <!-- No related issue -->

  ## Changes

  - Added `curriculum/challenges/english/blocks/review-javascript-error-handling/6a202f39453c840520c40802.md` — challenge markdown with
  `challengeType: 31`, sections `# --interactive--` and `# --assignment--`, using `:::interactive_editor` blocks for executable code examples.
  - Added `curriculum/structure/blocks/review-javascript-error-handling.json` — block structure with `blockLabel: "review"` and `blockLayout:
  "link"`.
  - Updated `curriculum/structure/superblocks/javascript-v9.json` — inserted block in the `debugging-javascript` module, between
  `lab-random-background-color-changer` and `review-debugging-javascript`.
  - Updated `client/i18n/locales/english/intro.json` — added i18n entry for the new block.

  ## Testing

  - `pnpm run lint-challenges` passes with no errors.
  - `vitest run` for the generated block test (`review-javascript-error-handling.test.js`) passes 3/3 tests.
  - Verified visually with Gatsby dev server: page renders correctly at
  `/learn/javascript-v9/review-javascript-error-handling/review-javascript-error-handling`.
