### PR TITLE
fix(curriculum): correct :visited pseudo-class wording

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
+++ b/curriculum/challenges/english/blocks/quiz-css-backgrounds-and-borders/66ed8fd7f45ce3ece4053eb0.md
@@ -645,7 +645,7 @@ Unvisited links
 
 #### --text--
 
-What pseudo-class styles a link when the user has already clicked on it?
+What pseudo-class styles a link that has already been visited by the user?
 
 #### --distractors--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68050

Corrected the wording of the CSS :visited pseudo-class question to accurately describe visited links.