### PR TITLE
docs: fix fortune teller step 13 image snippet

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e0280810407794171d6558.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e0280810407794171d6558.md
@@ -7,7 +7,7 @@ dashedName: step-13
 
 # --description--
 
-Now, add a `div` with the class `img-loader`. After that, create an `img` element and give it a conditional URL for the image using `{img ? ${CDN_URL}/${img} : LOCAL_DEFAULT_IMG}`.
+Now, add a `div` with the class `img-loader`. After that, create an `img` element and give it a conditional URL for the image using ``${img ? `${CDN_URL}/${img}` : LOCAL_DEFAULT_IMG}``.
 
 # --hints--
 


### PR DESCRIPTION
## Summary
- fix the malformed inline code snippet in Workshop Fortune Teller App step 13
- preserve the intended template literal by using a double-backtick code span

## Testing
- git diff --check
