### PR TITLE
fix(curriculum): rounding edge case in challenge 312

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a15cadf5f240d05a2649556.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a15cadf5f240d05a2649556.md
@@ -32,22 +32,22 @@ Return the total cost rounded to two decimal places in the format `"$D.CC"`.
 assert.equal(getStreamingBill([{ format: "HD", type: "rent" }], "none"), "$3.99");
 ```
 
-`getStreamingBill([{ format: "HD", type: "rent" }, { format: "HD", type: "buy" }], "premium")` should return `"$12.73"`.
+`getStreamingBill([{ format: "HD", type: "rent" }, { format: "HD", type: "buy" }], "basic")` should return `"$15.28"`.
 
 ```js
-assert.equal(getStreamingBill([{ format: "HD", type: "rent" }, { format: "HD", type: "buy" }], "premium"), "$12.73");
+assert.equal(getStreamingBill([{ format: "HD", type: "rent" }, { format: "HD", type: "buy" }], "basic"), "$15.28");
 ```
 
-`getStreamingBill([{ format: "HD", type: "rent" }, { format: "HD", type: "rent" }, { format: "HD", type: "buy" }], "basic")` should return `"$18.87"`.
+`getStreamingBill([{ format: "HD", type: "rent" }, { format: "HD", type: "rent" }, { format: "HD", type: "buy" }], "premium")` should return `"$15.73"`.
 
 ```js
-assert.equal(getStreamingBill([{ format: "HD", type: "rent" }, { format: "HD", type: "rent" }, { format: "HD", type: "buy" }], "basic"), "$18.87");
+assert.equal(getStreamingBill([{ format: "HD", type: "rent" }, { format: "HD", type: "rent" }, { format: "HD", type: "buy" }], "premium"), "$15.73");
 ```
 
-`getStreamingBill([{ format: "4K", type: "buy" }, { format: "4K", type: "buy" }], "premium")` should return `"$29.98"`.
+`getStreamingBill([{ format: "4K", type: "buy" }, { format: "4K", type: "buy" }], "basic")` should return `"$35.98"`.
 
 ```js
-assert.equal(getStreamingBill([{ format: "4K", type: "buy" }, { format: "4K", type: "buy" }], "premium"), "$29.98");
+assert.equal(getStreamingBill([{ format: "4K", type: "buy" }, { format: "4K", type: "buy" }], "basic"), "$35.98");
 ```
 
 `getStreamingBill([{ format: "HD", type: "rent" }, { format: "4K", type: "rent" }, { format: "HD", type: "buy" }, { format: "4K", type: "buy" }], "none")` should return `"$42.96"`.
@@ -56,10 +56,10 @@ assert.equal(getStreamingBill([{ format: "4K", type: "buy" }, { format: "4K", ty
 assert.equal(getStreamingBill([{ format: "HD", type: "rent" }, { format: "4K", type: "rent" }, { format: "HD", type: "buy" }, { format: "4K", type: "buy" }], "none"), "$42.96");
 ```
 
-`getStreamingBill([{ format: "HD", type: "rent" }, { format: "4K", type: "rent" }, { format: "HD", type: "buy" }, { format: "4K", type: "buy" }, { format: "HD", type: "buy" }], "basic")` should return `"$50.36"`.
+`getStreamingBill([{ format: "HD", type: "rent" }, { format: "4K", type: "rent" }, { format: "HD", type: "buy" }, { format: "4K", type: "buy" }, { format: "HD", type: "buy" }], "premium")` should return `"$41.96"`.
 
 ```js
-assert.equal(getStreamingBill([{ format: "HD", type: "rent" }, { format: "4K", type: "rent" }, { format: "HD", type: "buy" }, { format: "4K", type: "buy" }, { format: "HD", type: "buy" }], "basic"), "$50.36");
+assert.equal(getStreamingBill([{ format: "HD", type: "rent" }, { format: "4K", type: "rent" }, { format: "HD", type: "buy" }, { format: "4K", type: "buy" }, { format: "HD", type: "buy" }], "premium"), "$41.96");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a15cadf5f240d05a2649556.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a15cadf5f240d05a2649556.md
@@ -35,30 +35,30 @@ TestCase().assertEqual(get_streaming_bill([{"format": "HD", "type": "rent"}], "n
 }})
 ```
 
-`get_streaming_bill([{ "format": "HD", "type": "rent" }, { "format": "HD", "type": "buy" }], "premium")` should return `"$12.73"`.
+`get_streaming_bill([{ "format": "HD", "type": "rent" }, { "format": "HD", "type": "buy" }], "basic")` should return `"$15.28"`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(get_streaming_bill([{"format": "HD", "type": "rent"}, {"format": "HD", "type": "buy"}], "premium"), "$12.73")`)
+TestCase().assertEqual(get_streaming_bill([{"format": "HD", "type": "rent"}, {"format": "HD", "type": "buy"}], "basic"), "$15.28")`)
 }})
 ```
 
-`get_streaming_bill([{ "format": "HD", "type": "rent" }, { "format": "HD", "type": "rent" }, { "format": "HD", "type": "buy" }], "basic")` should return `"$18.87"`.
+`get_streaming_bill([{ "format": "HD", "type": "rent" }, { "format": "HD", "type": "rent" }, { "format": "HD", "type": "buy" }], "premium")` should return `"$15.73"`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(get_streaming_bill([{"format": "HD", "type": "rent"}, {"format": "HD", "type": "rent"}, {"format": "HD", "type": "buy"}], "basic"), "$18.87")`)
+TestCase().assertEqual(get_streaming_bill([{"format": "HD", "type": "rent"}, {"format": "HD", "type": "rent"}, {"format": "HD", "type": "buy"}], "premium"), "$15.73")`)
 }})
 ```
 
