### PR TITLE
test: move daily coding challenge coverage to client

### DIFF
--- a/client/src/client-only-routes/show-daily-coding-challenge.test.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import store from 'store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ShowDailyCodingChallenge from './show-daily-coding-challenge';
+
+const showClassic = vi.hoisted(() => vi.fn());
+
+interface ShowClassicProps {
+  isDailyCodingChallenge: boolean;
+  dailyCodingChallengeLanguage: string;
+  data: {
+    challengeNode: {
+      challenge: {
+        title: string;
+        description: string;
+        challengeType: number;
+        challengeFiles: Array<{
+          ext: string;
+          name: string;
+          contents: string;
+        }>;
+      };
+    };
+  };
+}
+
+vi.mock('../templates/Challenges/classic/show', () => ({
+  default: (props: unknown) => {
+    showClassic(props);
+    return <div>classic challenge</div>;
+  }
+}));
+vi.mock('../utils/get-words', () => ({
+  randomQuote: () => ({ quote: 'Test quote', author: 'Test author' })
+}));
+
+const mockDailyChallenge = {
+  id: 'test-challenge-id',
+  challengeNumber: 1,
+  title: 'Test title',
+  date: '2026-06-22T00:00:00.000Z',
+  description: 'Test description',
+  javascript: {
+    tests: [
+      {
+        text: 'Test text',
+        testString: 'assert.strictEqual(true, true);'
+      }
+    ],
+    challengeFiles: [
+      {
+        fileKey: 'scriptjs',
+        contents: '// JavaScript seed code'
+      }
+    ]
+  },
+  python: {
+    tests: [
+      {
+        text: 'Test text',
+        testString: '({test: () => { runPython(`assert True == True`)}})'
+      }
+    ],
+    challengeFiles: [
+      {
+        fileKey: 'mainpy',
+        contents: '# Python seed code'
+      }
+    ]
+  }
+};
+
+describe('<ShowDailyCodingChallenge />', () => {
+  afterEach(() => {
+    store.clearAll();
+    vi.restoreAllMocks();
+    showClassic.mockClear();
+  });
+
+  it('renders the not found page when the API request fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+
+    render(<ShowDailyCodingChallenge date='2026-06-22' />);
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'daily-coding-challenges.not-found'
+      })
+    ).toBeInTheDocument();
+    expect(showClassic).not.toHaveBeenCalled();
+  });
+
+  it('renders the not found page when the API returns invalid challenge data', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ invalid: 'data structure' })
+    } as unknown as Response);
+
+    render(<ShowDailyCodingChallenge date='2026-06-22' />);
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'daily-coding-challenges.not-found'
+      })
+    ).toBeInTheDocument();
+    expect(showClassic).not.toHaveBeenCalled();
+  });
+
+  it('formats valid API data before rendering the daily challenge', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: vi.fn().mockResolvedValue(mockDailyChallenge)
+    } as unknown as Response);
+
+    render(<ShowDailyCodingChallenge date='2026-06-22' />);
+
+    expect(await screen.findByText('classic challenge')).toBeInTheDocument();
+
+    await waitFor(() => expect(showClassic).toHaveBeenCalled());
+
+    const props = showClassic.mock.calls[0]?.[0] as unknown as ShowClassicProps;
+    const challenge = props.data.challengeNode.challenge;
+
+    expect(props.isDailyCodingChallenge).toBe(true);
+    expect(props.dailyCodingChallengeLanguage).toBe('javascript');
+    expect(challenge.title).toBe('Test title');
+    expect(challenge.description).toBe(
+      '<section id="description">\nTest description\n</section>'
+    );
+    expect(challenge.challengeType).toBe(28);
+    expect(challenge.challengeFiles[0]).toEqual(
+      expect.objectContaining({
+        ext: 'js',
+        name: 'script',
+        contents: '// JavaScript seed code'
+      })
+    );
+  });
+});

