### PR TITLE
fix(curriculum): fixed misleading description in "Build an Error Message Component - 10"

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-error-message-component/684d07cbfa43a20d6a002ed7.md
+++ b/curriculum/challenges/english/blocks/workshop-error-message-component/684d07cbfa43a20d6a002ed7.md
@@ -9,15 +9,15 @@ dashedName: step-10
 
 The styles for the `div` element are starting to come together. But it would be nice if there were some space around the text. 
 
-To apply `padding` to an element using Tailwind CSS, you can use the following pattern: `p-number`, where `number` represents the pixels you want to apply on all four sides. 
+To apply `padding` to an element using Tailwind CSS, you can use the following pattern: `p-number`, where each `number` unit represents 0.25rem (or 4px) you want to apply on all four sides. 
 
-Here is an example of applying `padding` of `8px` to an element:
+Here is an example of applying `padding` of `32px` to an element:
 
 ```html
 <p class="p-8">This is padding.</p>
 ```
 
-Inside your opening `div` tag, use the correct utility class to apply `padding` of `4px`.
+Inside your opening `div` tag, use the correct utility class to apply `padding` of `16px`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-error-message-component/684d09cad4ec900e41db2e74.md
+++ b/curriculum/challenges/english/blocks/workshop-error-message-component/684d09cad4ec900e41db2e74.md
@@ -7,17 +7,17 @@ dashedName: step-11
 
 # --description--
 
-Right now the `div` element is placed in the upper left hand corner of the preview screen. But it would be nice to add some space to the top of the element. To apply `margin`, to an element using Tailwind CSS, you can use the following pattern: `m-number`, where `number` represents the fixed pixels to apply to all four sides.
+Right now the `div` element is placed in the upper left hand corner of the preview screen. But it would be nice to add some space to the top of the element. To apply `margin`, to an element using Tailwind CSS, you can use the following pattern: `m-number`, where each `number` unit represents 0.25rem (or 4 pixels) to apply to all four sides.
 
 If you want to apply margin to only one side, you can use any of the following patterns: `mt-number` (margin top), `mb-number` (margin bottom), `mr-number` (margin right) and `ml-number` (margin left).
 
-Here is an example of apply `margin-bottom` to an element:
+Here is an example of applying `margin-bottom` of 32px to an element:
 
 ```html
 <p class="mb-8">This is margin.</p>
 ```
 
-Inside your opening `div` tag, use the correct utility class to apply `margin-top` of `4px`.
+Inside your opening `div` tag, use the correct utility class to apply `margin-top` of `16px`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-error-message-component/684d0eeb9c81e5109e52fe8b.md
+++ b/curriculum/challenges/english/blocks/workshop-error-message-component/684d0eeb9c81e5109e52fe8b.md
@@ -9,7 +9,7 @@ dashedName: step-15
 
 The `div` element is starting to look better. But now the dismiss `button` is a little too close to the paragraph element. 
 
-To create space between the flex items, you can use the following pattern: `gap-number`. `number` represents the fixed space between both rows and columns in a flex layout.
+To create space between the flex items, you can use the following pattern: `gap-number`, where each `number` unit represents 0.25rem (or 4px) of fixed space between both rows and columns in a flex layout.
 
 Here is an example of applying a `gap` to an element:
 
@@ -17,7 +17,7 @@ Here is an example of applying a `gap` to an element:
 <p class="flex gap-8">This is gap.</p>
 ```
 
-Inside your opening `div` tag, use the correct utility class for setting the `gap` to `4`.
+Inside your opening `div` tag, use the correct utility class for setting the `gap` to `16px`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67882

<!-- Feel free to add any additional description of changes below this line -->
Step 10:
Since each unit of number in the standart Tailwind CSS spacing represents 0.25rem (4px), description should be changed to:
p-8 -> 32px (instead of current 8px)
p-4 -> 16px (instead of current 4px)

Step 11:
same for margin

Step 15:
added what each unit of number represents in "gap-number"