### PR TITLE
fix(learn): show independent lower jaw shortcut hints

### DIFF
--- a/client/src/templates/Challenges/components/independent-lower-jaw.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.tsx
@@ -30,6 +30,7 @@ import {
   socratesHintStateSelector
 } from '../redux/selectors';
 import { apiLocation } from '../../../../config/env.json';
+import { MAX_MOBILE_WIDTH } from '../../../../config/misc';
 import { openModal, executeChallenge, askSocrates } from '../redux/actions';
 import { saveChallenge } from '../../../redux/actions';
 import Help from '../../../assets/icons/help';
@@ -252,10 +253,19 @@ export function IndependentLowerJaw({
   };
 
   const isMacOS = navigator.userAgent.includes('Mac OS');
+  const isDesktop = window.innerWidth > MAX_MOBILE_WIDTH;
   const showRevertButton = isSignedIn && challengeMeta.saveSubmissionToDB;
-  const checkButtonText = isMacOS
+  const shortcutText = isMacOS
     ? t('buttons.command-enter')
     : t('buttons.ctrl-enter');
+  const checkButtonText = isDesktop
+    ? isMacOS
+      ? t('buttons.check-code-cmd')
+      : t('buttons.check-code-ctrl')
+    : t('buttons.check-code');
+  const submitButtonText = isDesktop
+    ? `${t('buttons.submit-continue')} (${shortcutText})`
+    : t('buttons.submit-continue');
 
   const askSocratesAttempt = () => {
     setShowSocratesResults(true);
@@ -398,30 +408,24 @@ export function IndependentLowerJaw({
           {isChallengeComplete ? (
             <Button
               block
-              className={`${isSignedIn && 'btn-cta'} tooltip`}
+              className={isSignedIn ? 'btn-cta' : undefined}
               id='independent-lower-jaw-submit-button'
               data-playwright-test-label='independentLowerJaw-submit-button'
-              aria-label={t('buttons.submit-continue')}
+              aria-label={submitButtonText}
               onClick={() => submitChallenge()}
               ref={submitButtonRef}
             >
-              {t('buttons.submit-continue')}
-              <span className='tooltiptext left-tooltip'>
-                {checkButtonText}
-              </span>
+              {submitButtonText}
             </Button>
           ) : (
             <button
               type='button'
-              className='btn-cta tooltip'
+              className='btn-cta'
               data-playwright-test-label='independentLowerJaw-check-button'
-              aria-label={t('buttons.check-code')}
+              aria-label={checkButtonText}
               onClick={handleCheckButtonClick}
             >
-              {t('buttons.check-code')}
-              <span className='tooltiptext left-tooltip'>
-                {checkButtonText}
-              </span>
+              {checkButtonText}
             </button>
           )}
         </div>

--- a/e2e/independent-lower-jaw.spec.ts
+++ b/e2e/independent-lower-jaw.spec.ts
@@ -41,6 +41,18 @@ test('Clicking "Check Your Code" reveals failing feedback', async ({
   ).toBeVisible();
 });
 
+test('Displays the platform shortcut hint on the check button', async ({
+  page,
+  browserName
+}) => {
+  await page.goto(workshopChallengeUrl);
+
+  const shortcut = browserName === 'webkit' ? 'Command' : 'Ctrl';
+  await expect(
+    page.getByTestId('independentLowerJaw-check-button')
+  ).toHaveAccessibleName(`Check Your Code (${shortcut} + Enter)`);
+});
+
 test('Reset button opens and closes the reset modal', async ({ page }) => {
   await page.goto(workshopChallengeUrl);
 
@@ -147,8 +159,11 @@ test.describe('Authenticated user', () => {
     await page.getByTestId('independentLowerJaw-check-button').click();
 
     const submitButton = page.getByTestId('independentLowerJaw-submit-button');
+    const shortcut = browserName === 'webkit' ? '\u2318' : 'Ctrl';
     await expect(submitButton).toBeVisible();
-    await expect(submitButton).toContainText('Submit and continue');
+    await expect(submitButton).toHaveAccessibleName(
+      `Submit and continue (${shortcut} + Enter)`
+    );
     await expect(submitButton).toBeFocused();
     await expect(
       page.getByTestId('independentLowerJaw-signin-link')


### PR DESCRIPTION
## Summary
- show platform-specific shortcut hints directly in the IndependentLowerJaw check button text
- show the shortcut hint in the completed-state submit button text on desktop
- cover both button labels in the existing IndependentLowerJaw Playwright spec

Closes #67944

## Testing
- `git diff --check`
- `pnpm dlx prettier@3.8.2 --check client/src/templates/Challenges/components/independent-lower-jaw.tsx e2e/independent-lower-jaw.spec.ts`

Could not run the targeted Playwright spec locally because this clone does not have the workspace dependencies installed; `pnpm -F e2e exec playwright test independent-lower-jaw.spec.ts --project=chromium` resolved to a non-project Playwright binary and failed with `unknown command 'test'`.
