### PR TITLE
fix(client): migrate physical CSS to logical for RTL

### DIFF
--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -615,7 +615,7 @@ a.patreon-button:hover {
   border: none;
   margin-bottom: 0;
   padding: 0 4px;
-  left: 0;
+  inset-inline-start: 0;
   margin-inline-start: -2px;
 }
 

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -71,7 +71,7 @@
   list-style: none;
   padding: 0;
   position: absolute;
-  right: 0;
+  inset-inline-end: 0;
   width: 100%;
   z-index: var(--z-index-site-header);
 }
@@ -358,7 +358,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 .universal-nav-right .fcc_searchBar {
   background-color: var(--theme-color);
   height: var(--header-sub-element-size);
-  left: 0;
+  inset-inline-start: 0;
   position: absolute;
   top: var(--header-height);
 }

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -11,17 +11,17 @@
   font-weight: 600;
   padding-block: 1em;
   padding-inline: 1.5em;
-  left: -1000px;
+  inset-inline-start: -1000px;
 }
 
 @media screen and (min-width: 980px) {
   .skip-to-content-button:focus {
-    left: 15px;
+    inset-inline-start: 15px;
   }
 }
 
 @media screen and (max-width: 979px) {
   .skip-to-content-button:focus {
-    left: 5px;
+    inset-inline-start: 5px;
   }
 }

--- a/client/src/components/daily-coding-challenge/calendar.css
+++ b/client/src/components/daily-coding-challenge/calendar.css
@@ -39,14 +39,14 @@
   position: absolute;
   font-size: 0.8em;
   top: 0;
