### PR TITLE
feat(client): update forum help categories to restructured slugs

### DIFF
--- a/client/i18n/locales/chinese-traditional/links.json
+++ b/client/i18n/locales/chinese-traditional/links.json
@@ -25,10 +25,17 @@
     "podcast": "open.spotify.com/show/3dIVV6XRRPMs75z2xDtsOg?si=Ugm6rwlcTgiEJ1Udw9WzVQ"
   },
   "help": {
-    "HTML-CSS": "chinese/html-css",
-    "JavaScript": "chinese/javascript",
-    "Python": "chinese/python",
-    "Backend Development": "chinese/programming-help",
-    "English": "English"
+    "HTML-CSS": "world-languages/chinese",
+    "JavaScript": "world-languages/chinese",
+    "Python": "world-languages/chinese",
+    "Backend Development": "world-languages/chinese",
+    "C-Sharp": "world-languages/chinese",
+    "English": "world-languages/chinese",
+    "Spanish Curriculum": "world-languages/chinese",
+    "Chinese Curriculum": "world-languages/chinese",
+    "Odin": "world-languages/chinese",
+    "Euler": "world-languages/chinese",
+    "Rosetta": "world-languages/chinese",
+    "General": "world-languages/chinese"
   }
 }

--- a/client/i18n/locales/chinese/links.json
+++ b/client/i18n/locales/chinese/links.json
@@ -25,10 +25,17 @@
     "podcast": "open.spotify.com/show/3dIVV6XRRPMs75z2xDtsOg?si=Ugm6rwlcTgiEJ1Udw9WzVQ"
   },
   "help": {
-    "HTML-CSS": "chinese/html-css",
-    "JavaScript": "chinese/javascript",
-    "Python": "chinese/python",
-    "Backend Development": "chinese/programming-help",
-    "English": "English"
+    "HTML-CSS": "world-languages/chinese",
+    "JavaScript": "world-languages/chinese",
+    "Python": "world-languages/chinese",
+    "Backend Development": "world-languages/chinese",
+    "C-Sharp": "world-languages/chinese",
+    "English": "world-languages/chinese",
+    "Spanish Curriculum": "world-languages/chinese",
+    "Chinese Curriculum": "world-languages/chinese",
+    "Odin": "world-languages/chinese",
+    "Euler": "world-languages/chinese",
+    "Rosetta": "world-languages/chinese",
+    "General": "world-languages/chinese"
   }
 }

--- a/client/i18n/locales/english/links.json
+++ b/client/i18n/locales/english/links.json
@@ -27,17 +27,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "HTML-CSS",
-    "JavaScript": "JavaScript",
-    "Python": "Python",
-    "Backend Development": "Backend Development",
-    "C-Sharp": "C-Sharp",
-    "English": "English",
-    "Spanish Curriculum": "Spanish Curriculum",
-    "Chinese Curriculum": "Chinese Curriculum",
-    "Odin": "The Odin Project",
-    "Euler": "Project Euler",
-    "Rosetta": "Rosetta Code",
+    "HTML-CSS": "programming/html-css",
+    "JavaScript": "programming/javascript",
+    "Python": "programming/python",
+    "Backend Development": "programming/backend-development",
+    "C-Sharp": "programming/c-sharp",
+    "English": "world-languages/english",
+    "Spanish Curriculum": "world-languages/spanish-curriculum",
+    "Chinese Curriculum": "world-languages/chinese-curriculum",
+    "Odin": "programming/the-odin-project",
+    "Euler": "programming/project-euler",
+    "Rosetta": "programming/rosetta-code",
     "General": "General"
   }
 }

