### PR TITLE
fix(curriculum): correct editable region markers in workshop-tailwind…

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/686383abac6c625a84458ea9.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/686383abac6c625a84458ea9.md
@@ -41,9 +41,9 @@ assert.equal(document.querySelector("h1")?.textContent, "Choose your listening p
   </head>
   <body>
     <main>
-    --fcc-editable-region--
-    
-    --fcc-editable-region--
+      --fcc-editable-region--
+      
+      --fcc-editable-region--
     </main>
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864e580f94941dcfa2bb26d.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864e580f94941dcfa2bb26d.md
@@ -59,6 +59,7 @@ assert.isTrue(listenerPlanWrapper.classList.contains("grid-rows-[1fr_auto]"))
       <div class="grid grid-cols-1 md:grid-cols-3 max-w-6xl mx-auto gap-8 mt-16">
         --fcc-editable-region--
         <div class="bg-gray-100 ring-1 ring-gray-300 ">
+        --fcc-editable-region--
           <div>
             <h2>Listener</h2>
             <p>$0<span>/month</span></p>
@@ -72,7 +73,6 @@ assert.isTrue(listenerPlanWrapper.classList.contains("grid-rows-[1fr_auto]"))
           </div>
           <a href="#">Start listening</a>
         </div>
-        --fcc-editable-region--
         <div>
           <div>Most Popular</div>
           <div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864e996adaf0b13437f1d11.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864e996adaf0b13437f1d11.md
@@ -56,6 +56,7 @@ assert.isTrue(listenerPlanWrapper.classList.contains("ring-gray-300"))
       <div class="grid grid-cols-1 md:grid-cols-3 max-w-6xl mx-auto gap-8 mt-16">
         --fcc-editable-region--
         <div>
+        --fcc-editable-region--
           <div>
             <h2>Listener</h2>
             <p>$0<span>/month</span></p>
@@ -69,7 +70,6 @@ assert.isTrue(listenerPlanWrapper.classList.contains("ring-gray-300"))
           </div>
           <a href="#">Start listening</a>
         </div>
-        --fcc-editable-region--
         <div>
           <div>Most Popular</div>
           <div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864ebcd123f7c335e92d6dd.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864ebcd123f7c335e92d6dd.md
@@ -56,6 +56,7 @@ assert.isTrue(listenerPlanWrapper.classList.contains("gap-6"))
       <div class="grid grid-cols-1 md:grid-cols-3 max-w-6xl mx-auto gap-8 mt-16">
 --fcc-editable-region--
         <div class="bg-gray-100 ring-1 ring-gray-300 grid grid-rows-[1fr_auto] ">
+--fcc-editable-region--
           <div>
             <h2>Listener</h2>
             <p>$0<span>/month</span></p>
@@ -69,7 +70,6 @@ assert.isTrue(listenerPlanWrapper.classList.contains("gap-6"))
           </div>
           <a href="#">Start listening</a>
         </div>
---fcc-editable-region--
         <div>
           <div>Most Popular</div>
           <div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864ed58edec4b4aaeb571cc.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864ed58edec4b4aaeb571cc.md
@@ -57,6 +57,7 @@ assert.isTrue(listenerPlanInnerDiv.classList.contains("gap-y-2"))
         <div class="bg-gray-100 ring-1 ring-gray-300 grid grid-rows-[1fr_auto] rounded-xl p-8 gap-6">
 --fcc-editable-region--
           <div>
+--fcc-editable-region--
             <h2>Listener</h2>
             <p>$0<span>/month</span></p>
             <p>
@@ -67,7 +68,6 @@ assert.isTrue(listenerPlanInnerDiv.classList.contains("gap-y-2"))
               <li><span>&#10003;</span>Curated playlists</li>
             </ul>
           </div>
---fcc-editable-region--
           <a href="#">Start listening</a>
         </div>
         <div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864f704409f85463386cd91.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864f704409f85463386cd91.md
@@ -43,9 +43,9 @@ assert.equal(targetP.className, "text-gray-600")
             <p class="text-4xl font-bold text-gray-900">$0<span class="text-base font-medium text-gray-500">/month</span></p>
             --fcc-editable-region--
             <p>
+            --fcc-editable-region--
               Start exploring millions of songs with basic features and ads.
             </p>
-            --fcc-editable-region--
             <ul>
               <li><span>&#10003;</span>Ad-supported streaming</li>
               <li><span>&#10003;</span>Curated playlists</li>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864f7985a9b7e5285e27257.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864f7985a9b7e5285e27257.md
@@ -69,10 +69,10 @@ assert.isTrue(firstUl.classList.contains("text-gray-700"))
             </p>
             --fcc-editable-region--
             <ul>
+            --fcc-editable-region--
               <li><span>&#10003;</span>Ad-supported streaming</li>
               <li><span>&#10003;</span>Curated playlists</li>
             </ul>
-            --fcc-editable-region--
           </div>
           <a href="#">Start listening</a>
         </div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864f81018a0085ae30afa9b.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864f81018a0085ae30afa9b.md
@@ -70,12 +70,12 @@ firstTwoSpans.forEach(span => {
             <p class="text-gray-600">
               Start exploring millions of songs with basic features and ads.
             </p>
---fcc-editable-region--
             <ul class="mt-6 space-y-2 text-sm text-gray-700">
+              --fcc-editable-region--
               <li><span>&#10003;</span>Ad-supported streaming</li>
               <li><span>&#10003;</span>Curated playlists</li>
+              --fcc-editable-region--
             </ul>
---fcc-editable-region--
           </div>
           <a href="#">Start listening</a>
         </div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864fa68aae44b80f7d0863c.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864fa68aae44b80f7d0863c.md
@@ -65,9 +65,9 @@ assert.isTrue(firstATag.classList.contains("rounded-md"))
             href="#"
             class="bg-indigo-100 px-4 py-2 text-center font-semibold text-indigo-700 hover:bg-indigo-200"
           >
+          --fcc-editable-region--
             Start listening
           </a>
-          --fcc-editable-region--
         </div>
         <div>
           <div>Most Popular</div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864fb24b8070f904768c24f.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6864fb24b8070f904768c24f.md
@@ -95,6 +95,7 @@ assert.isTrue(premiumPlanWrapper.classList.contains("p-8"))
         </div>
         --fcc-editable-region--
         <div>
+        --fcc-editable-region--
           <div>Most Popular</div>
           <div>
             <h2>Premium</h2>
@@ -111,7 +112,6 @@ assert.isTrue(premiumPlanWrapper.classList.contains("p-8"))
           </div>
           <a href="#">Go Premium</a>
         </div>
-        --fcc-editable-region--
         <div>
           <div>
             <h2>Family</h2>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667227c6b33aaf41d4e086.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667227c6b33aaf41d4e086.md
@@ -87,6 +87,7 @@ assert.isTrue(premiumPlanWrapper.classList.contains("rounded-xl"))
         </div>
 --fcc-editable-region--
         <div class="bg-gray-950 text-white ring-2 ring-fuchsia-500 p-8">
+--fcc-editable-region--
           <div>Most Popular</div>
           <div>
             <h2>Premium</h2>
@@ -103,7 +104,6 @@ assert.isTrue(premiumPlanWrapper.classList.contains("rounded-xl"))
           </div>
           <a href="#">Go Premium</a>
         </div>
---fcc-editable-region--
         <div>
           <div>
             <div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6866733f0b8f85bcb9587646.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6866733f0b8f85bcb9587646.md
@@ -71,6 +71,7 @@ assert.isTrue(premiumPlanWrapper.classList.contains("scale-105"))
         </div>
 --fcc-editable-region--
         <div class="bg-gray-950 text-white ring-2 ring-fuchsia-500 p-8 grid grid-rows-[1fr_auto] gap-6 rounded-xl">
+--fcc-editable-region--
           <div>Most Popular</div>
           <div>
             <h2>Premium</h2>
@@ -87,7 +88,6 @@ assert.isTrue(premiumPlanWrapper.classList.contains("scale-105"))
           </div>
           <a href="#">Go Premium</a>
         </div>
---fcc-editable-region--
         <div>
           <div>
             <h2>Family</h2>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6866740a0f532cc7e9e21877.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6866740a0f532cc7e9e21877.md
@@ -82,6 +82,7 @@ assert.isTrue(badgeDiv.classList.contains("absolute"))
 --fcc-editable-region--
         <div class=" bg-gray-950 text-white ring-2 ring-fuchsia-500 p-8 grid grid-rows-[1fr_auto] gap-6 rounded-xl scale-105">
           <div >Most Popular</div>
+--fcc-editable-region--
           <div>
             <h2>Premium</h2>
             <p>$9.99<span>/month</span></p>
@@ -97,7 +98,6 @@ assert.isTrue(badgeDiv.classList.contains("absolute"))
           </div>
           <a href="#">Go Premium</a>
         </div>
---fcc-editable-region--
         <div>
           <div>
             <h2>Family</h2>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667a42c6784620c088505c.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667a42c6784620c088505c.md
@@ -81,6 +81,7 @@ assert.isTrue(innerWrapperDiv.classList.contains("gap-y-2"))
           <div class="absolute -top-3 right-3 bg-gradient-to-r from-fuchsia-500 to-indigo-500 rounded-full px-3 py-1 text-xs font-bold text-white">Most Popular</div>
           --fcc-editable-region--
           <div>
+          --fcc-editable-region--
             <h2>Premium</h2>
             <p>$9.99<span>/month</span></p>
             <p>
@@ -93,7 +94,6 @@ assert.isTrue(innerWrapperDiv.classList.contains("gap-y-2"))
               <li><span>&#10003;</span>Unlimited skips</li>
             </ul>
           </div>
-          --fcc-editable-region--
           <a href="#">Go Premium</a>
         </div>
         <div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667c8eca7580479ead76a0.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667c8eca7580479ead76a0.md
@@ -67,10 +67,10 @@ assert.equal(targetP.className, "text-gray-300")
             </p>
             --fcc-editable-region--
             <p>
+            --fcc-editable-region--
               Enjoy the full music experience with unlimited access and
               downloads.
             </p>
-            --fcc-editable-region--
             <ul>
               <li><span>&#10003;</span>Ad-free listening</li>
               <li><span>&#10003;</span>Offline playback</li>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667cefaa5ad54e5ec212a4.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667cefaa5ad54e5ec212a4.md
@@ -96,11 +96,11 @@ assert.isTrue(secondUl.classList.contains("text-fuchsia-100"))
             </p>
             --fcc-editable-region--
             <ul>
+            --fcc-editable-region--
               <li><span>&#10003;</span>Ad-free listening</li>
               <li><span>&#10003;</span>Offline playback</li>
               <li><span>&#10003;</span>Unlimited skips</li>
             </ul>
-            --fcc-editable-region--
           </div>
           <a href="#">Go Premium</a>
         </div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667da4251a7c59e083bb7e.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667da4251a7c59e083bb7e.md
@@ -97,13 +97,13 @@ premiumSpans.forEach(span => {
               Enjoy the full music experience with unlimited access and
               downloads.
             </p>
-            --fcc-editable-region--
             <ul class="mt-6 space-y-2 text-sm text-fuchsia-100">
+              --fcc-editable-region--
               <li><span>&#10003;</span>Ad-free listening</li>
               <li><span>&#10003;</span>Offline playback</li>
               <li><span>&#10003;</span>Unlimited skips</li>
-            </ul>
             --fcc-editable-region--
+            </ul>
           </div>
           <a href="#">Go Premium</a>
         </div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667f8aa360b17a01982b7c.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68667f8aa360b17a01982b7c.md
@@ -103,9 +103,9 @@ assert.isTrue(premiumATag.classList.contains("font-semibold"))
             href="#"
             class="block rounded-md bg-gradient-to-r from-fuchsia-500 to-indigo-600 text-white hover:from-fuchsia-600 hover:to-indigo-700"
           >
+--fcc-editable-region--
             Go Premium
           </a>
---fcc-editable-region--
         </div>
         <div>
           <div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68668014d6a84384018dc302.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/68668014d6a84384018dc302.md
@@ -125,6 +125,7 @@ assert.isTrue(familyPlanWrapper.classList.contains("rounded-xl"))
         </div>
 --fcc-editable-region--
         <div>
+--fcc-editable-region--
           <div>
             <h2>Family</h2>
             <p>$14.99<span>/month</span></p>
@@ -148,7 +149,6 @@ assert.isTrue(familyPlanWrapper.classList.contains("rounded-xl"))
             </ul>
           </div>
           <a href="#">Start Family Plan</a>
---fcc-editable-region--
         </div>
       </div>
     </main>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867c7b1f41ee104cf4aaa16.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867c7b1f41ee104cf4aaa16.md
@@ -109,6 +109,7 @@ assert.isTrue(familyPlanWrapper.classList.contains("gap-6"))
         </div>
 --fcc-editable-region--
         <div class="bg-gray-100 ring-1 ring-gray-300 p-8 rounded-xl ">
+--fcc-editable-region--
           <div>
             <h2>Family</h2>
             <p>$14.99<span>/month</span></p>
@@ -132,7 +133,6 @@ assert.isTrue(familyPlanWrapper.classList.contains("gap-6"))
             </ul>
           </div>
           <a href="#">Start Family Plan</a>
---fcc-editable-region--
         </div>
       </div>
     </main>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867c8a8185485144ebbb453.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867c8a8185485144ebbb453.md
@@ -110,6 +110,7 @@ assert.isTrue(familyPlanInnerDiv.classList.contains("gap-y-2"))
         <div class="bg-gray-100 ring-1 ring-gray-300 p-8 rounded-xl grid grid-rows-[1fr_auto] gap-6">
         --fcc-editable-region--
           <div >
+        --fcc-editable-region--
             <h2>Family</h2>
             <p>$14.99<span>/month</span></p>
             <p>
@@ -131,7 +132,6 @@ assert.isTrue(familyPlanInnerDiv.classList.contains("gap-y-2"))
               </li>
             </ul>
           </div>
-        --fcc-editable-region--
           <a href="#">Start Family Plan</a>
         </div>
       </div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867caa0dbbeb93570ec0069.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867caa0dbbeb93570ec0069.md
@@ -97,9 +97,9 @@ assert.equal(targetP.className, "text-gray-600")
             </p>
 --fcc-editable-region--
             <p>
+--fcc-editable-region--
               Enjoy all of the features with a plan for up to 6 family members.
             </p>
---fcc-editable-region--
             <ul>
               <li>
                 <span>&#10003;</span>All Premium features

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867cb70e797d142df4b88e5.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867cb70e797d142df4b88e5.md
@@ -124,6 +124,7 @@ assert.isTrue(thirdUl.classList.contains("text-gray-700"))
             </p>
 --fcc-editable-region--
             <ul >
+--fcc-editable-region--
               <li>
                 <span>&#10003;</span>All Premium features
               </li>
@@ -138,7 +139,6 @@ assert.isTrue(thirdUl.classList.contains("text-gray-700"))
                 <span>&#10003;</span>Family Mix playlists
               </li>
             </ul>
---fcc-editable-region--
           </div>
           <a href="#">Start Family Plan</a>
         </div>

--- a/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867cbfbbb4a9f4bc73b01e6.md
+++ b/curriculum/challenges/english/blocks/workshop-tailwind-pricing-component/6867cbfbbb4a9f4bc73b01e6.md
@@ -125,8 +125,8 @@ familyPlanSpans.forEach(span => {
             <p class="text-gray-600">
               Enjoy all of the features with a plan for up to 6 family members.
             </p>
---fcc-editable-region--
             <ul class="mt-6 space-y-2 text-sm text-gray-700">
+              --fcc-editable-region--
               <li>
                 <span>&#10003;</span>All Premium features
               </li>
@@ -140,8 +140,8 @@ familyPlanSpans.forEach(span => {
               <li>
                 <span>&#10003;</span>Family Mix playlists
               </li>
+              --fcc-editable-region--
             </ul>
---fcc-editable-region--
           </div>
           <a href="#">Start Family Plan</a>
         </div>


### PR DESCRIPTION
…-pricing-component

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Refrence to https://github.com/freeCodeCamp/freeCodeCamp/issues/67721

This PR is part of Naomi's Sprint for editable regions.

This PR fixes editable regions in workshop-tailwind-pricing-component
<!-- Feel free to add any additional description of changes below this line -->
