### PR TITLE
fix: fix : Standalone css-flexbox superblock is missing the workshop-colorful-boxes

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -9892,6 +9892,12 @@
           "In this workshop, you'll use Flexbox to build a responsive photo gallery webpage."
         ]
       },
+      "workshop-colorful-boxes": {
+        "title": "Design a Set of Colorful Boxes",
+        "intro": [
+          "In this workshop, you will practice working with CSS flexbox by designing a set of colored boxes."
+        ]
+      },
       "lab-pricing-plans-layout": {
         "title": "Build a Pricing Plans Layout",
         "intro": [

--- a/curriculum/structure/superblocks/css-flexbox.json
+++ b/curriculum/structure/superblocks/css-flexbox.json
@@ -2,6 +2,7 @@
   "blocks": [
     "lecture-working-with-css-flexbox",
     "workshop-flexbox-photo-gallery",
+    "workshop-colorful-boxes",
     "lab-pricing-plans-layout",
     "lab-page-of-playing-cards",
     "review-css-flexbox",


### PR DESCRIPTION
Checklist:

* [x] I have read and followed the contribution guidelines.
* [x] I have read and followed the how to open a pull request guide.
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68031 

