### PR TITLE
fix(curriculum): add missing DOCTYPE declaration to HTML steps

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68ec99e478211dc578699944.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68ec99e478211dc578699944.md
@@ -38,6 +38,7 @@ assert.exists(document.querySelector('.card h2 + p'));
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca11e99e3c5c894ca9d69.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca11e99e3c5c894ca9d69.md
@@ -42,6 +42,7 @@ assert.equal(document.querySelector('.card button')?.innerText.trim(), 'Buy Now'
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca2a795b333ca5fee30a8.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca2a795b333ca5fee30a8.md
@@ -34,6 +34,7 @@ assert.exists(document.querySelector('.card + .card'));
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca3cfeebef2cd8cc5f814.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca3cfeebef2cd8cc5f814.md
@@ -30,6 +30,7 @@ assert.equal(cards[1]?.id, 'dave-cooking-book');
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca4c4b0f952cf09fabe09.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca4c4b0f952cf09fabe09.md
@@ -30,6 +30,7 @@ assert.equal(cards[1]?.querySelector('h2')?.innerText.trim(), "Dave's Cooking Ad
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca5412b5dd9d06b3d6404.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca5412b5dd9d06b3d6404.md
@@ -41,6 +41,7 @@ assert.exists(cards[1]?.querySelector('h2 + p'));
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca5c0065c82d256d29ca3.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca5c0065c82d256d29ca3.md
@@ -46,6 +46,7 @@ assert.equal(cards[1]?.querySelector('button')?.innerText.trim(), 'Buy Now');
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6364c5616d393389a30.md
@@ -55,6 +55,7 @@ assert.exists(document.querySelector('p + .btn-container'));
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6e5a6759ed4ea0034dc.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6e5a6759ed4ea0034dc.md
@@ -119,6 +119,7 @@ assert.equal(buttons[1]?.innerText.trim(), 'Checkout');
 # --solutions--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6e5a6759ed4ea0034dc.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/68eca6e5a6759ed4ea0034dc.md
@@ -79,6 +79,7 @@ assert.equal(buttons[1]?.innerText.trim(), 'Checkout');
 ## --seed-contents--
 
 ```html
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ X ] My pull request targets the `main` branch of freeCodeCamp.
- [ X ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #67721 

<!-- Feel free to add any additional description of changes below this line -->
@majestic-owl448 pointed out that `<!DOCTYPE html>` is missing from step 11 onward. So added missing `DOCTYPE` declaration to affected steps. 