### PR TITLE
fix(curriculum): correct error handling lesson text

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c8ef26f3cad09f36b95b9.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c8ef26f3cad09f36b95b9.md
@@ -81,7 +81,7 @@ For example, if you want to look at the type of elements throughout your code at
 Function divide
 ```
 
-As you can see, by the time you run `.set_trace()`, the type of the parameter `a` is an integer, and `divide` is a function.
+As you can see, by the time you run `set_trace()`, the type of the parameter `a` is an integer, and `divide` is a function.
 
 Then to continue execution of your code, you can use the `continue` command, or one of its aliases, `cont` or `c`:
 
@@ -147,7 +147,7 @@ Use the debug toolbar to:
 
 IDE debugging tools provide a visual interface to examine the state of your program, making it easier to identify and fix issues compared to using print statements alone.
 
-By mastering these foundational debugging techniques - using `print()` statements, the `pdb` module, and IDE tools - you can effectively identify and resolve issues in your Python code. Each technique has its place: `print()` statements for quick checks, `pdb` for interactive exploration, and IDE debuggers for visual inspection.
+By mastering these foundational debugging techniques (`print()` statements, the `pdb` module, and IDE tools), you can effectively identify and resolve issues in your Python code. Each technique has its place: `print()` statements for quick checks, `pdb` for interactive exploration, and IDE debuggers for visual inspection.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c3313b264122a694a08.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c3313b264122a694a08.md
@@ -22,7 +22,7 @@ except ZeroDivisionError:
 
 - `try`: The block of code where you anticipate an error might occur.
 
-- `except`: This block runs if an error of the specified type is raised inside the try.
+- `except`: This block runs if an error of the specified type is raised inside the `try` block.
 
 - In this case, dividing by zero raises a `ZeroDivisionError`, which is then caught and handled.
 
@@ -41,7 +41,7 @@ finally:
 
 - `else`: Runs if no exception is raised in the try block.
 
-- `finally`: Runs no matter what—whether or not an exception occurred. Useful for clean-up tasks like closing files or releasing resources.
+- `finally`: Runs no matter what, whether or not an exception occurred. Useful for clean-up tasks like closing files or releasing resources.
 
 You can also catch multiple exceptions with separate `except` blocks:
 
@@ -164,7 +164,7 @@ Which statement is used to catch a specific error?
 
 ### --feedback--
 
-Refer back to beginning of the lesson about Python error handling.
+Refer back to the beginning of the lesson about Python error handling.
 
 ---
 
@@ -172,7 +172,7 @@ Refer back to beginning of the lesson about Python error handling.
 
 ### --feedback--
 
-Refer back to beginning of the lesson about Python error handling.
+Refer back to the beginning of the lesson about Python error handling.
 
 ---
 
@@ -180,7 +180,7 @@ Refer back to beginning of the lesson about Python error handling.
 
 ### --feedback--
 
-Refer back to beginning of the lesson about Python error handling.
+Refer back to the beginning of the lesson about Python error handling.
 
 ---
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling/688c9c4fe5fef91262f9bdf8.md
@@ -46,7 +46,7 @@ except ValueError:
     print('Handled at higher level')
 ```
 
-Here the keyword `raise` (without arguments), re-raises the current exception that's being handled.
+Here the keyword `raise` (without arguments) re-raises the current exception that's being handled.
 
 This allows you to log or perform cleanup while still propagating the error up the call stack.
 
@@ -90,7 +90,7 @@ def parse_config(filename):
 config = parse_config('config.txt')
 ```
 
-Here you can see that `raise ... from None`, suppresses the original exception context:
+Here you can see that `raise ... from None` suppresses the original exception context:
 
 ```bash
 Traceback (most recent call last):
@@ -102,7 +102,7 @@ Traceback (most recent call last):
 ValueError: Configuration file is missing
 ```
 
-And `raise ... from e`, chains the new exception to the original one, preserving the error trail.
+And `raise ... from e` chains the new exception to the original one, preserving the error trail:
 
 ```bash
 Traceback (most recent call last):


### PR DESCRIPTION
## Checklist

* [x] I have read and followed the contribution guidelines.
* [x] I have read and followed the how to open a pull request guide.
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67976

### Changes made

* Corrected `.set_trace()` to `set_trace()`
* Replaced parenthetical dashes with parentheses in the debugging techniques lecture
* Updated "raised inside the try" to "raised inside the `try` block`
* Replaced the em dash in the `finally` description
* Added the missing article in quiz feedback ("the beginning")
* Fixed punctuation issues in the `raise` statement lecture
* Changed the final sentence introducing a code block to end with a colon
