### PR TITLE
fix(client): don't show user-info error to signed-out users on slow c…

### DIFF
--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -10,7 +10,7 @@ import {
   fetchUserTimeout
 } from './actions';
 
-function* fetchSessionUser() {
+export function* fetchSessionUser() {
   const timeoutTask = yield fork(function* () {
     // The server should not take anywhere near 2 seconds to respond. If it
     // does, we assume the request has failed and dispatch a timeout action to
@@ -35,8 +35,15 @@ function* fetchSessionUser() {
     yield put(fetchUserComplete({ user }));
   } catch (e) {
     console.log('failed to fetch user', e);
-    const handledError = wrapHandledError(e, UserFetchErrorMessage);
-    yield put(fetchUserError(handledError));
+    const isNetworkOrTimeoutError =
+      e instanceof DOMException ||
+      e instanceof TypeError ||
+      e.name === 'TimeoutError' ||
+      e.name === 'AbortError';
+    const payload = isNetworkOrTimeoutError
+      ? { message: e.message }
+      : wrapHandledError(e, UserFetchErrorMessage);
+    yield put(fetchUserError(payload));
   } finally {
     yield cancel(timeoutTask);
   }

--- a/client/src/redux/fetch-user-saga.test.js
+++ b/client/src/redux/fetch-user-saga.test.js
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+
+import { isHandledError, unwrapHandledError } from '../utils/handled-error';
+import { FlashMessages } from '../components/Flash/redux/flash-messages';
+import { fetchUserComplete, fetchUserError } from './actions';
+import { fetchSessionUser } from './fetch-user-saga';
+
+const driveToOutcome = inject => {
+  const gen = fetchSessionUser();
+  gen.next();
+  gen.next();
+  return inject(gen);
+};
+
+const dispatchedAction = effect => effect.value.payload.action;
+
+describe('fetchSessionUser', () => {
+  it('does not surface a flash-triggering error when the request times out on a slow connection', () => {
+    const effect = driveToOutcome(gen =>
+      gen.throw(new DOMException('The operation timed out', 'TimeoutError'))
+    );
+    const action = dispatchedAction(effect);
+
+    expect(action.type).toBe(fetchUserError().type);
+    expect(isHandledError(action.payload)).toBe(false);
+  });
+
+  it('does not surface a flash-triggering error on a network failure', () => {
+    const effect = driveToOutcome(gen =>
+      gen.throw(new TypeError('Failed to fetch'))
+    );
+    const action = dispatchedAction(effect);
+
+    expect(action.type).toBe(fetchUserError().type);
+    expect(isHandledError(action.payload)).toBe(false);
+  });
+
+  it('still surfaces the user-fetch-error flash when the server responds with a 5xx', () => {
+    const effect = driveToOutcome(gen =>
+      gen.next({
+        response: {
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error'
+        },
+        data: null
+      })
+    );
+    const action = dispatchedAction(effect);
+
+    expect(action.type).toBe(fetchUserError().type);
+    expect(isHandledError(action.payload)).toBe(true);
+    expect(unwrapHandledError(action.payload).message).toBe(
+      FlashMessages.UserFetchError
+    );
+  });
+
+  it('completes without error for a signed-out user (401)', () => {
+    const effect = driveToOutcome(gen =>
+      gen.next({ response: { ok: false, status: 401 }, data: null })
+    );
+    const action = dispatchedAction(effect);
+
+    expect(action.type).toBe(fetchUserComplete({ user: null }).type);
+  });
+});


### PR DESCRIPTION
fix(client): don't show user-info error to signed-out users on slow connections

Body (pegá esto tal cual al abrir el PR — calza con la plantilla del repo):

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67901

## Problem

On a slow connection, the *"Unable to retrieve your user information. You can
still use the site, but your progress may not be saved."* flash message was
shown to **signed-out** visitors on the learn platform.

Every page mounts the default layout, which dispatches `fetchUser()` to resolve
the session. When the request to `getSessionUser` is aborted by the 10s
`AbortSignal.timeout` (slow connection) or fails at the network layer,
`fetchSessionUser` caught the error and unconditionally dispatched a handled
error, which `error-saga` turns into the flash — without ever knowing whether a
session existed.

A signed-out user is normally detected via a `401`, which is already handled
gracefully (no flash). The bug only surfaces when the request never completes,
and in that case the session cookie (`httpOnly` in production) can't tell the
client whether the user was ever logged in. Since signed-out users have no user
info to retrieve nor progress to save, the message is just noise for them.

## Solution

In `fetchSessionUser`, distinguish the failure type in the `catch` block:

- **Network / timeout failures** (`DOMException` / `TimeoutError` / `AbortError`
  from `AbortSignal.timeout`, or a `TypeError` network error) now dispatch a
  plain payload, which `error-saga` ignores — so no flash is shown.
- **Genuine server errors (5xx)** keep the existing handled-error behaviour, so
  the flash still appears when the server actually responded with an error.

This is a minimal change scoped to the saga; no styling or unrelated refactors.
Added `fetch-user-saga.test.js` covering the timeout, network-error, 5xx and
signed-out (401) paths.

## How to test

1. Open the learn platform signed out with Network throttling (DevTools) so the
   session request times out / is aborted.
2. **Before:** the user-info error toast appears. **After:** it does not.
3. Signed in, force a 500 on the session endpoint → the toast still appears.
4. `cd client && npx vitest run src/redux/fetch-user-saga.test.js`