### PR TITLE
fix(curriculum): correct grammar and technical inaccuracies in Review CSS lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc1e24c1e54df5ad89bd.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc1e24c1e54df5ad89bd.md
@@ -44,7 +44,7 @@ Inline elements, unlike block-level elements, only take up as much width as they
 
 Inline elements have the CSS property `display: inline;` applied by default. This property ensures that the element remains within the flow of the content and does not break onto a new line.
 
-Common inline elements are `span`, `anchor`, and `img` elements.
+Common inline elements are `span`, `a`, and `img` elements.
 
 Here's an example to better understand inline elements:
 

--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -41,7 +41,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 ## Inline, Block, and Inline-Block Level Elements
 
-- **Inline Level Elements**: Inline elements only take up as much width as they need and do not start on a new line. These elements flow within the content, allowing text and other inline elements to appear alongside them. Common inline elements are `span`, `anchor`, and `img` elements.
+- **Inline Level Elements**: Inline elements only take up as much width as they need and do not start on a new line. These elements flow within the content, allowing text and other inline elements to appear alongside them. Common inline elements are `span`, `a`, and `img` elements.
 - **Block Level Elements**: Block-level elements take up the full width available to them by default, stretching across the width of their container. Some common block-level elements are `div`, `p`, and `section` elements.
 - **Inline-Block Level Elements**: You can set an element to `inline-block` by using the `display` property. These elements behave like inline elements but can have a `width` and `height` set like block-level elements. 
 
@@ -56,7 +56,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 - **Inline CSS Specificity**: Inline CSS has the highest specificity because it is applied directly to the element. It overrides any internal or external CSS. The specificity value for inline styles is (1, 0, 0, 0).
 - **Internal CSS Specificity**: Internal CSS is defined within a `style` element in the `head` section of the HTML document. It has lower specificity than inline styles. Both internal and external CSS share the same specificity level, which is determined by their selectors, not their location.
-- **External CSS Specificity**: External CSS is linked via a `link` element in the `head` section and is written in separate `.css` files. Like internal CSS, its specificity is determined by the selectors used. When two rules have equal specificity, source order determines the winner — the rule that appears later in the document takes precedence. External CSS provides the best maintainability for larger projects.
+- **External CSS Specificity**: External CSS is linked via a `link` element in the `head` section and is written in separate `.css` files. Like internal CSS, its specificity is determined by the selectors used. When two rules have equal specificity, source order determines the winner: the rule that appears later in the document takes precedence. External CSS provides the best maintainability for larger projects.
 - **Universal Selector (`*`)**: This is a special type of CSS selector that matches any element in the document. It is often used to apply a style to all elements on the page, which can be useful for resetting or normalizing styles across different browsers. The universal selector has the lowest specificity value of any selector. It contributes 0 to all parts of the specificity value (0, 0, 0, 0). 
 - **Type Selectors**: These selectors target elements based on their tag name. Type selectors have a relatively low specificity compared to other selectors. The specificity value for a type selector is (0, 0, 0, 1). 
 - **Class Selectors**: These selectors are defined by a period (`.`) followed by the class name. The specificity value for a class selector is (0, 0, 1, 0). This means that class selectors can override type selectors, but they can be overridden by ID selectors and inline styles.
@@ -103,7 +103,7 @@ Review the concepts below to prepare for the upcoming exam.
 - **Infinite Scroll**: This is a design pattern that loads more content as the user scrolls down the page. You should consider using a load more button because it gives a user control over when they want to see more content. You can also add a back button so users have the ability to go back to the previous page without having to scroll all the way back up. 
 - **Modal Dialog**: This is a type of pop-up that will display on top of existing page content. Usually the background content will have a dim color overlay in order to help the user better focus on the modal content. Also, it is always a good idea to allow the user to click outside of the modal to close it. When you use the HTML `dialog` element, you will get a lot of the functionality and accessibility benefits built in.
 - **Progress Indication for Form Registration**: This is a way to show users how far they are in a process. It can be used in forms, registration, and setup processes. Your design should be simple, easy to find, and make it possible to go back to previous steps.
-- **Shopping Cart**: Carts are a place for user to see what item they have already selected on an e-commerce platform. Your carts should always be visible to the user, use a common icon like a cart, bag or basket, and have a clear call-to-action button for users to proceed to checkout.
+- **Shopping Cart**: Carts are a place for users to see what items they have already selected on an e-commerce platform. Your carts should always be visible to the user, use a common icon like a cart, bag or basket, and have a clear call-to-action button for users to proceed to checkout.
 
 ## Common Design Tools
 
@@ -120,7 +120,7 @@ Review the concepts below to prepare for the upcoming exam.
 - **`mm` (Millimeters)**: This absolute unit is equal to 1/10th of a centimeter.
 - **`q` (Quarter-Millimeters)**: This absolute unit is equal to 1/40th of a centimeter.
 - **`pc` (Picas)**: This absolute unit is equal to 1/6th of an inch.
