### PR TITLE
fix(curriculum): decouple hasattr check in salary tracker step 31

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-salary-tracker/68c9cab4b1118da59eecfc56.md
+++ b/curriculum/challenges/english/blocks/workshop-salary-tracker/68c9cab4b1118da59eecfc56.md
@@ -38,7 +38,16 @@ When `new_level` is equal to `self.level`, you should raise a `ValueError` with 
 Your `if` statement should use `hasattr(self, '_level')` to check if `_level` exists before comparing.
 
 ```js
-({ test: () => assert(runPython(`_Node(_code).find_class("Employee").find_functions("level")[1].find_ifs()[2].find_conditions()[0].is_equivalent("hasattr(self, '_level') and new_level == self.level")`)) })
+({ test: () => assert(runPython(`"hasattr(self, '_level')" in str(_Node(_code).find_class("Employee").find_functions("level")[1].find_ifs()[2].find_conditions()[0])`)) })
+```
+
+Your `if` statement should compare `new_level` against `self.level`.
+
+```js
+({ test: () => assert(runPython(`
+cond = _Node(_code).find_class("Employee").find_functions("level")[1].find_ifs()[2].find_conditions()[0]
+cond.is_equivalent("hasattr(self, '_level') and new_level == self.level") or cond.is_equivalent("hasattr(self, '_level') and self.level == new_level")
+`)) })
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67890

<!-- Feel free to add any additional description of changes below this line -->

So... yeah, basically, Step 31 was still using a single coupled assertion to check both the `hasattr` check and the comparison logic... which meant if a learner got the comparison slightly off (like swapping the operand order), they'd get a confusing hint telling them they forgot `hasattr` even when they wrote it perfectly.

This PR splits that single coupled test into two separate hints... just like we did for Step 32. 

Tested it locally and it works properly...