### PR TITLE
fix: resolve CSS specificity lecture formatting inconsistencies

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672aa62178d5ff57fe4f98e0.md
+++ b/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672aa62178d5ff57fe4f98e0.md
@@ -67,7 +67,7 @@ Examples include class selectors such as `.container` and `.button`, attribute s
 
 **NOTE**: You will learn more about pseudo-classes in future lessons.
 
-In this example, the first paragraph will be red because an `id` selector has a higher specificity than classes and type selectors. The `.example-para` elements will have a color of green while the remaining paragraph elements will have a color of blue. 
+In this example, the first paragraph will be red because an ID selector has a higher specificity than classes and type selectors. The `.example-para` elements will have a color of green while the remaining paragraph elements will have a color of blue.
 
 :::interactive_editor
 
@@ -124,8 +124,7 @@ p {
 
 Finally, the universal selector, represented by an asterisk `*`, has the lowest specificity of all.
 
-Here is an example of setting the color for all elements to red using the `*` selector. You won't see any red elements though because there are ID and type selectors that override those styles which highlights the low specificity of the `*` selector. 
-
+Here is an example of setting the color for all elements to red using the `*` selector. You won't see any red elements though because there are ID and type selectors that override those styles which highlights the low specificity of the `*` selector.
 :::interactive_editor
 
 ```html

--- a/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8e8adcc27e235a154231.md
+++ b/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8e8adcc27e235a154231.md
@@ -139,7 +139,7 @@ This selector targets all elements and has the lowest specificity.
 
 ---
 
-An Inline style.
+An inline style.
 
 ### --feedback--
 
@@ -147,7 +147,7 @@ This selector targets all elements and has the lowest specificity.
 
 ---
 
-A Universal selector.
+A universal selector.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f23511adf25646b4236.md
+++ b/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f23511adf25646b4236.md
@@ -13,7 +13,7 @@ The process begins with **relevance**. The browser first filters all the CSS rul
 
 A media query is a CSS technique used to apply styles based on the characteristics of the device or viewport, such as its width, height, or orientation.
 
-Next, the algorithm considers **origin and importance**. CSS can come from different sources: the browser’s default styles (user-agent), styles set by the user, and styles written by the author (you).
+Next, the algorithm considers **origin and importance**. CSS can come from different sources: the browser's default styles (user-agent), styles set by the user, and styles written by the author (you).
 
 Following the consideration of origin, the algorithm then evaluates the importance of each rule, giving priority to rules marked with `!important`, which override other rules regardless of their source.
 

--- a/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f382370e025aadd3f4e.md
+++ b/curriculum/challenges/english/blocks/lecture-css-specificity-the-cascade-algorithm-and-inheritance/672b8f382370e025aadd3f4e.md
@@ -53,7 +53,7 @@ Inheritance is especially useful for maintaining consistency and reducing redund
 
 Instead of writing the same style rule for multiple elements, you can define it once on a parent element, and the child elements will inherit it. This can make your CSS more concise and easier to manage.
 
-However, it’s important to remember that inheritance only works in one direction – from parent to child. If you override a style on a child element, it won’t affect the parent element.
+However, it's important to remember that inheritance only works in one direction, from parent to child. If you override a style on a child element, it won't affect the parent element.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67870

<!-- Feel free to add any additional description of changes below this line -->

Description

This PR fixes content and formatting inconsistencies in the CSS Specificity, the Cascade Algorithm, and Inheritance lecture block.

Changes made:

* Replaced `id` selector terminology with `ID selector` where referring to the selector category.
* Fixed capitalization inconsistencies in answer options.
* Replaced smart apostrophes and an en dash with standard punctuation.
* Removed unnecessary trailing whitespace from the affected lines.

