### PR TITLE
fix(curriculum): accept explicit forEach syntax in fortune teller step 7

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
@@ -28,7 +28,7 @@ assert.match(__helpers.removeJSComments(code), parameterWithRegex);
 Inside the forEach method, you should add the hidden class using the `classList.add` method.
 
 ```js
-const classWithRegex = /elements\s*\.\s*forEach\s*\(\s*\(?\s*(\w+)\s*\)?\s*=>\s*(?:\{[\s\S]*?\1\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\)[\s\S]*?\}|\1\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\))/;
+const classWithRegex = /elements\s*\.\s*forEach\s*\(\s*(?:function\s*\(?\s*\w+\s*\)?|(\w+)\s*=>|\(\s*(\w+)\s*\)\s*=>)\s*(?:\(?\s*(?:\1|\2)\s*\??\.\s*classList\s*\.\s*add\s*\(\s*["`']\s*hidden\s*["`']\s*\)\s*\)?|[\s\S]*?(?:\1|\2)\s*\??\.\s*classList\s*\.\s*add\s*\(\s*["`']\s*hidden\s*["`']\s*\)[\s\S]*?\})/;
 assert.match(__helpers.removeJSComments(code), classWithRegex);
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
@@ -28,7 +28,7 @@ assert.match(__helpers.removeJSComments(code), parameterWithRegex);
 Inside the forEach method, you should add the hidden class using the `classList.add` method.
 
 ```js
-const classWithRegex = /elements\s*\.\s*forEach\s*\(\s*\(?\s*(\w+)\s*\)?\s*=>[\s\S]*?\1\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\)/;
+const classWithRegex = /elements\s*\.\s*forEach\s*\(\s*\(?\s*(\w+)\s*\)?\s*=>\s*(?:\{[\s\S]*?\1\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\)[\s\S]*?\}|\1\s*\.\s*classList\s*\.\s*add\s*\(\s*["']\s*hidden\s*["']\s*\))/;
 assert.match(__helpers.removeJSComments(code), classWithRegex);
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
@@ -28,8 +28,15 @@ assert.match(__helpers.removeJSComments(code), parameterWithRegex);
 Inside the forEach method, you should add the hidden class using the `classList.add` method.
 
 ```js
-const classWithRegex = /elements\s*\.\s*forEach\s*\(\s*(?:function\s*\(?\s*\w+\s*\)?|(\w+)\s*=>|\(\s*(\w+)\s*\)\s*=>)\s*(?:\(?\s*(?:\1|\2)\s*\??\.\s*classList\s*\.\s*add\s*\(\s*["`']\s*hidden\s*["`']\s*\)\s*\)?|[\s\S]*?(?:\1|\2)\s*\??\.\s*classList\s*\.\s*add\s*\(\s*["`']\s*hidden\s*["`']\s*\)[\s\S]*?\})/;
-assert.match(__helpers.removeJSComments(code), classWithRegex);
+const paramMatch = __helpers.removeJSComments(code).match(
+  /elements\s*\.\s*forEach\s*\(\s*(?:function\s*\(\s*(\w+)\s*\)|\(\s*(\w+)\s*\)|(\w+)\s*=>)/
+);
+assert.isNotNull(paramMatch, "Could not find a valid forEach callback parameter.");
+const param = paramMatch[1] || paramMatch[2] || paramMatch[3];
+const usageRegex = new RegExp(
+  param + "\\s*\\??\\s*\\.\\s*classList\\s*\\.\\s*add\\s*\\(\\s*[\"'`]\\s*hidden\\s*[\"'`]\\s*\\)"
+);
+assert.match(__helpers.removeJSComments(code), usageRegex);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded29daa36f4e42ae63e97.md
@@ -21,7 +21,7 @@ assert.match(__helpers.removeJSComments(code), methodWithRegex);
 Your forEach method should take a callback parameter.
 
 ```js
-const parameterWithRegex = /elements\s*\.\s*forEach\s*\(\s*\(?\s*\w+\s*\)?\s*=>/;
+const parameterWithRegex = /elements\s*\.\s*forEach\s*\(\s*(?:function\s*\(\s*\w+\s*\)|\(\s*\w+\s*\)|\w+)\s*(?:=>|\{)/;
 assert.match(__helpers.removeJSComments(code), parameterWithRegex);
 ```
 
@@ -34,7 +34,7 @@ const paramMatch = __helpers.removeJSComments(code).match(
 assert.isNotNull(paramMatch, "Could not find a valid forEach callback parameter.");
 const param = paramMatch[1] || paramMatch[2] || paramMatch[3];
 const usageRegex = new RegExp(
-  param + "\\s*\\??\\s*\\.\\s*classList\\s*\\.\\s*add\\s*\\(\\s*[\"'`]\\s*hidden\\s*[\"'`]\\s*\\)"
+  "\\b" + param + "\\s*\\??\\s*\\.\\s*classList\\s*\\.\\s*add\\s*\\(\\s*[\"'`]\\s*hidden\\s*[\"'`]\\s*\\)"
 );
 assert.match(__helpers.removeJSComments(code), usageRegex);
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67966

### Problem
Step 7 only accepted implicit arrow function syntax:
  elements.forEach(el => el.classList.add("hidden"))

But the explicit block body form is functionally identical and was being rejected:
  elements.forEach((element) => {
    element.classList.add("hidden");
  })

### Fix
Updated the third test regex to accept both syntactic styles using 
a non-capturing group that matches either a block body or a concise 
arrow function body.

### Testing
Verified the updated regex manually in browser console — 
both implicit and explicit forms return true. (screenshot attached)                                                         
<img width="1097" height="637" alt="image" src="https://github.com/user-attachments/assets/5451b198-19c9-4b58-a8ee-316d489ebcf5" />