-- **`pt` (Points)**: This absolute unit is equal to 1/72th of an inch.
+- **`pt` (Points)**: This absolute unit is equal to 1/72nd of an inch.
 
 ## Relative Units
 
@@ -159,7 +159,7 @@ Review the concepts below to prepare for the upcoming exam.
 ## Location Pseudo-classes
 
 - **Location Pseudo-classes**: These pseudo-classes are used for styling links and elements that are targeted within the current document.
-- **`:any-link` Pseudo-class**: This pseudo-class is a combination of the `:link` and `:visited` pseudo-classes. So, it matches any anchor element with an href attribute, regardless of whether it's visited or not.
+- **`:any-link` Pseudo-class**: This pseudo-class is a combination of the `:link` and `:visited` pseudo-classes. So, it matches any anchor element with an `href` attribute, regardless of whether it's visited or not.
 - **`:link` Pseudo-class**: This pseudo-class allows you to target all unvisited links on a webpage. You can use it to style links differently before the user clicks on them.
 - **`:local-link` Pseudo-class**: This pseudo-class targets links that point to the same document. It can be useful when you want to differentiate internal links from external ones.
 - **`:visited` Pseudo-class**: This pseudo-class targets a link the user has visited. 
@@ -184,9 +184,9 @@ Review the concepts below to prepare for the upcoming exam.
 ## Functional Pseudo-classes
 
 - **Functional Pseudo-classes**: Functional pseudo-classes allow you to select elements based on more complex conditions or relationships. Unlike regular pseudo-classes which target elements based on a state (for example, `:hover`, `:focus`), functional pseudo-classes accept arguments.
-- **`:is()` Pseudo-class**: This pseudo-class takes a list of selectors (ex. `ol`, `ul`) and selects an element that matches one of the selectors in the list.
-- **`:where()` Pseudo-class**: This pseudo-class takes a list of selectors (ex. `ol`, `ul`) and selects an element that matches one of the selectors in the list. The difference between `:is` and `:where` is that the latter will have a specificity of 0.
-- **`:has()` Pseudo-class**: This pseudo-class is often dubbed the `"parent"` selector because it allows you to style elements who contain child elements specified in the selector list.
+- **`:is()` Pseudo-class**: This pseudo-class takes a list of selectors (e.g., `ol`, `ul`) and selects an element that matches one of the selectors in the list.
+- **`:where()` Pseudo-class**: This pseudo-class takes a list of selectors (e.g., `ol`, `ul`) and selects an element that matches one of the selectors in the list. The difference between `:is` and `:where` is that the latter will have a specificity of 0.
+- **`:has()` Pseudo-class**: This pseudo-class is often dubbed the `"parent"` selector because it allows you to style elements that contain child elements specified in the selector list.
 
 ## Pseudo-elements 
 

--- a/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
+++ b/curriculum/challenges/english/blocks/review-css/671a9a0a140c2b9d6a75629f.md
@@ -185,7 +185,7 @@ Review the concepts below to prepare for the upcoming exam.
 
 - **Functional Pseudo-classes**: Functional pseudo-classes allow you to select elements based on more complex conditions or relationships. Unlike regular pseudo-classes which target elements based on a state (for example, `:hover`, `:focus`), functional pseudo-classes accept arguments.
 - **`:is()` Pseudo-class**: This pseudo-class takes a list of selectors (e.g., `ol`, `ul`) and selects an element that matches one of the selectors in the list.
-- **`:where()` Pseudo-class**: This pseudo-class takes a list of selectors (e.g., `ol`, `ul`) and selects an element that matches one of the selectors in the list. The difference between `:is` and `:where` is that the latter will have a specificity of 0.
+- **`:where()` Pseudo-class**: This pseudo-class takes a list of selectors (e.g., `ol`, `ul`) and selects an element that matches one of the selectors in the list. The difference between `:is()` and `:where()` is that the latter will have a specificity of 0.
 - **`:has()` Pseudo-class**: This pseudo-class is often dubbed the `"parent"` selector because it allows you to style elements that contain child elements specified in the selector list.
 
 ## Pseudo-elements 


### PR DESCRIPTION
Checklist:


- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68076

## Description

This PR fixes multiple grammar, formatting, and technical accuracy issues in the Review CSS lesson.

### Changes made

* Replaced `anchor` with the correct HTML element name `a`
* Replaced an em dash with a colon for proper sentence structure
* Fixed grammar issues related to carts and selected items
* Corrected `1/72th` to `1/72nd`
* Added missing backticks around the `href` attribute
* Replaced `ex.` with `e.g.`
* Updated pseudo-class references from `:is` and `:where` to `:is()` and `:where()`
* Replaced `who` with `that` when referring to HTML elements
