### PR TITLE
fix: Fix/lab hotkey submit redirect

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -61,7 +61,10 @@ import {
 } from '../utils/index';
 import { initializeMathJax, isMathJaxAllowed } from '../../../utils/math-jax';
 import { getScrollbarWidth } from '../../../utils/scrollbar-width';
-import { isProjectBased } from '../../../utils/curriculum-layout';
+import {
+  isLabChallenge,
+  isProjectBased
+} from '../../../utils/curriculum-layout';
 import envConfig from '../../../../config/env.json';
 import LowerJaw from './lower-jaw';
 import { attachContentWidgetEvents } from './content-widget-events';
@@ -634,7 +637,11 @@ const Editor = (props: EditorProps): JSX.Element => {
       ],
       run: () => {
         const shouldShowCompletionModal = !props.showIndependentLowerJaw;
-        if (props.usesMultifileEditor && !isProjectBased(props.challengeType)) {
+        if (
+          props.usesMultifileEditor &&
+          (!isProjectBased(props.challengeType) ||
+            isLabChallenge(props.challengeType))
+        ) {
           if (challengeIsComplete()) {
             tryToSubmitChallenge();
           } else {

--- a/client/src/templates/Challenges/components/hotkeys.tsx
+++ b/client/src/templates/Challenges/components/hotkeys.tsx
@@ -27,7 +27,10 @@ import {
   isShortcutsModalOpenSelector
 } from '../redux/selectors';
 import './hotkeys.css';
-import { isProjectBased } from '../../../utils/curriculum-layout';
+import {
+  isLabChallenge,
+  isProjectBased
+} from '../../../utils/curriculum-layout';
 import type { EditorProps } from '../classic/editor';
 import { useSubmit } from '../utils/fetch-all-curriculum-data';
 
@@ -158,15 +161,15 @@ function Hotkeys({
 
       const testsArePassing = tests.every(test => test.pass && !test.err);
 
-      if (
-        usesMultifileEditor &&
-        typeof challengeType == 'number' &&
-        !isProjectBased(challengeType)
-      ) {
-        if (testsArePassing) {
-          submitChallenge();
+      if (usesMultifileEditor && typeof challengeType == 'number') {
+        if (!isProjectBased(challengeType) || isLabChallenge(challengeType)) {
+          if (testsArePassing) {
+            submitChallenge();
+          } else {
+            executeChallenge();
+          }
         } else {
-          executeChallenge();
+          executeChallenge({ showCompletionModal: !showIndependentLowerJaw });
         }
       } else {
         executeChallenge({ showCompletionModal: !showIndependentLowerJaw });

--- a/client/src/utils/curriculum-layout.ts
+++ b/client/src/utils/curriculum-layout.ts
@@ -19,6 +19,14 @@ const projectBasedChallengeTypes = [
   challengeTypes.dailyChallengePy
 ];
 
+export function isLabChallenge(challengeType: number): boolean {
+  return (
+    challengeType === challengeTypes.lab ||
+    challengeType === challengeTypes.jsLab ||
+    challengeType === challengeTypes.pyLab
+  );
+}
+
 export const isProjectBased = (
   challengeType: number,
   blockDashedName: unknown = null

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -273,3 +273,49 @@ test('Cmd+Enter should not open completion modal in multifile editor (uses lower
     page
   });
 });
+
+test('Ctrl+Enter should redirect to next challenge after tests pass in multifile lab', async ({
+  page,
+  browserName
+}) => {
+  await page.goto(links.multifileLab);
+
+  const editor = getEditors(page);
+  await editor.focus();
+  await expect(editor).toBeFocused();
+  await clearEditor({ page, browserName });
+  await editor.fill(multifileLabSolution);
+
+  await page.keyboard.press('Control+Enter');
+
+  await expect(
+    page.getByTestId('independentLowerJaw-submit-button')
+  ).toBeVisible();
+
+  await page.keyboard.press('Control+Enter');
+
+  await expect(page).not.toHaveURL(links.multifileLab);
+});
+
+test('Cmd+Enter should redirect to next challenge after tests pass in multifile lab', async ({
+  page,
+  browserName
+}) => {
+  await page.goto(links.multifileLab);
+
+  const editor = getEditors(page);
+  await editor.focus();
+  await expect(editor).toBeFocused();
+  await clearEditor({ page, browserName });
+  await editor.fill(multifileLabSolution);
+
+  await page.keyboard.press('Meta+Enter');
+
+  await expect(
+    page.getByTestId('independentLowerJaw-submit-button')
+  ).toBeVisible();
+
+  await page.keyboard.press('Meta+Enter');
+
+  await expect(page).not.toHaveURL(links.multifileLab);
+});


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67865

---

## Problem

On all lab challenge types (`jsLab`, `pyLab`), pressing `Ctrl+Enter` after tests pass does not redirect to the next challenge. It re-runs the tests instead. Clicking the "Submit & Continue" button works correctly.

Steps to reproduce:
1. Go to any lab, e.g. https://www.freecodecamp.org/learn/javascript-v9/lab-range-based-lcm-calculator/implement-a-range-based-lcm-calculator
2. Write a correct solution and press `Ctrl+Enter` — tests pass, "Congratulations" banner appears
3. Press `Ctrl+Enter` again — tests re-run instead of redirecting to the next challenge

## Root cause

`jsLab` and `pyLab` are included in `projectBasedChallengeTypes`, so `isProjectBased()` returns `true` for them. Both the hotkey handler in `hotkeys.tsx` and the Monaco editor keybinding in `editor.tsx` had the condition:

```ts
if (usesMultifileEditor && !isProjectBased(challengeType)) {
  if (testsArePassing) {
    submitChallenge();
  } else {
    executeChallenge();
  }
} else {
  executeChallenge({ showCompletionModal: !showIndependentLowerJaw });
}
```

Because `isProjectBased()` returns `true` for labs, `!isProjectBased()` is always `false` for them, so the code always falls into the `else` branch and calls `executeChallenge()` unconditionally — regardless of whether tests are passing.

The "Submit & Continue" button works correctly because `IndependentLowerJaw` renders a different button when `isChallengeComplete` is `true`, which directly calls `submitChallenge()`. The hotkey path never had equivalent branching logic for labs.

## Fix

Added `isLabChallenge()` to `curriculum-layout.ts` that returns `true` for `lab`, `jsLab`, and `pyLab`. Updated the condition in both `hotkeys.tsx` and `editor.tsx` to explicitly opt labs into the submit-when-passing behavior:

```ts
if (usesMultifileEditor && (!isProjectBased(challengeType) || isLabChallenge(challengeType))) {
  if (testsArePassing) {
    submitChallenge();
  } else {
    executeChallenge();
  }
} else {
  executeChallenge({ showCompletionModal: !showIndependentLowerJaw });
}
```

This leaves true project-based challenges (cert projects, CodeAlly, exams, daily challenges) unaffected.

## Files changed

- `client/src/utils/curriculum-layout.ts` — added `isLabChallenge()` export
- `client/src/templates/Challenges/components/hotkeys.tsx` — updated condition to include labs
- `client/src/templates/Challenges/classic/editor.tsx` — updated condition to include labs
- `e2e/hotkeys.spec.ts` — added two tests covering the second `Ctrl+Enter`/`Cmd+Enter` press on a passing lab confirming redirect occurs