### PR TITLE
fix: Fix/course progress screen reader

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -47,7 +47,6 @@
   align-items: center;
 }
 
-
 .super-block-accordion .chapter-link {
   text-decoration: none;
   display: flex;
@@ -125,7 +124,6 @@ button .block-header-button-text {
   gap: 10px;
   color: var(--primary-color);
 }
-
 
 .super-block-accordion .block-header {
   width: 100%;

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -32,11 +32,7 @@
 .super-block-accordion .module-header-wrapper .module-button-main {
   flex: 1;
   min-width: 0;
-}
-
-.super-block-accordion .chapter-header-wrapper .chapter-button-toggle,
-.super-block-accordion .module-header-wrapper .module-button-toggle {
-  flex-shrink: 0;
+  justify-content: space-between;
 }
 
 .super-block-accordion .chapter-header-wrapper {
@@ -51,9 +47,6 @@
   align-items: center;
 }
 
-.super-block-accordion .chapter-button-toggle {
-  padding-left: 0;
-}
 
 .super-block-accordion .chapter-link {
   text-decoration: none;
@@ -133,9 +126,6 @@ button .block-header-button-text {
   color: var(--primary-color);
 }
 
-.super-block-accordion .module-button-toggle {
-  padding-left: 0;
-}
 
 .super-block-accordion .block-header {
   width: 100%;

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -145,7 +145,7 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
+    // The module-button-right div is inside the main button and carries the testid
     const moduleRight = screen.getByTestId('module-button-right');
     const moduleSteps = within(moduleRight).getByText(
       /learn\.steps-completed/i
@@ -184,7 +184,7 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
+    // The module-button-right div is inside the main button and carries the testid
     const moduleRight = screen.getByTestId('module-button-right');
     expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
   });
@@ -219,7 +219,7 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
+    // The module-button-right div is inside the main button and carries the testid
     const moduleRight = screen.getByTestId('module-button-right');
     expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
   });
@@ -547,9 +547,11 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // When expandAll=true, both chapters are open so their module main buttons are visible
-    expect(screen.getByRole('button', { name: 'mod-one' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'mod-two' })).toBeInTheDocument();
+    // When expandAll=true, both chapters are open so their module buttons are visible.
+    // Each module renders both an accordion button and a reset button with the module name
+    // in its accessible name, so use getAllByRole to avoid an ambiguous match.
+    expect(screen.getAllByRole('button', { name: /mod-one/ })[0]).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /mod-two/ })[0]).toBeInTheDocument();
   });
 
   it('should not render a module when all its challenges are filtered out', () => {
@@ -576,12 +578,13 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // mod-one has a challenge — its main module button should render
-    expect(screen.getByRole('button', { name: 'mod-one' })).toBeInTheDocument();
+    // mod-one has a challenge — its module buttons (accordion + reset) should render.
+    // Use getAllByRole since both buttons include the module name in their accessible name.
+    expect(screen.getAllByRole('button', { name: /mod-one/ })[0]).toBeInTheDocument();
 
     // mod-two has no challenges — its main module button should not render
     expect(
-      screen.queryByRole('button', { name: 'mod-two' })
+      screen.queryByRole('button', { name: /mod-two/ })
     ).not.toBeInTheDocument();
   });
 });

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -550,8 +550,12 @@ describe('SuperBlockAccordion', () => {
     // When expandAll=true, both chapters are open so their module buttons are visible.
     // Each module renders both an accordion button and a reset button with the module name
     // in its accessible name, so use getAllByRole to avoid an ambiguous match.
-    expect(screen.getAllByRole('button', { name: /mod-one/ })[0]).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: /mod-two/ })[0]).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: /mod-one/ })[0]
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: /mod-two/ })[0]
+    ).toBeInTheDocument();
   });
 
   it('should not render a module when all its challenges are filtered out', () => {
@@ -580,7 +584,9 @@ describe('SuperBlockAccordion', () => {
 
     // mod-one has a challenge — its module buttons (accordion + reset) should render.
     // Use getAllByRole since both buttons include the module name in their accessible name.
-    expect(screen.getAllByRole('button', { name: /mod-one/ })[0]).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: /mod-one/ })[0]
+    ).toBeInTheDocument();
 
     // mod-two has no challenges — its main module button should not render
     expect(

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -117,9 +117,6 @@ const Chapter = ({
   const panelId = `chapter-panel-${dashedName}`;
   const isComplete = completedSteps === totalSteps && totalSteps > 0;
   const chapterLabel = t(`intro:${superBlock}.chapters.${dashedName}`);
-  const toggleLabel = open
-    ? t('intro:misc-text.collapse')
-    : t('intro:misc-text.expand');
   const showResetButton = !comingSoon && !isLinkChapter;
   const isResetDisabled = completedSteps === 0;
 
@@ -202,19 +199,9 @@ const Chapter = ({
           type='button'
         >
           {chapterButtonLeftContent}
-        </button>
-        {resetButton}
-        <button
-          aria-controls={panelId}
-          aria-expanded={open}
-          aria-label={`${toggleLabel} ${chapterLabel}`}
-          className='chapter-button chapter-button-toggle'
-          data-playwright-test-label='chapter-button-toggle'
-          onClick={toggleOpen}
-          type='button'
-        >
           {chapterButtonRightContent}
         </button>
+        {resetButton}
       </div>
       {open && (
         <ul className='chapter-panel' id={panelId}>
@@ -255,9 +242,6 @@ const Module = ({
   const panelId = `module-panel-${dashedName}`;
   const isComplete = totalSteps === 0 ? false : completedSteps === totalSteps;
   const moduleLabel = t(`intro:${superBlock}.modules.${dashedName}`);
-  const toggleLabel = open
-    ? t('intro:misc-text.collapse')
-    : t('intro:misc-text.expand');
   const { note, intro } = t(`intro:${superBlock}.module-intros.${dashedName}`, {
     returnObjects: true
   }) as {
@@ -311,18 +295,7 @@ const Module = ({
             </span>
             {moduleLabel}
           </div>
-        </button>
-        {resetButton}
-        <button
-          aria-controls={panelId}
-          aria-expanded={open}
-          aria-label={`${toggleLabel} ${moduleLabel}`}
-          className='module-button module-button-toggle'
-          data-testid='module-button-right'
-          onClick={toggleOpen}
-          type='button'
-        >
-          <div className='module-button-right'>
+          <div className='module-button-right' data-testid='module-button-right'>
             {!comingSoon && !!totalSteps && (
               <span className='module-steps'>
                 {t('learn.steps-completed', {
@@ -333,6 +306,7 @@ const Module = ({
             )}
           </div>
         </button>
+        {resetButton}
       </div>
       {open && (
         <ul className='module-panel' id={panelId}>

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -295,7 +295,10 @@ const Module = ({
             </span>
             {moduleLabel}
           </div>
-          <div className='module-button-right' data-testid='module-button-right'>
+          <div
+            className='module-button-right'
+            data-testid='module-button-right'
+          >
             {!comingSoon && !!totalSteps && (
               <span className='module-steps'>
                 {t('learn.steps-completed', {

--- a/e2e/navigation-from-last-challenge.spec.ts
+++ b/e2e/navigation-from-last-challenge.spec.ts
@@ -63,6 +63,7 @@ test.describe('Should take you to the next superblock (with editor solution)', (
     browserName,
     context
   }) => {
+    test.setTimeout(30000);
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
     await page.goto(rwdChallenge.url);
     await focusEditor({ page, isMobile });
@@ -84,7 +85,7 @@ test.describe('Should take you to the next superblock (with editor solution)', (
     const submitButton = page.locator(
       '[data-playwright-test-label="independentLowerJaw-submit-button"]'
     );
-    await expect(submitButton).toBeVisible();
+    await expect(submitButton).toBeVisible({ timeout: 15000 });
     await submitButton.click();
     await page.waitForURL(rwdChallenge.nextUrl);
   });

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -255,6 +255,7 @@ test.describe('Submit button should be shown after submitting a project', () => 
     isMobile
   }) => {
     test.skip(isMobile);
+    test.setTimeout(30000);
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
     const tributeContent = [

--- a/e2e/super-block-page.spec.ts
+++ b/e2e/super-block-page.spec.ts
@@ -321,7 +321,7 @@ test.describe('Super Block Page - Search Lessons', () => {
     await page.goto('/learn/javascript-v9/');
 
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/ })
     ).toBeVisible();
 
     await page
@@ -332,7 +332,7 @@ test.describe('Super Block Page - Search Lessons', () => {
       page.getByRole('heading', { name: 'Build a Greeting Bot' })
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/ })
     ).not.toBeVisible();
     await expect(
       page.getByText(
@@ -343,7 +343,7 @@ test.describe('Super Block Page - Search Lessons', () => {
     await page.getByRole('button', { name: 'Clear search terms' }).click();
 
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/ })
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
  Checklist:                                                                                                          
                                                                                                                      
  - [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).                  
  - [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).                                            
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.                               
                                                                                                                      
  Closes #67770

  The module and chapter accordion components previously had two side-by-side buttons: a main button (showing the
  name) and a toggle button (showing steps progress with an explicit `aria-label`). Because the toggle button had an
  explicit `aria-label`, screen readers read only that label and skipped the button's inner text, meaning users never
  heard both the module name and their progress together.

  This fix removes the toggle button entirely and moves the steps count inside the main button. Now the main button's
  accessible name includes both the module/chapter name and the progress count, so screen readers announce both in a
  single interaction. The CSS was updated to preserve the visual layout using `justify-content: space-between`.
  
  ---                                                                                                                 
  The Playwright failures were timing issues specific to HTML/CSS project challenges (tribute page and personal       
  portfolio), where:                                                                                                  
  - The iframe preview needs to load                                                                                  
  - The challenge tests run against the rendered DOM                                                                  
  - Redux state updates and React re-renders
                                                                                                                      
  This process takes longer than the default 15s test timeout (for projects.spec.ts) and the default 5s assertion     
  timeout (for navigation-from-last-challenge.spec.ts). Both tests now use test.setTimeout(30000), and the explicit   
  toBeVisible() assertion uses { timeout: 15000 }.                                                                    