### PR TITLE
fix(curriculum): editable regions in workshop sentence analyzer

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-sentence-analyzer/66e2f376df6f315ee81de81a.md
+++ b/curriculum/challenges/english/blocks/workshop-sentence-analyzer/66e2f376df6f315ee81de81a.md
@@ -84,15 +84,15 @@ const punctuationCount = getPunctuationCount("WHAT?!?!?!?!?");
 console.log(`Punctuation Count: ${punctuationCount}`);
 
 function getWordCount(sentence) {
-  if (sentence.trim() === '') {
+  if (sentence.trim() === "") {
     return 0;
   }
   
-  const words = sentence.trim().split(' ');
+  const words = sentence.trim().split(" ");
   let count = 0;
 
   for (const word of words) {
-    if (word !== '') {
+    if (word !== "") {
       count++;
     }
   }
@@ -154,15 +154,15 @@ const punctuationCount = getPunctuationCount("WHAT?!?!?!?!?");
 console.log(`Punctuation Count: ${punctuationCount}`);
 
 function getWordCount(sentence) {
-  if (sentence.trim() === '') {
+  if (sentence.trim() === "") {
     return 0;
   }
   
-  const words = sentence.trim().split(' ');
+  const words = sentence.trim().split(" ");
   let count = 0;
 
   for (const word of words) {
-    if (word !== '') {
+    if (word !== "") {
       count++;
     }
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

References to: #67721

<!-- Feel free to add any additional description of changes below this line -->

This PR is part for Naomi's sprint for editable regions in workshops.

This workshop didn't need editable regions changed, but it used single quotes in these places when it is preferred to use double quotes.