### PR TITLE
test: keep action-row spec true e2e

### DIFF
--- a/client/src/templates/Challenges/classic/action-row.test.tsx
+++ b/client/src/templates/Challenges/classic/action-row.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import store from 'store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createStore } from '../../../redux/create-store';
+import { createFiles, initVisibleEditors } from '../redux/actions';
+import { render } from '../../../../utils/test-utils';
+import ActionRow from './action-row';
+
+vi.mock('../../../utils/get-words');
+
+const challengeFiles = [
+  {
+    contents: '',
+    editableRegionBoundaries: [],
+    ext: 'html',
+    fileKey: 'indexhtml',
+    name: 'index'
+  },
+  {
+    contents: '',
+    editableRegionBoundaries: [],
+    ext: 'css',
+    fileKey: 'stylescss',
+    name: 'styles'
+  }
+];
+
+const defaultProps = {
+  areInstructionsDisplayable: true,
+  dailyCodingChallengeLanguage: 'javascript' as const,
+  hasNotes: false,
+  hasPreview: true,
+  isDailyCodingChallenge: false,
+  setDailyCodingChallengeLanguage: vi.fn(),
+  showConsole: false,
+  showInstructions: true,
+  showNotes: false,
+  showPreviewPane: true,
+  showPreviewPortal: false,
+  togglePane: vi.fn(),
+  usesTerminal: false
+};
+
+const renderActionRow = (props: Partial<typeof defaultProps> = {}) => {
+  const reduxStore = createStore();
+  reduxStore.dispatch(createFiles(challengeFiles));
+  reduxStore.dispatch(initVisibleEditors());
+
+  return render(<ActionRow {...defaultProps} {...props} />, reduxStore);
+};
+
+describe('<ActionRow />', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    store.clearAll();
+  });
+
+  it('renders instructions, editor, console, and preview controls', () => {
+    renderActionRow();
+
+    expect(
+      screen.getByRole('button', { name: 'learn.editor-tabs.instructions' })
+    ).toHaveAttribute('aria-expanded', 'true');
+    expect(
+      screen.getByRole('button', { name: /index.html/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /styles.css/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'learn.editor-tabs.console' })
+    ).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.getByRole('button', { name: 'aria.hide-preview' })
+    ).toHaveTextContent('aria.hide-previewlearn.editor-tabs.preview');
+    expect(
+      screen.getByRole('button', {
+        name: 'aria.move-preview-to-new-window'
+      })
+    ).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('uses terminal labels for terminal challenges', () => {
+    renderActionRow({ usesTerminal: true });
+
+    expect(
+      screen.getByRole('button', { name: 'aria.hide-terminal' })
+    ).toHaveTextContent('aria.hide-terminallearn.editor-tabs.terminal');
+    expect(
+      screen.getByRole('button', {
+        name: 'aria.move-terminal-to-new-window'
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('does not render preview controls when preview is disabled', () => {
+    renderActionRow({ hasPreview: false });
+
+    expect(
+      screen.queryByRole('button', { name: 'aria.hide-preview' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'aria.move-preview-to-new-window'
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls togglePane with the clicked pane name', async () => {
+    const user = userEvent.setup();
+    const togglePane = vi.fn();
+    renderActionRow({ togglePane });
+
+    await user.click(
+      screen.getByRole('button', { name: 'learn.editor-tabs.instructions' })
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'learn.editor-tabs.console' })
+    );
+    await user.click(screen.getByRole('button', { name: 'aria.hide-preview' }));
+    await user.click(
+      screen.getByRole('button', {
+        name: 'aria.move-preview-to-new-window'
+      })
+    );
+
+    expect(togglePane).toHaveBeenNthCalledWith(1, 'showInstructions');
+    expect(togglePane).toHaveBeenNthCalledWith(2, 'showConsole');
+    expect(togglePane).toHaveBeenNthCalledWith(3, 'showPreviewPane');
+    expect(togglePane).toHaveBeenNthCalledWith(4, 'showPreviewPortal');
+  });
+
+  it('renders daily coding challenge language controls', async () => {
+    const user = userEvent.setup();
+    const setDailyCodingChallengeLanguage = vi.fn();
+    renderActionRow({
+      isDailyCodingChallenge: true,
+      setDailyCodingChallengeLanguage
+    });
+
+    expect(screen.getByRole('button', { name: 'JavaScript' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Python' })).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: 'Python' }));
+
+    expect(setDailyCodingChallengeLanguage).toHaveBeenCalledWith('python');
+    expect(store.get('dailyCodingChallengeLanguage')).toBe('python');
+  });
+
+  it('renders content outline and interactive editor controls', async () => {
+    const user = userEvent.setup();
+    const onToggleContentOutline = vi.fn();
+    const toggleInteractiveEditor = vi.fn();
+    const reduxStore = createStore();
+
+    render(
+      <ActionRow
+        hasContentOutline={true}
+        hasInteractiveEditor={true}
+        onToggleContentOutline={onToggleContentOutline}
+        showContentOutline={false}
+        showInteractiveEditor={true}
+        toggleInteractiveEditor={toggleInteractiveEditor}
+      />,
+      reduxStore
+    );
+
+    await user.click(screen.getByRole('button', { name: 'buttons.outline' }));
+    await user.click(
+      screen.getByRole('button', {
+        name: 'learn.editor-tabs.interactive-editor'
+      })
+    );
+
+    expect(onToggleContentOutline).toHaveBeenCalledTimes(1);
+    expect(toggleInteractiveEditor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/e2e/action-row.spec.ts
+++ b/e2e/action-row.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
-const buttonNames = ['Instructions', 'index.html', 'styles.css', 'Console'];
-
 test.describe('Desktop view', () => {
   test.skip(({ isMobile }) => isMobile, 'Only test on desktop');
 
@@ -13,67 +11,12 @@ test.describe('Desktop view', () => {
       );
     });
 
-    test('Action row buttons are visible', async ({ page }) => {
-      const previewPaneButton = page.getByTestId('preview-pane-button');
-      const previewPortalButton = page.getByRole('button', {
-        name: translations.aria['move-preview-to-new-window']
-      });
-      const actionRow = page.getByTestId('action-row');
-
-      for (const name of buttonNames) {
-        await expect(actionRow.getByRole('button', { name })).toBeVisible();
-      }
-
-      await expect(previewPaneButton).toBeVisible();
-      await expect(previewPortalButton).toBeVisible();
-    });
-
-    test('Preview button is visible during HTML/CSS/JS challenges', async ({
-      page
-    }) => {
-      const previewPaneButton = page.getByTestId('preview-pane-button');
-      const previewPortalButton = page.getByRole('button', {
-        name: translations.aria['move-preview-to-new-window']
-      });
-
-      expect(previewPortalButton).toBeDefined();
-
-      const hidePreviewText = translations.aria['hide-preview'];
-      const previewText = translations.learn['editor-tabs']['preview'];
-
-      await expect(previewPaneButton).toHaveText(hidePreviewText + previewText);
-    });
-
-    test('Terminal button is visible during Python challenges', async ({
-      page
-    }) => {
-      await page.goto('/learn/python-v9/workshop-caesar-cipher/step-1');
-      const terminalPaneButton = page.getByTestId('preview-pane-button');
-      const terminalPortalButton = page.getByRole('button', {
-        name: translations.aria['move-terminal-to-new-window']
-      });
-
-      const hideTerminalText = translations.aria['hide-terminal'];
-      const terminalText = translations.learn['editor-tabs']['terminal'];
-
-      await expect(terminalPaneButton).toHaveText(
-        hideTerminalText + terminalText
-      );
-      expect(terminalPortalButton).toBeDefined();
-    });
-
-    test('Clicking instructions button hides instructions panel, but not any buttons', async ({
+    test('Clicking instructions button hides the instructions panel', async ({
       page
     }) => {
       const instructionsButton = page.getByTestId('instructions-button');
-      const actionRow = page.getByTestId('action-row');
 
-      // Click instructions button to hide instructions panel
       await instructionsButton.click();
-
-      for (const name of buttonNames) {
-        await expect(actionRow.getByRole('button', { name })).toBeVisible();
-      }
 
       const instructionsPanelTitle = page.getByRole('heading', {
         name: 'Build an Event Flyer Page'
@@ -83,11 +26,11 @@ test.describe('Desktop view', () => {
 
     test('Clicking Console button shows console panel', async ({ page }) => {
       const actionRow = page.getByTestId('action-row');
-      const consoleBtn = actionRow.getByRole('button', { name: 'Console' });
+      const consoleText = translations.learn['editor-tabs'].console;
+      const consoleBtn = actionRow.getByRole('button', { name: consoleText });
 
-      // Click the console button to show the console panel
       await consoleBtn.click();
-      const consolePanel = page.getByLabel('Console');
+      const consolePanel = page.getByLabel(consoleText);
       await expect(consolePanel).toBeVisible();
     });
 
@@ -117,16 +60,6 @@ test.describe('Desktop view', () => {
       await expect(newPage).toHaveURL('about:blank');
 
       await newPage.close();
-    });
-  });
-
-  test.describe('Pages without previews', () => {
-    test('Preview Buttons should not appear when preview is disabled', async ({
-      page
-    }) => {
-      await page.goto('/learn/javascript-v9/workshop-greeting-bot/step-1');
-      const previewButton = page.getByTestId('preview-pane-button');
-      await expect(previewButton).toHaveCount(0);
     });
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This PR keeps the action row Playwright spec focused on true end-to-end interactions by moving static action row rendering and button-state coverage into a Vitest component test.


