### PR TITLE
fix(curriculum): correct template literal syntax in fortune teller app step 13

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e0280810407794171d6558.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e0280810407794171d6558.md
@@ -7,7 +7,7 @@ dashedName: step-13
 
 # --description--
 
-Now, add a `div` with the class `img-loader`. After that, create an `img` element and give it a conditional URL for the image using `{img ? ${CDN_URL}/${img} : LOCAL_DEFAULT_IMG}`.
+Now, add a `div` with the class `img-loader`. After that, create an `img` element and give it a conditional URL for the image using ``${img ? `${CDN_URL}/${img}` : LOCAL_DEFAULT_IMG}``.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67963

### Description
This PR fixes a malformed inline code snippet in Step 13 of the Workshop Fortune Teller App block. 

The inner template-literal backticks and leading `$` were rendering incorrectly because the snippet was wrapped in a single-backtick inline code span. I have updated the snippet to be wrapped in double backticks so that the full expression `${img ? `${CDN_URL}/${img}` : LOCAL_DEFAULT_IMG}` displays correctly to campers.

**Affected Page:**
https://freecodecamp.org

