### PR TITLE
fix(curriculum): add missing commas in async JavaScript review

### DIFF
--- a/curriculum/challenges/english/blocks/review-asynchronous-javascript/6723d35bb07d1bd220d0f28d.md
+++ b/curriculum/challenges/english/blocks/review-asynchronous-javascript/6723d35bb07d1bd220d0f28d.md
@@ -196,7 +196,7 @@ In the above example, the `try` block contains the code that might throw an erro
 
 - The Geolocation API provides a way for websites to request the user's location.
 
-- The example below demonstrates the API's `getCurrentPosition()` method which is used to get the user's current location.
+- The example below demonstrates the API's `getCurrentPosition()` method, which is used to get the user's current location.
 
 ```js
 navigator.geolocation.getCurrentPosition(
@@ -210,7 +210,7 @@ navigator.geolocation.getCurrentPosition(
 );
 ```
 
-In this code, we're calling `getCurrentPosition` and passing it a function which will be called when the position is successfully obtained.
+In this code, we're calling `getCurrentPosition` and passing it a function, which will be called when the position is successfully obtained.
 
 The `position` object contains a variety of information, but here we have selected `latitude` and `longitude` only.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68063

<!-- Feel free to add any additional description of changes below this line -->

Add missing commas before two non-restrictive "which" clauses in the Review Asynchronous JavaScript lesson.
