### PR TITLE
fix: allow any callback parameter in step 7 test

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
@@ -18,7 +18,7 @@ const methodWithRegex = /elements\s*\.\s*forEach\s*/;
 assert.match(__helpers.removeJSComments(code), methodWithRegex);
 ```
 
-Your forEach method should take a callback parameter and use it inside the callback.
+Your forEach method should take a callback parameter.
 
 ```js
 const parameterWithRegex = /elements\s*\.\s*forEach\s*\(\s*\(?\s*\w+\s*\)?\s*=>/;

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
@@ -18,7 +18,7 @@ const methodWithRegex = /elements\s*\.\s*forEach\s*/;
 assert.match(__helpers.removeJSComments(code), methodWithRegex);
 ```
 
-Your forEach method should take a parameter named `el`.
+Your forEach method should take a callback parameter and use it inside the callback.
 
 ```js
 const parameterWithRegex = /elements\s*\.\s*forEach\s*\(\s*\(?\s*\w+\s*\)?\s*=>/;
@@ -28,7 +28,7 @@ assert.match(__helpers.removeJSComments(code), parameterWithRegex);
 Inside the forEach method, you should add the hidden class using the `classList.add` method.
 
 ```js
-const classWithRegex = /\w+\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\)/;
+const classWithRegex = /elements\s*\.\s*forEach\s*\(\s*\(?\s*(\w+)\s*\)?\s*=>[\s\S]*?\1\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\)/;
 assert.match(__helpers.removeJSComments(code), classWithRegex);
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
@@ -28,7 +28,7 @@ assert.match(__helpers.removeJSComments(code), parameterWithRegex);
 Inside the forEach method, you should add the hidden class using the `classList.add` method.
 
 ```js
-const classWithRegex = /el\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\)/;
+const classWithRegex = /\w+\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\)/;
 assert.match(__helpers.removeJSComments(code), classWithRegex);
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67849

Updated the Step 7 test for the Fortune Teller App workshop to allow any valid callback parameter name in the `forEach` callback instead of requiring `el`.

Previously, solutions such as:

elements.forEach(e => e.classList.add("hidden"));

would fail even though they satisfy the instructions. The updated regex now accepts any valid identifier used as the callback parameter while still ensuring that `classList.add("hidden")` is called on that parameter.