### PR TITLE
fix: correct typos in test descriptions

### DIFF
--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -95,7 +95,7 @@ describe('/exam-environment/', () => {
 
         expect(res.body).toStrictEqual({
           code: 'FCC_ERR_EXAM_ENVIRONMENT_EXAM_ATTEMPT',
-          // NOTE: message may not necessarily be a part of the api compatability guarantee.
+          // NOTE: message may not necessarily be a part of the api compatibility guarantee.
           //       That is, it could be changed without requiring a major version bump, because it is just
           //       a human-readable/debug message.
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/api/src/plugins/cookie-update.test.ts
+++ b/api/src/plugins/cookie-update.test.ts
@@ -91,7 +91,7 @@ describe('Cookie updates', () => {
     );
   });
 
-  test('should respect the default cookie config if not overriden', async () => {
+  test('should respect the default cookie config if not overridden', async () => {
     await setup({});
 
     const res = await fastify.inject({


### PR DESCRIPTION
This is an independent contribution.

## Summary
Fixed two spelling errors in API test file descriptions.

## Root Cause
- `overriden` in `cookie-update.test.ts` line 94 is missing a second d
- `compatability` in `exam-environment.test.ts` line 98 is missing an i

## Fix
- `overriden` -> `overridden`
- `compatability` -> `compatibility`

## Testing
- These are string-level changes in test descriptions and comments only - no logic or assertions were modified
- The existing test suite continues to pass as the changes are cosmetic

Closes #68137