### PR TITLE
chore(curriculum): remove both tooling-and-deployment and node-and-sql modules

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -7110,10 +7110,8 @@
       "express-middleware": "Express Middleware",
       "error-handling-in-express": "Error Handling in Express",
       "websockets": "WebSockets",
-      "node-and-sql": "Node and SQL",
       "security-and-privacy": "Security and Privacy",
       "authentication": "Authentication",
-      "tooling-and-deployment": "Tooling and Deployment",
       "back-end-development-and-apis-certification-exam": "Back-End Development and APIs Certification Exam"
     },
     "module-intros": {
@@ -7171,12 +7169,6 @@
           "In this module, you will be introduced to websockets, which is a protocol used for real time communication with the client and server. You will then practice what you have learned in labs and workshops and test your knowledge with a short quiz."
         ]
       },
-      "node-and-sql": {
-        "note": "Coming Late 2026",
-        "intro": [
-          "In this module, you will practice building applications with Node and SQL. Then you will take a short quiz to test your knowledge."
-        ]
-      },
       "security-and-privacy": {
         "note": "Coming Late 2026",
         "intro": [
@@ -7187,12 +7179,6 @@
         "note": "Coming Late 2026",
         "intro": [
           "In this module, you will learn about how authentication works in web applications along with other important concepts including JWTs, CSRFs, Passport, Helmet, cryptography and encryption, and more.  You will then practice what you have learned in labs and workshops and test your knowledge with a short quiz."
-        ]
-      },
-      "tooling-and-deployment": {
-        "note": "Coming Late 2026",
-        "intro": [
-          "In this module, you will learn about common tools used in the industry for deploying your full-stack applications. Then you will take a short quiz to test your knowledge."
         ]
       },
       "back-end-development-and-apis-certification-exam": {

--- a/curriculum/structure/superblocks/back-end-development-and-apis-v9.json
+++ b/curriculum/structure/superblocks/back-end-development-and-apis-v9.json
@@ -101,18 +101,12 @@
             "quiz-websockets"
           ]
         },
-        { "dashedName": "node-and-sql", "comingSoon": true, "blocks": [] },
         {
           "dashedName": "security-and-privacy",
           "comingSoon": true,
           "blocks": []
         },
-        { "dashedName": "authentication", "comingSoon": true, "blocks": [] },
-        {
-          "dashedName": "tooling-and-deployment",
-          "comingSoon": true,
-          "blocks": []
-        }
+        { "dashedName": "authentication", "comingSoon": true, "blocks": [] }
       ]
     },
     {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

This removes both the tooling and deployment and the node and sql modules.

The backstory is that those modules were added when the plan was to have a unified full-stack developer curriculum. Now that we've split it into separate frontend and backend curricula, they no longer fit here.