### PR TITLE
fix(client): prevent user fetch timeout flash for guests and improve contrast

### DIFF
--- a/client/src/components/signout-modal/index.tsx
+++ b/client/src/components/signout-modal/index.tsx
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal, Spacer } from '@freecodecamp/ui';
+import store from 'store';
 
 import { closeSignoutModal } from '../../redux/actions';
 import { isSignoutModalOpenSelector } from '../../redux/selectors';
@@ -54,6 +55,7 @@ function SignoutModal(props: SignoutModalProps): JSX.Element {
   const handleSignout = () => {
     closeSignoutModal();
     callGA({ event: 'sign_out', user_id: undefined });
+    store.remove('fcc-is-logged-in');
     const redirect = () => {
       window.location.pathname = pathAfterSignout(window.location.pathname);
     };

--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -1,4 +1,5 @@
 import { call, cancel, delay, fork, put, takeEvery } from 'redux-saga/effects';
+import store from 'store';
 import { getSessionUser, getUserProfile } from '../utils/ajax';
 import { wrapHandledError } from '../utils/handled-error';
 import { UserFetchErrorMessage } from '../utils/error-messages';
@@ -25,6 +26,7 @@ function* fetchSessionUser() {
     const res = yield call(getSessionUser, AbortSignal.timeout(10000));
 
     const isSignedOut = res.response.status === 401;
+
     if (!res.response.ok && !isSignedOut) {
       throw new Error(
         `HTTP Error: ${res.response.status} ${res.response.statusText}`
@@ -32,11 +34,21 @@ function* fetchSessionUser() {
     }
 
     const { data: user } = res;
+
+    if (user !== null) {
+      store.set('fcc-is-logged-in', true);
+    } else {
+      store.remove('fcc-is-logged-in');
+    }
     yield put(fetchUserComplete({ user }));
   } catch (e) {
     console.log('failed to fetch user', e);
-    const handledError = wrapHandledError(e, UserFetchErrorMessage);
-    yield put(fetchUserError(handledError));
+    if (store.get('fcc-is-logged-in')) {
+      const handledError = wrapHandledError(e, UserFetchErrorMessage);
+      yield put(fetchUserError(handledError));
+    } else {
+      yield put(fetchUserError(''));
+    }
   } finally {
     yield cancel(timeoutTask);
   }

--- a/client/src/utils/error-messages.ts
+++ b/client/src/utils/error-messages.ts
@@ -26,6 +26,6 @@ export const msTrophyVerified = {
 };
 
 export const UserFetchErrorMessage = {
-  type: 'danger',
+  type: 'info',
   message: FlashMessages.UserFetchError
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

### Description

This PR fixes two issues with the "Unable to retrieve user info" flash message on slow network connections:

- **Shown to guests incorrectly:** Previously, If `getSessionUser` timed out, the app displayed the warning before confirming whether the user was logged in. As a result, logged-out users could see an unnecessary error message.
**Fix:** Added an `fcc-is-logged-in` local storage flag (via the store package). The flag is set when a valid user is returned and cleared when the user signs out or no user is found. If a request times out and the user is a guest, the app now fails silently.

- **Poor background contrast:** The background of the warning message blended too closely with the page's layout background, making it hard to notice.
**Fix:** Updated the type of `UserFetchErrorMessage `in `error-messages.ts` from `danger` (red) to `info` (blue). This provides much better contrast and visual distinction against the surrounding elements while preserving the semantic meaning of the notification.

### Screenshots
**Before**

<img width="1020" height="345" alt="image" src="https://github.com/user-attachments/assets/2902a4e3-cafe-4f19-badd-defaed176cc7" />



**After**

_Logged-in user experiencing a network timeout: The banner displays with improved blue contrast to warn the user that their profile failed to load._

<img width="1725" height="425" alt="Logged-in user" src="https://github.com/user-attachments/assets/38468d98-5e17-4d49-ae95-11f064eade5b" />


_Guest user experiencing a network timeout: The banner correctly remains hidden, allowing guests to browse uninterrupted._

<img width="1726" height="331" alt="Guest user" src="https://github.com/user-attachments/assets/813130ad-a6ac-4374-98aa-b16235874f92" />

### How to Verify
**Guest user**

1. Log out and run `localStorage.clear()` in DevTools.
2. Enable your extremely slow custom network throttling profile.
3. Refresh the page and wait ~10 seconds.
4. The request should time out, but no flash message should appear.

**Logged-in user**

1. Sign in to freeCodeCamp.
2. Enable your extremely slow custom network throttling profile.
3. Refresh the page and wait ~10 seconds.
4. The flash message should appear and use the updated blue info styling.

Closes #67901

<!-- Feel free to add any additional description of changes below this line -->
