### PR TITLE
test: keep archive spec true e2e

### DIFF
--- a/client/src/pages/learn/archive.test.tsx
+++ b/client/src/pages/learn/archive.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { archivedSuperBlocks } from '@freecodecamp/shared/config/curriculum';
+
+import ArchivePage from './archive';
+
+vi.mock('gatsby', () => ({
+  graphql: vi.fn(),
+  Link: ({
+    children,
+    to,
+    ...rest
+  }: {
+    children?: React.ReactNode;
+    to: string;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+  StaticQuery: vi.fn(),
+  useStaticQuery: vi.fn(),
+  withPrefix: (path: string) => path
+}));
+
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string) => key
+  }
+}));
+
+vi.mock('../../components/layouts/learn', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => (
+    <main>{children}</main>
+  )
+}));
+
+describe('ArchivePage', () => {
+  test('renders the archive page heading and current curriculum link', () => {
+    render(<ArchivePage />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'learn.archive.title'
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('landing.legacy-curriculum-heading')
+    ).toBeInTheDocument();
+
+    const currentCurriculumLink = screen.getByRole('link', {
+      name: 'placeholder'
+    });
+    expect(currentCurriculumLink).toHaveAttribute('href', '/learn');
+  });
+
+  test('renders archived superblock links in order', () => {
+    render(<ArchivePage />);
+
+    const curriculumLinks = screen
+      .getAllByRole('link')
+      .filter(
+        link =>
+          link.getAttribute('href')?.startsWith('/learn/') &&
+          link.getAttribute('href') !== '/learn'
+      );
+
+    expect(curriculumLinks).toHaveLength(archivedSuperBlocks.length);
+
+    for (const [index, superBlock] of archivedSuperBlocks.entries()) {
+      const link = curriculumLinks[index];
+
+      expect(link).toHaveAttribute('href', `/learn/${superBlock}/`);
+      expect(link).toHaveTextContent(`intro:${superBlock}.title`);
+    }
+  });
+});

--- a/e2e/archive.spec.ts
+++ b/e2e/archive.spec.ts
@@ -1,44 +1,30 @@
 import { expect, test } from '@playwright/test';
-import intro from '../client/i18n/locales/english/intro.json';
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
-
-const archivedSuperBlocks = [
-  intro[SuperBlocks.RespWebDesignNew].title,
-  intro[SuperBlocks.JsAlgoDataStructNew].title,
-  intro[SuperBlocks.FrontEndDevLibs].title,
-  intro[SuperBlocks.DataVis].title,
-  intro[SuperBlocks.RelationalDb].title,
-  intro[SuperBlocks.BackEndDevApis].title,
-  intro[SuperBlocks.QualityAssurance].title,
-  intro[SuperBlocks.SciCompPy].title,
-  intro[SuperBlocks.DataAnalysisPy].title,
-  intro[SuperBlocks.InfoSec].title,
-  intro[SuperBlocks.MachineLearningPy].title,
-  intro[SuperBlocks.CollegeAlgebraPy].title,
-  intro[SuperBlocks.RespWebDesign].title,
-  intro[SuperBlocks.JsAlgoDataStruct].title,
-  intro[SuperBlocks.PythonForEverybody].title
-];
 
 test.describe('Archive Page', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/learn/archive');
   });
 
-  test('Links to /learn', async ({ page }) => {
+  test('links back to the current curriculum', async ({ page }) => {
     const newCurriculumLink = page.locator(
       '.archived-warning a[href="/learn"]'
     );
-    await expect(newCurriculumLink).toBeVisible();
+    await newCurriculumLink.click();
+
+    await expect(page).toHaveURL('/learn');
   });
 
-  test('Links to all archived superblocks in order', async ({ page }) => {
-    const curriculumBtns = page.getByTestId('curriculum-map-button');
-    await expect(curriculumBtns).toHaveCount(archivedSuperBlocks.length);
-    for (let index = 0; index < archivedSuperBlocks.length; index++) {
-      const btn = curriculumBtns.nth(index);
-      const link = btn.getByRole('link', { name: archivedSuperBlocks[index] });
-      await expect(link).toBeVisible();
-    }
+  test('opens an archived superblock from the archive map', async ({
+    page
+  }) => {
+    const archivedSuperBlockPath = `/learn/${SuperBlocks.RespWebDesignNew}/`;
+    const archivedSuperBlockLink = page.locator(
+      `a[href="${archivedSuperBlockPath}"]`
+    );
+
+    await archivedSuperBlockLink.click();
+
+    await expect(page).toHaveURL(archivedSuperBlockPath);
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This PR keeps the archive Playwright spec focused on browser navigation by moving static archive page rendering coverage into a Vitest component test.
