### PR TITLE
fix(curriculum): audit editable regions for workshop-ferris-wheel

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140c7e645d8e905819f1dd4.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140c7e645d8e905819f1dd4.md
@@ -52,13 +52,13 @@ assert.strictEqual(linkElement?.dataset?.href, "styles.css");
 ```html
 <!DOCTYPE html>
 <html lang="en">
---fcc-editable-region--
   <head>
     <meta charset="UTF-8">
     <title>Ferris Wheel</title>
-
-  </head>
 --fcc-editable-region--
+    
+--fcc-editable-region--
+  </head>
   <body>
 
   </body>

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140c9d35015ae0ba0c250e8.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140c9d35015ae0ba0c250e8.md
@@ -64,13 +64,13 @@ assert.lengthOf(document.querySelectorAll('.cabin'), 6);
   <head>
     <meta charset="UTF-8">
     <title>Ferris Wheel</title>
-    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./styles.css">
   </head>
---fcc-editable-region--
   <body>
-
-  </body>
 --fcc-editable-region--
+    
+--fcc-editable-region--
+  </body>
 </html>
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140cd32d018ed0f600eefce.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140cd32d018ed0f600eefce.md
@@ -62,11 +62,12 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.width, '5
 ```
 
 ```css
---fcc-editable-region--
 .wheel {
   border: 2px solid black;
   border-radius: 50%;
   margin-left: 50px;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140cfc08ca9c5128c3e6478.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140cfc08ca9c5128c3e6478.md
@@ -73,11 +73,12 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.line')?.top, '50%'
   max-height: 500px;
 }
 
---fcc-editable-region--
 .line {
   background-color: black;
   width: 50%;
   height: 2px;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140d0069049f5139d78da40.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140d0069049f5139d78da40.md
@@ -64,7 +64,6 @@ assert.oneOf(transformOrigin, ['0% 0%', '0% 0% 0px']);
   max-height: 500px;
 }
 
---fcc-editable-region--
 .line {
   background-color: black;
   width: 50%;
@@ -72,6 +71,8 @@ assert.oneOf(transformOrigin, ['0% 0%', '0% 0% 0px']);
   position: absolute;
   top: 50%;
   left: 50%;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140d2b687a2cd17bac5730c.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140d2b687a2cd17bac5730c.md
@@ -93,11 +93,12 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.cabin')?.border, '
   transform: rotate(300deg);
 }
 
---fcc-editable-region--
 .cabin {
   background-color: red;
   width: 20%;
   height: 20%;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140d36b8b747718b50d4b7a.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140d36b8b747718b50d4b7a.md
@@ -88,13 +88,14 @@ assert.oneOf(transformOrigin, ['50% 0%', '50% 0% 0px']);
   transform: rotate(300deg);
 }
 
---fcc-editable-region--
 .cabin {
   background-color: red;
   width: 20%;
   height: 20%;
   position: absolute;
   border: 2px solid;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140dc5e13d0c81e7496f182.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140dc5e13d0c81e7496f182.md
@@ -131,9 +131,9 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[0]
   top: 7%;
 }
 
---fcc-editable-region--
 @keyframes wheel {
-
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140dd77e0bc5a1f70bd7466.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140dd77e0bc5a1f70bd7466.md
@@ -121,11 +121,11 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[0]
   top: 7%;
 }
 
---fcc-editable-region--
 @keyframes wheel {
-   0% {
-
-   }
-}
+  0% {
 --fcc-editable-region--
+    
+--fcc-editable-region--
+  }
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140de31b1f5b420410728ff.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140de31b1f5b420410728ff.md
@@ -135,12 +135,12 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[0]
   top: 7%;
 }
 
---fcc-editable-region--
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-
-}
+  0% {
+    transform: rotate(0deg);
+  }
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140df547f09402144e40b92.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140df547f09402144e40b92.md
@@ -58,7 +58,6 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.animation
 ```
 
 ```css
---fcc-editable-region--
 .wheel {
   border: 2px solid black;
   border-radius: 50%;
@@ -68,8 +67,10 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.animation
   width: 55vw;
   max-width: 500px;
   max-height: 500px;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 
 .line {
   background-color: black;
@@ -132,11 +133,11 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.animation
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140e0d875ec16262f26432b.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140e0d875ec16262f26432b.md
@@ -58,7 +58,6 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.animation
 ```
 
 ```css
---fcc-editable-region--
 .wheel {
   border: 2px solid black;
   border-radius: 50%;
@@ -70,8 +69,10 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.animation
   max-height: 500px;
   animation-name: wheel;
   animation-duration: 10s;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 
 .line {
   background-color: black;
@@ -134,11 +135,11 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.animation
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140f4b5c1555a2960de1e5f.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6140f4b5c1555a2960de1e5f.md
@@ -177,12 +177,12 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/614100d7d335bb2a5ff74f1f.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/614100d7d335bb2a5ff74f1f.md
@@ -97,7 +97,6 @@ assert.strictEqual(cabinElementStyles?.animationIterationCount, "infinite");
   transform: rotate(300deg);
 }
 
---fcc-editable-region--
 .cabin {
   background-color: red;
   width: 20%;
@@ -105,8 +104,10 @@ assert.strictEqual(cabinElementStyles?.animationIterationCount, "infinite");
   position: absolute;
   border: 2px solid;
   transform-origin: 50% 0%;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 
 .cabin:nth-of-type(1) {
   right: -8.5%;
@@ -134,12 +135,12 @@ assert.strictEqual(cabinElementStyles?.animationIterationCount, "infinite");
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes cabins {

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/61410126fa3a6d2b3cda502e.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/61410126fa3a6d2b3cda502e.md
@@ -98,7 +98,6 @@ assert.strictEqual(cabinElementStyles?.animationIterationCount, "infinite");
   transform: rotate(300deg);
 }
 
---fcc-editable-region--
 .cabin {
   background-color: red;
   width: 20%;
@@ -106,9 +105,10 @@ assert.strictEqual(cabinElementStyles?.animationIterationCount, "infinite");
   position: absolute;
   border: 2px solid;
   transform-origin: 50% 0%;
-  animation: cabins 10s linear infinite;
-}
 --fcc-editable-region--
+  animation: cabins 10s linear infinite;
+--fcc-editable-region--
+}
 
 .cabin:nth-of-type(1) {
   right: -8.5%;
@@ -136,12 +136,12 @@ assert.strictEqual(cabinElementStyles?.animationIterationCount, "infinite");
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes cabins {

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6141019eadec6d2c6c6f007b.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6141019eadec6d2c6c6f007b.md
@@ -127,22 +127,23 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
---fcc-editable-region--
 @keyframes cabins {
   0% {
     transform: rotate(0deg);
+--fcc-editable-region--
+    
+--fcc-editable-region--
   }
   100% {
     transform: rotate(-360deg);
   }
 }
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6141026ec9882f2d39dcf2b8.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6141026ec9882f2d39dcf2b8.md
@@ -140,23 +140,24 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
---fcc-editable-region--
 @keyframes cabins {
   0% {
     transform: rotate(0deg);
     background-color: yellow;
   }
+--fcc-editable-region--
+  
+--fcc-editable-region--
   100% {
     transform: rotate(-360deg);
   }
 }
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6169ab1aaeb4cd1174def700.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6169ab1aaeb4cd1174def700.md
@@ -129,19 +129,20 @@ assert.isEmpty(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]?.cs
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
---fcc-editable-region--
 @keyframes cabins {
   0% {
     transform: rotate(0deg);
+--fcc-editable-region--
     background-color: yellow;
+--fcc-editable-region--
   }
   50% {
     background-color: purple;
@@ -150,5 +151,4 @@ assert.isEmpty(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]?.cs
     transform: rotate(-360deg);
   }
 }
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6169b1357fcb701bb5efc619.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6169b1357fcb701bb5efc619.md
@@ -140,19 +140,21 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
---fcc-editable-region--
 @keyframes cabins {
   0% {
     transform: rotate(0deg);
   }
+--fcc-editable-region--
+  
+--fcc-editable-region--
   50% {
     background-color: purple;
   }
@@ -160,5 +162,4 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]
     transform: rotate(-360deg);
   }
 }
---fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/6169b284950e171d8d0bb16a.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/6169b284950e171d8d0bb16a.md
@@ -142,15 +142,14 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
---fcc-editable-region--
 @keyframes cabins {
   0% {
     transform: rotate(0deg);
@@ -161,11 +160,13 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]
   50% {
     background-color: purple;
   }
+--fcc-editable-region--
+  
+--fcc-editable-region--
   100% {
     transform: rotate(-360deg);
   }
 }
---fcc-editable-region--
 ```
 
 # --solutions--
