### PR TITLE
refactor: extract AUTH_LINK_WAIT_MINUTES constant

### DIFF
--- a/api/src/routes/protected/settings.ts
+++ b/api/src/routes/protected/settings.ts
@@ -10,6 +10,8 @@ import { API_LOCATION } from '../../utils/env.js';
 import { getRedirectParams } from '../../utils/redirection.js';
 import { isRestricted } from '../helpers/is-restricted.js';
 
+const AUTH_LINK_WAIT_MINUTES = 5;
+
 type WaitMesssageArgs = {
   sentAt: Date | null;
   now?: Date;
@@ -34,7 +36,7 @@ export function getWaitMessage({ sentAt, now = new Date() }: WaitMesssageArgs) {
 
 function getWaitPeriod({ sentAt, now }: Required<WaitMesssageArgs>) {
   if (sentAt == null) return 0;
-  return 5 - differenceInMinutes(now, sentAt);
+  return AUTH_LINK_WAIT_MINUTES - differenceInMinutes(now, sentAt);
 }
 
 /**


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Replaces magic number `5` in `getWaitPeriod` with a named constant `AUTH_LINK_WAIT_MINUTES`.
Improves readability and makes the wait period configurable by name. The value `5` was unexplained at the call site.