### PR TITLE
docs(curriculum): fix Step 13 image interpolation example

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e0280810407794171d6558.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68e0280810407794171d6558.md
@@ -7,7 +7,7 @@ dashedName: step-13
 
 # --description--
 
-Now, add a `div` with the class `img-loader`. After that, create an `img` element and give it a conditional URL for the image using `{img ? ${CDN_URL}/${img} : LOCAL_DEFAULT_IMG}`.
+Now, add a `div` with the class `img-loader`. After that, create an `img` element and give it a conditional URL for the image using ``${img ? `${CDN_URL}/${img}` : LOCAL_DEFAULT_IMG}``.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67963

<!-- Feel free to add any additional description of changes below this line -->
Fix the Step 13 curriculum text so the conditional image source example renders with the correct template literal syntax.