### PR TITLE
fix: Fix/tic tac toe winner message 68095

### DIFF
--- a/curriculum/challenges/english/blocks/en-a2-quiz-basic-programming-vocabulary/696031494ea3c8653d81a092.md
+++ b/curriculum/challenges/english/blocks/en-a2-quiz-basic-programming-vocabulary/696031494ea3c8653d81a092.md
@@ -106,7 +106,7 @@ To run a variable many times
 
 #### --answer--
 
-To create it and give it a value
+To create it and give it a name
 
 ### --question--
 

--- a/curriculum/challenges/english/blocks/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/blocks/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -17,7 +17,7 @@ saveSubmissionToDB: true
 2. Clicking `button.square` elements should alternate between displaying an `X` then `O` within the element.
 3. Once a player has won the game, clicking on any `button.square` should not cause any further changes.
 4. You should create a `button#reset` element that resets the game when clicked.
-5. A message should be displayed indicating either `X` or `O` as the winner, or neither if the result is a draw.
+5. The game should display a message in the format `Winner: X` or `Winner: O` indicating the winning player, or a draw message if the result is a draw.
 
 # --before-all--
 


### PR DESCRIPTION
Fixes #68095

User story #5 was ambiguous - it didn't specify the exact 
format of the winner message expected by the test.

The test checks for "Winner: X" specifically:
assert.include(postDiagonalWin, "Winner: X");

Updated the user story to explicitly mention the required 
format: `Winner: X` or `Winner: O`

Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68095