### PR TITLE
fix(client): remove blank lines around editable region comments in forum help post

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -49,22 +49,22 @@ export function insertEditableRegions(challengeFiles = []) {
     const editableRegionStrings = fileExtension => {
       switch (fileExtension) {
         case 'html':
-          return '\n<!-- User Editable Region -->\n';
+          return '<!-- User Editable Region -->';
         case 'css':
-          return '\n/* User Editable Region */\n';
+          return '/* User Editable Region */';
         case 'py':
-          return '\n# User Editable Region\n';
+          return '# User Editable Region';
 
         case 'js':
         case 'ts':
-          return '\n// User Editable Region\n';
+          return '// User Editable Region';
 
         case 'jsx':
         case 'tsx':
-          return '\n{/* User Editable Region */}\n';
+          return '{/* User Editable Region */}';
 
         default:
-          return '\nUser Editable Region\n';
+          return 'User Editable Region';
       }
     };
 
@@ -112,7 +112,7 @@ function editableRegionsToMarkdown(challengeFiles = []) {
 
     const [start, end] = challengeFile.editableRegionBoundaries;
     const lines = challengeFile.contents.split('\n');
-    const editableRegion = lines.slice(start + 1, end + 4).join('\n');
+    const editableRegion = lines.slice(start, end + 1).join('\n');
 
     return `${fileString}\`\`\`${fileExtension}\n${fileDescription}${editableRegion}\n\`\`\`\n\n`;
   }, '\n');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

reason: with of the tightening of the editable regions, removing the blank lines make the code in the help posts match better the one in the editor, + it removes a few characters and so allows for slighly longer code in the help post