### PR TITLE
fix(curriculum): add missing quotes to test 5 expected output

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a151d32d772271dd2448c2c.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a151d32d772271dd2448c2c.md
@@ -54,7 +54,7 @@ assert.equal(britishToAmerican("It's an honour to meet someone with such humour.
 assert.equal(britishToAmerican("The unrecognised artist analysed his colour palette at the centre."), "The unrecognized artist analyzed his color palette at the center.");
 ```
 
-`britishToAmerican("The offence analysed, with organisation, the defence centre and recognised that the neighbouring labouror was humourous, flavourful, and colourful.")` should return `The offense analyzed, with organisation, the defense center and recognized that the neighboring laboror was humorous, flavorful, and colorful.`
+`britishToAmerican("The offence analysed, with organisation, the defence centre and recognised that the neighbouring labouror was humourous, flavourful, and colourful.")` should return `"The offense analyzed, with organisation, the defense center and recognized that the neighboring laboror was humorous, flavorful, and colorful."`
 
 ```js
 assert.equal(britishToAmerican("The offence analysed, with organisation, the defence centre and recognised that the neighbouring labouror was humourous, flavourful, and colourful."), "The offense analyzed, with organisation, the defense center and recognized that the neighboring laboror was humorous, flavorful, and colorful.");

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a151d32d772271dd2448c2c.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a151d32d772271dd2448c2c.md
@@ -66,7 +66,7 @@ TestCase().assertEqual(british_to_american("The unrecognised artist analysed his
 }})
 ```
 
-`british_to_american("The offence analysed, with organisation, the defence centre and recognised that the neighbouring labouror was humourous, flavourful, and colourful.")` should return `The offense analyzed, with organisation, the defense center and recognized that the neighboring laboror was humorous, flavorful, and colorful.`
+`british_to_american("The offence analysed, with organisation, the defence centre and recognised that the neighbouring labouror was humourous, flavourful, and colourful.")` should return `"The offense analyzed, with organisation, the defense center and recognized that the neighboring laboror was humorous, flavorful, and colorful."`
 
 ```js
 ({test: () => { runPython(`


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67984

<!-- Feel free to add any additional description of changes below this line -->

Added the missing double quotes around the expected string output for test case 5 in both JavaScript and Python curriculum files.