### PR TITLE
fix(tests): e2e profile tests

### DIFF
--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -171,7 +171,9 @@ test.describe('Profile component', () => {
     }) => {
       // @certifieduser doesn't have portfolio information, but session users
       // always see the section so they can add projects
-      await expect(page.getByText(translations.profile.projects)).toBeVisible();
+      await expect(
+        page.locator(`h2:text-is("${translations.profile.projects}")`)
+      ).toBeVisible();
       await expect(
         page.getByRole('button', { name: translations.aria['add-portfolio'] })
       ).toBeVisible();


### PR DESCRIPTION
`profile.spec.ts` e2e tests seem to be consistently failing. The `page.getByText(translations.profile.projects)` selector is finding two elements - it seems like there's a new one being found with `Take home Projects` in the title in the timeline on the profile. This makes it so it gets the intended element - I tried some other methods - `getByRole`, etc, didn't work.

I think the bug was likely introduced from https://github.com/freeCodeCamp/freeCodeCamp/pull/67969 or https://github.com/freeCodeCamp/freeCodeCamp/pull/67912

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
