### PR TITLE
fix(curriculum): correct editable region markers in workshop-reusable-profile-card-component

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e4691659.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e4691659.md
@@ -138,11 +138,11 @@ body {
 ```jsx
 export function Card({ name, title, bio }) {
   return (
-    --fcc-editable-region--
     <div className="card">
-      
-    </div>
     --fcc-editable-region--
+      
+    --fcc-editable-region--
+    </div>
   )
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/687799aefd1f2af1704065d0.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/687799aefd1f2af1704065d0.md
@@ -134,15 +134,15 @@ export function App() {
   ];
   return (
     <div className="flex-container">
-      --fcc-editable-region--
       {profiles.map((profile) => (
+        --fcc-editable-region--
         <Card
           name={profile.name}
           title={profile.title}
           bio={profile.bio}
         />
-      ))}
       --fcc-editable-region--
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Refrence to https://github.com/freeCodeCamp/freeCodeCamp/issues/67721

This PR is part of Naomi's Sprint for editable regions.

This PR fixes editable regions in  workshop-reusable-profile-card-component
<!-- Feel free to add any additional description of changes below this line -->
