### PR TITLE
fix(signout): clear stale query params on logout

### DIFF
--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -267,6 +267,8 @@ function NavLinks({
           <button
             className='nav-link nav-link-signout'
             data-value='sign-out-button'
+            aria-haspopup='dialog'
+            aria-controls='signout-modal'
             onClick={handleSignOutClick}
             onKeyDown={handleSignOutKeys}
           >

--- a/client/src/components/signout-modal/index.test.ts
+++ b/client/src/components/signout-modal/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { pathAfterSignout } from './index';
+
+describe('pathAfterSignout', () => {
+  it('redirects /settings to /learn', () => {
+    expect(pathAfterSignout('/settings')).toBe('/learn');
+  });
+
+  it('redirects /settings/ to /learn', () => {
+    expect(pathAfterSignout('/settings/')).toBe('/learn');
+  });
+
+  it('redirects /update-email to /learn', () => {
+    expect(pathAfterSignout('/update-email')).toBe('/learn');
+  });
+
+  it('does not change unrelated paths', () => {
+    expect(pathAfterSignout('/learn')).toBe('/learn');
+    expect(pathAfterSignout('/some/other/path')).toBe('/some/other/path');
+  });
+});

--- a/client/src/components/signout-modal/index.tsx
+++ b/client/src/components/signout-modal/index.tsx
@@ -55,7 +55,9 @@ function SignoutModal(props: SignoutModalProps): JSX.Element {
     closeSignoutModal();
     callGA({ event: 'sign_out', user_id: undefined });
     const redirect = () => {
-      window.location.pathname = pathAfterSignout(window.location.pathname);
+      // Replace the full URL so any stale query params or hashes are cleared
+      const newPath = pathAfterSignout(window.location.pathname);
+      window.location.href = `${window.location.origin}${newPath}`;
     };
     void fetch(`${apiLocation}/signout`, {
       method: 'GET',
@@ -66,7 +68,13 @@ function SignoutModal(props: SignoutModalProps): JSX.Element {
   };
 
   return (
-    <Modal size='large' variant='danger' open={show} onClose={handleModalHide}>
+    <Modal
+      id='signout-modal'
+      size='large'
+      variant='danger'
+      open={show}
+      onClose={handleModalHide}
+    >
       <Modal.Header showCloseButton={true} closeButtonClassNames='close'>
         {t('signout.heading')}
       </Modal.Header>


### PR DESCRIPTION
This fixes logout redirect so any stale query parameters or hashes are removed on signout and adds a unit test for `pathAfterSignout`.

Changes:
- client/src/components/signout-modal/index.tsx: replace redirect to clear query params and add `id="signout-modal"`.
- client/src/components/signout-modal/index.test.ts: add tests for `pathAfterSignout`.
- client/src/components/Header/components/nav-links.tsx: add `aria-haspopup` and `aria-controls` for sign-out button.

Validation:
- Added Vitest unit tests (4 tests) — all pass locally.

Notes:
- Branch: `fix/signout-clear-stale-query` (pushed from fork)

Please let me know if you'd like me to reword the commit message.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. -->
Referances #66515 

<!-- Feel free to add any additional description of changes below this line -->