### PR TITLE
fix(curriculum): correct regex review explanations (#68114)

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -117,7 +117,7 @@ console.log(end.test("freecodecamp")); // true
 
 :::
 
-- **`m` Flag**: Anchors look for the beginning and end of the entire string. But you can make a regex handle multiple lines with the `m` flag, or the multi-line modifier.flag, or the multi-line modifier.
+- **`m` Flag**: Anchors look for the beginning and end of the entire string. But you can make a regex handle multiple lines with the `m` flag, or the multi-line modifier.
 
 :::interactive_editor
 
@@ -175,7 +175,7 @@ const regex = /a./;
 const regex = /\d/;
 ```
 
-- **`\w`**: This is used to match any word character (`a-z0-9_`) in a string. A word character is defined as any letter, from a to z, or a number from 0 to 9, or the underscore character.
+- **`\w`**: This is used to match any word character (`a-zA-Z0-9_`) in a string. A word character is defined as any letter, from a to z or A to Z, or a number from 0 to 9, or the underscore character.
 
 ```js
 const regex = /\w/;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68114



### Changes made

* Updated the `m` flag description by removing the duplicated phrase:

  * From: `the multi-line modifier.flag, or the multi-line modifier`
  * To: `the multi-line modifier`

* Corrected the `\w` character class definition:

  * From: `a-z0-9_`
  * To: `a-zA-Z0-9_`

* Updated the accompanying explanation to indicate that `\w` matches letters from `a-z` and `A-Z`, digits (`0-9`), and the underscore (`_`).
