### PR TITLE
fix(client): include workshop title in Get a Hint forum search

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -245,7 +245,7 @@ function ShowClassic({
     query: `(max-width: ${MAX_MOBILE_WIDTH}px)`
   });
 
-  const guideUrl = getGuideUrl({ forumTopicId, title });
+  const guideUrl = getGuideUrl({ forumTopicId, title, block, superBlock });
 
   const blockNameTitle = `${t(
     `intro:${superBlock}.blocks.${block}.title`

--- a/client/src/templates/Challenges/utils/index.test.ts
+++ b/client/src/templates/Challenges/utils/index.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import envData from '../../../../config/env.json';
+import i18n from '../../../../i18n/config-for-tests';
 import { getGuideUrl } from './index';
 
 const { forumLocation } = envData;
+
+vi.unmock('react-i18next');
 
 describe('index', () => {
   describe('getGuideUrl', () => {
@@ -20,6 +23,18 @@ describe('index', () => {
       });
       expect(value).toEqual(
         `${forumLocation}/search?q=%26%20a%20sample%20title%3F%20in%3Atitle%20order%3Aviews`
+      );
+    });
+
+    it('should prepend the block title to the search query when block and superBlock are supplied', async () => {
+      await i18n.reloadResources('en', 'intro');
+      const value = getGuideUrl({
+        title: 'Step 10',
+        block: 'learn-basic-javascript-by-building-a-role-playing-game',
+        superBlock: 'javascript-algorithms-and-data-structures-v8'
+      });
+      expect(value).toEqual(
+        `${forumLocation}/search?q=javascript-algorithms-and-data-structures-v8.blocks.learn-basic-javascript-by-building-a-role-playing-game.title%20-%20Step%2010%20in%3Atitle%20order%3Aviews`
       );
     });
   });

--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -6,13 +6,26 @@ const { forumLocation } = envData;
 interface GuideData {
   forumTopicId?: number;
   title?: string;
+  block?: string;
+  superBlock?: string;
 }
 
-export function getGuideUrl({ forumTopicId, title = '' }: GuideData): string {
-  title = encodeURIComponent(title);
-  return forumTopicId
-    ? `https://forum.freecodecamp.org/t/${forumTopicId}`
-    : `${forumLocation}/search?q=${title}%20in%3Atitle%20order%3Aviews`;
+export function getGuideUrl({
+  forumTopicId,
+  title = '',
+  block,
+  superBlock
+}: GuideData): string {
+  if (forumTopicId) {
+    return `https://forum.freecodecamp.org/t/${forumTopicId}`;
+  }
+  const blockTitle =
+    block && superBlock
+      ? i18next.t(`intro:${superBlock}.blocks.${block}.title`)
+      : '';
+  const searchTitle = blockTitle ? `${blockTitle} - ${title}` : title;
+  const query = encodeURIComponent(`${searchTitle} in:title order:views`);
+  return `${forumLocation}/search?q=${query}`;
 }
 
 export function isGoodXHRStatus(status?: string): boolean {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66832

The "Get a Hint" button on workshop/lab steps produced a forum search containing only the step title (e.g. `Step 19 in:title order:views`), omitting the block title. This made it inconsistent with the "Create a Help Post" button, which already includes the block title via `generateSearchLink` (e.g. `Implement the Shortest Path Algorithm - Step 19 in:title`), so the hint search returned unrelated posts from any course's "Step 19".

`getGuideUrl` now accepts optional `block` and `superBlock` and prepends the resolved block title to the search query, matching the help-post format while keeping the existing `order:views` sort. The new parameters are optional, so callers that pass a `forumTopicId` (e.g. certification projects) are unaffected.

Added a unit test in `utils/index.test.ts` covering the block-qualified search query.