### PR TITLE
fix(curriculum): add missing spaces in renderCard signature

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed4446ffffb4c52a7d40d1.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed4446ffffb4c52a7d40d1.md
@@ -423,7 +423,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed44cdcb4ff9d0caea0e84.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed44cdcb4ff9d0caea0e84.md
@@ -427,7 +427,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
     <h2>${drawingType}</h2>
       <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed4585f6a1d6e07b9d09c5.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ed4585f6a1d6e07b9d09c5.md
@@ -433,7 +433,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string => `
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
   <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68f1ec48c0e7969eddbef24c.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68f1ec48c0e7969eddbef24c.md
@@ -1013,7 +1013,7 @@ const index = Math.floor(Math.random() * items.length);
 return items[index];
 };
 
-const renderCard = (drawingType: string,isReversed: boolean,shortName: string, img: string): string =>`
+const renderCard = (drawingType: string, isReversed: boolean, shortName: string, img: string): string => `
   <div>
     <h2>${drawingType}</h2>
     <figure class="card_container ${isReversed ? "reversed-card" : ""}" data-id="${shortName}">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67874

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes missing spaces in the `renderCard` function signature in the Fortune Teller App workshop.

It updates the affected steps by adding spaces after commas in the function parameters, and adds the missing space before the template literal in step 55.