### PR TITLE
fix: correct duplicated words and typos in football player card builder workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bce.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bce.md
@@ -7,7 +7,7 @@ dashedName: step-39
 
 # --description--
 
-Now add a `div` with the `className` of `form-group`. Inside it, add a `label` of  `className` of `label` and an `htmlFor` attribute of `name`. Under that add an `input` with an `id` set to `name`, a `className` of of `input`, and a `type` attribute of `text`.
+Now add a `div` with the `className` of `form-group`. Inside it, add a `label` of `className` of `label` and an `htmlFor` attribute of `name`. Under that add an `input` with an `id` set to `name`, a `className` of `input`, and a `type` attribute of `text`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd0.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd0.md
@@ -7,7 +7,7 @@ dashedName: step-42
 
 # --description--
 
-After the `form-row`, add a `div` with the `className` of `form-group`. Inside it, add a `label` element with the `className` of `label`, an `htmlFor` of `club`, and the text `Club`. Then add an input element with an `id` of `club`, a `className` of of `input`, and a `type` of `text`.
+After the `form-row`, add a `div` with the `className` of `form-group`. Inside it, add a `label` element with the `className` of `label`, an `htmlFor` of `club`, and the text `Club`. Then add an input element with an `id` of `club`, a `className` of `input`, and a `type` of `text`.
 
 # --hints--
 
