### PR TITLE
fix: correct Review CSS Backgrounds and Borders copy

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
+++ b/curriculum/challenges/english/blocks/review-css-backgrounds-and-borders/671a88d636cebc5fbd407b78.md
@@ -9,8 +9,8 @@ dashedName: review-css-backgrounds-and-borders
 
 ## Styling Lists
 
-- **`line-height` Property**: This property is used to create space between lines of text. The accepted `line-height` values include the keyword `normal`, numbers, percentages and length units like the `em` unit.
-- **`list-style-type` Property**: This property is used to specify the marker for a list item. Acceptable values can include a circle, disc, or decimal.
+- **`line-height` Property**: This property is used to create space between lines of text. The accepted `line-height` values include the keyword `normal`, numbers, percentages, and length units like the `em` unit.
+- **`list-style-type` Property**: This property is used to specify the marker for a list item. Acceptable values can include a `circle`, `disc`, or `decimal`.
 
 Here's an example using `list-style-type` to change the bullet style:
 
@@ -33,7 +33,7 @@ ul {
 
 :::
 
-- **`list-style-position` Property**: This property is used to set the position for the list marker. The only two acceptable values are inside and outside.
+- **`list-style-position` Property**: This property is used to set the position for the list marker. The only two acceptable values are `inside` and `outside`.
 
 Here's an example showing the difference between `inside` and `outside`:
 
@@ -94,7 +94,7 @@ Here's an example using `margin-bottom` to space list items:
 
 ## Styling Links
 
-- **`pseudo-class`**: This is a keyword added to a selector that allows you to select elements based on a particular state. Common states would include the `:hover`, `:visited` and `:focus` states.
+- **`pseudo-class`**: This is a keyword added to a selector that allows you to select elements based on a particular state. Common states would include the `:hover`, `:visited`, and `:focus` states.
 - **`:link pseudo-class`**: This pseudo-class is used to style links that have not been visited by the user.
 
 Here's an example using the `:link` pseudo-class:
@@ -114,7 +114,7 @@ a:link {
 
 :::
 
-- **`:visited pseudo-class`**: This pseudo-class is used to style links where a user has already visited.
+- **`:visited pseudo-class`**: This pseudo-class is used to style links that a user has already visited.
 - **`:hover pseudo-class`**: This pseudo-class is used to style elements where a user is actively hovering over them.
 
 Here's an example using the `:hover` pseudo-class:
@@ -135,7 +135,7 @@ a:hover {
 
 :::
 
-- **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples would include `input` or `select` elements where the clicks or tabs on the element to focus it.
+- **`:focus pseudo-class`**: This pseudo-class is used to style an element when it receives focus. Examples would include `input` or `select` elements where the user clicks or tabs on the element to focus it.
 
 Here's an example using the `:focus` pseudo-class:
 
@@ -211,7 +211,7 @@ Here's an example using `background-size: contain`:
 
 :::
 
-- **`background-repeat` Property**: This property is used to determine how background images should be repeated along the horizontal and vertical axes. The default value for `background-repeat` is `repeat` meaning the image will repeat both horizontally and vertically. You can also specify that there should be no repeat by using the `no-repeat` property.
+- **`background-repeat` Property**: This property is used to determine how background images should be repeated along the horizontal and vertical axes. The default value for `background-repeat` is `repeat`, meaning the image will repeat both horizontally and vertically. You can also specify that there should be no repeat by using the `no-repeat` value.
 
 Here's an example using `background-repeat: no-repeat`:
 
@@ -251,7 +251,7 @@ Here's an example using `background-position`:
 :::
 
 - **`background-attachment` Property**: This property is used to specify whether the background image should scroll with the content or remain fixed in place. The main values are `scroll` (default), where the background image scrolls with the content, and `fixed`, where the background image stays in the same position on the screen.
-- **`background-image` Property**: This property is used to set the background image of an element. You can set multiple background images at the same time and use either the `url`, `radial-gradient` or `linear-gradient` functions as values.
+- **`background-image` Property**: This property is used to set the background image of an element. You can set multiple background images at the same time and use the `url`, `radial-gradient`, or `linear-gradient` functions as values.
 
 Here's an example using `background-image`:
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67919

## Summary

This fixes the wording and formatting issues reported in #67919 for the RWD v9 "Review CSS Backgrounds and Borders" lesson.

## What changed

- added the missing Oxford commas in the reported lists
- wrapped the reported CSS keyword values in backticks
- corrected the two grammar issues in the link and focus descriptions
- fixed the `no-repeat` wording to describe it as a value, not a property

## Verification

- `git diff --check`
