### PR TITLE
fix(curriculum): sync backend module order to match planning sheet

### DIFF
--- a/curriculum/structure/superblocks/back-end-development-and-apis-v9.json
+++ b/curriculum/structure/superblocks/back-end-development-and-apis-v9.json
@@ -70,6 +70,16 @@
           ]
         },
         {
+          "dashedName": "error-handling-in-express",
+          "comingSoon": true,
+          "blocks": [
+            "lecture-understanding-error-handling-and-health-checks",
+            "workshop-error-handling-in-express-by-building-a-bank-api",
+            "review-error-handling-in-express",
+            "quiz-error-handling-in-express"
+          ]
+        },
+        {
           "dashedName": "express-middleware",
           "comingSoon": true,
           "blocks": [
@@ -78,16 +88,6 @@
             "lab-data-sanitizer",
             "review-express-middleware",
             "quiz-express-middleware"
-          ]
-        },
-        {
-          "dashedName": "error-handling-in-express",
-          "comingSoon": true,
-          "blocks": [
-            "lecture-understanding-error-handling-and-health-checks",
-            "workshop-error-handling-in-express-by-building-a-bank-api",
-            "review-error-handling-in-express",
-            "quiz-error-handling-in-express"
           ]
         },
         {


### PR DESCRIPTION
Swap the express-middleware and error-handling-in-express modules in the Back End Development and APIs (v9) structure so error-handling-in-express comes first, matching the documented order.

Closes #67829

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67829

<!-- Feel free to add any additional description of changes below this line -->
