### PR TITLE
fix(gha): allow PRs from assignees of Naomi's Sprints

### DIFF
--- a/.github/scripts/pr-guidelines/check-linked-issue.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.js
@@ -45,29 +45,27 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
     return;
   }
 
-  // Naomi's Sprints assignees are exempt from the triage and open-for-contribution gates
-  // so this check must run before them.
+  // Assignees of a linked issue are exempt from the triage and open-for-contribution gates
+  // below, so this check must run before them. Naomi's Sprints assignees additionally get
+  // the label applied.
   const prAuthor = context.payload.pull_request.user.login;
-  const isNaomiSprintAssignee = linkedIssues.some(
-    issue =>
-      issue.labels.nodes.some(l => l.name === "Naomi's Sprints") &&
-      issue.assignees.nodes.some(a => a.login === prAuthor)
-  );
-  if (isNaomiSprintAssignee) {
-    await github.rest.issues.addLabels({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      issue_number: context.payload.pull_request.number,
-      labels: ["Naomi's Sprints"]
-    });
-    return;
-  }
-
-  // Assignees of a linked issue are also exempt from the triage and open-for-contribution gates.
-  const isLinkedIssueAssignee = linkedIssues.some(issue =>
+  const assignedIssues = linkedIssues.filter(issue =>
     issue.assignees.nodes.some(a => a.login === prAuthor)
   );
-  if (isLinkedIssueAssignee) return;
+  if (assignedIssues.length > 0) {
+    const isNaomiSprintAssignee = assignedIssues.some(issue =>
+      issue.labels.nodes.some(l => l.name === "Naomi's Sprints")
+    );
+    if (isNaomiSprintAssignee) {
+      await github.rest.issues.addLabels({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.payload.pull_request.number,
+        labels: ["Naomi's Sprints"]
+      });
+    }
+    return;
+  }
 
   const hasWaitingTriage = linkedIssues.some(issue =>
     issue.labels.nodes.some(l => l.name === 'status: waiting triage')

--- a/.github/scripts/pr-guidelines/check-linked-issue.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.js
@@ -45,16 +45,8 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
     return;
   }
 
-  const hasWaitingTriage = linkedIssues.some(issue =>
-    issue.labels.nodes.some(l => l.name === 'status: waiting triage')
-  );
-  if (hasWaitingTriage) {
-    core.setOutput('failure_reason', 'waiting_triage');
-    core.setFailed('Linked issue has not been triaged yet.');
-    await addDeprioritizedLabel(github, context);
-    return;
-  }
-
+  // Naomi's Sprints assignees are exempt from the triage and open-for-contribution
+  // gates below, so this check must run before them.
   const prAuthor = context.payload.pull_request.user.login;
   const isNaomiSprintAssignee = linkedIssues.some(
     issue =>
@@ -68,6 +60,16 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
       issue_number: context.payload.pull_request.number,
       labels: ["Naomi's Sprints"]
     });
+    return;
+  }
+
+  const hasWaitingTriage = linkedIssues.some(issue =>
+    issue.labels.nodes.some(l => l.name === 'status: waiting triage')
+  );
+  if (hasWaitingTriage) {
+    core.setOutput('failure_reason', 'waiting_triage');
+    core.setFailed('Linked issue has not been triaged yet.');
+    await addDeprioritizedLabel(github, context);
     return;
   }
 

--- a/.github/scripts/pr-guidelines/check-linked-issue.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.js
@@ -45,8 +45,8 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
     return;
   }
 
-  // Naomi's Sprints assignees are exempt from the triage and open-for-contribution
-  // gates below, so this check must run before them.
+  // Naomi's Sprints assignees are exempt from the triage and open-for-contribution gates
+  // so this check must run before them.
   const prAuthor = context.payload.pull_request.user.login;
   const isNaomiSprintAssignee = linkedIssues.some(
     issue =>
@@ -62,6 +62,12 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
     });
     return;
   }
