### PR TITLE
fix: accept explicit return in reduce callback for Shopping Cart step 44

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02a4ef92d711ec1ff618c.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02a4ef92d711ec1ff618c.md
@@ -42,18 +42,18 @@ const afterCalculateTotal = code.split('calculateTotal')[1];
 assert.match(afterCalculateTotal, /\(\s*total\s*,\s*item\s*\)\s*=>/);
 ```
 
-Your `reduce` callback should return the sum of `total` and `item.price`. Use an implicit return.
+Your `reduce` callback should return the sum of `total` and `item.price`.
 
 ```js
 const afterCalculateTotal = code.split('calculateTotal')[1];
-assert.match(afterCalculateTotal, /\(\s*total\s*,\s*item\s*\)\s*=>\s*(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)/);
+assert.match(afterCalculateTotal, /\(\s*total\s*,\s*item\s*\)\s*=>(?:\s*(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)|\s*\{\s*return\s+(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)\s*;?\s*\})/);
 ```
 
 Your `reduce` call should have an initial value of `0`.
 
 ```js
 const afterCalculateTotal = code.split('calculateTotal')[1];
-assert.match(afterCalculateTotal, /this\s*\.\s*items\s*\.\s*reduce\s*\(\s*\(\s*total\s*,\s*item\s*\)\s*=>\s*(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)\s*,\s*0\s*\)/);
+assert.match(afterCalculateTotal, /this\s*\.\s*items\s*\.\s*reduce\s*\(\s*\(\s*total\s*,\s*item\s*\)\s*=>(?:\s*(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)|\s*\{\s*return\s+(?:total\s*\+\s*item\.price|item\.price\s*\+\s*total)\s*;?\s*\})\s*,\s*0\s*\)/);
 ```
 
 # --seed--


### PR DESCRIPTION
## What is the bug?

Closes #67841

Step 44 of the Shopping Cart workshop requires learners to use `reduce` to calculate `subTotal`, but the test only accepts the **implicit return** form of the arrow function:

```js
// Passes ✅
const subTotal = this.items.reduce((total, item) => total + item.price, 0);

// Fails ❌ (functionally identical)
const subTotal = this.items.reduce((total, item) => {
  return total + item.price;
}, 0);
```

The explicit return form is semantically equivalent and is valid JavaScript — rejecting it is confusing and inconsistent with how the rest of the curriculum handles arrow functions.

## What was changed?

In `63f02a4ef92d711ec1ff618c.md` (workshop-shopping-cart, step 44):

1. **Hint 5 text** — removed the prescriptive phrase *"Use an implicit return."* since both forms are now accepted.
2. **Hint 5 regex** — updated to match both `=> total + item.price` (implicit) and `=> { return total + item.price; }` (explicit).
3. **Hint 6 regex** — updated the full `reduce(...)` pattern to similarly accept both implicit and explicit return forms.

## Testing

The updated regexes accept:
- `(total, item) => total + item.price` ✅
- `(total, item) => item.price + total` ✅
- `(total, item) => { return total + item.price; }` ✅
- `(total, item) => { return item.price + total; }` ✅

And still reject incorrect patterns like wrong parameter names or missing `reduce`.

## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67841