### PR TITLE
fix(curriculum): correct renderCard spacing in fortune teller workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e023b93769353c635fb93a.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e023b93769353c635fb93a.md
@@ -437,7 +437,7 @@ const getRandomItem = <T,>(items: T[]): T => {
 };
 
 --fcc-editable-region--
-const renderCard = (drawingType: string, isReversed: boolean,shortName: string, img: string): string =>`
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string =>`
 
 `
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e4220fadf4239b7e722e0a.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e4220fadf4239b7e722e0a.md
@@ -429,7 +429,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string =>` 
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string =>` 
 <div>
   <h2>${drawingType}</h2>
   <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed40e9b9a39c757618f302.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed40e9b9a39c757618f302.md
@@ -436,7 +436,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed42285f674a9475629831.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed42285f674a9475629831.md
@@ -437,7 +437,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed42f744fc8aa6d479e926.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed42f744fc8aa6d479e926.md
@@ -486,7 +486,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
   <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed43845b59b9b3787eb175.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed43845b59b9b3787eb175.md
@@ -437,7 +437,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed43f08c01c7bca5b4e66f.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed43f08c01c7bca5b4e66f.md
@@ -509,7 +509,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
   <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed4446ffffb4c52a7d40d1.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed4446ffffb4c52a7d40d1.md
@@ -423,7 +423,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed44cdcb4ff9d0caea0e84.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed44cdcb4ff9d0caea0e84.md
@@ -427,7 +427,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
     <h2>${drawingType}</h2>
       <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed4585f6a1d6e07b9d09c5.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed4585f6a1d6e07b9d09c5.md
@@ -433,7 +433,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68f1ec48c0e7969eddbef24c.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68f1ec48c0e7969eddbef24c.md
@@ -1013,7 +1013,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string =>`
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string =>`
   <div>
     <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/69e113baa731600992be8090.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/69e113baa731600992be8090.md
@@ -449,7 +449,7 @@ const getRandomItem = <T,>(items: T[]): T => {
   return items[index];
 };
 
-const renderCard = (drawingType: string, isReversed: boolean,shortName: string, img: string): string =>`
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string =>`
 <div>
   <h2>${drawingType}</h2>
   <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67871
Closes #67873
Closes #67874

<!-- Feel free to add any additional description of changes below this line -->

This updates the Fortune Teller App workshop curriculum seeds to fix the missing spacing in the `renderCard` function signature across the affected steps.