--- a/client/src/pages/learn/daily-coding-challenge/archive.test.tsx
+++ b/client/src/pages/learn/daily-coding-challenge/archive.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createStore } from '../../../redux/create-store';
+import { initialState } from '../../../redux';
+import { ns as MainApp } from '../../../redux/action-types';
+import {
+  configure,
+  render,
+  screen,
+  waitFor
+} from '../../../../utils/test-utils';
+import {
+  formatDate,
+  getTodayUsCentral
+} from '../../../components/daily-coding-challenge/helpers';
+import Archive from './archive';
+
+vi.mock('../../../components/Map', () => ({
+  default: () => <div>curriculum map</div>
+}));
+vi.mock('../../../utils/get-words', () => ({
+  randomQuote: () => ({ quote: 'Test quote', author: 'Test author' })
+}));
+
+const todayUsCentral = getTodayUsCentral();
+const [year, month, day] = todayUsCentral.split('-').map(Number);
+const todayMidnight = `${todayUsCentral}T00:00:00.000Z`;
+const adjacentDate = formatDate({
+  year,
+  month,
+  day: day === 1 ? day + 1 : day - 1
+});
+const daysInMonth = new Date(year, month, 0).getDate();
+
+function renderArchive() {
+  const store = createStore({
+    [MainApp]: {
+      ...initialState,
+      user: {
+        ...initialState.user,
+        sessionUser: {
+          completedDailyCodingChallenges: [
+            {
+              id: 'completed-challenge-id',
+              languages: ['javascript']
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  return render(<Archive />, store);
+}
+
+describe('<DailyCodingChallengeArchive />', () => {
+  beforeEach(() => {
+    configure({ testIdAttribute: 'data-playwright-test-label' });
+  });
+
+  afterEach(() => {
+    configure({ testIdAttribute: 'data-testid' });
+    vi.restoreAllMocks();
+  });
+
+  it('renders the calendar from the daily coding challenge API', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: vi.fn().mockResolvedValue([
+        {
+          id: 'completed-challenge-id',
+          date: todayMidnight,
+          challengeNumber: 1,
+          title: 'Today challenge'
+        },
+        {
+          id: 'not-completed-challenge-id',
+          date: `${adjacentDate}T00:00:00.000Z`,
+          challengeNumber: 2,
+          title: 'Adjacent challenge'
+        }
+      ])
+    } as unknown as Response);
+
+    renderArchive();
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'daily-coding-challenges.title'
+      })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'aria.previous-month' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'aria.next-month' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'buttons.go-to-dcc-today' })
+    ).toHaveAttribute(
+      'href',
+      `/learn/daily-coding-challenge/${todayUsCentral}`
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('calendar-day')).toHaveLength(daysInMonth);
+    });
+    expect(screen.getAllByTestId('calendar-day-completed')).toHaveLength(1);
+    expect(screen.getAllByTestId('calendar-day-not-completed')).toHaveLength(1);
+  });
+
+  it('renders the not found page when the API response is invalid', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ invalid: 'data structure' })
+    } as unknown as Response);
+
+    renderArchive();
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'daily-coding-challenges.not-found'
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -1,15 +1,12 @@
 import { test, expect } from '@playwright/test';
 import {
   getTodayUsCentral,
-  formatDate,
   formatDisplayDate
 } from '../client/src/components/daily-coding-challenge/helpers';
 
 const dateRouteRe = /.*\/daily-coding-challenge\/date\/.*/;
-const allRouteRe = /.*\/daily-coding-challenge\/all/;
 
 const todayUsCentral = getTodayUsCentral();
-const [year, month, day] = todayUsCentral.split('-').map(Number);
 
 const todayMidnight = `${todayUsCentral}T00:00:00.000Z`;
 
@@ -49,22 +46,6 @@ const mockApiChallenge = {
   }
 };
 
