### PR TITLE
fix(curriculum): audit editable regions for workshop-planets-tablist

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685976a92ffab8b2dc744b72.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685976a92ffab8b2dc744b72.md
@@ -48,7 +48,7 @@ assert.equal(document.querySelector(".tabs div").getAttribute("aria-labelledby")
     <div class="tabs">
       <h2 id="tabs-title">Planets</h2>
       --fcc-editable-region--
-
+      
       --fcc-editable-region--
     </div>
     

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685976a92ffab8b2dc744b72.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685976a92ffab8b2dc744b72.md
@@ -47,7 +47,6 @@ assert.equal(document.querySelector(".tabs div").getAttribute("aria-labelledby")
   <body>
     <div class="tabs">
       <h2 id="tabs-title">Planets</h2>
-
       --fcc-editable-region--
 
       --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/68599633407374c0d574587b.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/68599633407374c0d574587b.md
@@ -59,7 +59,7 @@ assert.equal(thirdBtn.textContent, "🔴 Mars");
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/68599e9259c0eec3e78c52fd.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/68599e9259c0eec3e78c52fd.md
@@ -52,7 +52,7 @@ assert.equal(thirdBtn.getAttribute("aria-selected"), "false");
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">
@@ -66,7 +66,7 @@ assert.equal(thirdBtn.getAttribute("aria-selected"), "false");
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/68599f9df77791c4a311cc5f.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/68599f9df77791c4a311cc5f.md
@@ -83,7 +83,7 @@ assert.equal(thirdBtn.getAttribute("id"), "tab-mars");
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859a1270ac255c571352189.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859a1270ac255c571352189.md
@@ -48,7 +48,7 @@ assert.lengthOf(document.querySelectorAll('div[role="tabpanel"] p'), 3);
       </div>
 
       --fcc-editable-region--
-
+      
       --fcc-editable-region--
     </div>
 

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859a1270ac255c571352189.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859a1270ac255c571352189.md
@@ -36,7 +36,7 @@ assert.lengthOf(document.querySelectorAll('div[role="tabpanel"] p'), 3);
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">
@@ -52,7 +52,7 @@ assert.lengthOf(document.querySelectorAll('div[role="tabpanel"] p'), 3);
       --fcc-editable-region--
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859a484a55387c6543ab2c0.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859a484a55387c6543ab2c0.md
@@ -56,7 +56,7 @@ assert.equal(
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">
@@ -67,9 +67,10 @@ assert.equal(
         <button role="tab" aria-controls="panel-mars" aria-selected="false" id="tab-mars">🔴 Mars</button>
       </div>
 
-      --fcc-editable-region--
       <div role="tabpanel">
+        --fcc-editable-region--
         <p></p>
+        --fcc-editable-region--
       </div>
       <div role="tabpanel">
         <p></p>
@@ -77,10 +78,9 @@ assert.equal(
       <div role="tabpanel">
         <p></p>
       </div>
-      --fcc-editable-region--
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859a484a55387c6543ab2c0.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859a484a55387c6543ab2c0.md
@@ -70,13 +70,13 @@ assert.equal(
       <div role="tabpanel">
         --fcc-editable-region--
         <p></p>
+      </div>
+      <div role="tabpanel">
+        <p></p>
+      </div>
+      <div role="tabpanel">
+        <p></p>
         --fcc-editable-region--
-      </div>
-      <div role="tabpanel">
-        <p></p>
-      </div>
-      <div role="tabpanel">
-        <p></p>
       </div>
     </div>
 

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859ab9ba7a915c84fa69851.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859ab9ba7a915c84fa69851.md
@@ -90,6 +90,7 @@ assert.equal(document.querySelectorAll('[role="tabpanel"]')[2].getAttribute("ari
       </div>
       --fcc-editable-region--
       <div role="tabpanel">
+      --fcc-editable-region--
         <p>
           Saturn is famous for its beautiful and extensive ring system made of ice and rock particles. It's a gas giant with dozens of moons orbiting it.
         </p>
@@ -99,10 +100,9 @@ assert.equal(document.querySelectorAll('[role="tabpanel"]')[2].getAttribute("ari
           Mars, the red planet, is a rocky world with the tallest volcano and deepest canyon in the solar system. It's a key focus for exploration in the search for past or present life.
         </p>
       </div>
-      --fcc-editable-region--
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859ab9ba7a915c84fa69851.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859ab9ba7a915c84fa69851.md
@@ -90,12 +90,12 @@ assert.equal(document.querySelectorAll('[role="tabpanel"]')[2].getAttribute("ari
       </div>
       --fcc-editable-region--
       <div role="tabpanel">
-      --fcc-editable-region--
         <p>
           Saturn is famous for its beautiful and extensive ring system made of ice and rock particles. It's a gas giant with dozens of moons orbiting it.
         </p>
       </div>
       <div role="tabpanel">
+      --fcc-editable-region--
         <p>
           Mars, the red planet, is a rocky world with the tallest volcano and deepest canyon in the solar system. It's a key focus for exploration in the search for past or present life.
         </p>

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859acc690736fc911a70967.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859acc690736fc911a70967.md
@@ -54,12 +54,12 @@ assert.isTrue(document.querySelectorAll('div[role="tabpanel"]')[2].hasAttribute(
       </div>
       --fcc-editable-region--
       <div id="panel-saturn" role="tabpanel" aria-labelledby="tab-saturn">
-      --fcc-editable-region--
         <p>
           Saturn is famous for its beautiful and extensive ring system made of ice and rock particles. It's a gas giant with dozens of moons orbiting it.
         </p>
       </div>
       <div id="panel-mars" role="tabpanel" aria-labelledby="tab-mars">
+      --fcc-editable-region--
         <p>
           Mars, the red planet, is a rocky world with the tallest volcano and deepest canyon in the solar system. It's a key focus for exploration in the search for past or present life.
         </p>

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859acc690736fc911a70967.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859acc690736fc911a70967.md
@@ -54,6 +54,7 @@ assert.isTrue(document.querySelectorAll('div[role="tabpanel"]')[2].hasAttribute(
       </div>
       --fcc-editable-region--
       <div id="panel-saturn" role="tabpanel" aria-labelledby="tab-saturn">
+      --fcc-editable-region--
         <p>
           Saturn is famous for its beautiful and extensive ring system made of ice and rock particles. It's a gas giant with dozens of moons orbiting it.
         </p>
@@ -63,10 +64,9 @@ assert.isTrue(document.querySelectorAll('div[role="tabpanel"]')[2].hasAttribute(
           Mars, the red planet, is a rocky world with the tallest volcano and deepest canyon in the solar system. It's a key focus for exploration in the search for past or present life.
         </p>
       </div>
-      --fcc-editable-region--
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/6859ae3ef795c4c9d4badf9c.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/6859ae3ef795c4c9d4badf9c.md
@@ -86,7 +86,7 @@ assert.deepEqual(
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c3e887d32ea71964cd981.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c3e887d32ea71964cd981.md
@@ -37,7 +37,7 @@ assert.match(code, /tabs\.forEach\(\s*tab\s*=>\s*\{/);
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">
@@ -65,7 +65,7 @@ assert.match(code, /tabs\.forEach\(\s*tab\s*=>\s*\{/);
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c454eb1e7fb7341f1c6ae.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c454eb1e7fb7341f1c6ae.md
@@ -69,7 +69,7 @@ assert.match(code, /tab\.addEventListener\(["']click["']\s*,\s*\(\)\s*=>\s*\{\s*
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```
@@ -104,10 +104,9 @@ assert.match(code, /tab\.addEventListener\(["']click["']\s*,\s*\(\)\s*=>\s*\{\s*
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
-
 tabs.forEach(tab => {
 --fcc-editable-region--
-
+  
 --fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c454eb1e7fb7341f1c6ae.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c454eb1e7fb7341f1c6ae.md
@@ -104,9 +104,10 @@ assert.match(code, /tab\.addEventListener\(["']click["']\s*,\s*\(\)\s*=>\s*\{\s*
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
---fcc-editable-region--
-tabs.forEach(tab => {
 
-});
+tabs.forEach(tab => {
 --fcc-editable-region--
+
+--fcc-editable-region--
+});
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c49c6e1db1c74a9762eae.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c49c6e1db1c74a9762eae.md
@@ -111,7 +111,7 @@ const panels = document.querySelectorAll('[role="tabpanel"]');
 tabs.forEach(tab => {
   tab.addEventListener("click", () => {
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
   });
 });

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c49c6e1db1c74a9762eae.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c49c6e1db1c74a9762eae.md
@@ -73,7 +73,7 @@ allTabs.forEach(tab => {
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c49c6e1db1c74a9762eae.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c49c6e1db1c74a9762eae.md
@@ -108,11 +108,11 @@ allTabs.forEach(tab => {
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
---fcc-editable-region--
 tabs.forEach(tab => {
   tab.addEventListener("click", () => {
+--fcc-editable-region--
 
+--fcc-editable-region--
   });
 });
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c4b88d56b107579124d3d.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c4b88d56b107579124d3d.md
@@ -36,7 +36,7 @@ panels.forEach(panel => {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">
@@ -64,7 +64,7 @@ panels.forEach(panel => {
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```
@@ -99,12 +99,11 @@ panels.forEach(panel => {
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
-
 tabs.forEach(tab => {
   tab.addEventListener("click", () => {
     tabs.forEach(t => t.setAttribute("aria-selected", "false"));
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
   });
 });

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c4b88d56b107579124d3d.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c4b88d56b107579124d3d.md
@@ -99,12 +99,13 @@ panels.forEach(panel => {
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
---fcc-editable-region--
+
 tabs.forEach(tab => {
   tab.addEventListener("click", () => {
     tabs.forEach(t => t.setAttribute("aria-selected", "false"));
+--fcc-editable-region--
 
+--fcc-editable-region--
   });
 });
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c52352f98cc76d66714dd.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c52352f98cc76d66714dd.md
@@ -32,7 +32,7 @@ assert.equal(secondTab.getAttribute("aria-selected"), "true");
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">
@@ -60,7 +60,7 @@ assert.equal(secondTab.getAttribute("aria-selected"), "true");
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```
@@ -99,8 +99,9 @@ tabs.forEach(tab => {
   tab.addEventListener("click", () => {
     tabs.forEach(t => t.setAttribute("aria-selected", "false"));
     panels.forEach(p => p.hidden = true);
---fcc-editable-region--
 
+--fcc-editable-region--
+    
 --fcc-editable-region--
   });
 });

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c52352f98cc76d66714dd.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c52352f98cc76d66714dd.md
@@ -95,13 +95,13 @@ assert.equal(secondTab.getAttribute("aria-selected"), "true");
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
---fcc-editable-region--
 tabs.forEach(tab => {
   tab.addEventListener("click", () => {
     tabs.forEach(t => t.setAttribute("aria-selected", "false"));
     panels.forEach(p => p.hidden = true);
+--fcc-editable-region--
 
+--fcc-editable-region--
   });
 });
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c539a33f20877c4ef59d2.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c539a33f20877c4ef59d2.md
@@ -96,15 +96,15 @@ assert.match(
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
---fcc-editable-region--
 tabs.forEach(tab => {
   tab.addEventListener("click", () => {
     tabs.forEach(t => t.setAttribute("aria-selected", "false"));
     panels.forEach(p => p.hidden = true);
 
     tab.setAttribute("aria-selected", "true");
+--fcc-editable-region--
 
+--fcc-editable-region--
   });
 });
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c539a33f20877c4ef59d2.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c539a33f20877c4ef59d2.md
@@ -103,7 +103,7 @@ tabs.forEach(tab => {
 
     tab.setAttribute("aria-selected", "true");
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
   });
 });

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c539a33f20877c4ef59d2.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c539a33f20877c4ef59d2.md
@@ -33,7 +33,7 @@ assert.match(
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">
@@ -61,7 +61,7 @@ assert.match(
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c560bfde79c78a3f01a64.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c560bfde79c78a3f01a64.md
@@ -93,7 +93,6 @@ assert.match(code, /(?:const|let|var)\s+panel\s*=\s*document\.getElementById\(as
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
---fcc-editable-region--
 tabs.forEach(tab => {
   tab.addEventListener("click", () => {
     tabs.forEach(t => t.setAttribute("aria-selected", "false"));
@@ -101,8 +100,9 @@ tabs.forEach(tab => {
 
     tab.setAttribute("aria-selected", "true");
     const associatedPanel = tab.getAttribute("aria-controls");
+--fcc-editable-region--
 
+--fcc-editable-region--
   });
 });
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c560bfde79c78a3f01a64.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c560bfde79c78a3f01a64.md
@@ -101,7 +101,7 @@ tabs.forEach(tab => {
     tab.setAttribute("aria-selected", "true");
     const associatedPanel = tab.getAttribute("aria-controls");
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
   });
 });

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c57ae785a337969745135.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c57ae785a337969745135.md
@@ -106,7 +106,7 @@ tabs.forEach(tab => {
     const associatedPanel = tab.getAttribute("aria-controls");
     const panel = document.getElementById(associatedPanel);
 --fcc-editable-region--
-
+    
 --fcc-editable-region--
   });
 });
@@ -121,7 +121,7 @@ tabs.forEach(tab => {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planets Facts</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <div class="tabs">
@@ -149,7 +149,7 @@ tabs.forEach(tab => {
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c57ae785a337969745135.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c57ae785a337969745135.md
@@ -97,7 +97,6 @@ assert.isFalse(document.getElementById("panel-saturn").hidden);
 const tabs = document.querySelectorAll('[role="tab"]');
 const panels = document.querySelectorAll('[role="tabpanel"]');
 
---fcc-editable-region--
 tabs.forEach(tab => {
   tab.addEventListener("click", () => {
     tabs.forEach(t => t.setAttribute("aria-selected", "false"));
@@ -106,10 +105,11 @@ tabs.forEach(tab => {
     tab.setAttribute("aria-selected", "true");
     const associatedPanel = tab.getAttribute("aria-controls");
     const panel = document.getElementById(associatedPanel);
+--fcc-editable-region--
 
+--fcc-editable-region--
   });
 });
---fcc-editable-region--
 ```
 
 # --solutions--

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c57ae785a337969745135.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c57ae785a337969745135.md
@@ -62,7 +62,7 @@ assert.isFalse(document.getElementById("panel-saturn").hidden);
       </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685db0bd1280154ae85bcf9f.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685db0bd1280154ae85bcf9f.md
@@ -61,7 +61,7 @@ assert.equal(document.querySelector(".tabs h2").textContent, "Planets");
   </head>
   <body>
     --fcc-editable-region--
-
+    
     --fcc-editable-region--
     
     <script src="./script.js"></script>


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Part of #67721

<!-- Feel free to add any additional description of changes below this line -->

This PR completes the editable-region audit for workshop-planets-tablist.

Changes:

Removed an extra blank line above the editable region in Step 2 for cleaner appearance and consistency with other steps.

Narrowed editable regions that included code that should not be modified by campers.
