### PR TITLE
fix(client): render challenge console output as text

### DIFF
--- a/client/src/templates/Challenges/components/output.test.tsx
+++ b/client/src/templates/Challenges/components/output.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Output from './output';
+
+describe('Output', () => {
+  it('renders HTML entities as text instead of interpreting them as HTML', () => {
+    render(<Output defaultOutput='' output={'Dolce &amp; Gabbana'} />);
+
+    expect(screen.getByText('Dolce &amp; Gabbana')).toBeInTheDocument();
+    expect(screen.queryByText('Dolce & Gabbana')).not.toBeInTheDocument();
+  });
+
+  it('renders the default output when output is empty', () => {
+    render(<Output defaultOutput='Default output' output='' />);
+
+    expect(screen.getByText('Default output')).toBeInTheDocument();
+  });
+});

--- a/client/src/templates/Challenges/components/output.test.tsx
+++ b/client/src/templates/Challenges/components/output.test.tsx
@@ -5,16 +5,74 @@ import { describe, expect, it } from 'vitest';
 import Output from './output';
 
 describe('Output', () => {
-  it('renders HTML entities as text instead of interpreting them as HTML', () => {
+  it.each(['&amp;', '&lt;', '&gt;', '&quot;', '&apos;'])(
+    'renders %s as text instead of decoding it',
+    entity => {
+      render(<Output defaultOutput='' output={entity} />);
+
+      expect(screen.getByText(entity)).toBeInTheDocument();
+    }
+  );
+
+  it('renders HTML entities inside a larger string as text instead of decoding them', () => {
     render(<Output defaultOutput='' output={'Dolce &amp; Gabbana'} />);
 
     expect(screen.getByText('Dolce &amp; Gabbana')).toBeInTheDocument();
     expect(screen.queryByText('Dolce & Gabbana')).not.toBeInTheDocument();
   });
 
+  it('does not change normal ampersands', () => {
+    render(<Output defaultOutput='' output={'Tom & Jerry'} />);
+
+    expect(screen.getByText('Tom & Jerry')).toBeInTheDocument();
+  });
+
+  it('renders allowed HTML tags in console output', () => {
+    render(
+      <Output
+        defaultOutput=''
+        output={
+          'You should declare <code>myName</code> with the <code>var</code> keyword, ending with a semicolon'
+        }
+      />
+    );
+
+    expect(
+      screen.getByText('myName', { selector: 'code' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('var', { selector: 'code' })).toBeInTheDocument();
+  });
+
+  it('renders encoded HTML tags as text instead of interpreting them as HTML', () => {
+    render(
+      <Output defaultOutput='' output={'&lt;code&gt;myName&lt;/code&gt;'} />
+    );
+
+    expect(
+      screen.getByText('&lt;code&gt;myName&lt;/code&gt;')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('myName', { selector: 'code' })
+    ).not.toBeInTheDocument();
+  });
+
   it('renders the default output when output is empty', () => {
     render(<Output defaultOutput='Default output' output='' />);
 
     expect(screen.getByText('Default output')).toBeInTheDocument();
+  });
+
+  it('removes disallowed HTML tags from console output', () => {
+    render(
+      <Output
+        defaultOutput=''
+        output={
+          '<img alt="bad" src=x onerror=alert("bad")><iframe title="bad"></iframe>'
+        }
+      />
+    );
+
+    expect(screen.queryByAltText('bad')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('bad')).not.toBeInTheDocument();
   });
 });

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -1,6 +1,5 @@
 import { isEmpty } from 'lodash-es';
 import React from 'react';
-import sanitizeHtml from 'sanitize-html';
 import i18next from 'i18next';
 
 import './output.css';
@@ -11,19 +10,19 @@ interface OutputProps {
 }
 
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-  const message = sanitizeHtml(!isEmpty(output) ? output : defaultOutput, {
-    allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
-  });
+  const message = !isEmpty(output) ? output : defaultOutput;
+
   return (
     <pre
       className='output-text'
       data-playwright-test-label='output-text'
-      dangerouslySetInnerHTML={{ __html: message }}
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
-    />
+    >
+      {message}
+    </pre>
   );
 }
 

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash-es';
 import React from 'react';
+import sanitizeHtml from 'sanitize-html';
 import i18next from 'i18next';
 
 import './output.css';
@@ -9,20 +10,30 @@ interface OutputProps {
   output: string;
 }
 
+const htmlEntityRegex = /&(#\d+|#x[\da-f]+|[a-z][\da-z]+);/gi;
+
+function preserveHtmlEntities(message: string): string {
+  return message.replace(htmlEntityRegex, '&amp;$1;');
+}
+
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-  const message = !isEmpty(output) ? output : defaultOutput;
+  const message = sanitizeHtml(
+    preserveHtmlEntities(!isEmpty(output) ? output : defaultOutput),
+    {
+      allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
+    }
+  );
 
   return (
     <pre
       className='output-text'
       data-playwright-test-label='output-text'
+      dangerouslySetInnerHTML={{ __html: message }}
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
-    >
-      {message}
-    </pre>
+    />
   );
 }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63788

Changed the output component so console output is shown as text instead of HTML. This keeps HTML entities like `&amp;` from showing as `&` when users log their output.

I also added a test for HTML entity output and the default output behavior.

Tested locally with:

```bash
pnpm exec vitest run src/templates/Challenges/components/output.test.tsx
```