### PR TITLE
fix(client): show correct lab progress on resubmission

### DIFF
--- a/client/src/utils/get-completion-percentage.test.ts
+++ b/client/src/utils/get-completion-percentage.test.ts
@@ -84,6 +84,22 @@ describe('get-completion-percentage', () => {
 
       expect(result).toBe(33);
     });
+
+    it('reports 100% when resubmitting an already-completed single-challenge lab block', () => {
+      // Regression test for #67867: a completed lab whose block contains only
+      // the lab itself should read 100%, not 0%, on resubmission.
+      const labId = 'lab-challenge';
+      const completedChallengesIds = [labId];
+      const currentBlockIds = [labId];
+
+      const result = getCompletedPercentage(
+        completedChallengesIds,
+        currentBlockIds,
+        labId
+      );
+
+      expect(result).toBe(100);
+    });
   });
 
   describe('getCompletedChallengesInBlock', () => {
@@ -249,6 +265,40 @@ describe('get-completion-percentage', () => {
       );
 
       expect(result).toEqual(['project-1', 'project-2']);
+    });
+
+    // Regression test for #67867: labs are project-based but each is its own
+    // standalone block, so they must use their block IDs rather than the
+    // certification's tests (otherwise resubmitting a completed lab reads 0%).
+    it('returns block IDs for labs even when a certificate is available', () => {
+      const allChallengesInfo: AllChallengesInfo = {
+        challengeNodes: [
+          {
+            challenge: {
+              id: 'lab-challenge',
+              block: 'lab-all-true-property-validator',
+              certification: Certification.JsV9
+            }
+          } as Partial<ChallengeNode> as ChallengeNode
+        ],
+        certificateNodes: [
+          {
+            challenge: {
+              certification: Certification.JsV9,
+              tests: [{ id: 'javascript-certification-exam' }]
+            }
+          }
+        ]
+      };
+
+      const result = getCurrentBlockIds(
+        allChallengesInfo,
+        'lab-all-true-property-validator',
+        Certification.JsV9,
+        challengeTypes.jsLab
+      );
+
+      expect(result).toEqual(['lab-challenge']);
     });
 
     it('returns empty array when no matching challenges found', () => {

--- a/client/src/utils/get-completion-percentage.ts
+++ b/client/src/utils/get-completion-percentage.ts
@@ -1,4 +1,5 @@
 import { type Certification } from '@freecodecamp/shared/config/certification-settings';
+import { getIsLabChallenge } from '@freecodecamp/shared/config/challenge-types';
 import { AllChallengesInfo } from '../redux/prop-types';
 import { isProjectBased } from './curriculum-layout';
 
@@ -53,7 +54,10 @@ export const getCurrentBlockIds = (
     )
     .map(node => node.challenge.id);
 
-  if (isProjectBased(challengeType)) {
+  // Labs are project-based, but each lab is its own standalone block rather than
+  // part of a certification's project list. Excluding them keeps the progress bar
+  // accurate (otherwise an already-completed lab reads 0% on resubmit). See #67867.
+  if (isProjectBased(challengeType) && !getIsLabChallenge(challengeType)) {
     return currentCertificateIds.length > 0
       ? currentCertificateIds
       : currentBlockIds;

--- a/packages/shared/src/config/challenge-types.ts
+++ b/packages/shared/src/config/challenge-types.ts
@@ -178,6 +178,15 @@ const dailyCodingChallengeTypes = [
 export const getIsDailyCodingChallenge = (challengeType: number): boolean =>
   dailyCodingChallengeTypes.includes(challengeType);
 
+const labChallengeTypes = [
+  challengeTypes.lab,
+  challengeTypes.jsLab,
+  challengeTypes.pyLab
+];
+
+export const getIsLabChallenge = (challengeType: number): boolean =>
+  labChallengeTypes.includes(challengeType);
+
 const dailyCodingChallengeLanguages = {
   [challengeTypes.dailyChallengeJs]: 'javascript',
   [challengeTypes.dailyChallengePy]: 'python'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67867

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the progress bar showing 0% instead of 100% when a camper resubmits a passing solution to a lab they have already completed.

**Cause:** lab challenge types (`lab`, `jsLab`, `pyLab`) are project-based, so `getCurrentBlockIds` returned the certification's test ids (e.g. the cert exam) instead of the lab's own block. Because the lab's id isn't in that list, a resubmitted (already-completed) lab counted 0 of the certification's tests as done, so the bar read 0%. First submissions only appeared correct because of an optimistic `+1` in the completion count.

**Fix:** added a `getIsLabChallenge` helper (alongside the existing `getIsDailyCodingChallenge`) and excluded labs from the certification-tests branch in `getCurrentBlockIds`, so each lab uses its own block. Certification projects are unaffected and still aggregate to the certification's tests.

Added regression tests covering both the resubmission percentage and the block-id selection for labs.
