### PR TITLE
fix(client): pass correct arguments to onApprove in captureOneTimePayment

### DIFF
--- a/client/src/components/Donation/paypal-button-script-loader.tsx
+++ b/client/src/components/Donation/paypal-button-script-loader.tsx
@@ -141,12 +141,10 @@ export default class PayPalButtonScriptLoader extends Component<
     actions: { order: { capture: () => Promise<unknown> } }
   ): unknown {
     return actions.order.capture().then((details: unknown) => {
-      // TODO: this looks like a bug (it probably should not be passing details)
-      // but the api does not care what data it gets (yet). If we start to use
-      // that, this will need to be changed.
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      return this.props.onApprove(details, data);
+      return this.props.onApprove(
+        data as DonationApprovalData,
+        details as { order: { capture: () => Promise<unknown> } }
+      );
     });
   }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68087