### PR TITLE
docs(curriculum): fix wording in review CSS backgrounds and borders

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -63,7 +63,9 @@ Here's an example showing the difference between `inside` and `outside`:
 
 :::
 
-- **`list-style-image` Property**: This property is used to use an image for the list item marker. A common use case is to use the `url` function with a value set to a valid image location.
+- **`list-style-position` Property**: This property is used to set the position for the list marker. The only two acceptable values are `inside` and `outside`.
+
+- **`list-style-image` Property**: This property is used to set an image for the list item marker. A common use is the `url()` function with a valid image URL.
 
 ## Spacing list items using `margin`
 
@@ -136,6 +138,11 @@ a:hover {
 :::
 
 - **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples would include `input` or `select` elements where the clicks or tabs on the element to focus it.
+
+- **`:visited pseudo-class`**: This pseudo-class styles links that the user has already visited.
+- **`:hover pseudo-class`**: This pseudo-class styles elements that the user is hovering over.
+
+- **`:focus pseudo-class`**: This pseudo-class styles an element when it receives focus. Examples include `input` or `select` elements that receive focus via mouse click or keyboard navigation.
 
 Here's an example using the `:focus` pseudo-class:
 
@@ -213,6 +220,8 @@ Here's an example using `background-size: contain`:
 
 - **`background-repeat` Property**: This property is used to determine how background images should be repeated along the horizontal and vertical axes. The default value for `background-repeat` is `repeat` meaning the image will repeat both horizontally and vertically. You can also specify that there should be no repeat by using the `no-repeat` property.
 
+- **`background-repeat` Property**: This property determines how background images are repeated along the horizontal and vertical axes. The default value for `background-repeat` is `repeat`, which repeats the image both horizontally and vertically. You can also prevent repeating by using the value `no-repeat`.
+
 Here's an example using `background-repeat: no-repeat`:
 
 :::interactive_editor
@@ -252,6 +261,8 @@ Here's an example using `background-position`:
 
 - **`background-attachment` Property**: This property is used to specify whether the background image should scroll with the content or remain fixed in place. The main values are `scroll` (default), where the background image scrolls with the content, and `fixed`, where the background image stays in the same position on the screen.
 - **`background-image` Property**: This property is used to set the background image of an element. You can set multiple background images at the same time and use either the `url`, `radial-gradient` or `linear-gradient` functions as values.
+
+- **`background-image` Property**: This property sets the background image of an element. You can set multiple background images at the same time and use functions such as `url()`, `radial-gradient()` or `linear-gradient()` as values.
 
 Here's an example using `background-image`:
 

--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -33,7 +33,9 @@ ul {
 
 :::
 
-- **`list-style-position` Property**: This property is used to set the position for the list marker. The only two acceptable values are inside and outside.
+- **`list-style-position` Property**: This property is used to set the position for the list marker. The only two acceptable values are `inside` and `outside`.
+
+
 
 Here's an example showing the difference between `inside` and `outside`:
 
@@ -63,9 +65,8 @@ Here's an example showing the difference between `inside` and `outside`:
 
 :::
 
-- **`list-style-position` Property**: This property is used to set the position for the list marker. The only two acceptable values are `inside` and `outside`.
-
 - **`list-style-image` Property**: This property is used to set an image for the list item marker. A common use is the `url()` function with a valid image URL.
+
 
 ## Spacing list items using `margin`
 
@@ -139,10 +140,6 @@ a:hover {
 
 - **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples include `input` or `select` elements where the user clicks or tabs on the element to focus it.
 
-- **`:visited pseudo-class`**: This pseudo-class styles links that the user has already visited.
-- **`:hover pseudo-class`**: This pseudo-class styles elements that the user is hovering over.
-
-- **`:focus pseudo-class`**: This pseudo-class styles an element when it receives focus. Examples include `input` or `select` elements that receive focus via mouse click or keyboard navigation.
 
 Here's an example using the `:focus` pseudo-class:
 
@@ -217,8 +214,6 @@ Here's an example using `background-size: contain`:
 ```
 
 :::
-
-- **`background-repeat` Property**: This property is used to determine how background images should be repeated along the horizontal and vertical axes. The default value for `background-repeat` is `repeat` meaning the image will repeat both horizontally and vertically. You can also specify that there should be no repeat by using the `no-repeat` property.
 
 - **`background-repeat` Property**: This property determines how background images are repeated along the horizontal and vertical axes. The default value for `background-repeat` is `repeat`, which repeats the image both horizontally and vertically. You can also prevent repeating by using the value `no-repeat`.
 

--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -9,8 +9,8 @@ dashedName: review-css-backgrounds-and-borders
 
 ## Styling Lists
 
-- **`line-height` Property**: This property is used to create space between lines of text. The accepted `line-height` values include the keyword `normal`, numbers, percentages and length units like the `em` unit.
-- **`list-style-type` Property**: This property is used to specify the marker for a list item. Acceptable values can include a circle, disc, or decimal.
+- **`line-height` Property**: This property is used to create space between lines of text. The accepted `line-height` values include the keyword `normal`, numbers, percentages, and length units like the `em` unit.
+- **`list-style-type` Property**: This property is used to specify the marker for a list item. Acceptable values can include a `circle`, `disc`, or `decimal`.
 
 Here's an example using `list-style-type` to change the bullet style:
 
@@ -96,7 +96,7 @@ Here's an example using `margin-bottom` to space list items:
 
 ## Styling Links
 
-- **`pseudo-class`**: This is a keyword added to a selector that allows you to select elements based on a particular state. Common states would include the `:hover`, `:visited` and `:focus` states.
+- **`pseudo-class`**: This is a keyword added to a selector that allows you to select elements based on a particular state. Common states would include the `:hover`, `:visited`, and `:focus` states.
 - **`:link pseudo-class`**: This pseudo-class is used to style links that have not been visited by the user.
 
 Here's an example using the `:link` pseudo-class:
@@ -116,7 +116,7 @@ a:link {
 
 :::
 
-- **`:visited pseudo-class`**: This pseudo-class is used to style links where a user has already visited.
+- **`:visited pseudo-class`**: This pseudo-class is used to style links that a user has already visited.
 - **`:hover pseudo-class`**: This pseudo-class is used to style elements where a user is actively hovering over them.
 
 Here's an example using the `:hover` pseudo-class:
@@ -137,7 +137,7 @@ a:hover {
 
 :::
 
-- **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples would include `input` or `select` elements where the clicks or tabs on the element to focus it.
+- **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples include `input` or `select` elements where the user clicks or tabs on the element to focus it.
 
 - **`:visited pseudo-class`**: This pseudo-class styles links that the user has already visited.
 - **`:hover pseudo-class`**: This pseudo-class styles elements that the user is hovering over.
@@ -260,9 +260,7 @@ Here's an example using `background-position`:
 :::
 
 - **`background-attachment` Property**: This property is used to specify whether the background image should scroll with the content or remain fixed in place. The main values are `scroll` (default), where the background image scrolls with the content, and `fixed`, where the background image stays in the same position on the screen.
-- **`background-image` Property**: This property is used to set the background image of an element. You can set multiple background images at the same time and use either the `url`, `radial-gradient` or `linear-gradient` functions as values.
-
-- **`background-image` Property**: This property sets the background image of an element. You can set multiple background images at the same time and use functions such as `url()`, `radial-gradient()` or `linear-gradient()` as values.
+- **`background-image` Property**: This property sets the background image of an element. You can set multiple background images at the same time and use functions such as `url()`, `radial-gradient()`, or `linear-gradient()` as values.
 
 Here's an example using `background-image`:
 


### PR DESCRIPTION
Fixes grammar, wording, and formatting in the review-css-backgrounds-and-borders lesson.

Changes:

Clarify list-style-image and list-style-position descriptions
Improve :hover, :visited, and :focus wording
Clarify background-repeat and background-image wording
Checklist:

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67919 

<!-- Feel free to add any additional description of changes below this line -->