### PR TITLE
fix(curriculum): extend label association test to include select and textarea

### DIFF
--- a/curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md
+++ b/curriculum/challenges/english/blocks/lab-job-application-form/66faac4139dbbd5dd632c860.md
@@ -89,8 +89,8 @@ You should associate every `input` element with a `label` element.
 ```js
 const els = document.querySelectorAll('input');
 assert.isNotEmpty(els);
-els.forEach(input => {
-  const label = document.querySelector(`label[for="${input.id}"]`) || input.parentElement;
+els.forEach(el => {
+  const label = document.querySelector(`label[for="${el.id}"]`) || el.parentElement;
   assert.exists(label); 
   assert.equal(label.tagName, "LABEL");
 })


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67857

The selector was updated from `input` to `input`, `select`, `textarea` to cover all labeled form elements. The loop variable was renamed from input to el accordingly, since the variable now holds select and textarea nodes as well — keeping the name input would be semantically incorrect.