### PR TITLE
fix(curriculum): audit editable regions for workshop-music-player

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-music-player/6747237371f13173c9f6c27e.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6747237371f13173c9f6c27e.md
@@ -582,10 +582,10 @@ assert.equal(previousButton, document.getElementById('previous'));
 ```
 
 ```js
---fcc-editable-region--
 const playlistSongs = document.getElementById("playlist-songs");
 const playButton = document.getElementById("play");
 const pauseButton = document.getElementById("pause");
+--fcc-editable-region--
 
 --fcc-editable-region--
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/6747257cdf5412781e138bb2.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6747257cdf5412781e138bb2.md
@@ -611,9 +611,9 @@ const playButton = document.getElementById("play");
 const pauseButton = document.getElementById("pause");
 const nextButton = document.getElementById("next");
 const previousButton = document.getElementById("previous");
---fcc-editable-region--
 const allSongs = [
-  
-]
 --fcc-editable-region--
+  
+--fcc-editable-region--
+]
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/6747257cdf5412781e138bb2.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6747257cdf5412781e138bb2.md
@@ -615,5 +615,5 @@ const allSongs = [
 --fcc-editable-region--
   
 --fcc-editable-region--
-]
+];
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/6747274264e8a5799fb3e0b5.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6747274264e8a5799fb3e0b5.md
@@ -620,7 +620,7 @@ const allSongs = [
     src: "https://cdn.freecodecamp.org/curriculum/js-music-player/scratching-the-surface.mp3",
   },
 --fcc-editable-region--
-
+  
 --fcc-editable-region--
 ];
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/674728eda5829d7b4c360643.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674728eda5829d7b4c360643.md
@@ -613,7 +613,6 @@ const allSongs = [
     duration: "4:25",
     src: "https://cdn.freecodecamp.org/curriculum/js-music-player/scratching-the-surface.mp3",
   },
-
   {
     id: 1,
     title: "Can't Stay Down",
@@ -621,9 +620,8 @@ const allSongs = [
     duration: "4:15",
     src: "https://cdn.freecodecamp.org/curriculum/js-music-player/can't-stay-down.mp3",
   },
-
 --fcc-editable-region--
-
+  
 --fcc-editable-region--
 ];
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/67472eef7b4b7ba77b50929b.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67472eef7b4b7ba77b50929b.md
@@ -656,9 +656,9 @@ const allSongs = [
 
 const audio = new Audio();
 
---fcc-editable-region--
 const userData = {
-  
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+};
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/67473042e8751eac62fafc82.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67473042e8751eac62fafc82.md
@@ -654,7 +654,8 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
+
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-music-player/674735e3b28351b8b8f05807.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674735e3b28351b8b8f05807.md
@@ -700,10 +700,11 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
---fcc-editable-region--
+};
+
 const playSong = id => {
-  
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/674757668684f9deaa6ac3c0.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674757668684f9deaa6ac3c0.md
@@ -656,11 +656,12 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
---fcc-editable-region--
+};
+
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
-  
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/674836ba82e9057dfee1849c.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674836ba82e9057dfee1849c.md
@@ -672,14 +672,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }

--- a/curriculum/challenges/english/blocks/workshop-music-player/674850b437668dd08edddbe2.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674850b437668dd08edddbe2.md
@@ -654,21 +654,22 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
-  playButton.classList.add("playing")
-  audio.play()
+  playButton.classList.add("playing");
+  audio.play();
 }
+
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-music-player/6748567229cc8fe3f706de02.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6748567229cc8fe3f706de02.md
@@ -664,20 +664,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
-  playButton.classList.add("playing")
-  audio.play()
+  playButton.classList.add("playing");
+  audio.play();
 }
 
 --fcc-editable-region--
@@ -698,7 +698,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/6748bab9827a356c39559214.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6748bab9827a356c39559214.md
@@ -664,26 +664,26 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
   userData.songCurrentTime = audio.currentTime;
 --fcc-editable-region--
-
+  
 --fcc-editable-region--
 }
 
@@ -701,7 +701,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/674dda6c6ae8bb538678e125.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674dda6c6ae8bb538678e125.md
@@ -659,7 +659,7 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);

--- a/curriculum/challenges/english/blocks/workshop-music-player/674de4ee2039496c30a31b71.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674de4ee2039496c30a31b71.md
@@ -677,17 +677,16 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
---fcc-editable-region--
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
+--fcc-editable-region--
   } 
-  
 --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/674e2e4e04eb381ccfe92e15.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674e2e4e04eb381ccfe92e15.md
@@ -662,20 +662,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -698,7 +698,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/674e305b7bda7c1f4f37a930.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674e305b7bda7c1f4f37a930.md
@@ -670,20 +670,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -710,7 +710,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/674e316e3892d32108ad2bb9.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674e316e3892d32108ad2bb9.md
@@ -654,24 +654,25 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
-  playButton.classList.add("playing")
-  audio.play()
+  playButton.classList.add("playing");
+  audio.play();
 }
