### PR TITLE
fix(curriculum): correct ARIA lecture inaccuracies and formatting

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a53cf67140d8cd85d4b0f.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a53cf67140d8cd85d4b0f.md
@@ -19,13 +19,13 @@ So, the primary purpose of WAI-ARIA is to improve accessibility for dynamic cont
 
 WAI-ARIA works by introducing a set of attributes you can add to HTML elements to provide additional semantic information. These attributes are categorized into roles, states, and properties.
 
-ARIA role defines the purpose of an element within a website or web app. Here is an example of setting the role to `button` for a `div` element.
+An ARIA role defines the purpose of an element within a website or web app. Here is an example of setting the role to `button` for a `div` element.
 
 ```html
 <div role="button">Click Me</div>
 ```
 
-By doing this you are indicating to assistive technology that the element is a button. Roles do not provide any functionality however. Merely giving this `div` a `role` of `button` will not make it act like a button. To make it look and behave like a button you would need to use CSS and JavaScript to get the desired result. 
+By doing this you are indicating to assistive technology that the element is a button. Roles do not provide any functionality, however. Merely giving this `div` a `role` of `button` will not make it act like a button. To make it look and behave like a button you would need to use CSS and JavaScript to get the desired result. 
 
 Here is an example of using HTML, CSS and JavaScript to create a custom `button` element. 
 
@@ -94,7 +94,7 @@ This will make the elements understandable and navigable for users of assistive 
 
 To get the best out of WAI-ARIA, try to stick with native HTML whenever possible since it generally provides more accessibility out of the box.
 
-Use WAI-ARIA only when HTML falls short, and don’t forget to test with assistive technologies like screen readers, or have people with disabilities test your work. Also, make sure your WAI-ARIA states and properties update with the content in real time. Avoid overusing ARIA, as it can often be confusing.
+Use WAI-ARIA only when HTML falls short, and don't forget to test with assistive technologies like screen readers, or have people with disabilities test your work. Also, make sure your WAI-ARIA states and properties update with the content in real time. Avoid overusing ARIA, as it can often be confusing.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a549231b8728f7171ed9d.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a549231b8728f7171ed9d.md
@@ -76,7 +76,7 @@ There are six main categories of ARIA roles:
 - Landmark roles
 - Live region roles
 - Window roles
-- And Abstract roles
+- Abstract roles
 
 Let's take a look at them in more detail.
 
@@ -409,7 +409,7 @@ And finally, we have abstract roles. These roles help organize the document. The
 
 With ARIA roles, you can create accessible and inclusive websites and web applications. They provide semantic information about the purpose and function of HTML elements.
 
-Screen readers and other assistive technologies use this information to help users understand the content of your page and set expectations for how to use it, which helps ensure  that everyone can have a great user experience.
+Screen readers and other assistive technologies use this information to help users understand the content of your page and set expectations for how to use it, which helps ensure that everyone can have a great user experience.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a54a6675c168faa84252d.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a54a6675c168faa84252d.md
@@ -13,7 +13,7 @@ For people using screen readers, the `aria-label` and `aria-labelledby` attribut
 
 Let's look at what the `aria-label` and `aria-labelledby` attributes are and the roles they play in making the web accessible to people with visual impairments and related disabilities.
 
-You'll notice both `aria-label` and `aria-labelledby` are prefixed with aria. So what does that mean? ARIA stands for Accessible Rich Internet Applications. It's a set of attributes prefixed with `aria-`, which lets developers communicate the purpose of elements to assistive technologies. The `aria-label` attribute is an invisible label for interactive elements. It adds a text label to an element that screen readers can read.
+You'll notice both `aria-label` and `aria-labelledby` are prefixed with `aria-`. So what does that mean? ARIA stands for Accessible Rich Internet Applications. It's a set of attributes prefixed with `aria-`, which lets developers communicate the purpose of elements to assistive technologies. The `aria-label` attribute is an invisible label for interactive elements. It adds a text label to an element that screen readers can read.
 
 `aria-label` is especially useful for elements that do not have visible text but still need to be described by screen readers. For example, buttons with only icons often need `aria-label` to convey their purpose.
 