--- a/client/i18n/locales/espanol/links.json
+++ b/client/i18n/locales/espanol/links.json
@@ -25,10 +25,17 @@
     "podcast": "https://www.freecodecamp.org/espanol/news/el-podcast-de-freecodecamp-en-espanol/"
   },
   "help": {
-    "HTML-CSS": "Espanol/HTML-CSS",
-    "JavaScript": "Espanol/JavaScript",
-    "Python": "Espanol/Python",
-    "Backend Development": "espanol/ayuda-de-programacion",
-    "English": "English"
+    "HTML-CSS": "world-languages/espanol",
+    "JavaScript": "world-languages/espanol",
+    "Python": "world-languages/espanol",
+    "Backend Development": "world-languages/espanol",
+    "C-Sharp": "world-languages/espanol",
+    "English": "world-languages/espanol",
+    "Spanish Curriculum": "world-languages/espanol",
+    "Chinese Curriculum": "world-languages/espanol",
+    "Odin": "world-languages/espanol",
+    "Euler": "world-languages/espanol",
+    "Rosetta": "world-languages/espanol",
+    "General": "world-languages/espanol"
   }
 }

--- a/client/i18n/locales/german/links.json
+++ b/client/i18n/locales/german/links.json
@@ -25,10 +25,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "German/HTML-CSS",
-    "JavaScript": "German/JavaScript",
-    "Python": "German/Python",
-    "Backend Development": "German/programming-help",
-    "English": "English"
+    "HTML-CSS": "world-languages/german",
+    "JavaScript": "world-languages/german",
+    "Python": "world-languages/german",
+    "Backend Development": "world-languages/german",
+    "C-Sharp": "world-languages/german",
+    "English": "world-languages/german",
+    "Spanish Curriculum": "world-languages/german",
+    "Chinese Curriculum": "world-languages/german",
+    "Odin": "world-languages/german",
+    "Euler": "world-languages/german",
+    "Rosetta": "world-languages/german",
+    "General": "world-languages/german"
   }
 }

--- a/client/i18n/locales/italian/links.json
+++ b/client/i18n/locales/italian/links.json
@@ -25,10 +25,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "Italiano/HTML-CSS",
-    "JavaScript": "Italiano/JavaScript",
-    "Python": "Italiano/Python",
-    "Backend Development": "italiano/aiuto-programmazione",
-    "English": "English"
+    "HTML-CSS": "world-languages/italiano",
+    "JavaScript": "world-languages/italiano",
+    "Python": "world-languages/italiano",
+    "Backend Development": "world-languages/italiano",
+    "C-Sharp": "world-languages/italiano",
+    "English": "world-languages/italiano",
+    "Spanish Curriculum": "world-languages/italiano",
+    "Chinese Curriculum": "world-languages/italiano",
+    "Odin": "world-languages/italiano",
+    "Euler": "world-languages/italiano",
+    "Rosetta": "world-languages/italiano",
+    "General": "world-languages/italiano"
   }
 }

--- a/client/i18n/locales/japanese/links.json
+++ b/client/i18n/locales/japanese/links.json
@@ -25,10 +25,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "Japanese/HTML-CSS",
-    "JavaScript": "Japanese/JavaScript",
-    "Python": "Japanese/Python",
-    "Backend Development": "Japanese/programming-help",
-    "English": "English"
+    "HTML-CSS": "world-languages/japanese",
+    "JavaScript": "world-languages/japanese",
+    "Python": "world-languages/japanese",
+    "Backend Development": "world-languages/japanese",
+    "C-Sharp": "world-languages/japanese",
+    "English": "world-languages/japanese",
+    "Spanish Curriculum": "world-languages/japanese",
+    "Chinese Curriculum": "world-languages/japanese",
+    "Odin": "world-languages/japanese",
+    "Euler": "world-languages/japanese",
+    "Rosetta": "world-languages/japanese",
+    "General": "world-languages/japanese"
   }
 }

--- a/client/i18n/locales/korean/links.json
+++ b/client/i18n/locales/korean/links.json
@@ -27,14 +27,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "HTML-CSS",
-    "JavaScript": "JavaScript",
-    "Python": "Python",
-    "Backend Development": "Backend Development",
-    "C-Sharp": "C-Sharp",
-    "English": "English",
-    "Odin": "The Odin Project",
-    "Euler": "Project Euler",
-    "Rosetta": "Rosetta Code"
+    "HTML-CSS": "world-languages",
+    "JavaScript": "world-languages",
+    "Python": "world-languages",
+    "Backend Development": "world-languages",
+    "C-Sharp": "world-languages",
+    "English": "world-languages",
+    "Spanish Curriculum": "world-languages",
+    "Chinese Curriculum": "world-languages",
+    "Odin": "world-languages",
+    "Euler": "world-languages",
+    "Rosetta": "world-languages",
+    "General": "world-languages"
   }
 }

