### PR TITLE
fix: correct typo and capitalization in Bash and SQL quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-bash-and-sql/66f1affc0ef4fcca423d4688.md
+++ b/curriculum/challenges/english/blocks/quiz-bash-and-sql/66f1affc0ef4fcca423d4688.md
@@ -311,7 +311,7 @@ Executing one large, complex query and sending it back to the server.
 
 ---
 
-A query that returns too much data at once but sorts it alpabetically.
+A query that returns too much data at once but sorts it alhpabetically.
 
 ---
 
@@ -443,7 +443,7 @@ Only student IDs.
 
 ---
 
-Only Course IDs.
+Only course IDs.
 
 ---
 
@@ -451,5 +451,5 @@ Full student and course details.
 
 #### --answer--
 
-Both IDs and Enrollment date.
+Both IDs and enrollment date.
 

--- a/curriculum/challenges/english/blocks/quiz-bash-and-sql/66f1affc0ef4fcca423d4688.md
+++ b/curriculum/challenges/english/blocks/quiz-bash-and-sql/66f1affc0ef4fcca423d4688.md
@@ -311,7 +311,7 @@ Executing one large, complex query and sending it back to the server.
 
 ---
 
-A query that returns too much data at once but sorts it alhpabetically.
+A query that returns too much data at once but sorts it alphabetically.
 
 ---
 


### PR DESCRIPTION
Checklist:

* [x] I have read and followed the contribution guidelines.
* [x] I have read and followed the how to open a pull request guide.
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68017

Changes made:

* Fixed typo in the distractor text: "alpabetically" → "alphabetically"
* Standardized capitalization: "Only Course IDs" → "Only course IDs"
* Corrected capitalization: "Both IDs and Enrollment date" → "Both IDs and enrollment date"
