### PR TITLE
fix(curriculum): add missing JavaScript fundamentals review block

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2735,6 +2735,13 @@
           "In this lab you will create a function that skips elements in an array based on a specified step value."
         ]
       },
+      "lab-playlist-remix-engine": {
+        "title": "Build a Playlist Remix Engine",
+        "intro": [
+          "In this lab, you will build a Playlist Remix Engine using JavaScript arrays.",
+          "You will apply array methods and logic to transform data and generate a final remix schedule."
+        ]
+      },
       "review-javascript-fundamentals": {
         "title": "JavaScript Fundamentals Review",
         "intro": [

--- a/curriculum/structure/superblocks/javascript-fundamentals-review.json
+++ b/curriculum/structure/superblocks/javascript-fundamentals-review.json
@@ -22,6 +22,7 @@
     "lab-html-entitiy-converter",
     "lab-odd-fibonacci-sum-calculator",
     "lab-element-skipper",
+    "lab-playlist-remix-engine",
     "review-javascript-fundamentals",
     "quiz-javascript-fundamentals"
   ]


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68049

This syncs the standalone `javascript-fundamentals-review` catalog item with the source `javascript-v9` module by adding the missing `lab-playlist-remix-engine` block after `lab-element-skipper` and before `review-javascript-fundamentals`.

Validation:

- `jq empty curriculum/structure/superblocks/javascript-fundamentals-review.json client/i18n/locales/english/intro.json`
- Custom Node check confirmed the inserted block order, that every block in `javascript-fundamentals-review` has an English intro entry, and that the existing `lab-playlist-remix-engine` source structure/content files exist.
- `git diff --check`

Duplicate check:

- Searched open/all PRs for `#68049`, `lab-playlist-remix-engine`, and `javascript-fundamentals-review`. No open duplicate PR found. The related `lab-playlist-remix-engine` PR (#65515) was already merged and added the source module content, not this standalone catalog sync.

Note: `pnpm exec prettier --check curriculum/structure/superblocks/javascript-fundamentals-review.json client/i18n/locales/english/intro.json` could not run in this fresh clone because dependencies were not installed (`Command "prettier" not found`).
