### PR TITLE
fix(curriculum): fix technical and grammar issues in JS review lecture

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2844,20 +2844,20 @@ const regex = /a./;
 const regex = /\d/;
 ```
 
-- **`\w`**: This is used to match any word character (`a-z0-9_`) in a string. A word character is defined as any letter, from a to z, or a number from 0 to 9, or the underscore character.
+- **`\w`**: This is used to match any word character (`a-zA-Z0-9_`) in a string. A word character is defined as any letter, from a to z or A to Z, or a number from 0 to 9, or the underscore character.
 
 ```js
 const regex = /\w/;
 ```
 
-- **`\s`**: The white-space class `\s`, represented by a backslash followed by an `s`. This character class will match any white space, including new lines, spaces, tabs, and special unicode space characters.
+- **`\s`**: The white-space class `\s` is represented by a backslash followed by an `s`. This character class will match any white space, including new lines, spaces, tabs, and special unicode space characters.
 - **Negating Special Character Classes**: To negate one of these character classes, instead of using a lowercase letter after the backslash, you can use the uppercase equivalent. The following example does not match a numerical character. Instead, it matches any single character that is NOT a numerical character. 
 
 ```js
 const regex = /\D/;
 ```
 
-- **Custom Character Classes**: You can create custom character classes by placing the character you wish match inside a set of square brackets.
+- **Custom Character Classes**: You can create custom character classes by placing the character you wish to match inside a set of square brackets.
 
 ```js
 const regex = /[abcdf]/;
@@ -3089,7 +3089,7 @@ console.log(now); // prints the current date and time
 
 :::
 
-- **`Date.now()` Method**: This method is used to get the current date and time. `Date.now()` returns the number of milliseconds since January 1, 1970, 00:00:00 UTC. This is known as the Unix epoch time. Unix epoch time is a common way to represent dates and times in computer systems because it is an integer that can be easily stored and manipulated. UTC stands for Universal Time Coordinated, which is the primary time standard by which the world regulates clocks and time.
+- **`Date.now()` Method**: This method is used to get the current date and time. `Date.now()` returns the number of milliseconds since January 1, 1970, 00:00:00 UTC. This is known as the Unix epoch time. Unix epoch time is a common way to represent dates and times in computer systems because it is an integer that can be easily stored and manipulated. UTC stands for Coordinated Universal Time, which is the primary time standard by which the world regulates clocks and time.
 - **`getDate()` Method**: This method is used to get a day of the month based on the current date. `getDate()` will return an integer value between 1 and 31, depending on the day of the month. If the date is invalid, it will return `NaN` (Not a Number).
 
 :::interactive_editor
@@ -3272,7 +3272,7 @@ window.navigator.mediaDevices.getUserMedia({
 
 ## Media Source Extensions API
 
-- **topic**: The Media Source Extensions API is what allows you to directly pass a user's webcam feed to a video element with the `srcObject` property.
+- **Definition**: The Media Source Extensions API is what allows you to directly pass a user's webcam feed to a video element with the `srcObject` property.
 
 ## Web Audio API
 
@@ -3684,7 +3684,7 @@ In the above example, the `findFactorial` function is called recursively until `
 
 - Functional Programming is an approach to software development that emphasizes the use of functions to solve problems, focusing on what needs to be done rather than how to do it.
 - Functional programming encourages the use of techniques that help avoid side effects, such as using immutable data structures and higher-order functions. 
-- When used correctly, functional programming principles lead to cleaner and more maintainable code
+- When used correctly, functional programming principles lead to cleaner and more maintainable code.
 
 ## Currying
 
@@ -3906,7 +3906,7 @@ In the above example, the `try` block contains the code that might throw an erro
 
 - The `async` attribute tells the browser to download the script file asynchronously while continuing to parse the HTML document. 
 - Once the script is downloaded, the HTML parsing is paused, the script is executed, and then HTML parsing resumes.
-- You should use `async` for independent scripts where the order of execution doesn't matter
+- You should use `async` for independent scripts where the order of execution doesn't matter.
 
 ## The `defer` attribute
 


### PR DESCRIPTION
### Checklist
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine.

Closes #68164

I have corrected several technical accuracy, grammar, and formatting issues in the JavaScript Review lecture:
- Updated the `\w` regex description to include uppercase letters.
- Fixed the sentence fragment in the `\s` description.
- Added a missing "to" in the Custom Character Classes description.
- Corrected the expansion of UTC to "Coordinated Universal Time".
- Changed the bold label from "topic" to "Definition" for consistency.
- Added missing terminal periods to list items for improved clarity.