### PR TITLE
fix(client): resolve broken GitHub source link on daily coding challenges

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -389,7 +389,11 @@ function ShowClassic({
             instructions={instructions}
             superBlock={superBlock}
             challengeId={id}
-            block={block}
+            block={
+              isDailyCodingChallenge
+                ? `daily-coding-challenges-${dailyCodingChallengeLanguage}`
+                : block
+            }
           />
         }
         challengeTitle={

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -389,11 +389,7 @@ function ShowClassic({
             instructions={instructions}
             superBlock={superBlock}
             challengeId={id}
-            block={
-              isDailyCodingChallenge
-                ? `daily-coding-challenges-${dailyCodingChallengeLanguage}`
-                : block
-            }
+            block={block}
           />
         }
         challengeTitle={

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -4,7 +4,10 @@ import { mapTo, tap } from 'rxjs/operators';
 
 import envData from '../../../../config/env.json';
 import { transformEditorLink } from '../utils';
-import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
+import {
+  challengeTypes,
+  getDailyCodingChallengeLanguage
+} from '@freecodecamp/shared/config/challenge-types';
 import { actionTypes } from './action-types';
 import { closeModal } from './actions';
 import {
@@ -126,6 +129,14 @@ function linksOrMarkdown(projectFormValues, markdown) {
   );
 }
 
+// Daily coding challenges share a synthetic `daily-coding-challenge` block that
+// has no curriculum directory, so the source link must resolve to the real,
+// language-specific block (`daily-coding-challenges-javascript` or `-python`).
+export function getGithubLinkBlock(block, challengeType) {
+  const language = getDailyCodingChallengeLanguage(challengeType);
+  return language ? `daily-coding-challenges-${language}` : block;
+}
+
 function createQuestionEpic(action$, state$, { window }) {
   return action$.pipe(
     ofType(actionTypes.createQuestion),
@@ -163,7 +174,10 @@ function createQuestionEpic(action$, state$, { window }) {
         projectFormValuesSelector(state)
       );
 
-      const gitLink = generateGithubLink(id, block);
+      const gitLink = generateGithubLink(
+        id,
+        getGithubLinkBlock(block, challengeType)
+      );
       const gitInfo = i18next.t('forum-help.git-info', {
         gitLink
       });

--- a/client/src/templates/Challenges/redux/create-question-epic.test.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.test.js
@@ -1,8 +1,41 @@
 import { describe, it, expect } from 'vitest';
+import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
 import { transformEditorLink } from '../utils';
-import { insertEditableRegions } from './create-question-epic';
+import {
+  insertEditableRegions,
+  getGithubLinkBlock
+} from './create-question-epic';
 
 describe('create-question-epic', () => {
+  describe('getGithubLinkBlock', () => {
+    it('should map a JavaScript daily coding challenge to its language-specific block', () => {
+      expect(
+        getGithubLinkBlock(
+          'daily-coding-challenge',
+          challengeTypes.dailyChallengeJs
+        )
+      ).toBe('daily-coding-challenges-javascript');
+    });
+
+    it('should map a Python daily coding challenge to its language-specific block', () => {
+      expect(
+        getGithubLinkBlock(
+          'daily-coding-challenge',
+          challengeTypes.dailyChallengePy
+        )
+      ).toBe('daily-coding-challenges-python');
+    });
+
+    it('should leave a regular block unchanged', () => {
+      expect(
+        getGithubLinkBlock(
+          'learn-basic-javascript-by-building-a-role-playing-game',
+          challengeTypes.javascript
+        )
+      ).toBe('learn-basic-javascript-by-building-a-role-playing-game');
+    });
+  });
+
   describe('transformEditorLink', () => {
     const links = [
       {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68046

<!-- Feel free to add any additional description of changes below this line -->

The daily coding challenge route uses a synthetic block name `daily-coding-challenge`, which has no matching curriculum directory. As a result, the GitHub source link generated for the "Ask for Help" forum post always returns a 404.

The actual source files live in `daily-coding-challenges-javascript` and `daily-coding-challenges-python`. This passes the language-specific source directory to `ChallengeDescription` so the generated link resolves to the real challenge file, switching correctly as the camper toggles between JavaScript and Python.
