### PR TITLE
fix(curriculum): fix writing issues in debugging techniques lectures

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733aa9b006d29f4d11307a5.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733aa9b006d29f4d11307a5.md
@@ -15,7 +15,7 @@ A `SyntaxError` happens when you write something incorrectly in your code, like 
 const arr = ["Beau", "Quincy" "Tom"]
 ```
 
-Each array element needs to be separated by a comma otherwise it will result in an error message.
+Each array element needs to be separated by a comma, otherwise it will result in an error message.
 
 The second common JavaScript error is a `ReferenceError`. There are several types of `ReferenceError`s, triggered in different ways. The first type of `ReferenceError` would be not defined variables.
 
@@ -23,7 +23,7 @@ The second common JavaScript error is a `ReferenceError`. There are several type
 console.log(price);
 ```
 
-In this example, we are trying to log the `price` variable to the console but it hasn’t been defined. This is will result in a `ReferenceError`.
+In this example, we are trying to log the `price` variable to the console but it hasn’t been defined. This will result in a `ReferenceError`.
 
 Another example of a `ReferenceError` is trying to access a variable, declared with `let` or `const`, before it has been defined:
 

--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733aa9b006d29f4d11307a5.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733aa9b006d29f4d11307a5.md
@@ -23,7 +23,7 @@ The second common JavaScript error is a `ReferenceError`. There are several type
 console.log(price);
 ```
 
-In this example, we are trying to log the `price` variable to the console but it hasn’t been defined. This will result in a `ReferenceError`.
+In this example, we are trying to log the `price` variable to the console but it hasn't been defined. This will result in a `ReferenceError`.
 
 Another example of a `ReferenceError` is trying to access a variable, declared with `let` or `const`, before it has been defined:
 
@@ -50,7 +50,7 @@ This example will result in a `developerObj.map is not a function` error because
 
 The last common error we will look at is the `RangeError`.
 
-A `RangeError` happens when your code tries to use a value that’s outside the range of what JavaScript can handle. Here is an example of assigning an invalid value to an array's length:
+A `RangeError` happens when your code tries to use a value that's outside the range of what JavaScript can handle. Here is an example of assigning an invalid value to an array's length:
 
 ```js
 const arr = [];

--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733bec70d86e13522e98a4f.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733bec70d86e13522e98a4f.md
@@ -7,7 +7,7 @@ dashedName: how-does-the-throw-statement-work
 
 # --description--
 
-The `throw` statement in JavaScript is used to throw a user defined exception. An exception in programming, is when an unexpected event happens and disrupts the normal flow of the program.
+The `throw` statement in JavaScript is used to throw a user-defined exception. An exception in programming is when an unexpected event happens and disrupts the normal flow of the program.
 
 As programmers it is important to handle these exceptions, so your programs don’t crash unexpectedly when errors occur. Here is the basic syntax for the `throw` statement:
 
