### PR TITLE
fix(curriculum): accept explicit return in Shopping Cart Step 44

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02a4ef92d711ec1ff618c.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02a4ef92d711ec1ff618c.md
@@ -42,11 +42,11 @@ const afterCalculateTotal = code.split('calculateTotal')[1];
 assert.match(afterCalculateTotal, /\(\s*total\s*,\s*item\s*\)\s*=>/);
 ```
 
-Your `reduce` callback should return the sum of `total` and `item.price`. Use an implicit return.
+Your `reduce` callback should return the sum of `total` and `item.price`
 
 ```js
 const afterCalculateTotal = code.split('calculateTotal')[1];
-assert.match(afterCalculateTotal, /\(\s*total\s*,\s*item\s*\)\s*=>\s*(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)/);
+/\((\s*total\s*,\s*item\s*)\)\s*=>\s*(?:\{\s*return\s+(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)\s*;\s*\}|(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total))/
 ```
 
 Your `reduce` call should have an initial value of `0`.


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67841

The test on Step 44 only accepted implicit return syntax in the reduce callback.
This fix updates the regex and hint text to also accept explicit return syntax.

Tested both implicit and explicit return with Node.js - both pass ✅