### PR TITLE
fix(curriculum): audit editable region in workshop-countup

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-countup/6948705160b66cf93a916e29.md
+++ b/curriculum/challenges/english/blocks/workshop-countup/6948705160b66cf93a916e29.md
@@ -25,7 +25,7 @@ assert.match(countup.toString(), /(let|const|var)\s+countArray\s*=\s*\[\s*\]/);
 
 ```js
 function countup(number) {
---fcc-editable-region-- 
+--fcc-editable-region--
   
 --fcc-editable-region--
   if (number < 1) {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This PR audits the editable regions for `workshop-countup` as part of #67721. The regions were mostly correct, but I removed a trailing space on one of the markers in Step 3.