### PR TITLE
test: move breadcrumb rendering to client

### DIFF
--- a/client/src/templates/Challenges/components/bread-crumb.test.tsx
+++ b/client/src/templates/Challenges/components/bread-crumb.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import BreadCrumb from './bread-crumb';
+
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string) => key
+  }
+}));
+
+describe('<BreadCrumb />', () => {
+  test('renders superblock and block links', () => {
+    render(
+      <BreadCrumb
+        block='workshop-cat-photo-app'
+        superBlock='responsive-web-design-v9'
+      />
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'aria.breadcrumb-nav' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: 'intro:responsive-web-design-v9.title'
+      })
+    ).toHaveAttribute('href', '/learn/responsive-web-design-v9');
+    expect(
+      screen.getByRole('link', {
+        name: 'intro:responsive-web-design-v9.blocks.workshop-cat-photo-app.title'
+      })
+    ).toHaveAttribute(
+      'href',
+      '/learn/responsive-web-design-v9/#workshop-cat-photo-app'
+    );
+  });
+});

--- a/e2e/bread-crumb.spec.ts
+++ b/e2e/bread-crumb.spec.ts
@@ -12,7 +12,8 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Challenge Breadcrumb Tests', () => {
   test('should display correctly', async ({ page, isMobile }) => {
-    const breadcrumbTest = async (testId: string) => {
+    const mobileBreadcrumb = async () => {
+      const testId = 'breadcrumb-mobile';
       const superBlock = page.getByTestId(testId).getByRole('listitem').first();
       await expect(superBlock).toBeVisible();
 
@@ -40,7 +41,7 @@ test.describe('Challenge Breadcrumb Tests', () => {
 
     if (!isMobile) {
       await expect(page.getByTestId('breadcrumb-mobile')).toBeHidden();
-      await breadcrumbTest('breadcrumb-desktop');
+      await expect(page.getByTestId('breadcrumb-desktop')).toBeVisible();
 
       await page.setViewportSize({
         width: 766,
@@ -49,6 +50,6 @@ test.describe('Challenge Breadcrumb Tests', () => {
     }
 
     await expect(page.getByTestId('breadcrumb-desktop')).toBeHidden();
-    await breadcrumbTest('breadcrumb-mobile');
+    await mobileBreadcrumb();
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves the desktop breadcrumb link rendering checks into a focused client test for the `BreadCrumb` component. The Playwright spec still covers the browser-specific part of the behavior: switching between desktop and mobile breadcrumbs and checking the mobile breadcrumb generated by the classic editor.
