### PR TITLE
fix(curriculum): correct email simulator step 51 instructions

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-email-simulator/68540aa7dfd449ad074c285c.md
+++ b/curriculum/challenges/english/blocks/workshop-email-simulator/68540aa7dfd449ad074c285c.md
@@ -7,11 +7,11 @@ dashedName: step-51
 
 # --description--
 
-Now you'll demonstrate the inbox functionality. Ramy will check his inbox, read the first email, delete the second email, and then check his inbox again to see the changes.
+Now you'll demonstrate the inbox functionality. Ramy will check his inbox, read the first email, delete the first email, and then check his inbox again to see the changes.
 
 In your `main` function, after sending the emails, add code to:
 
-- Have Ramy check his inbox  using the `check_inbox` method.
+- Have Ramy check his inbox using the `check_inbox` method.
 - Have Ramy read the first email.
 - Have Ramy delete the first email.
 - Have Ramy check his inbox again.


### PR DESCRIPTION
Closes #68009

## Description

This PR fixes inconsistent instructions in Step 51 of the Email Simulator workshop.

## Changes made

- Corrected the introductory text to say "delete the first email" instead of "delete the second email".
- Removed the extra space in the instruction line.

## Checklist

- [x] I have read and followed the contribution guidelines.
- [x] I have tested my changes.
- [x] This PR is linked to the appropriate issue.