### PR TITLE
fix(client): prevent duplicate A2 English timeline titles

### DIFF
--- a/client/src/components/profile/components/time-line.test.tsx
+++ b/client/src/components/profile/components/time-line.test.tsx
@@ -13,50 +13,52 @@ import TimeLine from './time-line';
 const store = createStore();
 
 beforeEach(() => {
-  // @ts-expect-error
-  useStaticQuery.mockImplementationOnce(() => ({
-    allChallengeNode: {
-      edges: [
-        {
-          node: {
-            challenge: {
-              fields: {
-                slug: ''
-              },
-              id: '5e46f802ac417301a38fb92b',
-              title: 'Page View Time Series Visualizer'
-            }
-          }
-        },
-        {
-          node: {
-            challenge: {
-              fields: {
-                slug: ''
-              },
-              id: '5e4f5c4b570f7e3a4949899f',
-              title: 'Sea Level Predictor'
-            }
-          }
-        },
-        {
-          node: {
-            challenge: {
-              fields: {
-                slug: ''
-              },
-              id: '5e46f7f8ac417301a38fb92a',
-              title: 'Medical Data Visualizer'
-            }
-          }
-        }
-      ]
-    }
-  }));
+  vi.clearAllMocks();
 });
 
 describe('<TimeLine />', () => {
   it('Render button when only solution is present', () => {
+    // @ts-expect-error
+    useStaticQuery.mockImplementationOnce(() => ({
+      allChallengeNode: {
+        edges: [
+          {
+            node: {
+              challenge: {
+                fields: {
+                  slug: ''
+                },
+                id: '5e46f802ac417301a38fb92b',
+                title: 'Page View Time Series Visualizer'
+              }
+            }
+          },
+          {
+            node: {
+              challenge: {
+                fields: {
+                  slug: ''
+                },
+                id: '5e4f5c4b570f7e3a4949899f',
+                title: 'Sea Level Predictor'
+              }
+            }
+          },
+          {
+            node: {
+              challenge: {
+                fields: {
+                  slug: ''
+                },
+                id: '5e46f7f8ac417301a38fb92a',
+                title: 'Medical Data Visualizer'
+              }
+            }
+          }
+        ]
+      }
+    }));
+
     // @ts-expect-error
     render(<TimeLine {...propsForOnlySolution} />, store);
     const showViewButton = screen.getByRole('link', {
@@ -70,6 +72,47 @@ describe('<TimeLine />', () => {
 
   it('rendering the correct button when files is present', () => {
     // @ts-expect-error
+    useStaticQuery.mockImplementationOnce(() => ({
+      allChallengeNode: {
+        edges: [
+          {
+            node: {
+              challenge: {
+                fields: {
+                  slug: ''
+                },
+                id: '5e46f802ac417301a38fb92b',
+                title: 'Page View Time Series Visualizer'
+              }
+            }
+          },
+          {
+            node: {
+              challenge: {
+                fields: {
+                  slug: ''
+                },
+                id: '5e4f5c4b570f7e3a4949899f',
+                title: 'Sea Level Predictor'
+              }
+            }
+          },
+          {
+            node: {
+              challenge: {
+                fields: {
+                  slug: ''
+                },
+                id: '5e46f7f8ac417301a38fb92a',
+                title: 'Medical Data Visualizer'
+              }
+            }
+          }
+        ]
+      }
+    }));
+
+    // @ts-expect-error
     render(<TimeLine {...propsForOnlySolution} />, store);
 
     const viewButtons = screen.getAllByRole('button', {
@@ -78,6 +121,64 @@ describe('<TimeLine />', () => {
     viewButtons.forEach(button => {
       expect(button).toBeInTheDocument();
     });
+  });
+
+  it('does not duplicate A2 English timeline titles when the block title matches the challenge title', () => {
+    // @ts-expect-error
+    useStaticQuery.mockImplementationOnce(() => ({
+      allChallengeNode: {
+        edges: [
+          {
+            node: {
+              challenge: {
+                block: 'en-a2-quiz-discussing-new-ideas',
+                fields: {
+                  slug:
+                    '/learn/a2-english-for-developers/en-a2-quiz-discussing-new-ideas/en-a2-quiz-discussing-new-ideas'
+                },
+                hasEditableBoundaries: false,
+                id: 'a2-english-challenge-id',
+                superBlock: 'a2-english-for-developers',
+                title: 'Tech Updates and Trends Quiz'
+              }
+            }
+          }
+        ]
+      }
+    }));
+
+    const propsForA2EnglishChallenge = {
+      completedMap: [
+        {
+          id: 'a2-english-challenge-id',
+          completedDate: 1710000000000
+        }
+      ],
+      username: 'developmentuser',
+      t: (key: string) => {
+        if (
+          key ===
+          'intro:a2-english-for-developers.blocks.en-a2-quiz-discussing-new-ideas.title'
+        ) {
+          return 'Tech Updates and Trends Quiz';
+        }
+
+        return key;
+      }
+    };
+
+    // @ts-expect-error
+    render(<TimeLine {...propsForA2EnglishChallenge} />, store);
+
+    expect(
+      screen.getByRole('link', { name: 'Tech Updates and Trends Quiz' })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'Tech Updates and Trends Quiz - Tech Updates and Trends Quiz'
+      })
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -306,8 +306,13 @@ function useIdToNameMap(t: TFunction): Map<string, NameMap> {
       }
     }) => {
       const blockNameTitle = t(`intro:${superBlock}.blocks.${block}.title`);
+      const normalizedBlockTitle = blockNameTitle.trim();
+      const normalizedTitle = title.trim();
       const shouldAppendBlockNameToTitle =
-        hasEditableBoundaries || superBlock === SuperBlocks.A2English;
+        hasEditableBoundaries ||
+        (superBlock === SuperBlocks.A2English &&
+          normalizedBlockTitle !== normalizedTitle);
+
       idToNameMap.set(id, {
         challengeTitle: `${
           shouldAppendBlockNameToTitle ? blockNameTitle + ' - ' : ''


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67846

<!-- Feel free to add any additional description of changes below this line -->

### Summary 
This PR fixes an accessibility regression in the Learn UI where course progress was no longer conveyed to screen reader users.
Previously, screen reader users could understand progress for a lesson or block, but after the recent UI changes the progress bar became effectively visual-only. This update adds accessible progress semantics so assistive technologies can announce the course progress again.

### Changes
- add `role="progressbar"` to the course progress UI
- add `aria-label` using the block title and progress meta text
- add `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and aria-valuetext`
- add tests to verify progress is exposed to screen readers in both standard and minified modes
