### PR TITLE
test: keep backend spec true e2e

### DIFF
--- a/client/src/templates/Challenges/projects/solution-form.test.tsx
+++ b/client/src/templates/Challenges/projects/solution-form.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
+
+import SolutionForm from './solution-form';
+
+describe('SolutionForm', () => {
+  test('warns and prevents completion when backend project source code links are private', () => {
+    const onSubmit = vi.fn();
+    const updateSolutionForm = vi.fn();
+
+    render(
+      <SolutionForm
+        challengeType={challengeTypes.backEndProject}
+        onSubmit={onSubmit}
+        updateSolutionForm={updateSolutionForm}
+      />
+    );
+
+    const solutionInput = screen.getByLabelText('learn.solution-link');
+    const sourceCodeInput = screen.getByLabelText('learn.source-code-link');
+
+    fireEvent.change(solutionInput, {
+      target: { value: 'https://example.com' }
+    });
+    fireEvent.change(sourceCodeInput, {
+      target: { value: 'https://localhost:3000' }
+    });
+
+    expect(sourceCodeInput).toHaveAccessibleDescription(
+      'validation.source-code-link-public'
+    );
+    expect(solutionInput).not.toHaveAccessibleDescription(
+      'validation.source-code-link-public'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'learn.i-completed' }));
+
+    expect(updateSolutionForm).toHaveBeenNthCalledWith(1, {});
+    expect(updateSolutionForm).toHaveBeenLastCalledWith({
+      githubLink: 'https://localhost:3000',
+      solution: 'https://example.com'
+    });
+    expect(updateSolutionForm).toHaveBeenCalledTimes(2);
+    expect(onSubmit).toHaveBeenCalledWith({ showCompletionModal: false });
+  });
+});

--- a/e2e/backend.spec.ts
+++ b/e2e/backend.spec.ts
@@ -3,9 +3,7 @@ import { test, expect } from '@playwright/test';
 const locations = {
   index:
     'learn/back-end-development-and-apis/managing-packages-with-npm/' +
-    'how-to-use-package-json-the-core-of-any-node-js-project-or-npm-package',
-  project:
-    '/learn/back-end-development-and-apis/back-end-development-and-apis-projects/timestamp-microservice'
+    'how-to-use-package-json-the-core-of-any-node-js-project-or-npm-package'
 };
 
 const unhandledErrorMessage = 'Something is not quite right';
@@ -28,20 +26,5 @@ test.describe('Backend challenge', () => {
     await expect(page.getByText(runningOutput)).toContainText(finishedOutput);
 
     await expect(page.getByText(unhandledErrorMessage)).not.toBeVisible();
-  });
-});
-
-test.describe('Backend project', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(locations.project);
-  });
-
-  test('warns against private source code links', async ({ page }) => {
-    await page.fill('input[name="solution"]', 'https://example.com');
-    await page.fill('input[name="githubLink"]', 'https://localhost:3000');
-
-    await expect(
-      page.getByText('Source code link must be publicly visible.')
-    ).toBeVisible();
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This PR keeps the backend Playwright spec focused on the browser submission flow by moving backend project source-code-link validation coverage into a Vitest component test.
