### PR TITLE
fix: audit editable region markers for workshop-merge-sort

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-merge-sort/655cd899f8de09431eabb40c.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/655cd899f8de09431eabb40c.md
@@ -20,7 +20,6 @@ You should declare a function named `merge_sort` with a single parameter: `array
     test: () => assert(runPython(`_Node(_code).find_function("merge_sort").has_args("array")`))
 })
 ```
-git push origit push origin maingin main
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/655cd899f8de09431eabb40c.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/655cd899f8de09431eabb40c.md
@@ -20,7 +20,7 @@ You should declare a function named `merge_sort` with a single parameter: `array
     test: () => assert(runPython(`_Node(_code).find_function("merge_sort").has_args("array")`))
 })
 ```
-
+git push origit push origin maingin main
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6564aee9c077774ea49c3faf.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6564aee9c077774ea49c3faf.md
@@ -40,8 +40,8 @@ You should declare a `middle_point` variable and assign `len(array) // 2` to it.
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def merge_sort(array):
+--fcc-editable-region--
     pass
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656627b47bd2d2a4afbc945d.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656627b47bd2d2a4afbc945d.md
@@ -37,9 +37,9 @@ You should use the slice syntax to extract the left half of the array and assign
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def merge_sort(array):
     middle_point = len(array) // 2
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656627b47bd2d2a4afbc945d.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656627b47bd2d2a4afbc945d.md
@@ -40,6 +40,5 @@ You should use the slice syntax to extract the left half of the array and assign
 def merge_sort(array):
 --fcc-editable-region--
     middle_point = len(array) // 2
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656627b47bd2d2a4afbc945d.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656627b47bd2d2a4afbc945d.md
@@ -38,8 +38,8 @@ You should use the slice syntax to extract the left half of the array and assign
 
 ```py
 def merge_sort(array):
-    middle_point = len(array) // 2
 --fcc-editable-region--
+    middle_point = len(array) // 2
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656639771fed09b5c0e8fe71.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656639771fed09b5c0e8fe71.md
@@ -32,6 +32,5 @@ def merge_sort(array):
     left_part = array[:middle_point]
 --fcc-editable-region--
     right_part = array[middle_point:]
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656639771fed09b5c0e8fe71.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656639771fed09b5c0e8fe71.md
@@ -27,11 +27,11 @@ You should call `merge_sort` with the argument `left_part` at the bottom of your
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def merge_sort(array):
     middle_point = len(array) // 2
     left_part = array[:middle_point]
     right_part = array[middle_point:]
+    --fcc-editable-region--
 
---fcc-editable-region--
+    --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656639771fed09b5c0e8fe71.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656639771fed09b5c0e8fe71.md
@@ -30,8 +30,8 @@ You should call `merge_sort` with the argument `left_part` at the bottom of your
 def merge_sort(array):
     middle_point = len(array) // 2
     left_part = array[:middle_point]
+--fcc-editable-region--
     right_part = array[middle_point:]
-    --fcc-editable-region--
 
-    --fcc-editable-region--
+--fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656680b0fc79f2c38a34d90e.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656680b0fc79f2c38a34d90e.md
@@ -79,6 +79,5 @@ def merge_sort(array):
     merge_sort(left_part)
 --fcc-editable-region--
     merge_sort(right_part)
-    
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656680b0fc79f2c38a34d90e.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656680b0fc79f2c38a34d90e.md
@@ -77,8 +77,8 @@ def merge_sort(array):
     left_part = array[:middle_point]
     right_part = array[middle_point:]
     merge_sort(left_part)
-    merge_sort(right_part)
 --fcc-editable-region--
+    merge_sort(right_part)
     
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656702f8b4cbd8cbf0a433c6.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656702f8b4cbd8cbf0a433c6.md
@@ -48,8 +48,8 @@ def merge_sort(array):
 
     left_array_index = 0
     right_array_index = 0
-    sorted_index = 0
 --fcc-editable-region--
+    sorted_index = 0
     
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656702f8b4cbd8cbf0a433c6.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656702f8b4cbd8cbf0a433c6.md
@@ -50,6 +50,5 @@ def merge_sort(array):
     right_array_index = 0
 --fcc-editable-region--
     sorted_index = 0
-    
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656706afd65547d22bee0b68.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656706afd65547d22bee0b68.md
@@ -40,8 +40,8 @@ def merge_sort(array):
     right_array_index = 0
     sorted_index = 0
 
---fcc-editable-region--
     while left_array_index < len(left_part) and right_array_index < len(right_part):
+--fcc-editable-region--
         pass
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656707e11e671ed54c96f7ec.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656707e11e671ed54c96f7ec.md
@@ -42,10 +42,9 @@ def merge_sort(array):
     right_array_index = 0
     sorted_index = 0
 
---fcc-editable-region--
     while left_array_index < len(left_part) and right_array_index < len(right_part):
         if left_part[left_array_index] < right_part[right_array_index]:
+--fcc-editable-region--
             pass
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656709e50ed928da35260276.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656709e50ed928da35260276.md
@@ -46,8 +46,8 @@ def merge_sort(array):
     while left_array_index < len(left_part) and right_array_index < len(right_part):
         if left_part[left_array_index] < right_part[right_array_index]:
             array[sorted_index] = left_part[left_array_index]
-            left_array_index += 1
 --fcc-editable-region--
+            left_array_index += 1
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656709e50ed928da35260276.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656709e50ed928da35260276.md
@@ -48,6 +48,5 @@ def merge_sort(array):
             array[sorted_index] = left_part[left_array_index]
 --fcc-editable-region--
             left_array_index += 1
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656709e50ed928da35260276.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656709e50ed928da35260276.md
@@ -44,9 +44,10 @@ def merge_sort(array):
     sorted_index = 0
 
     while left_array_index < len(left_part) and right_array_index < len(right_part):
---fcc-editable-region--
         if left_part[left_array_index] < right_part[right_array_index]:
             array[sorted_index] = left_part[left_array_index]
             left_array_index += 1
+--fcc-editable-region--
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/65670d1ef177e7e2b76d9528.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/65670d1ef177e7e2b76d9528.md
@@ -49,7 +49,7 @@ def merge_sort(array):
             left_array_index += 1
         else:
             array[sorted_index] = right_part[right_array_index]
+--fcc-editable-region--
             right_array_index += 1
-    --fcc-editable-region--
-    --fcc-editable-region--
+--fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/65670d1ef177e7e2b76d9528.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/65670d1ef177e7e2b76d9528.md
@@ -43,7 +43,6 @@ def merge_sort(array):
     right_array_index = 0
     sorted_index = 0
 
---fcc-editable-region--
     while left_array_index < len(left_part) and right_array_index < len(right_part):
         if left_part[left_array_index] < right_part[right_array_index]:
             array[sorted_index] = left_part[left_array_index]
@@ -51,5 +50,6 @@ def merge_sort(array):
         else:
             array[sorted_index] = right_part[right_array_index]
             right_array_index += 1
---fcc-editable-region--
+    --fcc-editable-region--
+    --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656710d1e0ec62253426db24.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656710d1e0ec62253426db24.md
@@ -58,6 +58,5 @@ def merge_sort(array):
             right_array_index += 1
 --fcc-editable-region--
         sorted_index += 1
-    
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/656710d1e0ec62253426db24.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/656710d1e0ec62253426db24.md
@@ -56,8 +56,8 @@ def merge_sort(array):
         else:
             array[sorted_index] = right_part[right_array_index]
             right_array_index += 1
-        sorted_index += 1
 --fcc-editable-region--
+        sorted_index += 1
     
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b0a63423f65dd30888df.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b0a63423f65dd30888df.md
@@ -54,8 +54,8 @@ def merge_sort(array):
             right_array_index += 1
         sorted_index += 1
         
---fcc-editable-region--
     while left_array_index < len(left_part):
+--fcc-editable-region--
         pass
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b19d31a09b65b4bc390a.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b19d31a09b65b4bc390a.md
@@ -50,8 +50,8 @@ def merge_sort(array):
         sorted_index += 1
         
     while left_array_index < len(left_part):
-        array[sorted_index] = left_part[left_array_index]
 --fcc-editable-region--
+        array[sorted_index] = left_part[left_array_index]
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b19d31a09b65b4bc390a.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b19d31a09b65b4bc390a.md
@@ -49,9 +49,9 @@ def merge_sort(array):
             right_array_index += 1
         sorted_index += 1
         
---fcc-editable-region--
     while left_array_index < len(left_part):
         array[sorted_index] = left_part[left_array_index]
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b19d31a09b65b4bc390a.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b19d31a09b65b4bc390a.md
@@ -52,6 +52,5 @@ def merge_sort(array):
     while left_array_index < len(left_part):
 --fcc-editable-region--
         array[sorted_index] = left_part[left_array_index]
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b20f829b7e69d43c232a.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b20f829b7e69d43c232a.md
@@ -51,10 +51,10 @@ def merge_sort(array):
             right_array_index += 1
         sorted_index += 1
         
---fcc-editable-region--
     while left_array_index < len(left_part):
         array[sorted_index] = left_part[left_array_index]
         left_array_index += 1
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b20f829b7e69d43c232a.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b20f829b7e69d43c232a.md
@@ -53,8 +53,8 @@ def merge_sort(array):
         
     while left_array_index < len(left_part):
         array[sorted_index] = left_part[left_array_index]
-        left_array_index += 1
 --fcc-editable-region--
+        left_array_index += 1
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b20f829b7e69d43c232a.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b20f829b7e69d43c232a.md
@@ -55,6 +55,5 @@ def merge_sort(array):
         array[sorted_index] = left_part[left_array_index]
 --fcc-editable-region--
         left_array_index += 1
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b4e0bd29d17d4b53b16c.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b4e0bd29d17d4b53b16c.md
@@ -81,9 +81,7 @@ def merge_sort(array):
     while left_array_index < len(left_part):
         array[sorted_index] = left_part[left_array_index]
         left_array_index += 1
-        sorted_index += 1
-    
 --fcc-editable-region--
-    
+        sorted_index += 1 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b743630ee592a65a7e2f.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b743630ee592a65a7e2f.md
@@ -40,7 +40,6 @@ You should have a `return` statement in the body of the `if` statement.
 ```py
 --fcc-editable-region--
 def merge_sort(array):
