### PR TITLE
fix(curriculum): clarify winner message format for tic-tac-toe lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/blocks/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -241,7 +241,7 @@ Clicking on a `button.square` element after the game has ended should result in 
   }
 ```
 
-The game should display a message indicating the winner to be `X` or `O`.
+A message should be displayed indicating the winner in the format Winner: X or Winner: O, or neither if the result is a draw.
 
 ```js
   // Get to almost winning state


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68095

### Description of Changes
While reviewing the user stories for the Tic-Tac-Toe lab, I noticed that User Story #5 states a winner message should be displayed, but it doesn't specify the strict string format (`Winner: X` or `Winner: O`) that the automated test suite actually checks for. This ambiguity can easily lead to false negatives for campers who write valid logic but choose a different string layout.

I have updated the markdown file for the lab to explicitly mention the required `Winner: X` and `Winner: O` format. This should make the user story much clearer and prevent unnecessary confusion for students passing the challenge.