### PR TITLE
fix(curriculum): correct regex review descriptions

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -117,7 +117,7 @@ console.log(end.test("freecodecamp")); // true
 
 :::
 
-- **`m` Flag**: Anchors look for the beginning and end of the entire string. But you can make a regex handle multiple lines with the `m` flag, or the multi-line modifier.flag, or the multi-line modifier.
+- **`m` Flag**: Anchors look for the beginning and end of the entire string. But you can make a regex handle multiple lines with the `m` flag, or the multi-line modifier.
 
 :::interactive_editor
 
@@ -175,7 +175,7 @@ const regex = /a./;
 const regex = /\d/;
 ```
 
-- **`\w`**: This is used to match any word character (`a-z0-9_`) in a string. A word character is defined as any letter, from a to z, or a number from 0 to 9, or the underscore character.
+- **`\w`**: This is used to match any word character (`a-zA-Z0-9_`) in a string. A word character is defined as any letter, from a to z or A to Z, or a number from 0 to 9, or the underscore character.
 
 ```js
 const regex = /\w/;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68114

## Description

This PR fixes two issues in the JavaScript Regular Expressions review challenge documentation:

* Removes the duplicated phrase in the `m` flag description.
* Updates the `\w` shorthand description to include uppercase letters (`A-Z`) and adjusts the explanatory text accordingly.

These are documentation-only changes and do not affect functionality.