-    
 --fcc-editable-region--
    
     middle_point = len(array) // 2

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b743630ee592a65a7e2f.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b743630ee592a65a7e2f.md
@@ -38,8 +38,8 @@ You should have a `return` statement in the body of the `if` statement.
 ## --seed-contents--
 
 ```py
-def merge_sort(array):
 --fcc-editable-region--
+def merge_sort(array):
     
 --fcc-editable-region--
    

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569b743630ee592a65a7e2f.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569b743630ee592a65a7e2f.md
@@ -38,8 +38,8 @@ You should have a `return` statement in the body of the `if` statement.
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def merge_sort(array):
+--fcc-editable-region--
     
 --fcc-editable-region--
    

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c05b9166f9d5bb36c09e.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c05b9166f9d5bb36c09e.md
@@ -62,6 +62,5 @@ def merge_sort(array):
 if __name__ == '__main__':
 --fcc-editable-region--
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c05b9166f9d5bb36c09e.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c05b9166f9d5bb36c09e.md
@@ -59,8 +59,9 @@ def merge_sort(array):
         right_array_index += 1
         sorted_index += 1
 
---fcc-editable-region--
 if __name__ == '__main__':
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
+--fcc-editable-region--
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c05b9166f9d5bb36c09e.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c05b9166f9d5bb36c09e.md
@@ -60,8 +60,8 @@ def merge_sort(array):
         sorted_index += 1
 
 if __name__ == '__main__':
-    numbers = [4, 10, 6, 14, 2, 1, 8, 5]
 --fcc-editable-region--
+    numbers = [4, 10, 6, 14, 2, 1, 8, 5]
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c166d708dcdf7c8fd34c.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c166d708dcdf7c8fd34c.md
@@ -59,10 +59,10 @@ def merge_sort(array):
         right_array_index += 1
         sorted_index += 1
 
---fcc-editable-region--
 if __name__ == '__main__':
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
     print('Unsorted array: ')
+--fcc-editable-region--
     
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c166d708dcdf7c8fd34c.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c166d708dcdf7c8fd34c.md
@@ -63,6 +63,5 @@ if __name__ == '__main__':
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
 --fcc-editable-region--
     print('Unsorted array: ')
-    
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c166d708dcdf7c8fd34c.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c166d708dcdf7c8fd34c.md
@@ -61,8 +61,8 @@ def merge_sort(array):
 
 if __name__ == '__main__':
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
-    print('Unsorted array: ')
 --fcc-editable-region--
+    print('Unsorted array: ')
     
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c1aeecaf95e25a3e2573.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c1aeecaf95e25a3e2573.md
@@ -65,6 +65,5 @@ if __name__ == '__main__':
     print('Unsorted array: ')
 --fcc-editable-region--
     print(numbers)
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c1aeecaf95e25a3e2573.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c1aeecaf95e25a3e2573.md
@@ -60,11 +60,11 @@ def merge_sort(array):
         sorted_index += 1
 
 
---fcc-editable-region--
 if __name__ == '__main__':
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
     print('Unsorted array: ')
     print(numbers)
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c1aeecaf95e25a3e2573.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c1aeecaf95e25a3e2573.md
@@ -63,8 +63,8 @@ def merge_sort(array):
 if __name__ == '__main__':
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
     print('Unsorted array: ')
-    print(numbers)
 --fcc-editable-region--
+    print(numbers)
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c2cbf6c993ea8cd85682.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c2cbf6c993ea8cd85682.md
@@ -62,12 +62,12 @@ def merge_sort(array):
         sorted_index += 1
 
 
---fcc-editable-region--
 if __name__ == '__main__':
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
     print('Unsorted array: ')
     print(numbers)
     merge_sort(numbers)
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c2cbf6c993ea8cd85682.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c2cbf6c993ea8cd85682.md
@@ -68,7 +68,6 @@ if __name__ == '__main__':
     print(numbers)
 --fcc-editable-region--
     merge_sort(numbers)
-
 --fcc-editable-region--
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6569c2cbf6c993ea8cd85682.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6569c2cbf6c993ea8cd85682.md
@@ -66,8 +66,8 @@ if __name__ == '__main__':
     numbers = [4, 10, 6, 14, 2, 1, 8, 5]
     print('Unsorted array: ')
     print(numbers)
-    merge_sort(numbers)
 --fcc-editable-region--
+    merge_sort(numbers)
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6577254891048c8f2c19e961.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6577254891048c8f2c19e961.md
@@ -25,13 +25,13 @@ You should call `merge_sort()` with the argument `right_part` at the bottom of y
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def merge_sort(array):
     middle_point = len(array) // 2
     left_part = array[:middle_point]
     right_part = array[middle_point:]
     
     merge_sort(left_part)
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6577254891048c8f2c19e961.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6577254891048c8f2c19e961.md
@@ -32,6 +32,5 @@ def merge_sort(array):
     
 --fcc-editable-region--
     merge_sort(left_part)
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6577254891048c8f2c19e961.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6577254891048c8f2c19e961.md
@@ -30,8 +30,8 @@ def merge_sort(array):
     left_part = array[:middle_point]
     right_part = array[middle_point:]
     
-    merge_sort(left_part)
 --fcc-editable-region--
+    merge_sort(left_part)
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6577562501feabdf0984a184.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6577562501feabdf0984a184.md
@@ -44,6 +44,5 @@ def merge_sort(array):
         if left_part[left_array_index] < right_part[right_array_index]:
 --fcc-editable-region--
             array[sorted_index] = left_part[left_array_index]
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6577562501feabdf0984a184.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6577562501feabdf0984a184.md
@@ -41,9 +41,9 @@ def merge_sort(array):
     sorted_index = 0
 
     while left_array_index < len(left_part) and right_array_index < len(right_part):
---fcc-editable-region--
         if left_part[left_array_index] < right_part[right_array_index]:
             array[sorted_index] = left_part[left_array_index]
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/6577562501feabdf0984a184.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/6577562501feabdf0984a184.md
@@ -42,8 +42,8 @@ def merge_sort(array):
 
     while left_array_index < len(left_part) and right_array_index < len(right_part):
         if left_part[left_array_index] < right_part[right_array_index]:
-            array[sorted_index] = left_part[left_array_index]
 --fcc-editable-region--
+            array[sorted_index] = left_part[left_array_index]
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/657823a9f4f372518614c8b7.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/657823a9f4f372518614c8b7.md
@@ -46,7 +46,7 @@ def merge_sort(array):
             left_array_index += 1
         
         else:
+--fcc-editable-region--
             array[sorted_index] = right_part[right_array_index]
-    --fcc-editable-region--
-    --fcc-editable-region--
+--fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/657823a9f4f372518614c8b7.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/657823a9f4f372518614c8b7.md
@@ -45,9 +45,8 @@ def merge_sort(array):
             array[sorted_index] = left_part[left_array_index]
             left_array_index += 1
         
---fcc-editable-region--
         else:
             array[sorted_index] = right_part[right_array_index]
-
---fcc-editable-region--
+    --fcc-editable-region--
+    --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/657f3a661730891aa64f3568.md
@@ -32,9 +32,10 @@ You should use the slice syntax to extract the right half of the array and assig
 ## --seed-contents--
 
 ```py
