### PR TITLE
fix(curriculum): update print tests for build a bill splitter steps 7-8

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a8bbcbdd557886bd0718.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/6977a8bbcbdd557886bd0718.md
@@ -45,8 +45,18 @@ You should print the string `Bill per person:` followed by a space and the `fina
 
 ```js
 ({
-    test: () => assert(runPython(`
-    _Node(_code).has_call("print('Bill per person:', final_bill)") or _Node(_code).has_call("print(f'Bill per person: {final_bill}')")`))
+    test: () => runPython(`
+import io, contextlib, re
+
+buffer = io.StringIO()
+with contextlib.redirect_stdout(buffer):
+    exec(_code)
+
+match = re.search(r"Bill per person: ([0-9]+(?:\\.[0-9]+)?)", buffer.getvalue())
+
+assert match
+assert abs(float(match.group(1)) - (((37.89 + 57.34 + 39.39 + 64.21) * 1.25) / 4)) < 1e-6
+`)
 })
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bill-splitter/697a7f71ebfcd9e4cacd69c2.md
+++ b/curriculum/challenges/english/blocks/workshop-bill-splitter/697a7f71ebfcd9e4cacd69c2.md
@@ -48,8 +48,18 @@ You should use `print()` to display the string `Each person pays:` followed by a
 
 ```js
 ({
-    test: () => assert(runPython(`
-    _Node(_code).has_call("print('Each person pays:', each_pays)") or _Node(_code).has_call("print(f'Each person pays: {each_pays}')")`))
+    test: () => runPython(`
+import io, contextlib, re
+
+buffer = io.StringIO()
+with contextlib.redirect_stdout(buffer):
+    exec(_code)
+
+match = re.search(r"Each person pays: ([0-9]+(?:\\.[0-9]+)?)", buffer.getvalue())
+
+assert match
+assert abs(float(match.group(1)) - 62.13) < 1e-6
+`)
 })
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.



Closes #67819

Updates Steps 6, 7, and 8 of the "Build a Bill Splitter" Python project to use stdout redirection and regex validation for checking `print` outputs (with a float tolerance of `1e-6`). This aligns them with Steps 4 and 5, allowing valid alternative print formats (like string concatenation) that were previously blocked by structural AST syntax checking.
