### PR TITLE
test: move email settings coverage to client

### DIFF
--- a/client/src/components/settings/email.test.tsx
+++ b/client/src/components/settings/email.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { describe, expect, it, vi } from 'vitest';
+
+import EmailSettings from './email';
+
+const originalEmail = 'foo@bar.com';
+const newEmail = 'foo-update@bar.com';
+
+function renderEmailSettings(
+  props: Partial<React.ComponentProps<typeof EmailSettings>> = {}
+) {
+  const store = createStore(() => ({}));
+  return render(
+    <Provider store={store}>
+      <EmailSettings
+        email={originalEmail}
+        isEmailVerified={true}
+        sendQuincyEmail={false}
+        updateQuincyEmail={vi.fn()}
+        {...props}
+      />
+    </Provider>
+  );
+}
+
+describe('<EmailSettings />', () => {
+  it('renders current email and subscription state', () => {
+    renderEmailSettings();
+
+    expect(
+      screen.getByRole('heading', { name: 'settings.email.heading' })
+    ).toBeInTheDocument();
+    expect(screen.getByText(originalEmail)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'buttons.save settings.email.heading'
+      })
+    ).toHaveAttribute('aria-disabled', 'true');
+    expect(
+      screen.getByRole('group', { name: 'settings.email.weekly' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'buttons.yes-please' })
+    ).toHaveAttribute('aria-pressed', 'false');
+    expect(
+      screen.getByRole('button', { name: 'buttons.no-thanks' })
+    ).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows validation errors for invalid email input', async () => {
+    const user = userEvent.setup();
+    renderEmailSettings();
+
+    await user.type(
+      screen.getByLabelText('settings.email.new', { exact: true }),
+      newEmail
+    );
+    await user.type(
+      screen.getByLabelText('settings.email.confirm'),
+      originalEmail
+    );
+
+    expect(screen.getByText('validation.email-mismatch')).toBeInTheDocument();
+
+    await user.clear(
+      screen.getByLabelText('settings.email.new', { exact: true })
+    );
+    await user.type(
+      screen.getByLabelText('settings.email.new', { exact: true }),
+      originalEmail
+    );
+
+    expect(screen.getByText('validation.same-email')).toBeInTheDocument();
+  });
+
+  it('toggles the weekly email subscription', async () => {
+    const user = userEvent.setup();
+    const updateQuincyEmail = vi.fn();
+    renderEmailSettings({ updateQuincyEmail });
+
+    await user.click(
+      screen.getByRole('button', { name: 'buttons.yes-please' })
+    );
+
+    expect(updateQuincyEmail).toHaveBeenCalledWith(true);
+  });
+});

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -7,12 +7,9 @@ import translations from '../client/i18n/locales/english/translations.json';
 const settingsPageElement = {
   emailVerificationAlert: 'email-verification-alert',
   emailVerificationLink: 'email-verification-link',
-  flashMessageAlert: 'flash-message',
-  newEmailValidation: 'new-email-validation',
-  confirmEmailValidation: 'confirm-email-validation'
+  flashMessageAlert: 'flash-message'
 } as const;
 
-const originalEmail = 'foo@bar.com';
 const newEmail = 'foo-update@bar.com';
 
 test.beforeEach(async ({ page }) => {
@@ -21,38 +18,6 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('Email Settings', () => {
-  test('should display the content correctly', async ({ page }) => {
-    await expect(
-      page.getByRole('heading', { name: translations.settings.email.heading })
-    ).toBeVisible();
-
-    await expect(page.getByText(originalEmail)).toBeVisible();
-
-    await expect(
-      page.getByRole('button', {
-        name: `${translations.buttons.save} ${translations.settings.email.heading}`
-      })
-    ).toBeDisabled();
-
-    await expect(
-      page
-        .getByRole('group', { name: translations.settings.email.weekly })
-        .locator('legend')
-    ).toBeVisible();
-
-    await expect(
-      page.getByRole('button', {
-        name: translations.buttons['yes-please']
-      })
-    ).toHaveAttribute('aria-pressed', 'false');
-
-    await expect(
-      page.getByRole('button', {
-        name: translations.buttons['no-thanks']
-      })
-    ).toHaveAttribute('aria-pressed', 'true');
-  });
-
   test('should display email verification alert after email update', async ({
     page
   }) => {
@@ -89,55 +54,6 @@ test.describe('Email Settings', () => {
       'href',
       '/update-email'
     );
-  });
-
-  test('should show the user error messages if the input is invalid', async ({
-    page
-  }) => {
-    const newEmailInput = page.getByLabel(translations.settings.email.new, {
-      exact: true
-    });
-    const confirmEmailInput = page.getByLabel(
-      translations.settings.email.confirm
-    );
-    const confirmValidation = page.getByTestId(
-      settingsPageElement.confirmEmailValidation
-    );
-    const newEmailValidation = page.getByTestId(
-      settingsPageElement.newEmailValidation
-    );
-
-    await newEmailInput.fill(newEmail);
-    await confirmEmailInput.fill(originalEmail);
-
-    await expect(confirmValidation).toBeVisible();
-    await expect(confirmValidation).toContainText(
-      translations.validation['email-mismatch']
-    );
-
-    await newEmailInput.fill(originalEmail);
-
-    await expect(newEmailValidation).toBeVisible();
-    await expect(newEmailValidation).toContainText(
-      translations.validation['same-email']
-    );
-  });
-
-  test('should toggle email subscription correctly', async ({ page }) => {
-    const yesPleaseButton = page.getByRole('button', {
-      name: translations.buttons['yes-please']
-    });
-    const noThanksButton = page.getByRole('button', {
-      name: translations.buttons['no-thanks']
-    });
-
-    await yesPleaseButton.click();
-    await expect(yesPleaseButton).toHaveAttribute('aria-pressed', 'true');
-    await expect(noThanksButton).toHaveAttribute('aria-pressed', 'false');
-
-    await noThanksButton.click();
-    await expect(yesPleaseButton).toHaveAttribute('aria-pressed', 'false');
-    await expect(noThanksButton).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('should display flash message when email subscription is toggled', async ({


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves the email settings rendering and validation checks into a client test, where they can run closer to the form logic. The Playwright spec keeps the server-backed pieces: updating the email and seeing the verification alert, plus the subscription flash after the Quincy email preference changes.