### PR TITLE
fix(client): pass correct arguments to onApprove in PayPal button

### DIFF
--- a/client/src/components/Donation/paypal-button-script-loader.tsx
+++ b/client/src/components/Donation/paypal-button-script-loader.tsx
@@ -27,10 +27,7 @@ type PayPalButtonScriptLoaderProps = {
     }
   ) => unknown;
   isSubscription: boolean;
-  onApprove: (
-    data: DonationApprovalData,
-    actions?: { order: { capture: () => Promise<unknown> } }
-  ) => unknown;
+  onApprove: (data: DonationApprovalData, actions?: unknown) => unknown;
   isPaypalLoading: boolean;
   onCancel: () => unknown;
   onError: () => unknown;
@@ -137,16 +134,11 @@ export default class PayPalButtonScriptLoader extends Component<
   };
 
   captureOneTimePayment(
-    data: unknown,
+    data: DonationApprovalData,
     actions: { order: { capture: () => Promise<unknown> } }
   ): unknown {
     return actions.order.capture().then((details: unknown) => {
-      // TODO: this looks like a bug (it probably should not be passing details)
-      // but the api does not care what data it gets (yet). If we start to use
-      // that, this will need to be changed.
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      return this.props.onApprove(details, data);
+      return this.props.onApprove(data, details);
     });
   }
 
@@ -188,10 +180,7 @@ export default class PayPalButtonScriptLoader extends Component<
                 actions: { order: { capture: () => Promise<unknown> } }
               ) => onApprove(data, actions)
             : (
-                data: {
-                  [key: string]: unknown;
-                  error: string | null;
-                },
+                data: DonationApprovalData,
                 actions: { order: { capture: () => Promise<unknown> } }
               ) => this.captureOneTimePayment(data, actions)
         }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68087

Swaps the arguments to `onApprove` in `captureOneTimePayment` to pass `data` (which contains DonationApprovalData) as the first argument, and `details` (the captured order result) as the second argument. This matches the `onApprove` type signature, removing the need for a `@ts-ignore` annotation.