### PR TITLE
fix(tools): use intros from the same locale in external curriculum data tests

### DIFF
--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import fs, { readFileSync } from 'fs';
+import fs from 'fs';
 
 import readdirp from 'readdirp';
 import { afterEach, describe, test, expect, vi } from 'vitest';
@@ -16,7 +16,6 @@ import {
   availableSuperBlocksValidator
 } from './external-data-schema-v2';
 import {
-  type CurriculumIntros,
   type Curriculum,
   type GeneratedCurriculumProps,
   type GeneratedBlockBasedCurriculumProps,
@@ -24,16 +23,12 @@ import {
   type ChapterBasedCurriculumIntros,
   orderedSuperBlockInfo,
   OrderedSuperBlocks,
-  readCurriculumIntros
+  readCurriculumIntros,
+  getCurriculumLocale
 } from './build-external-curricula-data-v2';
 
 const VERSION = 'v2';
-const intros = JSON.parse(
-  readFileSync(
-    path.resolve(__dirname, '../../../client/i18n/locales/english/intro.json'),
-    'utf-8'
-  )
-) as CurriculumIntros;
+const intros = readCurriculumIntros(getCurriculumLocale());
 
 describe('external curriculum data build', () => {
   afterEach(() => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Updates `build-external-curricula-data-v2` test to use intros from the same locale instead of English.

This is causing a build failure in #67996. 

<img width="1022" height="489" alt="Screenshot 2026-06-17 at 03 28 28" src="https://github.com/user-attachments/assets/285b1baf-ddb8-4c4b-9c28-badae51be619" />

Log: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/27643211111/job/81755873446?pr=67996#step:12:675

<!-- Feel free to add any additional description of changes below this line -->
