### PR TITLE
fix: clarify hint wording in bill splitter step 6

### DIFF
--- a/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
+++ b/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
@@ -180,6 +180,7 @@ assert.isObject(result);
 assert.isArray(result.fridge);
 assert.isArray(result.pantry);
 ```
+
 Your `groupByZone` function should correctly group actions with the right content and count.
 
 ``` js
@@ -196,6 +197,7 @@ assert.lengthOf(result.pantry, 1);
 assert.strictEqual(result.fridge[0].item.sku, "A1");
 assert.strictEqual(result.pantry[0].type, "discard");
 ```
+
 You should define a function named `clonePantry` that accepts one parameter called `pantry`.
 
 ``` js

--- a/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
+++ b/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
@@ -180,7 +180,6 @@ assert.isObject(result);
 assert.isArray(result.fridge);
 assert.isArray(result.pantry);
 ```
-
 Your `groupByZone` function should correctly group actions with the right content and count.
 
 ``` js
@@ -197,7 +196,6 @@ assert.lengthOf(result.pantry, 1);
 assert.strictEqual(result.fridge[0].item.sku, "A1");
 assert.strictEqual(result.pantry[0].type, "discard");
 ```
-
 You should define a function named `clonePantry` that accepts one parameter called `pantry`.
 
 ``` js

--- a/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
+++ b/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
@@ -180,7 +180,6 @@ assert.isObject(result);
 assert.isArray(result.fridge);
 assert.isArray(result.pantry);
 ```
-Your `groupByZone` function should correctly group actions with the right content and count.
 
 Your `groupByZone` function should correctly group actions with the right content and count.
 

--- a/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
+++ b/curriculum/challenges/english/blocks/lab-smart-pantry-restocker/69a5f35669099ed52f8563b1.md
@@ -31,7 +31,7 @@ The `rawData` array contains pipe-separated strings with the format `sku|name|qt
    - Otherwise, if the shipment item's `sku` already exists in the pantry, the action `type` should be `"restock"`.
    - Otherwise (the shipment item's `sku` does not exist in the pantry), the action `type` should be `"donate"`.
 
-3. You should implement a `groupByZone(actions)` function that groups the actions into storage zones based on each item’s `zone` property.
+3. You should implement a `groupByZone(actions)` function that groups the actions into storage zones based on each item's `zone` property. The function should return an object where each key is a zone name and the value is an array of actions belonging to that zone. For example, if actions contain items with zones `"fridge"` and `"pantry"`, the result should be `{ fridge: [...], pantry: [...] }`.
 
 4. You should implement a `clonePantry(pantry)` function that returns a deep copy of the pantry so planning changes do not affect the original list. A deep copy means creating a new array with new objects, so modifying the copy does not change the original pantry.
 
@@ -180,7 +180,22 @@ assert.isObject(result);
 assert.isArray(result.fridge);
 assert.isArray(result.pantry);
 ```
+Your `groupByZone` function should correctly group actions with the right content and count.
 
+``` js
+const actions = [
+  { type: "restock", item: { sku: "A1", zone: "fridge" } },
+  { type: "donate",  item: { sku: "B1", zone: "fridge" } },
+  { type: "discard", item: { sku: "C1", zone: "pantry" } },
+];
+
+const result = groupByZone(actions);
+
+assert.lengthOf(result.fridge, 2);
+assert.lengthOf(result.pantry, 1);
+assert.strictEqual(result.fridge[0].item.sku, "A1");
+assert.strictEqual(result.pantry[0].type, "discard");
+```
 You should define a function named `clonePantry` that accepts one parameter called `pantry`.
 
 ``` js

--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 Now that you have calculated the tip, you need to add it to your `running_total` to find the final bill amount.
 
-Use the += operator to add the value of tip to your running_total. Finally, use print() to display the string Total with tip: followed by a space and the value of running_total.`
+Use the `+=` operator to add the value of `tip` to your `running_total`. Finally, use `print()` to display the string `Total with tip:` followed by a space and the value of `running_total`.
 
 # --hints--
 
@@ -23,7 +23,7 @@ You should use the `+=` operator to add the value of `tip` to your `running_tota
 })
 ```
 
-You should print the string Total with tip: followed by a space and the running_total variable.
+You should print the string `Total with tip:` followed by a space and the `running_total` variable.
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 Now that you have calculated the tip, you need to add it to your `running_total` to find the final bill amount.
 
-Use the `+=` operator to add the value of `tip` to your `running_total`. Finally, use `print()` to display the string `Total with tip:` followed by a space and the value of `running_total`.
+Use the `+=` operator to add the value of `tip` to your `running_total`. Finally, pass two arguments to `print()` to display the string `Total with tip:` and the value of `running_total`
 
 # --hints--
 
@@ -23,7 +23,7 @@ You should use the `+=` operator to add the value of `tip` to your `running_tota
 })
 ```
 
-You should print the string `Total with tip:` followed by a space and the `running_total` variable.
+You should pass two arguments to `print()` to display the string `Total with tip:` and the value of `running_total`.
 
 ```js
 ({

--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
@@ -27,8 +27,18 @@ You should pass two arguments to `print()` to display the string `Total with tip
 
 ```js
 ({
-    test: () => assert(runPython(`
-    _Node(_code).has_call("print('Total with tip:', running_total)") or _Node(_code).has_call("print(f'Total with tip: {running_total}')")`))
+    test: () => runPython(`
+import io, contextlib, re
+
+buffer = io.StringIO()
+with contextlib.redirect_stdout(buffer):
+    exec(_code)
+
+match = re.search(r"Total with tip: ([0-9]+(?:\\.[0-9]+)?)", buffer.getvalue())
+
+assert match
+assert abs(float(match.group(1)) - ((37.89 + 57.34 + 39.39 + 64.21) * 1.25)) < 1e-6
+    `)
 })
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a4306bb3e856690a4890.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 Now that you have calculated the tip, you need to add it to your `running_total` to find the final bill amount.
 
-Use the `+=` operator to add the value of `tip` to your `running_total`. Finally, pass two arguments to `print()` to display the string `Total with tip:` and the value of `running_total`
+Use the += operator to add the value of tip to your running_total. Finally, use print() to display the string Total with tip: followed by a space and the value of running_total.`
 
 # --hints--
 
@@ -23,7 +23,7 @@ You should use the `+=` operator to add the value of `tip` to your `running_tota
 })
 ```
 
-You should pass two arguments to `print()` to display the string `Total with tip:` and the value of `running_total`.
+You should print the string Total with tip: followed by a space and the running_total variable.
 
 ```js
 ({


### PR DESCRIPTION
Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #67819
<!-- Feel free to add any additional description of changes below this line -->
Continuation of #67442. Updates hint text in step 6 to match the description wording.