### PR TITLE
fix(curriculum): correct CSS language classification across lessons

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d26385dbe73203c4dac81.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d26385dbe73203c4dac81.md
@@ -9,7 +9,7 @@ dashedName: what-is-javascript
 
 JavaScript is a powerful programming language that brings interactivity and dynamic behavior to websites.
 
-While HTML and CSS are markup languages used to structure content and style elements on a page, JavaScript goes beyond those by enabling more complex functionality, such as handling user input, animating elements, and even building full web applications.
+While HTML is a markup language used to structure content and CSS is a stylesheet language used to style elements on a page, JavaScript goes beyond those by enabling more complex functionality, such as handling user input, animating elements, and even building full web applications.
 
 For example, when you click a button, submit a form, or hover over a menu, JavaScript determines how the page behaves.
 
@@ -130,7 +130,7 @@ Consider which languages define content and style, and which language handles fu
 
 ---
 
-HTML and CSS are markup languages, while JavaScript is a programming language.
+HTML is a markup language and CSS is a stylesheet language, while JavaScript is a programming language.
 
 ---
 

--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -11,7 +11,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## CSS Basics
 
-- **What is CSS?**: Cascading Style Sheets (CSS) is a markup language used to apply styles to HTML elements. CSS is used for colors, background images, layouts, and more.
+- **What is CSS?**: Cascading Style Sheets (CSS) is a stylesheet language used to apply styles to HTML elements. CSS is used for colors, background images, layouts, and more.
 - **Basic Anatomy of a CSS Rule**: A CSS rule is made up of two main parts: a selector and a declaration block. A selector is a pattern used in CSS to identify and target specific HTML elements for styling. A declaration block applies a set of styles for a given selector, or selectors.
 - **`meta name="viewport"` Element**: This `meta` element gives the browser instructions on how to control the page's dimensions and scaling on different devices, particularly on mobile phones and tablets.
 - **Default Browser Styles**: Each HTML element will have default browser styles applied to them. This usually includes items like default margins and paddings.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67863 

<!-- Feel free to add any additional description of changes below this line -->

These changes correct CSS being described as a "markup language" in two curriculum files. CSS is a stylesheet language — HTML is the markup language. Updated the inline lesson text and the quiz correct answer in the JavaScript introduction lecture, and the CSS review page.