---fcc-editable-region--
 def merge_sort(array):
     middle_point = len(array) // 2
-    left_part = array[:middle_point]
+    left_part = array[:middle_point]   
+--fcc-editable-region--
+
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/657f3a661730891aa64f3568.md
@@ -34,8 +34,8 @@ You should use the slice syntax to extract the right half of the array and assig
 ```py
 def merge_sort(array):
     middle_point = len(array) // 2
-    left_part = array[:middle_point]   
 --fcc-editable-region--
+    left_part = array[:middle_point]   
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/657f3a661730891aa64f3568.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/657f3a661730891aa64f3568.md
@@ -36,6 +36,5 @@ def merge_sort(array):
     middle_point = len(array) // 2
 --fcc-editable-region--
     left_part = array[:middle_point]   
-
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/657f59751d5a5c9b069ae0f3.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/657f59751d5a5c9b069ae0f3.md
@@ -73,9 +73,9 @@ def merge_sort(array):
     while right_array_index < len(right_part):
         array[sorted_index] = right_part[right_array_index]
         right_array_index += 1
+--fcc-editable-region--
         sorted_index += 1
 
---fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-merge-sort/657f59751d5a5c9b069ae0f3.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort/657f59751d5a5c9b069ae0f3.md
@@ -75,7 +75,5 @@ def merge_sort(array):
         right_array_index += 1
 --fcc-editable-region--
         sorted_index += 1
-
-
 --fcc-editable-region--
 ```


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Audited the --fcc-editable-region-- markers for workshop-merge-sort.
Ensured each marker wraps only the lines a camper must modify.

Reference to: https://github.com/freeCodeCamp/freeCodeCamp/issues/67721