### PR TITLE
fix(client): avoid duplicate challenge title in timeline

### DIFF
--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -310,7 +310,7 @@ function useIdToNameMap(t: TFunction): Map<string, NameMap> {
         hasEditableBoundaries || superBlock === SuperBlocks.A2English;
       idToNameMap.set(id, {
         challengeTitle: `${
-          shouldAppendBlockNameToTitle ? blockNameTitle + ' - ' : ''
+          shouldAppendBlockNameToTitle && blockNameTitle !== title ? blockNameTitle + ' - ' : ''
         }${title}`,
         challengePath: slug
       });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67846

<!-- Feel free to add any additional description of changes below this line -->
Fixes the issue where timeline titles are duplicated if the block name and the title are the exact same.
