### PR TITLE
fix(a11y): convey course progress to screen reader users

### DIFF
--- a/client/src/components/Progress/progress-inner.test.tsx
+++ b/client/src/components/Progress/progress-inner.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ProgressInner from './progress-inner';
+
+describe('<ProgressInner />', () => {
+  it('exposes progress information to screen readers', () => {
+    render(
+      <ProgressInner
+        title='Variables and Strings'
+        meta='34 of 100 steps complete'
+        completedPercent={34}
+      />
+    );
+
+    const progressBar = screen.getByRole('progressbar', {
+      name: 'Variables and Strings. 34 of 100 steps complete'
+    });
+
+    expect(progressBar).toHaveAttribute('aria-valuemin', '0');
+    expect(progressBar).toHaveAttribute('aria-valuemax', '100');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '34');
+    expect(progressBar).toHaveAttribute(
+      'aria-valuetext',
+      '34 of 100 steps complete'
+    );
+  });
+
+  it('exposes progress information to screen readers in minified mode', () => {
+    render(
+      <ProgressInner
+        title='Variables and Strings'
+        meta='34 of 100 steps complete'
+        completedPercent={34}
+        minified
+      />
+    );
+
+    const progressBar = screen.getByRole('progressbar', {
+      name: 'Variables and Strings. 34 of 100 steps complete'
+    });
+
+    expect(progressBar).toHaveAttribute('aria-valuenow', '34');
+    expect(progressBar).toHaveAttribute(
+      'aria-valuetext',
+      '34 of 100 steps complete'
+    );
+  });
+});

--- a/client/src/components/Progress/progress-inner.tsx
+++ b/client/src/components/Progress/progress-inner.tsx
@@ -45,6 +45,7 @@ function ProgressInner({
   const progressInnerWrap = useRef<HTMLDivElement>(null);
   const intervalRef = useRef<number | null>(null);
   const isProgressInViewport = useIsInViewport(progressInnerWrap);
+  const accessibleLabel = `${title}. ${meta}`;
 
   const animateProgressInner = (completedPercent: number) => {
     // Clear any existing interval
@@ -105,7 +106,12 @@ function ProgressInner({
         </div>
         <div
           className='progress-bar-wrap'
-          aria-hidden='true'
+          role='progressbar'
+          aria-label={accessibleLabel}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(completedPercent)}
+          aria-valuetext={meta}
           ref={progressInnerWrap}
         >
           <ProgressBar now={shownPercent} />
@@ -119,7 +125,12 @@ function ProgressInner({
       <div className='completion-block-name'>{title}</div>
       <div
         className='progress-bar-wrap'
-        aria-hidden='true'
+        role='progressbar'
+        aria-label={accessibleLabel}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(completedPercent)}
+        aria-valuetext={meta}
         ref={progressInnerWrap}
       >
         <ProgressBar now={shownPercent} />

--- a/client/src/components/Progress/progress-inner.tsx
+++ b/client/src/components/Progress/progress-inner.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+ import React, { useState, useEffect, useRef, useMemo } from 'react';
 
 import BezierEasing from 'bezier-easing';
 import { ProgressBar } from './progress-bar';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67770

<!-- Feel free to add any additional description of changes below this line -->

### Summary
This PR fixes an accessibility regression in the Learn UI where course progress was no longer conveyed to screen reader users.

Prevously, screen reader users could understand progress for a lesson or block, but after the recent UI changes the progress bar became effectively visual-only. This update adds accessible progress semantics so assistive technologies can announce the course progress again. 

### Changes
- add `role="progressbar"` to the course progress UI
- add `aria-label` using the block title and progress meta text
- add `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-valuetext`
- add tests to verify progress is exposed to screen readers in both standard and minified modes