### PR TITLE
fix(curriculum): editable regions in workshop decimal to binary converter

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64005eb6d2d06a15d9f7611f.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64005eb6d2d06a15d9f7611f.md
@@ -209,9 +209,9 @@ const result = document.getElementById("result");
 const checkUserInput = () => {
   --fcc-editable-region--
   if (numberInput.value === "") {
+  --fcc-editable-region--
 
   }
-  --fcc-editable-region--
 
   console.log(numberInput.value);
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/640067f276acd525509646cc.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/640067f276acd525509646cc.md
@@ -208,9 +208,9 @@ const result = document.getElementById("result");
 const checkUserInput = () => {
   --fcc-editable-region--
   if (!numberInput.value) {
+  --fcc-editable-region--
 
   }
-  --fcc-editable-region--
 
   console.log(numberInput.value);
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64007367d54d2a7efbf44fcf.md
@@ -217,9 +217,9 @@ const result = document.getElementById("result");
 const checkUserInput = () => {
   --fcc-editable-region--
   if (!numberInput.value || parseInt(numberInput.value)) {
+  --fcc-editable-region--
 
   }
-  --fcc-editable-region--
 
   console.log(numberInput.value);
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/644760f4fb15ce765baebb62.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/644760f4fb15ce765baebb62.md
@@ -197,8 +197,8 @@ const checkUserInput = () => {
     isNaN(parseInt(numberInput.value)) ||
     parseInt(numberInput.value) < 0
   ) {
-    --fcc-editable-region--
     alert("Please provide a decimal number greater than or equal to 0");
+    --fcc-editable-region--
 
     --fcc-editable-region--
   }

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6448b4107aadc110a6ab4f65.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6448b4107aadc110a6ab4f65.md
@@ -201,11 +201,11 @@ const numberInput = document.getElementById("number-input");
 const convertBtn = document.getElementById("convert-btn");
 const result = document.getElementById("result");
 
---fcc-editable-region--
 const decimalToBinary = (input) => {
+  --fcc-editable-region--
   
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 const checkUserInput = () => {
   if (

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6448fefcd6445d6b3d9d63db.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6448fefcd6445d6b3d9d63db.md
@@ -206,6 +206,6 @@ convertBtn.addEventListener("click", checkUserInput);
 --fcc-editable-region--
 numberInput.addEventListener("keydown", () => {
   
-});
 --fcc-editable-region--
+});
 ```

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645b65b681a62f5fa125ff62.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645b65b681a62f5fa125ff62.md
@@ -216,8 +216,8 @@ const decimalToBinary = (input) => {
     const quotient = Math.floor(input / 2);
     const remainder = input % 2;
 
-    --fcc-editable-region--
     inputs.push(input);
+    --fcc-editable-region--
 
     --fcc-editable-region--
     input = quotient;

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645b6c92876e836832538e34.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645b6c92876e836832538e34.md
@@ -210,8 +210,8 @@ const decimalToBinary = (input) => {
     input = quotient;
   }
 
-  --fcc-editable-region--
   console.log("Inputs: ", inputs);
+  --fcc-editable-region--
   
   --fcc-editable-region--
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645b9d56b48971997a8055dd.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645b9d56b48971997a8055dd.md
@@ -200,11 +200,11 @@ const decimalToBinary = (input) => {
   const quotients = [];
   const remainders = [];
 
-  --fcc-editable-region--
   if (input === 0) {
-  
-  }
   --fcc-editable-region--
+  
+  --fcc-editable-region--
+  }
 
   while (input > 0) {
     const quotient = Math.floor(input / 2);

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645c9e6cf5c7251f7b3308f6.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645c9e6cf5c7251f7b3308f6.md
@@ -200,9 +200,9 @@ const result = document.getElementById("result");
 const countdown = (number) => {
   console.log(number);
 
---fcc-editable-region--
   if (number === 0) {
     return;
+--fcc-editable-region--
   }
 --fcc-editable-region--
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ca381c8f87f263034954f.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ca381c8f87f263034954f.md
@@ -205,13 +205,13 @@ const result = document.getElementById("result");
 const countdown = (number) => {
   console.log(number);
 
---fcc-editable-region--
   if (number === 0) {
     return;
   } else {
-    
-  }
 --fcc-editable-region--
+    
+--fcc-editable-region--
+  }
 };
 
 const decimalToBinary = (input) => {

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cb07132281a380223e458.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cb07132281a380223e458.md
@@ -196,8 +196,8 @@ const countDownAndUp = (number) => {
     console.log("Reached base case");
     return;
   } else {
-    --fcc-editable-region--
     countDownAndUp(number - 1);
+    --fcc-editable-region--
 
     --fcc-editable-region--
   }

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cc5925f158b5b33e2698f.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cc5925f158b5b33e2698f.md
@@ -196,11 +196,11 @@ h2 {
 ```
 
 ```js
---fcc-editable-region--
 const callStack = [
-
-];
 --fcc-editable-region--
+
+--fcc-editable-region--
+];
 
 const a = () => {
   return "freeCodeCamp " + b();

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ccf7ec9aca267d84b053e.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ccf7ec9aca267d84b053e.md
@@ -199,11 +199,11 @@ h2 {
 ```
 
 ```js
---fcc-editable-region--
 const callStack = [
-  'a(): returns "freeCodeCamp " + b()'
-];
 --fcc-editable-region--
+  'a(): returns "freeCodeCamp " + b()'
+--fcc-editable-region--
+];
 
 const a = () => {
   return "freeCodeCamp " + b();

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd17b061afb6a8cba945a.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd17b061afb6a8cba945a.md
@@ -197,12 +197,12 @@ h2 {
 ```
 
 ```js
---fcc-editable-region--
 const callStack = [
   'a(): returns "freeCodeCamp " + b()',
-  'b(): returns "is " + c()'
-];
 --fcc-editable-region--
+  'b(): returns "is " + c()'
+--fcc-editable-region--
+];
 
 const a = () => {
   return "freeCodeCamp " + b();

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd267410ac06bfcaf0bd4.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd267410ac06bfcaf0bd4.md
@@ -199,13 +199,13 @@ h2 {
 ```
 
 ```js
---fcc-editable-region--
 const callStack = [
   'a(): returns "freeCodeCamp " + b()',
+--fcc-editable-region--
   'b(): returns "is " + c()',
   'c(): returns "awesome!"'
-];
 --fcc-editable-region--
+];
 
 const a = () => {
   return "freeCodeCamp " + b();

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd2b76488fd6cb8d1ae79.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd2b76488fd6cb8d1ae79.md
@@ -197,12 +197,12 @@ h2 {
 ```
 
 ```js
---fcc-editable-region--
 const callStack = [
   'a(): returns "freeCodeCamp " + b()',
-  'b(): returns "is " + c()'
-];
 --fcc-editable-region--
+  'b(): returns "is " + c()'
+--fcc-editable-region--
+];
 
 const a = () => {
   return "freeCodeCamp " + b();

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd4eb6edf6e6f91acabbb.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd4eb6edf6e6f91acabbb.md
@@ -195,12 +195,12 @@ h2 {
 ```
 
 ```js
---fcc-editable-region--
 const callStack = [
+--fcc-editable-region--
   'a(): returns "freeCodeCamp " + b()',
   'b(): returns "is " + "awesome!"'
-];
 --fcc-editable-region--
+];
 
 const a = () => {
   return "freeCodeCamp " + b();

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd5b506ed8970b7ea953d.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645cd5b506ed8970b7ea953d.md
@@ -187,11 +187,11 @@ h2 {
 ```
 
 ```js
---fcc-editable-region--
 const callStack = [
-  'a(): returns "freeCodeCamp " + "is awesome!"',
-];
 --fcc-editable-region--
+  'a(): returns "freeCodeCamp " + "is awesome!"',
+--fcc-editable-region--
+];
 
 const a = () => {
   return "freeCodeCamp " + b();

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ce315efe609814258b0bc.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ce315efe609814258b0bc.md
@@ -189,8 +189,8 @@ const numberInput = document.getElementById("number-input");
 const convertBtn = document.getElementById("convert-btn");
 const result = document.getElementById("result");
 
---fcc-editable-region--
 const decimalToBinary = (input) => {
+--fcc-editable-region--
   let binary = "";
 
   if (input === 0) {
@@ -203,8 +203,8 @@ const decimalToBinary = (input) => {
   }
 
   result.innerText = binary;
-};
 --fcc-editable-region--
+};
 
 const checkUserInput = () => {
   if (

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ce4375221138326895726.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/645ce4375221138326895726.md
@@ -202,9 +202,9 @@ const convertBtn = document.getElementById("convert-btn");
 const result = document.getElementById("result");
 
 const decimalToBinary = (input) => {
---fcc-editable-region--
   if (input === 0) {
     return "";
+--fcc-editable-region--
   }
 --fcc-editable-region--
 };

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/646203cdc054d012b5d71428.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/646203cdc054d012b5d71428.md
@@ -206,15 +206,15 @@ const convertBtn = document.getElementById("convert-btn");
 const result = document.getElementById("result");
 
 const decimalToBinary = (input) => {
---fcc-editable-region--
   if (input === 0) {
     return "0";
+--fcc-editable-region--
   } 
   
+--fcc-editable-region--
   else {
     return decimalToBinary(Math.floor(input / 2)) + (input % 2);
   }
---fcc-editable-region--
 };
 
 const checkUserInput = () => {

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6462060b0a8a2c15726649ec.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6462060b0a8a2c15726649ec.md
@@ -218,10 +218,10 @@ const decimalToBinary = (input) => {
     return "0";
   } else if (input === 1) {
     return "1";
+--fcc-editable-region--
   } else {
     return decimalToBinary(Math.floor(input / 2)) + (input % 2);
   }
---fcc-editable-region--
 };
 
 const checkUserInput = () => {

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/646467130d7acc9b4e565c42.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/646467130d7acc9b4e565c42.md
@@ -244,11 +244,11 @@ const showAnimation = () => {
 };
 
 const checkUserInput = () => {
---fcc-editable-region--
   const inputInt = parseInt(numberInput.value);
 
   if (
     !numberInput.value ||
+--fcc-editable-region--
     isNaN(parseInt(numberInput.value)) ||
     parseInt(numberInput.value) < 0
   ) {
@@ -262,8 +262,8 @@ const checkUserInput = () => {
   }
 
   result.textContent = decimalToBinary(parseInt(numberInput.value));
-  numberInput.value = "";
 --fcc-editable-region--
+  numberInput.value = "";
 };
 
 convertBtn.addEventListener("click", checkUserInput);

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/646486adf52652c0ee103aab.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/646486adf52652c0ee103aab.md
@@ -221,10 +221,10 @@ const numberInput = document.getElementById("number-input");
 const convertBtn = document.getElementById("convert-btn");
 const result = document.getElementById("result");
 const animationData = [
---fcc-editable-region--
   {
     inputVal: 5,
     addElDelay: 1000
+--fcc-editable-region--
   }
 --fcc-editable-region--
 ];

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64648963e014f8c42a65b83a.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64648963e014f8c42a65b83a.md
@@ -219,7 +219,6 @@ const numberInput = document.getElementById("number-input");
 const convertBtn = document.getElementById("convert-btn");
 const result = document.getElementById("result");
 const animationData = [
---fcc-editable-region--
   {
     inputVal: 5,
     addElDelay: 1000
@@ -227,6 +226,7 @@ const animationData = [
   {
     inputVal: 2,
     addElDelay: 1500
+--fcc-editable-region--
   },
 --fcc-editable-region--
 ];

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6464a057702d04e537d56d49.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6464a057702d04e537d56d49.md
@@ -213,12 +213,12 @@ const animationData = [
     inputVal: 2,
     addElDelay: 1500
   },
---fcc-editable-region--
   {
     inputVal: 1,
-    addElDelay: 2000
-  }
 --fcc-editable-region--
+    addElDelay: 2000
+--fcc-editable-region--
+  }
 ];
 
 const decimalToBinary = (input) => {

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6464a9f7d81939f08d04f435.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6464a9f7d81939f08d04f435.md
@@ -230,13 +230,13 @@ const animationData = [
     inputVal: 2,
     addElDelay: 1500
   },
---fcc-editable-region--
   {
     inputVal: 1,
     addElDelay: 2000,
-    msg: "decimalToBinary(1) returns '1' (base case) and gives that value to the stack below. Then it pops off the stack."
-  }
 --fcc-editable-region--
+    msg: "decimalToBinary(1) returns '1' (base case) and gives that value to the stack below. Then it pops off the stack."
+--fcc-editable-region--
+  }
 ];
 
 const decimalToBinary = (input) => {

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6464aabd17cd45f1d17cfe56.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6464aabd17cd45f1d17cfe56.md
@@ -250,12 +250,12 @@ const animationData = [
     inputVal: 5,
     addElDelay: 1000
   },
---fcc-editable-region--
   {
     inputVal: 2,
-    addElDelay: 1500
-  },
 --fcc-editable-region--
+    addElDelay: 1500
+--fcc-editable-region--
+  },
   {
     inputVal: 1,
     addElDelay: 2000,

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6464ab8c06ea92f30bc548d5.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6464ab8c06ea92f30bc548d5.md
@@ -246,12 +246,12 @@ const convertBtn = document.getElementById("convert-btn");
 const result = document.getElementById("result");
 const animationContainer = document.getElementById("animation-container");
 const animationData = [
---fcc-editable-region--
   {
     inputVal: 5,
-    addElDelay: 1000
-  },
 --fcc-editable-region--
+    addElDelay: 1000
+--fcc-editable-region--
+  },
   {
     inputVal: 2,
     addElDelay: 1500,


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

References to: #67721

This PR is part of Naomi's sprint for editable regions in workshops.

Audited the `--editable-region--` markers across the workshop-decimal-to-binary-converter steps so each marker wraps only the lines a camper must modify, removing surrounding context/unchanged lines.