### PR TITLE
fix(curriculum): add spaces in fortune teller renderCard

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e023b93769353c635fb93a.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e023b93769353c635fb93a.md
@@ -437,6 +437,8 @@ const getRandomItem = <T,>(items: T[]): T => {
 };
 
 --fcc-editable-region--
-const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean,shortName: string, img: string): string => `
+
+`
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e023b93769353c635fb93a.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e023b93769353c635fb93a.md
@@ -437,8 +437,6 @@ const getRandomItem = <T,>(items: T[]): T => {
 };
 
 --fcc-editable-region--
-const renderCard = (drawingType: string, isReversed: boolean,shortName: string, img: string): string =>`
-
-`
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e023b93769353c635fb93a.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e023b93769353c635fb93a.md
@@ -437,7 +437,7 @@ const getRandomItem = <T,>(items: T[]): T => {
 };
 
 --fcc-editable-region--
-const renderCard = (drawingType: string, isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
 
 `
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e4220fadf4239b7e722e0a.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e4220fadf4239b7e722e0a.md
@@ -429,7 +429,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string =>` 
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
 <div>
   <h2>${drawingType}</h2>
   <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed40e9b9a39c757618f302.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed40e9b9a39c757618f302.md
@@ -436,7 +436,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed42285f674a9475629831.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed42285f674a9475629831.md
@@ -437,7 +437,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed42285f674a9475629831.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed42285f674a9475629831.md
@@ -437,7 +437,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
+const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/69e113baa731600992be8090.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/69e113baa731600992be8090.md
@@ -449,7 +449,7 @@ const getRandomItem = <T,>(items: T[]): T => {
   return items[index];
 };
 
-const renderCard = (drawingType: string, isReversed: boolean,shortName: string, img: string): string =>`
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
 <div>
   <h2>${drawingType}</h2>
   <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67871

<!-- Feel free to add any additional description of changes below this line -->

Added the missing spaces in the renderCard signature for the Fortune Teller App steps mentioned in the issue.