### PR TITLE
docs: fix grammar and formatting in Links and Images lessons

### DIFF
--- a/curriculum/challenges/english/blocks/top-links-and-images/637f700b72c65bc8e73dfe2f.md
+++ b/curriculum/challenges/english/blocks/top-links-and-images/637f700b72c65bc8e73dfe2f.md
@@ -44,7 +44,7 @@ Save the `index.html` file and open it in a browser to view Charles in all his g
 
 What if you want to use the dog image in the `about` page? You would first have to go up one level out of the pages directory into its parent directory so you could then access the images directory.
 
-To go to the parent directory you need to use two dots in the relative filepath like this: `../.` Let’s see this in action, within the `body` of the `about.html` file, add the following image below the heading you added earlier:
+To go to the parent directory you need to use two dots in the relative filepath like this: `../` Let’s see this in action, within the `body` of the `about.html` file, add the following image below the heading you added earlier:
 
 ```html
 <img src="../images/dog.jpg">
@@ -66,7 +66,7 @@ Besides the `src` attribute, every image element should also have an `alt` (alte
 
 The `alt` attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 
-This is how the The Odin Project logo example you used earlier looks with an alt attribute included:
+This is how The Odin Project logo example you used earlier looks with an alt attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
 # --assignment--

--- a/curriculum/challenges/english/blocks/top-links-and-images/637f701572c65bc8e73dfe30.md
+++ b/curriculum/challenges/english/blocks/top-links-and-images/637f701572c65bc8e73dfe30.md
@@ -44,7 +44,7 @@ Save the `index.html` file and open it in a browser to view Charles in all his g
 
 What if you want to use the dog image in the `about` page? You would first have to go up one level out of the pages directory into its parent directory so you could then access the images directory.
 
-To go to the parent directory you need to use two dots in the relative filepath like this: `../.` Let’s see this in action, within the `body` of the `about.html` file, add the following image below the heading you added earlier:
+To go to the parent directory you need to use two dots in the relative filepath like this: `../` Let's see this in action, within the `body` of the `about.html` file, add the following image below the heading you added earlier:
 
 ```html
 <img src="../images/dog.jpg">
@@ -66,7 +66,7 @@ Besides the `src` attribute, every image element should also have an `alt` (alte
 
 The `alt` attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 
-This is how the The Odin Project logo example you used earlier looks with an alt attribute included:
+This is how The Odin Project logo example you used earlier looks with an alt attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
 # --questions--

--- a/curriculum/challenges/english/blocks/top-links-and-images/637f701c72c65bc8e73dfe31.md
+++ b/curriculum/challenges/english/blocks/top-links-and-images/637f701c72c65bc8e73dfe31.md
@@ -44,7 +44,7 @@ Save the `index.html` file and open it in a browser to view Charles in all his g
 
 What if you want to use the dog image in the `about` page? You would first have to go up one level out of the pages directory into its parent directory so you could then access the images directory.
 
-To go to the parent directory you need to use two dots in the relative filepath like this: `../.` Let’s see this in action, within the `body` of the `about.html` file, add the following image below the heading you added earlier:
+To go to the parent directory you need to use two dots in the relative filepath like this: `../` Let's see this in action, within the `body` of the `about.html` file, add the following image below the heading you added earlier:
 
 ```html
 <img src="../images/dog.jpg">
@@ -66,7 +66,7 @@ Besides the `src` attribute, every image element should also have an `alt` (alte
 
 The `alt` attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 
-This is how the The Odin Project logo example you used earlier looks with an alt attribute included:
+This is how The Odin Project logo example you used earlier looks with an alt attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
 # --questions--

--- a/curriculum/challenges/english/blocks/top-links-and-images/637f702372c65bc8e73dfe32.md
+++ b/curriculum/challenges/english/blocks/top-links-and-images/637f702372c65bc8e73dfe32.md
@@ -45,7 +45,7 @@ Save the `index.html` file and open it in a browser to view Charles in all his g
 
 What if you want to use the dog image in the `about` page? You would first have to go up one level out of the pages directory into its parent directory so you could then access the images directory.
 
-To go to the parent directory you need to use two dots in the relative filepath like this: `../.` Let’s see this in action, within the `body` of the `about.html` file, add the following image below the heading you added earlier:
+To go to the parent directory you need to use two dots in the relative filepath like this: `../` Let's see this in action, within the `body` of the `about.html` file, add the following image below the heading you added earlier:
 
 ```html
 <img src="../images/dog.jpg">
@@ -67,12 +67,12 @@ Besides the `src` attribute, every image element should also have an `alt` (alte
 
 The `alt` attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 
-This is how the The Odin Project logo example you used earlier looks with an `alt` attribute included:
+This is how The Odin Project logo example you used earlier looks with an `alt` attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
 # --assignment--
 
-Watch Kevin Powell’s HTML Images Video above.
+Watch Kevin Powell's HTML Images Video above.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67977

<!-- Feel free to add any additional description of changes below this line -->
Fixed grammar and formatting issues in the Links and Images block:
- Removed duplicate 'the' from "the The Odin Project"
- Fixed stray trailing dot in relative filepath example (`../.` → `../`)
- Replaced curly apostrophes (’) with straight apostrophes (')
