### PR TITLE
fix: Refactor/remove query string dependency

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -33,7 +33,6 @@
     "nodemailer": "6.10.1",
     "pino": "9.14.0",
     "pino-pretty": "10.3.1",
-    "query-string": "7.1.3",
     "stripe": "16.12.0",
     "typebox": "1.1.35",
     "validator": "13.15.35"

--- a/api/src/plugins/redirect-with-message.test.ts
+++ b/api/src/plugins/redirect-with-message.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect, beforeEach } from 'vitest';
 import Fastify, { FastifyInstance } from 'fastify';
-import qs from 'query-string';
 
 import redirectWithMessage from './redirect-with-message.js';
 
@@ -68,10 +67,10 @@ describe('redirectWithMessage plugin', () => {
         url: '/'
       });
 
-      expect(res.headers.location).toMatch(/^\/target\?messages=info/);
+      expect(res.headers.location).toMatch(/^\/target\?messages=/);
     });
 
-    test('should encode the message twice when creating the query string', async () => {
+    test('should encode the message when creating the query string', async () => {
       const expectedMessage = { danger: ['foo bar'] };
 
       fastify.get('/', (_req, reply) => {
@@ -87,16 +86,12 @@ describe('redirectWithMessage plugin', () => {
       });
       if (!isString(res.headers.location))
         throw new Error('Location is not a string');
-      const { search } = new URL(res.headers.location, 'http://localhost');
+      const { searchParams } = new URL(res.headers.location, 'http://localhost');
 
-      // The query string itself is encoded:
-      const { messages } = qs.parse(search, { arrayFormat: 'index' });
+      const messages = searchParams.get('messages');
       if (!isString(messages)) throw new Error('Messages is not a string');
 
-      // As is the message embedded in it:
-      expect(qs.parse(messages, { arrayFormat: 'index' })).toEqual(
-        expectedMessage
-      );
+      expect(JSON.parse(messages)).toEqual(expectedMessage);
     });
   });
 });

--- a/api/src/plugins/redirect-with-message.ts
+++ b/api/src/plugins/redirect-with-message.ts
@@ -1,8 +1,6 @@
 import { FastifyPluginCallback, type FastifyReply } from 'fastify';
 import fp from 'fastify-plugin';
-// TODO: (POST MVP)use node's querystring and just JSON stringify the message.
 // No need for query-string on either side.