@@ -15,7 +15,7 @@ As programmers it is important to handle these exceptions, so your programs don�
 throw expression;
 ```
 
-The `expression` in this case would be the object or value that represents the exception you want to throw. Examples of this would be the built in exception classes like the `Error`, `TypeError`, or `RangeError` class. Here is an example of using the `throw` statement to throw a `TypeError`:
+The `expression` in this case would be the object or value that represents the exception you want to throw. Examples of this would be the built-in exception classes like the `Error`, `TypeError`, or `RangeError` class. Here is an example of using the `throw` statement to throw a `TypeError`:
 
 ```js
 function validateNumber(input) {
@@ -41,7 +41,7 @@ function divide(numerator, denominator) {
 
 Here is an example of a function that will check if the denominator is `0`. If that is the case, then it will throw a custom error message saying `Cannot divide by zero`.
 
-In the next lesson, we will look at how to throw errors messages within the context of the `try`/`catch` block which is used to gracefully handle exceptions in JavaScript.
+In the next lesson, we will look at how to throw error messages within the context of the `try`/`catch` block which is used to gracefully handle exceptions in JavaScript.
 
 # --questions--
 
@@ -95,7 +95,7 @@ Think of a way to catch and handle errors without crashing the program.
 
 ---
 
-Use the `try…catch` syntax to handle the error and allow code execution to continue.
+Use the `try...catch` syntax to handle the error and allow code execution to continue.
 
 ---
 

--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733bec70d86e13522e98a4f.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733bec70d86e13522e98a4f.md
@@ -9,7 +9,7 @@ dashedName: how-does-the-throw-statement-work
 
 The `throw` statement in JavaScript is used to throw a user-defined exception. An exception in programming is when an unexpected event happens and disrupts the normal flow of the program.
 
-As programmers it is important to handle these exceptions, so your programs don’t crash unexpectedly when errors occur. Here is the basic syntax for the `throw` statement:
+As programmers it is important to handle these exceptions, so your programs don't crash unexpectedly when errors occur. Here is the basic syntax for the `throw` statement:
 
 ```js
 throw expression;

--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733becf4b0c353553b9bfa4.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733becf4b0c353553b9bfa4.md
@@ -49,7 +49,7 @@ let finalPrice = calculateTotalPrice(price, discount)
 console.log(`Final Price: ${finalPrice}`);
 ```
 
-In this example the `debugger` statement is placed at the top of the `calculateTotalPrice`. When the function is called, the function execution will be paused.
+In this example the `debugger` statement is placed at the top of the `calculateTotalPrice` function. When the function is called, the function execution will be paused.
 
 If you reload the page with the console opened, you'll see that the page keeps reloading, confirming that the execution of the code is only paused, not stopped. If you want the execution to continue, you can click the play button.
 

--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733befb703ca6361da3755b.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733befb703ca6361da3755b.md
@@ -15,7 +15,7 @@ To add a breakpoint to any line in your code in the Chrome browser, open the dev
 
 After the execution reaches the breakpoint and stops, you can step through the code by using the icons on the top right corner. You can also add a conditional breakpoint by right-clicking on a line and selecting "Add conditional breakpoint…"
 
-Now, let’s move on to watching expressions. Watch expressions lets you monitor the values of variables or expressions as the code runs even if they are out of the current scope.
+Now, let’s move on to watching expressions. Watch expressions let you monitor the values of variables or expressions as the code runs even if they are out of the current scope.
 
 To add a watch expression, navigate to the Sources tab of the developer tools, look for the watch panel on the right and click the plus (`+`) icon to add it.
 

--- a/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733befb703ca6361da3755b.md
+++ b/curriculum/challenges/english/blocks/lecture-debugging-techniques/6733befb703ca6361da3755b.md
@@ -15,7 +15,7 @@ To add a breakpoint to any line in your code in the Chrome browser, open the dev
 
 After the execution reaches the breakpoint and stops, you can step through the code by using the icons on the top right corner. You can also add a conditional breakpoint by right-clicking on a line and selecting "Add conditional breakpoint…"
 
-Now, let’s move on to watching expressions. Watch expressions let you monitor the values of variables or expressions as the code runs even if they are out of the current scope.
+Now, let's move on to watching expressions. Watch expressions let you monitor the values of variables or expressions as the code runs even if they are out of the current scope.
 
 To add a watch expression, navigate to the Sources tab of the developer tools, look for the watch panel on the right and click the plus (`+`) icon to add it.
 
@@ -25,7 +25,7 @@ To do that for your code, open the Performance tab, click record, and perform th
 
 This could be useful if your application is lagging during certain operations. With the profiler, you can see which function or other data in the code consumes the most resources.
 
-Now, let’s move onto inspecting network requests. Inspecting network requests can help you debug issues related to API requests such as parameter errors, address errors, or server errors.
+Now, let's move onto inspecting network requests. Inspecting network requests can help you debug issues related to API requests such as parameter errors, address errors, or server errors.
 
 To use the Network tab for debugging, open the developer tools and head over to the Network tab, then click on individual requests to see details like headers, responses, and payloads.
 


### PR DESCRIPTION
Checklist:                     

  - [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).                  
  - [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).                                            
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

  Closes #67920

  Fixed nine writing and formatting issues across four debugging technique lecture files:

  - Added missing comma: "separated by a comma, otherwise..."
  - Removed duplicate word: "This will result in a ReferenceError" (not "This is will")
  - Added missing hyphen: "user-defined exception"
  - Removed incorrect comma: "An exception in programming is when..."
  - Added missing hyphen: "built-in exception classes"
  - Fixed plural: "throw error messages" (not "errors messages")
  - Added missing word: "top of the `calculateTotalPrice` function"
  - Fixed subject-verb agreement: "Watch expressions let you monitor..." (not "lets")
  - Replaced Unicode ellipsis (…) with ASCII (...) in `try...catch`