### PR TITLE
fix: correct duplicated words, missing spaces, and typos in football player card builder

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd3.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd3.md
@@ -33,7 +33,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'PAC');
 ```
 
-Your first `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `pac` and a `type` of `number`.
+Your first `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an `id` of `pac` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -52,7 +52,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'SHO');
 ```
 
-Your second `div` element of `className` of `form-group` should have an `input` with an`id` of `sho`, a `className` of of `input`, and a `type` of `number`.
+Your second `div` element of `className` of `form-group` should have an `input` with an `id` of `sho`, a `className` of of `input`, and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd4.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd4.md
@@ -15,7 +15,7 @@ And for that of DRI, add a `label` with an `htmlFor` of `dri` and the text `DRI`
 
 # --hints--
 
-Your should add two  more `div` elements each with the `className` of `form-group` inside the `div` of `className` of `stats-grid`.
+Your should add two more `div` elements each with the `className` of `form-group` inside the `div` of `className` of `stats-grid`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -33,7 +33,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'PAS');
 ```
 
-Your third `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `pas` and a `type` of `number`.
+Your third `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an `id` of `pas` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -52,7 +52,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'DRI');
 ```
 
-Your fourth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `dri` and a `type` of `number`.
+Your fourth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an `id` of `dri` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd5.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69e8b296388ebbd517692bd5.md
@@ -33,7 +33,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'DEF');
 ```
 
-Your fifth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `def` and a `type` of `number`.
+Your fifth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an `id` of `def` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);
@@ -52,7 +52,7 @@ assert.exists(label);
 assert.include(label.textContent.trim(), 'PHY');
 ```
 
-Your fourth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an`id` of `phy` and a `type` of `number`.
+Your fourth `div` element of `className` of `form-group` should have an `input` with a `className` of of `input`, an `id` of `phy` and a `type` of `number`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69ea01c45b04f3e9de845036.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69ea01c45b04f3e9de845036.md
@@ -9,7 +9,7 @@ dashedName: step-63
 
 The issue right now is that once the preview refreshes or you reload the page, everything you add for the player card disappears.
 
-Saving all the inputs in localstorage will stop this. To begin with that, create a `STORAGE_KEY` constant with the the string `football_player_card` as its value.
+Saving all the inputs in localStorage will stop this. To begin with that, create a `STORAGE_KEY` constant with the string `football_player_card` as its value.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69ea0bb3e7000f44c207bb0e.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69ea0bb3e7000f44c207bb0e.md
@@ -9,7 +9,7 @@ dashedName: step-71
 
 To make the localStorage feature work finally, change the state initialization from `defaultPlayer` to `loadPlayer`. This ensures the state starts with any available saved data.
 
-Now test out the localstorage feature. Everything you enter should stick after the preview refreshes or you reload the page.
+Now test out the localStorage feature. Everything you enter should stick after the preview refreshes or you reload the page.
 
 You can also change the image `src` link to `https://cdn.freecodecamp.org/curriculum/typescript/tsx-workshop/maradona.png` to see the image change in realtime. Just make sure you change the player name to Maradona.
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69f1b1fb36c6c0c80907e8e1.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69f1b1fb36c6c0c80907e8e1.md
@@ -40,7 +40,7 @@ assert.exists(el);
 assert.match(el.className, /tier-/);
 ```
 
-Your `PlayerCard` should be rendered inside the the `div` element with `className` of `preview-box`.
+Your `PlayerCard` should be rendered inside the `div` element with `className` of `preview-box`.
 
 ```js
 const container = await __helpers.prepTestComponent(window.index.FootballPlayerCard);


### PR DESCRIPTION
## Description

This PR fixes several typographical errors and formatting issues in the Football Player Card Builder workshop curriculum content.

## Changes Made

- **Fixed duplicated `the the` -> `the`** in steps 37 and 63 (description and hint text)
- **Fixed missing space before backtick `an`id`` -> `an `id``** in steps 45, 46, and 47 (6 occurrences)
- **Fixed incorrect ordinal `fourth` -> `sixth`** in step 47 hint text (the PHY input is the 6th form-group, not the 4th)
- **Fixed `localstorage` -> `localStorage`** in steps 63 and 64 (correct Web API casing)
- **Fixed double space `two  more` -> `two more`** in step 46 hint text

## Affected Files

All changes are in `curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/`:

- `69f1b1fb36c6c0c80907e8e1.md` (Step 37)
- `69e8b296388ebbd517692bd3.md` (Step 45)
- `69e8b296388ebbd517692bd4.md` (Step 46)
- `69e8b296388ebbd517692bd5.md` (Step 47)
- `69ea01c45b04f3e9de845036.md` (Step 63)
- `69ea0bb3e7000f44c207bb0e.md` (Step 64)

## Checklist

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All changes are limited to curriculum content (challenge descriptions and hints).