### PR TITLE
fix(curriculum): audit editable region in workshop-library-manager

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-library-manager/681dc623b2b18887266777b1.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/681dc623b2b18887266777b1.md
@@ -123,7 +123,7 @@ console.log("Books in the Library:\n");
 
 function getBookInformation(catalog) {
 --fcc-editable-region--
-
+  
 --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/681dc623b2b18887266777b1.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/681dc623b2b18887266777b1.md
@@ -121,9 +121,9 @@ const library = [
 
 console.log("Books in the Library:\n");
 
---fcc-editable-region--
 function getBookInformation(catalog) {
-  
-}
 --fcc-editable-region--
+
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/6822595203b35c00b87c0524.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/6822595203b35c00b87c0524.md
@@ -122,11 +122,11 @@ const library = [
 
 console.log("Books in the Library:\n");
 
---fcc-editable-region--
 function getBookInformation(catalog) {
-  return catalog.map(book => book.title);
-}
 --fcc-editable-region--
+  return catalog.map(book => book.title);
+--fcc-editable-region--
+}
 
 console.log(getBookInformation(library));
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/68225ea2f1aae301fa4df0f4.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/68225ea2f1aae301fa4df0f4.md
@@ -125,11 +125,11 @@ const library = [
 
 console.log("Books in the Library:\n");
 
---fcc-editable-region--
 function getBookInformation(catalog) {
-  return catalog.map(book => `${book.title} by ${book.author}`)
-}
 --fcc-editable-region--
+  return catalog.map(book => `${book.title} by ${book.author}`)
+--fcc-editable-region--
+}
 
 console.log(getBookInformation(library));
 ```

--- a/curriculum/challenges/english/blocks/workshop-library-manager/6822694e3d34c807feeaba50.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/6822694e3d34c807feeaba50.md
@@ -127,8 +127,8 @@ console.log(getBookInformation(library));
 
 console.log("\nList of book summaries:\n");
 
---fcc-editable-region--
 function getBookSummaries(catalog) {
+--fcc-editable-region--
   return catalog.map((book) => book.about)
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Refs #67721 

<!-- Feel free to add any additional description of changes below this line -->

## Description

Auideted the region in `workshop-library-manager`.

## Changes

Step - 6
Step- 8
Step- 9
Step- 12

## Why

Keeping editable regions focused helps new learners understand exactly where they should make changes without accidentally editing surrounding context.