---fcc-editable-region--
+
 playButton.addEventListener("click", () => {
-  playSong(0);
-});
 --fcc-editable-region--
+  playSong(0);
+--fcc-editable-region--
+});
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/674e34c42ee8f1237e4623cc.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674e34c42ee8f1237e4623cc.md
@@ -661,26 +661,27 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
-  playButton.classList.add("playing")
-  audio.play()
+  playButton.classList.add("playing");
+  audio.play();
 }
---fcc-editable-region--
+
 playButton.addEventListener("click", () => {
-    if (userData.currentSong === null) {
+  if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-  }
-});
 --fcc-editable-region--
+  } 
+--fcc-editable-region--
+});
 ```

--- a/curriculum/challenges/english/blocks/workshop-music-player/674f489bf617af2bea9b92b5.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674f489bf617af2bea9b92b5.md
@@ -670,20 +670,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -712,7 +712,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
@@ -669,20 +669,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -713,7 +713,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
@@ -9,7 +9,7 @@ dashedName: step-26
 
 Now that you know how to find the next song to play, create a function named `playNextSong`. Inside the `playNextSong` function, create an `if` statement to check if the `currentSong` of `userData` is strictly equal to `null`. This will check if there's no current song playing in the `userData` object.
 
-If the condition is true, call the `playSong` function with the `id` of the first song in the `userData.songs` array as an argument.
+If the condition is true, call the `playSong` function with the `id` of the first song in the `userData.songs` array as an argument. Then add a `return` statement to the end of the `if` block.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
@@ -9,7 +9,7 @@ dashedName: step-26
 
 Now that you know how to find the next song to play, create a function named `playNextSong`. Inside the `playNextSong` function, create an `if` statement to check if the `currentSong` of `userData` is strictly equal to `null`. This will check if there's no current song playing in the `userData` object.
 
-If the condition is true, call the `playSong` function with the `id` of the first song in the `userData.songs` array as an argument. Then add a `return` statement to the end of the `if` block.
+If the condition is true, call the `playSong` function with the `id` of the first song in the `userData.songs` array as an argument.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/674f534fa181f64a789ffcf9.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674f534fa181f64a789ffcf9.md
@@ -721,15 +721,15 @@ const getCurrentSongIndex = () => userData.songs.indexOf(userData.currentSong);
 
 const getNextSong = () => userData.songs[getCurrentSongIndex() + 1];
 
---fcc-editable-region--
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
+    return;
   }
-
-}
 --fcc-editable-region--
-
+  
+--fcc-editable-region--
+}
 
 playButton.addEventListener("click", () => {
   if (userData.currentSong === null) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/674f534fa181f64a789ffcf9.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674f534fa181f64a789ffcf9.md
@@ -695,20 +695,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -745,7 +745,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/67503cecd563135d4f27b38e.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67503cecd563135d4f27b38e.md
@@ -691,7 +691,7 @@ const getNextSong = () => userData.songs[getCurrentSongIndex() + 1];
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/67503cecd563135d4f27b38e.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67503cecd563135d4f27b38e.md
@@ -662,20 +662,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -717,7 +717,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/675057ce9acd418619127da4.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675057ce9acd418619127da4.md
@@ -702,7 +702,7 @@ const getNextSong = () => userData.songs[getCurrentSongIndex() + 1];
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/675057ce9acd418619127da4.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675057ce9acd418619127da4.md
@@ -669,20 +669,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -728,7 +728,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/67505d3a32d45997d2af4c0f.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67505d3a32d45997d2af4c0f.md
@@ -671,20 +671,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -732,7 +732,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/67505d3a32d45997d2af4c0f.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67505d3a32d45997d2af4c0f.md
@@ -702,7 +702,7 @@ const getPreviousSong = () => userData.songs[getCurrentSongIndex() - 1];
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/67505d3a32d45997d2af4c0f.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67505d3a32d45997d2af4c0f.md
@@ -699,6 +699,10 @@ const getNextSong = () => userData.songs[getCurrentSongIndex() + 1];
 
 const getPreviousSong = () => userData.songs[getCurrentSongIndex() - 1];
 
+--fcc-editable-region--
+
+--fcc-editable-region--
+
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
@@ -713,10 +717,6 @@ const playNextSong = () => {
     pauseSong();
   }
 }
-
---fcc-editable-region--
-
---fcc-editable-region--
 
 playButton.addEventListener("click", () => {
   if (userData.currentSong === null) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/675069b67b8267b36fa550b3.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675069b67b8267b36fa550b3.md
@@ -698,7 +698,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/675069b67b8267b36fa550b3.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675069b67b8267b36fa550b3.md
@@ -658,20 +658,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -724,7 +724,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6750712ee950facad5edc203.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6750712ee950facad5edc203.md
@@ -689,7 +689,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6750712ee950facad5edc203.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6750712ee950facad5edc203.md
@@ -648,7 +648,7 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 --fcc-editable-region--
 const playSong = id => {
 --fcc-editable-region--
@@ -656,13 +656,13 @@ const playSong = id => {
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -715,7 +715,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6750712ee950facad5edc203.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6750712ee950facad5edc203.md
@@ -649,6 +649,7 @@ const userData = {
   currentSong: null,
   songCurrentTime: 0,
 };
+
 --fcc-editable-region--
 const playSong = id => {
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-music-player/67516a431252ed30832fa7c6.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67516a431252ed30832fa7c6.md
@@ -689,7 +689,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/67516a431252ed30832fa7c6.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67516a431252ed30832fa7c6.md
@@ -647,7 +647,7 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
@@ -656,13 +656,13 @@ const playSong = (id, start=true) => {
 --fcc-editable-region--
   if (userData.currentSong === null) {
 --fcc-editable-region--
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -715,7 +715,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/67516ca9b7fe6636208c5ab5.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67516ca9b7fe6636208c5ab5.md
@@ -686,7 +686,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/67516ca9b7fe6636208c5ab5.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67516ca9b7fe6636208c5ab5.md
@@ -646,20 +646,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -714,7 +714,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/67516e888477083c31614dc7.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67516e888477083c31614dc7.md
@@ -701,7 +701,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/67516e888477083c31614dc7.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67516e888477083c31614dc7.md
@@ -660,20 +660,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -731,7 +731,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/67517ef2fae05b65108212db.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67517ef2fae05b65108212db.md
@@ -719,7 +719,6 @@ const playNextSong = () => {
   }
 }
 
-
 const highlightCurrentSong = () => {
   const previousCurrentSong = document.querySelector('.playlist-song[aria-current="true"]');
   previousCurrentSong?.removeAttribute("aria-current");

--- a/curriculum/challenges/english/blocks/workshop-music-player/67517ef2fae05b65108212db.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67517ef2fae05b65108212db.md
@@ -666,20 +666,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -742,7 +742,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/67517ef2fae05b65108212db.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67517ef2fae05b65108212db.md
@@ -707,7 +707,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6751d5d32e58d065652e26a5.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6751d5d32e58d065652e26a5.md
@@ -698,7 +698,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6751d5d32e58d065652e26a5.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6751d5d32e58d065652e26a5.md
@@ -713,11 +713,12 @@ const playNextSong = () => {
 const highlightCurrentSong = () => {
   const previousCurrentSong = document.querySelector('.playlist-song[aria-current="true"]');
   previousCurrentSong?.removeAttribute("aria-current");
---fcc-editable-region--
   const songToHighlight = document.getElementById(
     `song-${userData.currentSong?.id}`
   );
 
+--fcc-editable-region--
+  
 --fcc-editable-region--
 };
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6751d5d32e58d065652e26a5.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6751d5d32e58d065652e26a5.md
@@ -657,20 +657,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -735,7 +735,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6751e1c117350b7d3f356e1b.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6751e1c117350b7d3f356e1b.md
@@ -656,14 +656,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
@@ -672,7 +672,7 @@ const playSong = (id, start=true) => {
 --fcc-editable-region--
   
 --fcc-editable-region--
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -737,7 +737,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6751e1c117350b7d3f356e1b.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6751e1c117350b7d3f356e1b.md
@@ -719,7 +719,6 @@ const highlightCurrentSong = () => {
     `song-${userData.currentSong?.id}`
   );
   
-  
   songToHighlight?.setAttribute("aria-current", "true");
 };
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6751e1c117350b7d3f356e1b.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6751e1c117350b7d3f356e1b.md
@@ -700,7 +700,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6752c62efa90554c01415e7b.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6752c62efa90554c01415e7b.md
@@ -716,7 +716,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6752c62efa90554c01415e7b.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6752c62efa90554c01415e7b.md
@@ -673,14 +673,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
@@ -756,7 +756,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6752c62efa90554c01415e7b.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6752c62efa90554c01415e7b.md
@@ -686,7 +686,6 @@ const playSong = (id, start=true) => {
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-
   highlightCurrentSong();
   audio.play();
 }

--- a/curriculum/challenges/english/blocks/workshop-music-player/6752ecd811c96d5dc33ae853.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6752ecd811c96d5dc33ae853.md
@@ -695,7 +695,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6752ecd811c96d5dc33ae853.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6752ecd811c96d5dc33ae853.md
@@ -650,14 +650,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
@@ -739,7 +739,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6752edba757ff96404faf9e9.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6752edba757ff96404faf9e9.md
@@ -709,7 +709,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6752edba757ff96404faf9e9.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6752edba757ff96404faf9e9.md
@@ -666,14 +666,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
@@ -757,7 +757,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/675304e7937e62902e08a3ab.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675304e7937e62902e08a3ab.md
@@ -694,7 +694,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/675304e7937e62902e08a3ab.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675304e7937e62902e08a3ab.md
@@ -648,14 +648,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
@@ -743,7 +743,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/675309b2795c2a9ae03b8812.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675309b2795c2a9ae03b8812.md
@@ -1332,14 +1332,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
@@ -1428,7 +1428,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/675309b2795c2a9ae03b8812.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675309b2795c2a9ae03b8812.md
@@ -591,14 +591,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
@@ -635,7 +635,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {
@@ -687,7 +687,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/675309b2795c2a9ae03b8812.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675309b2795c2a9ae03b8812.md
@@ -698,7 +698,7 @@ nextButton.addEventListener("click", playNextSong);
 previousButton.addEventListener("click", playPreviousSong);
 
 --fcc-editable-region--
-  
+
 --fcc-editable-region--
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/675309b2795c2a9ae03b8812.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675309b2795c2a9ae03b8812.md
@@ -1376,7 +1376,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/67532282ab9b95d7083617ee.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67532282ab9b95d7083617ee.md
@@ -713,7 +713,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/67532282ab9b95d7083617ee.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67532282ab9b95d7083617ee.md
@@ -669,14 +669,14 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
@@ -765,7 +765,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/675340b809683f45cae96539.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675340b809683f45cae96539.md
@@ -649,20 +649,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -718,7 +718,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/675340b809683f45cae96539.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/675340b809683f45cae96539.md
@@ -692,7 +692,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6757f2b25418da4f73e29eb6.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6757f2b25418da4f73e29eb6.md
@@ -670,21 +670,21 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = (id, start=true) => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null || start) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
   playButton.classList.add("playing");
   highlightCurrentSong();
-  audio.play()
+  audio.play();
 }
 
 const pauseSong = () => {
@@ -748,7 +748,7 @@ songs.forEach((song) => {
   const id = song.getAttribute("id").slice(5);
   const songBtn = song.querySelector("button");
   songBtn.addEventListener("click", () => {
-      playSong(Number(id));
+    playSong(Number(id));
   })
 })
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/6757f2b25418da4f73e29eb6.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6757f2b25418da4f73e29eb6.md
@@ -712,7 +712,7 @@ const playPreviousSong = () => {
 const playNextSong = () => {
   if (userData.currentSong === null) {
     playSong(userData.songs[0].id);
-    return
+    return;
   }
   const nextSong = getNextSong();
   if (nextSong) {

--- a/curriculum/challenges/english/blocks/workshop-music-player/6758a61fc7e949923716ec41.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/6758a61fc7e949923716ec41.md
@@ -660,20 +660,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
-  playButton.classList.add("playing")
-  audio.play()
+  playButton.classList.add("playing");
+  audio.play();
 }
 
 playButton.addEventListener("click", () => {

--- a/curriculum/challenges/english/blocks/workshop-music-player/67594f37fa0c684835f1b064.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/67594f37fa0c684835f1b064.md
@@ -656,20 +656,20 @@ const userData = {
   songs: allSongs,
   currentSong: null,
   songCurrentTime: 0,
-}
+};
 
 const playSong = id => {
   const song = userData.songs.find((song) => song.id === id);
   audio.src = song.src;
   audio.title = song.title;
   if (userData.currentSong === null) {
-    audio.currentTime = 0
+    audio.currentTime = 0;
   } else {
     audio.currentTime = userData.songCurrentTime;
   }
   userData.currentSong = song;
-  playButton.classList.add("playing")
-  audio.play()
+  playButton.classList.add("playing");
+  audio.play();
 }
 
 playButton.addEventListener("click", () => {
@@ -680,11 +680,11 @@ playButton.addEventListener("click", () => {
   }
 });
 
-
 const songs = document.querySelectorAll(".playlist-song");
---fcc-editable-region--
-songs.forEach((song) => {
 
-});
+songs.forEach((song) => {
 --fcc-editable-region--
+  
+--fcc-editable-region--
+});
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Part of #67721

<!-- Feel free to add any additional description of changes below this line -->

This PR completes the editable region audit for workshop-music-player.

Changes:

- Adjust editable regions to encompass only what campers are asked to modify
- Fix indentation
- Add or remove blank lines for consistent and clean formatting across steps 
- Add missing semicolons
- Add `return` statement to seed code in step 27 to match seed code in step 28
- Modify instructions for step 26 so that campers are asked to add the `return` statement that appears in the seed of step 28 (but now also in step 27)