### PR TITLE
fix(curriculum): add missing startStance tests for Daily Challenge 181 (Snowboarding)

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e6ff50d756c9b6935e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e6ff50d756c9b6935e.md
@@ -29,6 +29,18 @@ assert.equal(getLandingStance("Regular", 90), "Regular");
 assert.equal(getLandingStance("Regular", 180), "Goofy");
 ```
 
+`getLandingStance("Goofy", 90)` should return `"Goofy"`.
+
+```js
+assert.equal(getLandingStance("Goofy", 90), "Goofy");
+```
+
+`getLandingStance("Goofy", 180)` should return `"Regular"`.
+
+```js
+assert.equal(getLandingStance("Goofy", 180), "Regular");
+```
+
 `getLandingStance("Goofy", -270)` should return `"Regular"`.
 
 ```js


### PR DESCRIPTION
## What is the bug?

The existing tests for **Challenge 181: Snowboarding** do not verify that \`startStance\` is used. A solution that ignores \`startStance\` entirely passes all 6 existing tests:

\`\`\`js
// Ignores startStance — passes all current tests anyway
function getLandingStance(startStance, rotation) {
  let trick = 180 - rotation;
  return trick > 0 ? "Regular" : "Goofy";
}
\`\`\`

| Call | Expected | Buggy result | Passes? |
|---|---|---|---|
| \`("Regular", 90)\` | \`"Regular"\` | \`"Regular"\` | ✅ |
| \`("Regular", 180)\` | \`"Goofy"\` | \`"Goofy"\` | ✅ |
| \`("Goofy", -270)\` | \`"Regular"\` | \`"Regular"\` | ✅ |
| \`("Regular", 2340)\` | \`"Goofy"\` | \`"Goofy"\` | ✅ |
| \`("Goofy", 2160)\` | \`"Goofy"\` | \`"Goofy"\` | ✅ |
| \`("Goofy", -540)\` | \`"Regular"\` | \`"Regular"\` | ✅ |

## What was changed?

Added two new test cases using \`"Goofy"\` as the starting stance with simple rotations. The buggy solution fails both:

- \`getLandingStance("Goofy", 90)\` → \`"Goofy"\` — buggy returns \`"Regular"\` ❌
- \`getLandingStance("Goofy", 180)\` → \`"Regular"\` — buggy returns \`"Goofy"\` ❌

The reference solution passes all 8 tests correctly.

## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the \`main\` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67904