--- a/client/i18n/locales/portuguese/links.json
+++ b/client/i18n/locales/portuguese/links.json
@@ -25,10 +25,17 @@
     "podcast": "https://open.spotify.com/show/70m92At5oht4zY4f87lLEE?si=6tozUAOBQFSVyaqixy6aCg"
   },
   "help": {
-    "HTML-CSS": "Portugues/HTML-CSS",
-    "JavaScript": "Portugues/JavaScript",
-    "Python": "Portugues/Python",
-    "Backend Development": "Portugues/ajuda-em-programacao",
-    "English": "English"
+    "HTML-CSS": "world-languages/portugues",
+    "JavaScript": "world-languages/portugues",
+    "Python": "world-languages/portugues",
+    "Backend Development": "world-languages/portugues",
+    "C-Sharp": "world-languages/portugues",
+    "English": "world-languages/portugues",
+    "Spanish Curriculum": "world-languages/portugues",
+    "Chinese Curriculum": "world-languages/portugues",
+    "Odin": "world-languages/portugues",
+    "Euler": "world-languages/portugues",
+    "Rosetta": "world-languages/portugues",
+    "General": "world-languages/portugues"
   }
 }

--- a/client/i18n/locales/swahili/links.json
+++ b/client/i18n/locales/swahili/links.json
@@ -25,10 +25,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "HTML-CSS",
-    "JavaScript": "JavaScript",
-    "Python": "Python",
-    "Backend Development": "Backend Development",
-    "English": "English"
+    "HTML-CSS": "world-languages",
+    "JavaScript": "world-languages",
+    "Python": "world-languages",
+    "Backend Development": "world-languages",
+    "C-Sharp": "world-languages",
+    "English": "world-languages",
+    "Spanish Curriculum": "world-languages",
+    "Chinese Curriculum": "world-languages",
+    "Odin": "world-languages",
+    "Euler": "world-languages",
+    "Rosetta": "world-languages",
+    "General": "world-languages"
   }
 }

--- a/client/i18n/locales/ukrainian/links.json
+++ b/client/i18n/locales/ukrainian/links.json
@@ -25,10 +25,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "Ukrainian/HTML-CSS",
-    "JavaScript": "Ukrainian/JavaScript",
-    "Python": "Ukrainian/Python",
-    "Backend Development": "Ukrainian/programming-help",
-    "English": "English"
+    "HTML-CSS": "world-languages/ukrainian",
+    "JavaScript": "world-languages/ukrainian",
+    "Python": "world-languages/ukrainian",
+    "Backend Development": "world-languages/ukrainian",
+    "C-Sharp": "world-languages/ukrainian",
+    "English": "world-languages/ukrainian",
+    "Spanish Curriculum": "world-languages/ukrainian",
+    "Chinese Curriculum": "world-languages/ukrainian",
+    "Odin": "world-languages/ukrainian",
+    "Euler": "world-languages/ukrainian",
+    "Rosetta": "world-languages/ukrainian",
+    "General": "world-languages/ukrainian"
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Updates the `help` category values in every `links.json` locale to match the restructured forum categories. These values are dropped into the forum "new topic" URL as the `category` query param (`create-question-epic.js`), so they must match the new Discourse category slugs.

- **English**: each category now points to its specific slug, for example `programming/javascript`, `programming/html-css`, `world-languages/english`. `General` is left unchanged.
- Naomi has restructured the other languages subforums so now for **Spanish, German, Italian, Portuguese, Japanese, Ukrainian, Chinese, Chinese (Traditional)**: every category points to that language's `world-languages/<language>` slug (Chinese Traditional shares `world-languages/chinese`).
- We don't have Korean and Swahili subforums, **Korean, Swahili**: every category points to `world-languages`.

Each non-English locale's `help` object was also filled out to the full set of category keys so no `helpCategory` falls through to an unresolved key.