+
+  // Assignees of a linked issue are also exempt from the triage and open-for-contribution gates.
+  const isLinkedIssueAssignee = linkedIssues.some(issue =>
+    issue.assignees.nodes.some(a => a.login === prAuthor)
+  );
+  if (isLinkedIssueAssignee) return;
 
   const hasWaitingTriage = linkedIssues.some(issue =>
     issue.labels.nodes.some(l => l.name === 'status: waiting triage')

--- a/.github/scripts/pr-guidelines/check-linked-issue.test.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const checkLinkedIssue = require('./check-linked-issue.js');
+
+const OWNER = 'freeCodeCamp';
+const REPO = 'freeCodeCamp';
+const PR_NUMBER = 42;
+const PR_AUTHOR = 'camper';
+
+const WAITING_TRIAGE = 'status: waiting triage';
+const NAOMIS_SPRINTS = "Naomi's Sprints";
+
+/** Build a linked-issue node with the given label names and assignee logins. */
+function issue({ labels = [], assignees = [] } = {}) {
+  return {
+    number: 1,
+    labels: { nodes: labels.map(name => ({ name })) },
+    assignees: { nodes: assignees.map(login => ({ login })) }
+  };
+}
+
+/** Build the deps object passed to the script, with linked issues controllable. */
+function setup({ linkedIssues = [], pullRequest = {}, isAllowListed = 'false' } = {}) {
+  const graphqlResult =
+    pullRequest === null
+      ? { repository: { pullRequest: null } }
+      : {
+          repository: {
+            pullRequest: {
+              closingIssuesReferences: { nodes: linkedIssues }
+            }
+          }
+        };
+
+  const github = {
+    graphql: vi.fn().mockResolvedValue(graphqlResult),
+    rest: { issues: { addLabels: vi.fn().mockResolvedValue({}) } }
+  };
+
+  const context = {
+    repo: { owner: OWNER, repo: REPO },
+    payload: {
+      pull_request: {
+        number: PR_NUMBER,
+        user: { login: PR_AUTHOR }
+      }
+    }
+  };
+
+  const core = {
+    setOutput: vi.fn(),
+    setFailed: vi.fn()
+  };
+
+  return { github, context, core, isAllowListed };
+}
+
+/** Labels passed across every addLabels call, flattened. */
+function addedLabels(github) {
+  return github.rest.issues.addLabels.mock.calls.flatMap(([args]) => args.labels);
+}
+
+describe('check-linked-issue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should do nothing when the PR author is allow-listed', async () => {
+    const deps = setup({ isAllowListed: 'true' });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.github.graphql).not.toHaveBeenCalled();
+    expect(deps.github.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(deps.core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('should return without action when the pull request cannot be resolved', async () => {
+    const deps = setup({ pullRequest: null });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.github.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(deps.core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('should deprioritize when there is no linked issue', async () => {
+    const deps = setup({ linkedIssues: [] });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.core.setOutput).toHaveBeenCalledWith(
+      'failure_reason',
+      'no_linked_issue'
+    );
+    expect(deps.core.setFailed).toHaveBeenCalled();
+    expect(addedLabels(deps.github)).toContain('deprioritized');
+  });
+
+  // If a Naomi's Sprints issue carries the 'status: waiting triage' label,
+  // the sprint exemption must win.
+  it("should apply the Naomi's Sprints label and skip the triage gate when the author is a sprint assignee on a still-untriaged issue", async () => {
+    const deps = setup({
+      linkedIssues: [
+        issue({
+          labels: [NAOMIS_SPRINTS, WAITING_TRIAGE],
+          assignees: [PR_AUTHOR]
+        })
+      ]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(addedLabels(deps.github)).toContain(NAOMIS_SPRINTS);
+    expect(addedLabels(deps.github)).not.toContain('deprioritized');
+    expect(deps.core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('should pass without action when the PR author is an assignee of a still-untriaged linked issue', async () => {
+    const deps = setup({
+      linkedIssues: [issue({ labels: [WAITING_TRIAGE], assignees: [PR_AUTHOR] })]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.github.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(deps.core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('should pass without action when the PR author is an assignee of a linked issue not open for contribution', async () => {
+    const deps = setup({
+      linkedIssues: [
+        issue({ labels: ['some-other-label'], assignees: [PR_AUTHOR] })
+      ]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.github.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(deps.core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('should deprioritize a still-untriaged linked issue when the PR author is not an assignee', async () => {
+    const deps = setup({
+      linkedIssues: [
+        issue({ labels: [WAITING_TRIAGE], assignees: ['someone-else'] })
+      ]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.core.setOutput).toHaveBeenCalledWith(
+      'failure_reason',
+      'waiting_triage'
+    );
+    expect(addedLabels(deps.github)).toContain('deprioritized');
+  });
+
+  it("should not exempt a Naomi's Sprints issue when the PR author is not an assignee", async () => {
+    const deps = setup({
+      linkedIssues: [
+        issue({
+          labels: [NAOMIS_SPRINTS, WAITING_TRIAGE],
+          assignees: ['someone-else']
+        })
+      ]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(addedLabels(deps.github)).not.toContain(NAOMIS_SPRINTS);
+    expect(deps.core.setOutput).toHaveBeenCalledWith(
+      'failure_reason',
+      'waiting_triage'
+    );
+    expect(addedLabels(deps.github)).toContain('deprioritized');
+  });
+
+  it('should deprioritize when the linked issue is still waiting triage', async () => {
+    const deps = setup({
+      linkedIssues: [issue({ labels: [WAITING_TRIAGE] })]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.core.setOutput).toHaveBeenCalledWith(
+      'failure_reason',
+      'waiting_triage'
+    );
+    expect(deps.core.setFailed).toHaveBeenCalled();
+    expect(addedLabels(deps.github)).toContain('deprioritized');
+  });
+
+  it("should pass without action when the linked issue is labeled 'help wanted'", async () => {
+    const deps = setup({
+      linkedIssues: [issue({ labels: ['help wanted'] })]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.github.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(deps.core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it("should pass without action when the linked issue is labeled 'first timers only'", async () => {
+    const deps = setup({
+      linkedIssues: [issue({ labels: ['first timers only'] })]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.github.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(deps.core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('should deprioritize when the linked issue is not open for contribution', async () => {
+    const deps = setup({
+      linkedIssues: [issue({ labels: ['some-other-label'] })]
+    });
+
+    await checkLinkedIssue(deps);
+
+    expect(deps.core.setOutput).toHaveBeenCalledWith(
+      'failure_reason',
+      'not_open_for_contribution'
+    );
+    expect(deps.core.setFailed).toHaveBeenCalled();
+    expect(addedLabels(deps.github)).toContain('deprioritized');
+  });
+});

--- a/.github/workflows/github-scripts-tests.yml
+++ b/.github/workflows/github-scripts-tests.yml
@@ -38,13 +38,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
 
       - name: Run tests
-        # --dir scopes test discovery to .github/scripts while keeping the root
-        # (and module resolution) at the repo level, so `vitest` resolves even
-        # though .github/scripts is not a pnpm workspace package.
-        run: pnpm exec vitest run --dir .github/scripts
+        # Fetch vitest on demand as the scripts under .github/scripts
+        # are not part of the pnpm workspace and have no runtime dependencies.
+        run: pnpm dlx vitest@4 run --dir .github/scripts

--- a/.github/workflows/github-scripts-tests.yml
+++ b/.github/workflows/github-scripts-tests.yml
@@ -1,0 +1,50 @@
+name: GitHub - Scripts Tests
+
+# Unit tests for the scripts that backs our GHA workflows
+# These scripts are not part of the pnpm workspace, so they are not
+# covered by the repository-wide `turbo test` run. This workflow runs them
+# only when the scripts or this workflow change, so it stays off unrelated PRs.
+
+on:
+  pull_request:
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/github-scripts-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        node-version: [24]
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
+        with:
+          run_install: false
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        # --dir scopes test discovery to .github/scripts while keeping the root
+        # (and module resolution) at the repo level, so `vitest` resolves even
+        # though .github/scripts is not a pnpm workspace package.
+        run: pnpm exec vitest run --dir .github/scripts


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces - I ran the tests locally, but not the new workflow

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
 - Fixes an evaluation-order bug where PRs linked to a Naomi's Sprints issue received the `deprioritized` label (example: #67796). 
   - Cause: It's an order-of-execution bug. The `Naomi's Sprints` check ran after the triage and open-for-contribution gates, instead of before them.
- Expands the assignee check rule to allow any assignee of a linked issue open a PR without it being deprioritized: if the PR author is an assignee of a linked issue, the check returns early and won't fail. 
  - This covers contributors who are assigned to an issue that isn't part of a sprint (for whatever reason). 
  - If the linked issue carries the `Naomi's Sprints` label, the label is still added to the PR.
- Adds tests for the script and a new workflow to run them in CI 
  - I decided to split because it feels weird to consolidate this with /learn tests. The `.github` directory also need to be a workspace in order to be in that pipeline.
  - The workflow only runs when the scripts or the workflow file change.

<!-- Feel free to add any additional description of changes below this line -->
