### PR TITLE
fix(curriculum): clarify tic tac toe winner message

### DIFF
--- a/curriculum/challenges/english/blocks/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/blocks/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -17,7 +17,7 @@ saveSubmissionToDB: true
 2. Clicking `button.square` elements should alternate between displaying an `X` then `O` within the element.
 3. Once a player has won the game, clicking on any `button.square` should not cause any further changes.
 4. You should create a `button#reset` element that resets the game when clicked.
-5. A message should be displayed indicating either `X` or `O` as the winner, or neither if the result is a draw.
+5. A message should be displayed indicating the winner in the format `Winner: X` or `Winner: O`, or neither if the result is a draw.
 
 # --before-all--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68095

This clarifies the Tic Tac Toe lab user story for the expected winner message format. It now specifies `Winner: X` and `Winner: O`, matching the test expectation.

Tested with:

```sh
git diff --check
```
