### PR TITLE
fix(curriculum): correct toFixed() answer explanation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-numbers-and-common-number-methods/673280a1c29d0a0b17316e56.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-numbers-and-common-number-methods/673280a1c29d0a0b17316e56.md
@@ -179,7 +179,7 @@ Consider what the default behavior might be when no decimal place count is speci
 
 ---
 
-It returns a string representation of the number with no decimal places.
+It returns a string representation of the number rounded to zero decimal places.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #67790

Updated the correct answer for the toFixed() question to clarify that the number is rounded to zero decimal places before being returned as a string.

No other answers or feedback messages were changed.