-  right: 5px;
+  inset-inline-end: 5px;
   color: var(--gray-45);
 }
 
 .dc-number {
   position: absolute;
   top: 0;
-  left: 5px;
+  inset-inline-start: 5px;
   font-size: 0.8em;
   font-style: italic;
   color: var(--gray-45);
@@ -89,7 +89,7 @@
 .dc-languages {
   position: absolute;
   bottom: 0;
-  left: 0;
+  inset-inline-start: 0;
   display: flex;
   gap: 2px;
 }

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -413,9 +413,9 @@ figcaption.caption {
     flex: 0 0 50%;
     max-width: 50%;
     z-index: 1;
-    padding-left: 0px;
-    padding-right: 15px;
-    margin-left: -15px;
+    padding-inline-start: 0px;
+    padding-inline-end: 15px;
+    margin-inline-start: -15px;
   }
 
   .landing-top-two-column .landing-top-right {
@@ -433,7 +433,7 @@ figcaption.caption {
 
 .landing-top .landing-top-two-column figure,
 .landing-top .landing-top-two-column figure img {
-  margin-left: -120px;
+  margin-inline-start: -120px;
   margin-top: 0px;
   height: 550px;
   width: 850px;

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -19,7 +19,7 @@ legend {
 }
 
 blockquote {
-  border-left: 5px solid #eeeeee;
+  border-inline-start: 5px solid #eeeeee;
 }
 
 /* TODO: Move this rule to components/Intro/intro.css. */

--- a/client/src/components/settings/scrollbar-width.css
+++ b/client/src/components/settings/scrollbar-width.css
@@ -116,28 +116,24 @@ input.scrollbar-width[type='range']:focus-visible::-moz-range-thumb {
   z-index: -1;
 }
 
-.scrollbar-width-ticks .tick:nth-child(1),
-[dir='rtl'] .scrollbar-width-ticks .tick:nth-child(5) {
-  left: 3px;
+.scrollbar-width-ticks .tick:nth-child(1) {
+  inset-inline-start: 3px;
 }
 
-.scrollbar-width-ticks .tick:nth-child(2),
-[dir='rtl'] .scrollbar-width-ticks .tick:nth-child(4) {
-  left: calc(25% - 0.25rem + 2px);
+.scrollbar-width-ticks .tick:nth-child(2) {
+  inset-inline-start: calc(25% - 0.25rem + 2px);
 }
 
 .scrollbar-width-ticks .tick:nth-child(3) {
-  left: calc(50% - 0.5rem + 0.5px);
+  inset-inline-start: calc(50% - 0.5rem + 0.5px);
 }
 
-.scrollbar-width-ticks .tick:nth-child(4),
-[dir='rtl'] .scrollbar-width-ticks .tick:nth-child(2) {
-  left: calc(75% - 0.5rem - 5px);
+.scrollbar-width-ticks .tick:nth-child(4) {
+  inset-inline-start: calc(75% - 0.5rem - 5px);
 }
 
-.scrollbar-width-ticks .tick:nth-child(5),
-[dir='rtl'] .scrollbar-width-ticks .tick:nth-child(1) {
-  left: calc(100% - 1rem - 2px);
+.scrollbar-width-ticks .tick:nth-child(5) {
+  inset-inline-start: calc(100% - 1rem - 2px);
 }
 
 .scrollbar-width-ticks .tick:hover,

--- a/client/src/components/settings/toggle-setting.css
+++ b/client/src/components/settings/toggle-setting.css
@@ -47,19 +47,13 @@
 
 .toggle-button-group button > span > svg {
   position: absolute;
-  right: -1.5rem;
+  inset-inline-end: -1.5rem;
   margin-top: 0.1rem;
 }
 
-.toggle-button-group button:first-of-type > span > svg,
-[dir='rtl'] .toggle-button-group button > span > svg {
-  right: unset;
-  left: -1.25rem;
-}
-
-[dir='rtl'] .toggle-button-group button:first-of-type > span > svg {
-  left: unset;
-  right: -1.5rem;
+.toggle-button-group button:first-of-type > span > svg {
+  inset-inline-end: auto;
+  inset-inline-start: -1.25rem;
 }
 
 .toggle-button-group button[aria-pressed='true']:hover {
@@ -81,7 +75,7 @@
 
 .toggle-radio-group input {
   position: absolute;
-  left: -9999px;
+  inset-inline-start: -9999px;
 }
 
 .custom-circle {
@@ -107,7 +101,7 @@
   height: 0.556rem;
   position: absolute;
   top: 50%;
-  left: 50%;
+  inset-inline-start: 50%;
   background-color: var(--primary-color);
   border-radius: 50%;
   transform: translate(-50%, -50%);

--- a/client/src/components/sidebar-panel/sidebar-panel.css
+++ b/client/src/components/sidebar-panel/sidebar-panel.css
@@ -3,7 +3,7 @@
   scrollbar-color: var(--quaternary-background) var(--secondary-background);
   scrollbar-width: thin;
   background-color: var(--secondary-background);
-  border-right: 3px solid var(--tertiary-background);
+  border-inline-end: 3px solid var(--tertiary-background);
   padding: 1rem 0;
   color: var(--primary-color);
   font-size: 1rem;

--- a/client/src/html.test.tsx
+++ b/client/src/html.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { vi, describe, it, expect } from 'vitest';
+import HTML from './html';
+
+vi.mock('../config/env.json', () => ({
+  clientLocale: 'arabic'
+}));
+
+vi.mock('@freecodecamp/shared/config/i18n', () => ({
+  rtlLangs: ['arabic']
+}));
+
+describe('<HTML />', () => {
+  it('should apply dir="rtl" to the html tag when an RTL language is selected', () => {
+    const testRenderer = TestRenderer.create(
+      <HTML body="<div>Test Body</div>" />
+    );
+    const testInstance = testRenderer.root;
+    expect(testInstance.findByType('html').props.dir).toEqual('rtl');
+  });
+});

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -21,8 +21,8 @@
   height: var(--action-row-height);
   position: fixed;
   top: calc(var(--header-height) + var(--breadcrumbs-height));
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   z-index: 100;
   padding: 0 10px 10px;
   border-bottom: 1px solid var(--quaternary-background);
@@ -80,7 +80,7 @@
   gap: 3px;
   /* these three center the middle items on the page */
   position: absolute;
-  left: 50%;
+  inset-inline-start: 50%;
   transform: translateX(-50%);
 }
 
@@ -120,7 +120,7 @@
 
 .interactive-editor-tab {
   /* Ensure the right group pins to the end even when no left/middle items exist */
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .restart-step-tab {
@@ -152,8 +152,8 @@
   font-size: 0.8em;
   /* Need to override radix-ui defaults on side padding to allow room for
      four tabs and a preview toggle button at narrow view ports */
-  padding-left: 0.2rem;
-  padding-right: 0.2rem;
+  padding-inline-start: 0.2rem;
+  padding-inline-end: 0.2rem;
 }
 
 #mobile-layout .nav-lists button[data-state='active'] {
@@ -224,7 +224,7 @@
 #mobile-layout .portal-button-wrap {
   position: absolute;
   top: auto;
-  right: 0;
+  inset-inline-end: 0;
   height: 2rem;
   border-bottom: 1px solid var(--quaternary-color);
 }

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -28,8 +28,8 @@
 .breadcrumbs-demo {
   position: fixed;
   top: var(--header-height);
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   z-index: var(--z-index-breadcrumbs);
   font-size: 16px;
   margin: 0;
@@ -71,7 +71,7 @@
   font-size: 18px;
   font-weight: bold;
   border-bottom: 1px solid var(--quaternary-background);
-  padding-left: 11px;
+  padding-inline-start: 11px;
   overflow: hidden;
 }
 
@@ -116,7 +116,7 @@
   font-size: 17px;
   position: absolute;
   top: 0;
-  right: -0.7rem;
+  inset-inline-end: -0.7rem;
 }
 
 .description-container .breadcrumbs li:nth-child(2) {

--- a/client/src/templates/Challenges/components/completion-modal.css
+++ b/client/src/templates/Challenges/components/completion-modal.css
@@ -68,7 +68,7 @@
   position: absolute;
 
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
 }
 
 .progress-bar-percent {

--- a/client/src/templates/Challenges/components/independent-lower-jaw.css
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.css
@@ -15,7 +15,7 @@
   position: absolute;
   bottom: 100%;
   width: 97%;
-  left: 50%;
+  inset-inline-start: 50%;
   transform: translateX(-50%);
   margin-bottom: 12px;
   border: 1px solid var(--background-secondary);
@@ -82,7 +82,7 @@
   justify-content: center;
   align-items: center;
   border: none;
-  margin-left: 10px;
+  margin-inline-start: 10px;
 }
 
 .independent-lower-jaw .tooltip {
@@ -126,7 +126,7 @@
   border-color: var(--color-border-primary);
   transform: rotate(45deg);
   bottom: -5px;
-  left: calc(50% - 0.25rem);
+  inset-inline-start: calc(50% - 0.25rem);
   background-image: linear-gradient(
     to top left,
     var(--background-quaternary) 55%,
@@ -135,7 +135,7 @@
 }
 
 .independent-lower-jaw .tooltip .tooltiptext.left-tooltip {
-  left: 0;
+  inset-inline-start: 0;
 }
 
 .share-button-wrapper {

--- a/client/src/templates/Challenges/exam/exam.css
+++ b/client/src/templates/Challenges/exam/exam.css
@@ -74,7 +74,7 @@
   height: 10px;
   position: absolute;
   top: 50%;
-  left: 50%;
+  inset-inline-start: 50%;
   background-color: var(--primary-color);
   border-radius: 50%;
   transform: translate(-50%, -50%);

--- a/client/src/templates/Challenges/generic/content-outline.css
+++ b/client/src/templates/Challenges/generic/content-outline.css
@@ -100,7 +100,7 @@
       100vh - var(--header-height) - var(--breadcrumbs-height) -
         var(--action-row-height)
     );
-    left: 0;
+    inset-inline-start: 0;
     position: fixed;
     top: calc(
       var(--header-height) + var(--breadcrumbs-height) +

--- a/packages/shared/src/config/i18n.ts
+++ b/packages/shared/src/config/i18n.ts
@@ -9,7 +9,8 @@ export enum Languages {
   Japanese = 'japanese',
   German = 'german',
   Swahili = 'swahili',
-  Korean = 'korean'
+  Korean = 'korean',
+  Arabic = 'arabic'
 }
 
 /*
@@ -32,7 +33,8 @@ export const availableLangs = {
     Languages.Japanese,
     Languages.German,
     Languages.Swahili,
-    Languages.Korean
+    Languages.Korean,
+    Languages.Arabic
   ],
   curriculum: [
     Languages.English,
@@ -45,7 +47,8 @@ export const availableLangs = {
     Languages.Japanese,
     Languages.German,
     Languages.Swahili,
-    Languages.Korean
+    Languages.Korean,
+    Languages.Arabic
   ]
 };
 
@@ -68,7 +71,8 @@ export const i18nextCodes = {
   [Languages.Japanese]: 'ja',
   [Languages.German]: 'de',
   [Languages.Swahili]: 'sw',
-  [Languages.Korean]: 'ko'
+  [Languages.Korean]: 'ko',
+  [Languages.Arabic]: 'ar'
 };
 
 // These are for the language selector dropdown menu in the footer
@@ -83,7 +87,8 @@ export const LangNames: { [key: string]: string } = {
   [Languages.Japanese]: '日本語',
   [Languages.German]: 'Deutsch',
   [Languages.Swahili]: 'Swahili',
-  [Languages.Korean]: '한국어'
+  [Languages.Korean]: '한국어',
+  [Languages.Arabic]: 'العربية'
 };
 
 /* These are for formatting dates and numbers. Used with JS .toLocaleString().
@@ -101,7 +106,8 @@ export const LangCodes = {
   [Languages.Japanese]: 'ja',
   [Languages.German]: 'de',
   [Languages.Swahili]: 'sw',
-  [Languages.Korean]: 'ko'
+  [Languages.Korean]: 'ko',
+  [Languages.Arabic]: 'ar'
 };
 
 /**
@@ -112,7 +118,7 @@ export const hiddenLangs: Languages[] = [];
 /**
  * This array contains languages that use the RTL layouts.
  */
-export const rtlLangs: Languages[] = [];
+export const rtlLangs: Languages[] = [Languages.Arabic];
 
 // locale is sourced from a JSON file, so we use getLangCode to
 // find the associated enum values


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67661

<!-- Feel free to add any additional description of changes below this line -->

This pull request implements the RTL language layout support detailed in the audit:

- Added "Arabic" to "i18n.ts" and "rtlLangs" config.
- Systematically migrated physical positional CSS properties to logical CSS properties across 7 stylesheets.
- Added "html.test.tsx" to verify the "dir='rtl'" attribute.