### PR TITLE
test: move academic honesty rendering to client

### DIFF
--- a/client/src/components/settings/honesty.test.tsx
+++ b/client/src/components/settings/honesty.test.tsx
@@ -12,6 +12,16 @@ describe('<Honesty />', () => {
     expect(
       screen.getByRole('heading', { name: 'settings.headings.honesty' })
     ).toBeInTheDocument();
+    [
+      'settings.honesty.p1',
+      'settings.honesty.p2',
+      'settings.honesty.p3',
+      'settings.honesty.p4',
+      'settings.honesty.p5',
+      'settings.honesty.p6'
+    ].forEach(policyText => {
+      expect(screen.getByText(policyText)).toBeInTheDocument();
+    });
     expect(
       screen.getByRole('button', { name: 'buttons.agree-honesty' })
     ).toBeEnabled();

--- a/e2e/academic-honesty.spec.ts
+++ b/e2e/academic-honesty.spec.ts
@@ -15,30 +15,8 @@ test.describe('When the user has not accepted the Academic Honesty Policy', () =
   });
 
   test('they should be able to accept it', async ({ page }) => {
-    await page.goto('/settings');
-    await expect(
-      page.getByRole('heading', {
-        name: translations.settings.headings.honesty
-      })
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.settings.honesty.p1)
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.settings.honesty.p2)
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.settings.honesty.p3)
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.settings.honesty.p4)
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.settings.honesty.p5)
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.settings.honesty.p6)
-    ).toBeVisible();
+    await page.goto('/settings#honesty');
+
     const agreeButton = page.getByRole('button', {
       name: translations.buttons['agree-honesty']
     });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves the static Academic Honesty policy text checks into the existing client test for the settings Honesty component. The Playwright spec still covers the part that benefits from a browser and signed-in state: accepting the policy and confirming the certification gate changes afterward. That keeps the e2e test focused on the user flow instead of also checking static copy.
