### PR TITLE
fix(curriculum): allow explicit return in shopping cart step 44

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02a4ef92d711ec1ff618c.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02a4ef92d711ec1ff618c.md
@@ -42,18 +42,18 @@ const afterCalculateTotal = code.split('calculateTotal')[1];
 assert.match(afterCalculateTotal, /\(\s*total\s*,\s*item\s*\)\s*=>/);
 ```
 
-Your `reduce` callback should return the sum of `total` and `item.price`. Use an implicit return.
+Your `reduce` callback should return the sum of `total` and `item.price`.
 
 ```js
 const afterCalculateTotal = code.split('calculateTotal')[1];
-assert.match(afterCalculateTotal, /\(\s*total\s*,\s*item\s*\)\s*=>\s*(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)/);
+assert.match(afterCalculateTotal, /\(\s*total\s*,\s*item\s*\)\s*=>\s*(?:\{\s*return\s+(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)\s*;?\s*\}|(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total))/);
 ```
 
 Your `reduce` call should have an initial value of `0`.
 
 ```js
 const afterCalculateTotal = code.split('calculateTotal')[1];
-assert.match(afterCalculateTotal, /this\s*\.\s*items\s*\.\s*reduce\s*\(\s*\(\s*total\s*,\s*item\s*\)\s*=>\s*(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)\s*,\s*0\s*\)/);
+assert.match(afterCalculateTotal, /this\s*\.\s*items\s*\.\s*reduce\s*\(\s*\(\s*total\s*,\s*item\s*\)\s*=>\s*(?:\{\s*return\s+(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)\s*;?\s*\}|(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total))\s*,\s*0\s*\)/);
 ```
 
 # --seed--


### PR DESCRIPTION
Updates hint 4 text and the test regexes in workshop-shopping-cart step 44 to accept both implicit and explicit arrow function return styles.

Hint 4 said 'Use an implicit return' and the regex only matched concise arrow body syntax. A learner using an explicit return block would fail the test despite having correct code.

Changes:
- Removed 'Use an implicit return.' from hint 4 text
- Updated hint 4 regex to accept both implicit and explicit return
- Updated hint 5 regex with the same fix

Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67841