### PR TITLE
fix: remove unused argument from previewChallengeSaga call

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -351,7 +351,7 @@ export function* updatePreviewSaga(action) {
     yield updatePython(challengeData);
   } else {
     // all other challenges have to recreate the preview
-    yield previewChallengeSaga(action);
+    yield previewChallengeSaga();
   }
 }
 


### PR DESCRIPTION
* [x] I have read and followed the contribution guidelines.
* [x] I have read and followed the how to open a pull request guide.
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67695

## Description

This PR removes the unused `action` argument from the `previewChallengeSaga` invocation inside `updatePreviewSaga`.

### Changes

* Replaced `yield previewChallengeSaga(action)` with `yield previewChallengeSaga()`
* Preserved existing functionality
* Improved consistency with the function signature
* Eliminated the unnecessary argument passed to the generator

### Testing

Unable to run the project's lint/test suite locally because project dependencies were not installed (`turbo` command unavailable). The change is limited to removing an unused argument and does not alter behavior.
