### PR TITLE
fix(curriculum): inconsistencies across steps in accessible audio controller

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68e6aff5325410118e76e7be.md
+++ b/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68e6aff5325410118e76e7be.md
@@ -45,9 +45,11 @@ assert.strictEqual(h1Text, 'Audio Controls');
     <title>Accessible Controls</title>
   </head>
   <body>
+
 --fcc-editable-region--
     
 --fcc-editable-region--
+
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68eac57fadcc662ce917e75e.md
+++ b/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68eac57fadcc662ce917e75e.md
@@ -54,9 +54,11 @@ assert.strictEqual(button?.innerText.trim(), 'Play');
   <body>
 
     <h1>Audio Controls</h1>
+
 --fcc-editable-region--
     
 --fcc-editable-region--
+
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68ed3a96e0ebcc36565b39e5.md
+++ b/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68ed3a96e0ebcc36565b39e5.md
@@ -95,7 +95,7 @@ assert.equal(inputEl?.getAttribute('value'), '50');
       <span id="volume-label">Volume</span>
       <span id="volume-description">Adjust the sound level</span>
     --fcc-editable-region--
-    
+      
     --fcc-editable-region--
     </div>
 

--- a/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68ed4204ab7edc66b6cb2383.md
+++ b/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68ed4204ab7edc66b6cb2383.md
@@ -49,7 +49,7 @@ assert.oneOf(ariaLabelledbyAttr, ['volume-label volume-description', 'volume-des
       <span id="volume-label">Volume</span>
       <span id="volume-description">Adjust the sound level</span>
     --fcc-editable-region--
-    <input type="range" min="0" max="100" value="50">
+      <input type="range" min="0" max="100" value="50">
     --fcc-editable-region--
     </div>
 

--- a/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68ed488821845990c911a223.md
+++ b/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68ed488821845990c911a223.md
@@ -66,6 +66,7 @@ assert.equal(buttonEl?.innerText.trim(), 'Mute');
       <input type="range" min="0" max="100" value="50"
            aria-labelledby="volume-label volume-description">
     </div>
+
   --fcc-editable-region--
     
   --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68ed488821845990c911a223.md
+++ b/curriculum/challenges/english/blocks/workshop-accessible-audio-controller/68ed488821845990c911a223.md
@@ -64,7 +64,7 @@ assert.equal(buttonEl?.innerText.trim(), 'Mute');
       <span id="volume-label">Volume</span>
       <span id="volume-description">Adjust the sound level</span>
       <input type="range" min="0" max="100" value="50"
-           aria-labelledby="volume-label volume-description">
+        aria-labelledby="volume-label volume-description">
     </div>
 
   --fcc-editable-region--
@@ -94,7 +94,7 @@ assert.equal(buttonEl?.innerText.trim(), 'Mute');
       <span id="volume-label">Volume</span>
       <span id="volume-description">Adjust the sound level</span>
       <input type="range" min="0" max="100" value="50"
-             aria-labelledby="volume-label volume-description">
+        aria-labelledby="volume-label volume-description">
     </div>
 
     <button type="button">Mute</button>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In reference to: #67721 

<!-- Feel free to add any additional description of changes below this line -->
This PR is part of Naomi's sprint for editable regions in workshops.