### PR TITLE
fix(curriculum): fix writing issues in try...catch...finally lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733bee844600f35c05b8264.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733bee844600f35c05b8264.md
@@ -7,7 +7,7 @@ dashedName: how-does-try-catch-finally-work
 
 # --interactive--
 
-In the previous lesson, you learned how to throw exceptions in your programs. In this lesson, we will take a look at how to gracefully handle these errors in a `try…catch…finally` block.
+In the previous lesson, you learned how to throw exceptions in your programs. In this lesson, we will take a look at how to gracefully handle these errors in a `try...catch...finally` block.
 
 The `try` block is used to wrap code that might throw an error. It acts as a safe space to try something that could fail.
 
@@ -15,7 +15,7 @@ The `catch` block captures and handles errors that occur in the `try` block. You
 
 The `finally` block runs after the `try` and `catch` blocks, regardless of whether an error occurred. It’s commonly used for cleanup tasks, such as closing files or releasing resources.
 
-Here is an example of using a `try…catch` block:
+Here is an example of using a `try...catch` block:
 
 :::interactive_editor
 
@@ -41,13 +41,13 @@ try {
 
 In this example, we have a function called `processInput` that first checks if the `input` is not of type `string`. If that is the case, then we throw an error. Otherwise, we return the result of using the `toUpperCase` method on the `input`.
 
-We call the function inside of a `try` block. Since the function call throws an error, then it will be caught inside the `catch` block and the error message will be displayed in the console. 
+We call the function inside of a `try` block. Since the function call throws an error, it will be caught inside the `catch` block and the error message will be displayed in the console. 
 
 The error passed into the `catch` block is an `Error` object which contains information about that error. In this case, we are using the `message` property which displays human readable information to the user. 
 
 We are using the `console.error` because it is designed specifically to log errors. In many modern browsers, the output of `console.error()` appears in red in the console.
 
-The `finally` statement is executed regardless of if an exception was thrown or not.
+The `finally` statement is executed regardless of whether an exception was thrown.
 
 ```js
 try {
@@ -73,7 +73,7 @@ It’s for running code again automatically after an error occurs.
 
 ### --feedback--
 
-Think about the order of blocks in `try…catch…finally` statements, and the types of tasks each block handles.
+Think about the order of blocks in `try...catch...finally` statements, and the types of tasks each block handles.
 
 ---
 
@@ -81,7 +81,7 @@ It’s for handling errors.
 
 ### --feedback--
 
-Think about the order of blocks in `try…catch…finally` statements, and the types of tasks each block handles.
+Think about the order of blocks in `try...catch...finally` statements, and the types of tasks each block handles.
 
 ---
 
@@ -89,7 +89,7 @@ It’s for setup before an error is thrown.
 
 ### --feedback--
 
-Think about the order of blocks in `try…catch…finally` statements, and the types of tasks each block handles.
+Think about the order of blocks in `try...catch...finally` statements, and the types of tasks each block handles.
 
 ---
 


### PR DESCRIPTION
                                              
                  
Description:
  Closes #67921

  Fixed three writing and formatting issues in the "How Does try...catch...finally Work?" lecture:

  - Removed erroneous "then" from "Since the function call throws an error, then it will be caught..."
  - Changed "regardless of if" to "regardless of whether"
  - Replaced Unicode ellipsis characters (…) with ASCII equivalents (...) to match the rest of the file

  Checklist:
  - [x] I have read and followed the contribution guidelines.
  - [x] I have read and followed the how to open a pull request guide.
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.