### PR TITLE
fix(api): handle log statements in redirection utility

### DIFF
--- a/api/src/utils/redirection.test.ts
+++ b/api/src/utils/redirection.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import jwt from 'jsonwebtoken';
 
 import {
@@ -43,9 +43,7 @@ describe('redirection', () => {
     });
 
     test('should return a default url if the secrets do not match', () => {
-      const oldLog = console.log;
-      expect.assertions(2);
-      console.log = vi.fn();
+      expect.assertions(1);
       const encryptedReturnTo = jwt.sign(
         { returnTo: validReturnTo },
         invalidJWTSecret
@@ -53,8 +51,6 @@ describe('redirection', () => {
       expect(
         getReturnTo(encryptedReturnTo, validJWTSecret, defaultOrigin)
       ).toStrictEqual(defaultObject);
-      expect(console.log).toHaveBeenCalled();
-      console.log = oldLog;
     });
 
     test('should return a default url for unknown origins', () => {

--- a/api/src/utils/redirection.ts
+++ b/api/src/utils/redirection.ts
@@ -23,9 +23,7 @@ export function getReturnTo(
   let params;
   try {
     params = jwt.verify(encryptedParams, secret);
-  } catch (e) {
-    // TODO: report to Sentry? Probably not. Remove entirely?
-    console.log(e);
+  } catch {
     // something went wrong, use default params
     params = {
       returnTo: `${_homeLocation}/learn`,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60180

<!-- Feel free to add any additional description of changes below this line -->

This PR handles the raw console log statements inside the redirection utility catch block by cleanly returning default parameters and removing the noisy global console log. The associated tests tracking console logging have been updated and streamlined.