-const mockApiAllChallenges = [
-  // today
-  {
-    // real ID from certified user so it shows completed in calendar
-    id: '6814d8e1516e86b171929de4',
-    date: todayMidnight
-  },
-  // yesterday, or tomorrow if today is the first
-  {
-    id: 'other-id',
-    date: `${formatDate({ year, month, day: day === 1 ? day + 1 : day - 1 })}T00:00:00.000Z`
-  }
-];
-
-const mockDaysInMonth = new Date(year, month, 0).getDate();
-
 // Temporarily disabled
 // const runChallengeTest = async (page: Page, isMobile: boolean) => {
 //   if (isMobile) {
@@ -79,55 +60,6 @@ test.describe('Daily Coding Challenges', () => {
   test('should redirect to archive for invalid date', async ({ page }) => {
     await page.goto('/learn/daily-coding-challenge/invalid-date');
     await expect(page).toHaveURL('/learn/daily-coding-challenge/archive');
-  });
-
-  test('should show not found page for date without challenge', async ({
-    page
-  }) => {
-    await page.route(dateRouteRe, async route => {
-      await route.fulfill({
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-        json: { type: 'error', message: 'Challenge not found.' }
-      });
-    });
-
-    await page.goto('/learn/daily-coding-challenge/2025-01-01');
-    await expect(
-      page.getByText(/daily coding challenge not found\./i)
-    ).toBeVisible();
-  });
-
-  test('should show not found page for API error', async ({ page }) => {
-    await page.route(dateRouteRe, async route => {
-      await route.fulfill({
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-        json: { type: 'error', message: 'Internal server error.' }
-      });
-    });
-
-    await page.goto('/learn/daily-coding-challenge/2025-01-01');
-    await expect(
-      page.getByText(/daily coding challenge not found\./i)
-    ).toBeVisible();
-  });
-
-  test('should show not found page for invalid challenge data', async ({
-    page
-  }) => {
-    await page.route(dateRouteRe, async route => {
-      await route.fulfill({
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        json: { invalid: 'data structure' }
-      });
-    });
-
-    await page.goto('/learn/daily-coding-challenge/2025-06-27');
-    await expect(
-      page.getByText(/daily coding challenge not found\./i)
-    ).toBeVisible();
   });
 
   test('should load and display a daily coding challenge with a valid date, and should be able to switch between JavaScript and Python', async ({
@@ -224,47 +156,6 @@ test.describe('Daily Coding Challenge Archive', () => {
   }) => {
     await page.goto('/learn/daily-coding-challenge/path-1/path2');
     await expect(page).toHaveURL('/learn/daily-coding-challenge/archive');
-  });
-
-  test('archive should load and display the calendar', async ({ page }) => {
-    await page.route(allRouteRe, async route => {
-      await route.fulfill({
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        json: mockApiAllChallenges
-      });
-    });
-
-    await page.goto('/learn/daily-coding-challenge/archive');
-
-    await expect(page.getByText('Daily Coding Challenges')).toBeVisible();
-
-    await expect(
-      page.getByRole('button', { name: /previous month/i })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: /next month/i })
-    ).toBeVisible();
-
-    await expect(
-      page
-        .locator('div')
-        .filter({ hasText: /New challenges are released/ })
-        .getByRole('link', { name: /go to today/i })
-        .first()
-    ).toBeVisible();
-
-    const totalCalendarDays = await page.getByTestId('calendar-day').count();
-    expect(totalCalendarDays).toBe(mockDaysInMonth);
-
-    await expect(page.getByTestId('calendar-day-completed')).toHaveCount(1);
-
-    await expect(page.getByTestId('calendar-day-not-completed')).toHaveCount(1);
-
-    await page.getByTestId('calendar-day-completed').click();
-    await expect(page).toHaveURL(
-      `/learn/daily-coding-challenge/${todayUsCentral}`
-    );
   });
 });
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves the mocked daily coding challenge API branches into client tests, where they can run closer to the route and calendar logic. The Playwright spec now keeps the browser-facing pieces: route redirects and the editor flow for switching between JavaScript and Python daily challenges.