@@ -276,12 +277,12 @@ assert.strictEqual(new __helpers.CSSHelp(document).getCSSRules('keyframes')?.[1]
 }
 
 @keyframes wheel {
-   0% {
-     transform: rotate(0deg);
-   }
-   100% {
-     transform: rotate(360deg);
-   }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes cabins {

--- a/curriculum/challenges/english/blocks/workshop-ferris-wheel/617ace7d831f9c16a569b38a.md
+++ b/curriculum/challenges/english/blocks/workshop-ferris-wheel/617ace7d831f9c16a569b38a.md
@@ -56,7 +56,6 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.maxWidth,
 ```
 
 ```css
---fcc-editable-region--
 .wheel {
   border: 2px solid black;
   border-radius: 50%;
@@ -64,6 +63,8 @@ assert.strictEqual(new __helpers.CSSHelp(document).getStyle('.wheel')?.maxWidth,
   position: absolute;
   height: 55vw;
   width: 55vw;
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```


### PR DESCRIPTION
Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Ref #67721


Part of Naomi's sprint for editable regions in workshops. Tried to message on discord, let me know if something specific is needed.

I gone through and audeted the 29 steps of the Ferris Wheel workshop, so each editable region wraps only the lines a camper needs to modifY:
- Steps 1, 2, 4, 5, 7, 8, 12, 13, 17–21 and 23: regions wrapped a whole element or ruleset; they now wrap just the insertion point or the specific lines being changed.
- Step 24: region narrowed to the `animation` declaration the camper edits.
- Steps 25–29: regions in `@keyframes cabins` narrowed to the rule or line being added/removed.
- Step 2: `<link ... />` changed to `<link ...>` to match every other step in the workshop.
- Steps 18–29 (incl. the step 29 solution): normalized the `@keyframes wheel` block from 3-space to 2-space indentation to match the rest of the stylesheet. About half the diff is this re-indent — hiding whitespace in the diff view shows just the marker changes.

Steps 3, 6, 9-11, 14-16 and 22 already had correctly placed empty regions and are unchanged apart from the indentation fix in step 22. The legacy `learn-css-animation-by-building-a-ferris-wheel` block is intentionally untouched.

Tested locally: `FCC_BLOCK=workshop-ferris-wheel pnpm test` (244 passing), `pnpm lint-challenges`, and a full curriculum build and the others test scripts