-import qs from 'query-string';
 
 declare module 'fastify' {
   interface FastifyReply {
@@ -41,14 +39,8 @@ function redirectWithMessage(
  * @returns The formatted message string.
  */
 export function formatMessage(message: Message): string {
-  return qs.stringify(
-    {
-      messages: qs.stringify(prepareMessage(message), {
-        arrayFormat: 'index'
-      })
-    },
-    { arrayFormat: 'index' }
-  );
+  const messagesObject = prepareMessage(message);
+  return `messages=${encodeURIComponent(JSON.stringify(messagesObject))}`;
 }
 
 const plugin: FastifyPluginCallback = (fastify, _options, done) => {

--- a/client/package.json
+++ b/client/package.json
@@ -98,7 +98,6 @@
     "process": "0.11.10",
     "prop-types": "15.8.1",
     "qrcode.react": "^3.1.0",
-    "query-string": "7.1.3",
     "react": "18.3.1",
     "react-calendar-heatmap": "1.10.0",
     "react-dom": "18.3.1",

--- a/client/src/redux/app-mount-saga.js
+++ b/client/src/redux/app-mount-saga.js
@@ -1,23 +1,27 @@
-import qs from 'query-string';
 import { put, takeEvery } from 'redux-saga/effects';
 import { createFlashMessage } from '../components/Flash/redux';
 
 function* parseMessagesSaga() {
-  const search = window.location.search.slice();
+  const search = window.location.search;
   // TODO(Bouncey): Find a way to clear the search with causing a re-render
   if (search) {
-    const { messages } = qs.parse(search, { arrayFormat: 'index' });
+    const params = new URLSearchParams(search);
+    const messages = params.get('messages');
     if (messages) {
-      const flashMap = qs.parse(messages, { arrayFormat: 'index' });
-      const flash = Object.keys(flashMap).reduce(
-        (acc, type) => [
-          ...acc,
-          ...flashMap[type].map(message => ({ type, message }))
-        ],
-        []
-      );
-      for (let i = 0; i < flash.length; i++) {
-        yield put(createFlashMessage(flash[i]));
+      try {
+        const flashMap = JSON.parse(messages);
+        const flash = Object.keys(flashMap).reduce(
+          (acc, type) => [
+            ...acc,
+            ...flashMap[type].map(message => ({ type, message }))
+          ],
+          []
+        );
+        for (let i = 0; i < flash.length; i++) {
+          yield put(createFlashMessage(flash[i]));
+        }
+      } catch (e) {
+        console.error('Failed to parse redirect flash messages', e);
       }
     }
   }

--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5361ef88158b25fbfba7.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5361ef88158b25fbfba7.md
@@ -26,8 +26,8 @@ Therefore, software developers need to make their digital products accessible to
 
 All the mainstay Operating Systems have at least one magnifier built into them by their manufacturers:
 
-- macOS and iOS both have Zoom. You can turn it on on macOS by going to Settings, filter by Accessibility, and then click on "Zoom". Toggle the "Use keyboard shortcuts to zoom" option to enable it.
-  - You can turn it on on iPhone through _Settings > Accessibility > Zoom_.
+- macOS and iOS both have Zoom. You can enable it on macOS by going to Settings, filter by Accessibility, and then click on "Zoom". Toggle the "Use keyboard shortcuts to zoom" option to enable it.
+  - You can enable it on iPhone through _Settings > Accessibility > Zoom_.
 - Android devices have Magnification. To turn it on, go to _Settings > Special Function > Accessibility> Magnification_. Since this may vary from device to device, you can search for "Magnification" on the settings homepage to access it.
 - Windows has Magnifier. You can use it by going to _Settings > Ease of Access > Magnifier_.
 - The magnifiers for Linux operating systems vary. It is either Zoom or Magnifier.

--- a/curriculum/challenges/english/blocks/top-links-and-images/637f700b72c65bc8e73dfe2f.md
+++ b/curriculum/challenges/english/blocks/top-links-and-images/637f700b72c65bc8e73dfe2f.md
@@ -66,7 +66,7 @@ Besides the `src` attribute, every image element should also have an `alt` (alte
 
 The `alt` attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 
-This is how the The Odin Project logo example you used earlier looks with an alt attribute included:
+This is how The Odin Project logo example you used earlier looks with an alt attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
 # --assignment--

--- a/curriculum/challenges/english/blocks/top-links-and-images/637f701572c65bc8e73dfe30.md
+++ b/curriculum/challenges/english/blocks/top-links-and-images/637f701572c65bc8e73dfe30.md
@@ -66,7 +66,7 @@ Besides the `src` attribute, every image element should also have an `alt` (alte
 
 The `alt` attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 
-This is how the The Odin Project logo example you used earlier looks with an alt attribute included:
+This is how The Odin Project logo example you used earlier looks with an alt attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
 # --questions--

--- a/curriculum/challenges/english/blocks/top-links-and-images/637f701c72c65bc8e73dfe31.md
+++ b/curriculum/challenges/english/blocks/top-links-and-images/637f701c72c65bc8e73dfe31.md
@@ -66,7 +66,7 @@ Besides the `src` attribute, every image element should also have an `alt` (alte
 
 The `alt` attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 
-This is how the The Odin Project logo example you used earlier looks with an alt attribute included:
+This is how The Odin Project logo example you used earlier looks with an alt attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
 # --questions--


### PR DESCRIPTION
# Refactor: Replace `query-string` dependency with native Web APIs

## Problem & Rationale
Currently, the codebase imports the third-party `query-string` package in the API server (`api/src/plugins/redirect-with-message.ts`) and the client (`client/src/redux/app-mount-saga.js`) for the sole purpose of serializing and deserializing flash redirect messages.

This approach introduces unnecessary overhead:
1. **Monorepo bloat**: Adds a dependency to both the client and API packages.
2. **Client bundle size**: Serves extra third-party JavaScript to campers' browsers.
3. **Unnecessary double-encoding**: The previous implementation serialized query strings twice inside each other to encode objects, leading to hard-to-read URLs like `?messages=info%5B0%5D%3Dhello`.

Modern environments natively support `URLSearchParams` and standard `JSON` serialization, making `query-string` obsolete for this use case. This PR addresses a legacy TODO to clean up this code debt.

---

## Solution
We replaced `query-string` entirely with native Node/Browser APIs:
* **Serialization**: The server now wraps message objects in `JSON.stringify` and url-encodes the string once using `encodeURIComponent`.
* **Deserialization**: The client parses the search query using standard `URLSearchParams` and decodes the JSON payload using `JSON.parse`.

### Before vs. After (Conceptual serialization comparison)
* **Before**:
  `?messages=danger%5B0%5D%3Dfoo%2520bar` (Double-encoded query string)
* **After**:
  `?messages=%7B%22danger%22%3A%5B%22foo%20bar%22%5D%7D` (URL-encoded JSON structure)

---

## Detailed File Changes

### 1. API Platform (Fastify Backend)
* **[redirect-with-message.ts](file:///c:/Users/Himanshu/Downloads/Anti--%20MODEL/freeCodeCamp/api/src/plugins/redirect-with-message.ts)**:
  * Dropped `query-string` import.
  * Updated `formatMessage()` to stringify message payloads and single-encode them via `encodeURIComponent`.
* **[redirect-with-message.test.ts](file:///c:/Users/Himanshu/Downloads/Anti--%20MODEL/freeCodeCamp/api/src/plugins/redirect-with-message.test.ts)**:
  * Removed `query-string` from test helper imports.
  * Updated unit test suite to utilize native `URLSearchParams` and `JSON.parse` to assert exact redirect message payloads.
* **[package.json](file:///c:/Users/Himanshu/Downloads/Anti--%20MODEL/freeCodeCamp/api/package.json)**:
  * Removed `"query-string": "7.1.3"` from dependencies.

### 2. Client Platform (Gatsby Frontend)
* **[app-mount-saga.js](file:///c:/Users/Himanshu/Downloads/Anti--%20MODEL/freeCodeCamp/client/src/redux/app-mount-saga.js)**:
  * Dropped `query-string` import.
  * Refactored `parseMessagesSaga` to pull the `messages` parameter using `URLSearchParams` and parse the raw JSON string safely.
* **[package.json](file:///c:/Users/Himanshu/Downloads/Anti--%20MODEL/freeCodeCamp/client/package.json)**:
  * Removed `"query-string": "7.1.3"` from dependencies.

---

## Benefits of this Pull Request
* **No External Dependencies**: Eliminates dependency maintenance, security scanning, and update overhead for `query-string`.
* **Bundle Optimization**: Reduces Gatsby client production bundle sizes.
* **Prose & URL Clarity**: The generated redirect URLs are cleaner, standard JSON-serializations instead of nested arrays formatted as queries.

---

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation / dependencies.
- [x] I have updated the dependencies and tests accordingly.