### PR TITLE
chore: use native issue Type field in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01--issues-with-coding-challenges.yml
+++ b/.github/ISSUE_TEMPLATE/01--issues-with-coding-challenges.yml
@@ -1,6 +1,7 @@
 name: Issue - Content in our Coding Challenges
 description: Report issues with a specific challenge, like broken tests, unclear instructions, etc.
-labels: ['scope: curriculum', 'type: bug', 'status: waiting triage']
+type: Bug
+labels: ['scope: curriculum', 'status: waiting triage']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02--issues-with-software-on-platforms.yml
+++ b/.github/ISSUE_TEMPLATE/02--issues-with-software-on-platforms.yml
@@ -1,6 +1,7 @@
 name: Issue - User Interface on our Platforms
 description: Report a software bug on /learn, /news, Community Forum, Code Radio, or any of the platforms.
-labels: ['type: bug', 'status: waiting triage']
+type: Bug
+labels: ['status: waiting triage']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03--issues-with-content-on-articles-and-docs.yml
+++ b/.github/ISSUE_TEMPLATE/03--issues-with-content-on-articles-and-docs.yml
@@ -1,6 +1,7 @@
 name: Issues - Content in our Articles and other Documentation
 description: Report issues with content on a specific article, like broken links, typos, missing parts, etc.
-labels: ['type: bug', 'status: waiting triage']
+type: Bug
+labels: ['status: waiting triage']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/04--feature-request-for-freecodecamp-org-s-platforms.yml
+++ b/.github/ISSUE_TEMPLATE/04--feature-request-for-freecodecamp-org-s-platforms.yml
@@ -1,6 +1,7 @@
 name: New Feature - Request a new feature for our Platforms
 description: Suggest an idea for freeCodeCamp.org's /learn, /news, Community Forum, Code Radio, or other platforms.
-labels: ['type: feature request', 'status: waiting triage']
+type: Enhancement
+labels: ['status: waiting triage']
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

The issue templates list `type: bug` and `type: feature request` in their `labels:` frontmatter, but those labels no longer exist: they were migrated to GitHub's native issue Type metadata. As a result those entries are silent no-ops and new issues opened from the templates get no Type assigned.

This sets the native `type:` field on each form instead, and drops the dead label entries:

- `01--issues-with-coding-challenges.yml` → `type: Bug`
- `02--issues-with-software-on-platforms.yml` → `type: Bug`
- `03--issues-with-content-on-articles-and-docs.yml` → `type: Bug`
- `04--feature-request-for-freecodecamp-org-s-platforms.yml` → `type: Enhancement`

The still-valid labels (`scope: curriculum`, `status: waiting triage`) are kept.

> Note: issue-form YAML can only be verified on GitHub's new-issue UI, so the "tested locally" box is left unchecked.