@@ -19,7 +19,7 @@ const formGroupDiv = container.querySelectorAll('.form-panel > div > div.form-gr
 assert.lengthOf(formGroupDiv, 2);
 ```
 
-Your `div.form-group` should have a `label` with an `htmlFor` attribute of `club`, a `className` of of `label`, and the text `Club`.
+Your `div.form-group` should have a `label` with an `htmlFor` attribute of `club`, a `className` of `label`, and the text `Club`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -28,7 +28,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'Club');
 ```
 
-Your Club `form-group` should contain an `input` with an `id` of `club`, a `className` of `input`, and and a `type` of `text`.
+Your Club `form-group` should contain an `input` with an `id` of `club`, a `className` of `input`, and a `type` of `text`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd1.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd1.md
@@ -7,7 +7,7 @@ dashedName: step-43
 
 # --description--
 
-Add another `div` with the `className` of `form-group`. Inside it, add a `label` element with the `className` of `label`, an `htmlFor` of `imageUrl`, and the text `Image URL`. Then add an `input` element with an `id` of `imageUrl`, a `className` of of `input`, and a `type` of `text`.
+Add another `div` with the `className` of `form-group`. Inside it, add a `label` element with the `className` of `label`, an `htmlFor` of `imageUrl`, and the text `Image URL`. Then add an `input` element with an `id` of `imageUrl`, a `className` of `input`, and a `type` of `text`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd3.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd3.md
@@ -9,7 +9,7 @@ dashedName: step-45
 
 Inside the `stats-grid`, add two `div` elements each with the `className` of `form-group`.
 
-For the first, add a `label` with the `className` of `label`, an `htmlFor` of `pac`, and the text `PAC`, then an input with an `id` of `pac`, a `className` of of `input`, and a `type` of `number`.
+For the first, add a `label` with the `className` of `label`, an `htmlFor` of `pac`, and the text `PAC`, then an input with an `id` of `pac`, a `className` of `input`, and a `type` of `number`.
 
 And for the second, add `label` with an `htmlFor` of `sho` and the text `SHO`, then an input with an `id` of `sho` and a `type` of `number`.
 
@@ -23,7 +23,7 @@ const statsGridDiv = container.querySelectorAll('.form-panel > div > div.stats-g
 assert.lengthOf(statsGridDiv, 2);
 ```
 
-Your first `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `pac`, a `className` of of `label`, and a text `PAC`.
+Your first `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `pac`, a `className` of `label`, and a text `PAC`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -33,7 +33,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'PAC');
 ```
 
-Your first `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `pac` and a `type` of `number`.
+Your first `div` element of `className` of `form-group` should have an `input` with a `className` of `input`, an`id` of `pac` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -42,7 +42,7 @@ const statsGridDiv = container.querySelectorAll('.form-panel > div > div.stats-g
 assert.exists(statsGridDiv.querySelector('input#pac.input[type="number"]'));
 ```
 
-Your second `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `sho`, a `className` of of `label`, and a text `SHO`.
+Your second `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `sho`, a `className` of `label`, and a text `SHO`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -52,7 +52,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'SHO');
 ```
 
-Your second `div` element of `className` of `form-group` should have an `input` with an`id` of `sho`, a `className` of of `input`, and a `type` of `number`.
+Your second `div` element of `className` of `form-group` should have an `input` with an`id` of `sho`, a `className` of `input`, and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd4.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd4.md
@@ -23,7 +23,7 @@ const statsGridDiv = container.querySelectorAll('.form-panel > div > div.stats-g
 assert.lengthOf(statsGridDiv, 4);
 ```
 
-Your third `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `pas`, a `className` of of `label`, and a text `PAS`.
+Your third `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `pas`, a `className` of `label`, and a text `PAS`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -33,7 +33,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'PAS');
 ```
 
-Your third `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `pas` and a `type` of `number`.
+Your third `div` element of `className` of `form-group` should have an `input` with a `className` of `input`, an`id` of `pas` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -42,7 +42,7 @@ const statsGridDiv = container.querySelectorAll('.form-panel > div > div.stats-g
 assert.exists(statsGridDiv.querySelector('input#pas.input[type="number"]'));
 ```
 
-Your fourth `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `dri`, a `className` of of `label`, and a text `DRI`.
+Your fourth `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `dri`, a `className` of `label`, and a text `DRI`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -52,7 +52,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'DRI');
 ```
 
-Your fourth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `dri` and a `type` of `number`.
+Your fourth `div` element of `className` of `form-group` should have an `input` with a `className` of `input`, an`id` of `dri` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd5.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd5.md
@@ -23,7 +23,7 @@ const statsGridDiv = container.querySelectorAll('.form-panel > div > div.stats-g
 assert.lengthOf(statsGridDiv, 6);
 ```
 
-Your fifth `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `def`, a `className` of of `label`, and a text `DEF`.
+Your fifth `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `def`, a `className` of `label`, and a text `DEF`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -33,7 +33,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'DEF');
 ```
 
-Your fifth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `def` and a `type` of `number`.
+Your fifth `div` element of `className` of `form-group` should have an `input` with a `className` of `input`, an`id` of `def` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -42,7 +42,7 @@ const statsGridDiv = container.querySelectorAll('.form-panel > div > div.stats-g
 assert.exists(statsGridDiv.querySelector('input#def.input[type="number"]'));
 ```
 
-Your sixth `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `phy`, a `className` of of `label`, and a text `PHY`.
+Your sixth `div` element of `className` of `form-group` should have a `label` with an `htmlFor` attribute of `phy`, a `className` of `label`, and a text `PHY`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -52,7 +52,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'PHY');
 ```
 
-Your fourth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `phy` and a `type` of `number`.
+Your fourth `div` element of `className` of `form-group` should have an `input` with a `className` of `input`, an`id` of `phy` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69f1b1fb36c6c0c80907e8e1.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69f1b1fb36c6c0c80907e8e1.md
@@ -7,7 +7,7 @@ dashedName: step-37
 
 # --description--
 
-Inside the `preview-panel` element, add a `p` element of `className` of `preview-label` and text `Live Preview`, another `p` element of  `className` of `preview-hint` and the text `Updates as you type`, and a `div` with the `className` of set to the template literal `preview-box tier-${getPlayerTier(player.overallRating)}`.
+Inside the `preview-panel` element, add a `p` element of `className` of `preview-label` and text `Live Preview`, another `p` element of `className` of `preview-hint` and the text `Updates as you type`, and a `div` with the `className` set to the template literal `preview-box tier-${getPlayerTier(player.overallRating)}`.
 
 Inside the last `div`, move in the `PlayerCard` component and its prop.
 


### PR DESCRIPTION
## Description

This PR fixes several duplicated word typos and formatting issues in the Football Player Card Builder workshop curriculum content.

## Changes Made

- **Fixed duplicated `of of` -> `of`** in steps 39, 42, 43, 45, 46, and 47 (13 occurrences across 6 files)
- **Fixed duplicated `and and` -> `and`** in step 42 hint text
- **Fixed `className of set` -> `className set`** in step 37 description
- **Fixed double spaces** in steps 37 and 39 description text

## Affected Files

All changes are in `curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/`:

- `69e8b296388ebbd517692bce.md` (Step 39)
- `69e8b296388ebbd517692bd0.md` (Step 42)
- `69e8b296388ebbd517692bd1.md` (Step 43)
- `69e8b296388ebbd517692bd3.md` (Step 45)
- `69e8b296388ebbd517692bd4.md` (Step 46)
- `69e8b296388ebbd517692bd5.md` (Step 47)
- `69f1b1fb36c6c0c80907e8e1.md` (Step 37)

## Checklist

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All changes are limited to curriculum content (challenge descriptions and hints).