### PR TITLE
fix(curriculum): sync basic html music player block

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -9247,6 +9247,13 @@
           "In these lectures, you will learn how to work with the <code>audio</code> and <code>video</code> elements."
         ]
       },
+      "workshop-html-music-player": {
+        "title": "Build an HTML Music Player",
+        "intro": [
+          "In this workshop, you'll use HTML to create a basic music player.",
+          "This project will cover the <code>audio</code> element, the audio player setup, and more."
+        ]
+      },
       "workshop-html-video-player": {
         "title": "Build an HTML Video Player",
         "intro": [

--- a/curriculum/structure/superblocks/basic-html.json
+++ b/curriculum/structure/superblocks/basic-html.json
@@ -12,6 +12,7 @@
     "lecture-understanding-how-html-affects-seo",
     "lab-travel-agency-page",
     "lecture-working-with-audio-and-video-elements",
+    "workshop-html-music-player",
     "workshop-html-video-player",
     "lab-html-audio-and-video-player",
     "lecture-working-with-images-and-svgs",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68019

## Summary
- Add `workshop-html-music-player` to the standalone `basic-html` superblock.
- Add the matching English intro metadata for the new block.

## Reproduction
- Compare `curriculum/structure/superblocks/basic-html.json` with the `basic-html` module in `curriculum/structure/superblocks/responsive-web-design-v9.json`.
- `workshop-html-music-player` exists in the responsive web design v9 source module but is missing from standalone `basic-html`.

## Root cause
- The standalone `basic-html` catalog metadata was not kept in sync when the music player workshop was added.

## Changes
- Insert `workshop-html-music-player` between `lecture-working-with-audio-and-video-elements` and `workshop-html-video-player`.
- Add the corresponding `basic-html.blocks["workshop-html-music-player"]` intro entry.

## Tests
- `jq . curriculum/structure/superblocks/basic-html.json`
- `jq . client/i18n/locales/english/intro.json`
- `git diff --check origin/main..HEAD`
- Lightweight catalog data check:

```text
basic-html catalog block verified
order: lecture-working-with-audio-and-video-elements -> workshop-html-music-player -> workshop-html-video-player
title: Build an HTML Music Player
intro: In this workshop, you'll use HTML to create a basic music player. This project will cover the <code>audio</code> element, the audio player setup, and more.
```

## Screenshots/Logs
- I have not captured the local catalog UI for this change. The checkout I used is sparse and does not include enough of the client app to render the catalog page without setting up the full workspace.