@@ -45,6 +45,7 @@ Here's an example:
 :::
 
 In this case, the text for the button is being used as the label for the search input. Screen readers will announce the input as something like `Search, edit`. If you later decide you want to change the button text to `Find`, the label for the input will automatically be updated to the new text since it is referencing the button text.
+
 Combining multiple `id` values into a single `aria-labelledby` attribute value is also possible. Here's how that works:
 
 :::interactive_editor

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a54bc58319c8fe6f78ad4.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a54bc58319c8fe6f78ad4.md
@@ -16,7 +16,7 @@ This attribute hides the element and all of its children from the accessibility 
 - Icons and images that only have a decorative purpose.
 - Duplicated content.
 
-It is important to remember that `aria-hidden` only hides content from assistive technology, such as screen readers. If the content should be hidden from everyone, then you should not use `aria-hidden` to hide it. For example, a hamburger menu that is currently collapsed must be hidden from all keyboard users, not just screen reader users. In this case you could set the CSS `display` property to `none` on the menu to remove it from the DOM when it is collapsed.
+It is important to remember that `aria-hidden` only hides content from assistive technology, such as screen readers. If the content should be hidden from everyone, then you should not use `aria-hidden` to hide it. For example, a hamburger menu that is currently collapsed must be hidden from all keyboard users, not just screen reader users. In this case you could set the CSS `display` property to `none` on the menu to remove it from the rendered page and the accessibility tree when it is collapsed.
 
 You should never use `aria-hidden` to hide an element that is focusable with the keyboard. The `aria-hidden` attribute only removes the element from the accessibility tree. It does not remove it from the DOM. Thus, it will still be possible for screen reader users to tab to the element, but their screen reader will not announce the element, effectively causing them to focus on "nothing".
 
@@ -51,7 +51,7 @@ You do not need to use `aria-hidden` when:
 - The element or the element's ancestor is already hidden with `display: none`.
 - The element or the element's ancestor is already hidden with `visibility: hidden`.
 
-In these three cases, the element is already removed from the DOM and thus hidden from the accessibility tree, so the `aria-hidden` attribute is not necessary.
+In these three cases, the element is already hidden from the accessibility tree, so the `aria-hidden` attribute is not necessary.
 
 As with using any ARIA attributes, you should always test with assistive technologies, and preferably having people with disabilities test your work, to make sure that it's easy to understand, even with these hidden elements.
 
@@ -61,7 +61,7 @@ The `aria-hidden` attribute is used to hide elements from people who use assisti
 
 While it can be helpful for hiding purely decorative elements and duplicated content, it should be used sparingly to avoid hindering accessibility.
 
-In general, all content and functionality available on the page should also be available to people using assistive technology. The use case for `aria-hidden` is very narrow and should be limited primarily to making the experience cleaner for screen reader users by removing purely decorative or duplicate information. Do not use `aria-hidden` to hide content that you don’t think screen reader users would be interested in. Screen reader users deserve to have access to all information on the page.
+In general, all content and functionality available on the page should also be available to people using assistive technology. The use case for `aria-hidden` is very narrow and should be limited primarily to making the experience cleaner for screen reader users by removing purely decorative or duplicate information. Do not use `aria-hidden` to hide content that you don't think screen reader users would be interested in. Screen reader users deserve to have access to all information on the page.
 
 By following these best practices and testing the user experience, you can create inclusive online experiences for everyone.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #68124

### Changes made

- Corrected the technical inaccuracy regarding `display: none`, `visibility: hidden`, and `hidden` removing elements from the DOM.
- Fixed grammar issues including a missing article and a missing comma.
- Replaced smart apostrophes with straight apostrophes.
- Formatted `aria-` as inline code.
- Added the missing blank line between paragraphs.
- Removed the stray "And" from the list item.
- Fixed the double-space formatting issue.