### PR TITLE
fix(curriculum): add missing spaces in CSS comments

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-attribute-selectors/671a95990b86b68961340adc.md
+++ b/curriculum/challenges/english/blocks/review-css-attribute-selectors/671a95990b86b68961340adc.md
@@ -200,13 +200,13 @@ div[data-lang="fr"] {
 ```
 
 ```css
-/*Example targeting uppercase alphabetical numbering*/
+/* Example targeting uppercase alphabetical numbering */
 ol[type="A"] {
   color: purple;
   font-weight: bold;
 }
 
-/*Example targeting lowercase Roman numerals*/
+/* Example targeting lowercase Roman numerals */
 ol[type="i"] {
   color: green;
 }


### PR DESCRIPTION
Closes #68066

Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## Changes

Updated the CSS comments in Review CSS Attribute Selectors to include the missing spaces after `/*` and before `*/`.

Examples:

```css
/* Example targeting uppercase alphabetical numbering */

/* Example targeting lowercase Roman numerals */