-`get_streaming_bill([{ "format": "4K", "type": "buy" }, { "format": "4K", "type": "buy" }], "premium")` should return `"$29.98"`.
+`get_streaming_bill([{ "format": "4K", "type": "buy" }, { "format": "4K", "type": "buy" }], "basic")` should return `"$35.98"`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(get_streaming_bill([{"format": "4K", "type": "buy"}, {"format": "4K", "type": "buy"}], "premium"), "$29.98")`)
+TestCase().assertEqual(get_streaming_bill([{"format": "4K", "type": "buy"}, {"format": "4K", "type": "buy"}], "basic"), "$35.98")`)
 }})
 ```
 
@@ -71,12 +71,12 @@ TestCase().assertEqual(get_streaming_bill([{"format": "HD", "type": "rent"}, {"f
 }})
 ```
 
-`get_streaming_bill([{ "format": "HD", "type": "rent" }, { "format": "4K", "type": "rent" }, { "format": "HD", "type": "buy" }, { "format": "4K", "type": "buy" }, { "format": "HD", "type": "buy" }], "basic")` should return `"$50.36"`.
+`get_streaming_bill([{ "format": "HD", "type": "rent" }, { "format": "4K", "type": "rent" }, { "format": "HD", "type": "buy" }, { "format": "4K", "type": "buy" }, { "format": "HD", "type": "buy" }], "premium")` should return `"$41.96"`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(get_streaming_bill([{"format": "HD", "type": "rent"}, {"format": "4K", "type": "rent"}, {"format": "HD", "type": "buy"}, {"format": "4K", "type": "buy"}, {"format": "HD", "type": "buy"}], "basic"), "$50.36")`)
+TestCase().assertEqual(get_streaming_bill([{"format": "HD", "type": "rent"}, {"format": "4K", "type": "rent"}, {"format": "HD", "type": "buy"}, {"format": "4K", "type": "buy"}, {"format": "HD", "type": "buy"}], "premium"), "$41.96")`)
 }})
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68045

<!-- Feel free to add any additional description of changes below this line -->

Note: First PR ever. Written by hand.

My branch diverged from main at commit 14c02f1.

# Issue
In [coding challenge 312](https://www.freecodecamp.org/learn/daily-coding-challenge/2026-06-18) you have to calculate the price of a basket of goods, discount and round the number.

On test case 6 `get_streaming_bill([{ format: "HD", type: "rent" }, { format: "4K", type: "rent" }, { format: "HD", type: "buy" }, { format: "4K", type: "buy" }, { format: "HD", type: "buy" }], "basic")` in python you get different results based on the solution implementation.
1. float, sum prices then discount: 50.35499999999999687361 -> 50.35
2. float, discount individual prices then sum: 50.35500000000000397904 -> 50.36
3. Decimal, sum prices then discount: 50.35500000000000000000 -> 50.36 (rounding=ROUND_HALF_UP)
(expected value is 50.36)

# Fix
With floating point math it is always a gamble what you'll get when the theoretically correct number looks like XX.XX5000 (e.g. 23.675000). So I tweaked some of the tests to avoid this case while still having 2 tests of each subscription type.

Test 2: "premium" -> "basic",  should return "$12.73" -> should return "$15.28"
Test 3: "basic" -> "premium", should return "$18.87" -> should return "$15.73" // changed just to keep tests diverse
Test 4: "premium" -> "basic", should return "$29.98" -> should return "$35.98"
Test 6: "basic" -> "premium", should return "$50.36" -> should return "$42.96"
I think this keeps the spirit of the tests in tact.

`pnpm run test-curriculum-content` with the only `.env` change being `SHOW_UPCOMING_CHANGES=true` gave:
<img width="1124" height="236" alt="Screenshot 2026-06-20 at 15 54 11" src="https://github.com/user-attachments/assets/30fbc458-21bf-4b6a-9bf3-894646156451" />



# Looking if other code is affected
I looked in the python folder for other tests that mentioned rounding or 2 decimal places
```bash
rg -l -e round -e two decimal curriculum/challenges/english/blocks/daily-coding-challenges-python
```
and gave 15(5 at a time) of the 35 results to Claude to test using the Decimal class and looking for outputs that look like XX.XX5000

| Challenge | Has Boundary Issue |
| :--- | :---: |
| challenge-39 | No |
| challenge-57 | No |
| challenge-58 | No |
| challenge-59 | No |
| challenge-61 | No |
| challenge-71 | No |
| challenge-72 | No |
| challenge-94 | No |
| challenge-302 | No |
| challenge-312 | Yes — 3 tests |
| challenge-313 | No |
| challenge-315 | No |
| challenge-317 | No |
| challenge-324 | No |
| challenge-326 | No |