### PR TITLE
fix(ci): skip scheduled workflows on forks

### DIFF
--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -18,6 +18,7 @@ jobs:
   i18n-download-client-ui-translations:
     name: Client
     runs-on: ubuntu-24.04
+    if: github.repository == 'freeCodeCamp/freeCodeCamp'
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/crowdin-upload.client-ui.yml
+++ b/.github/workflows/crowdin-upload.client-ui.yml
@@ -18,6 +18,7 @@ jobs:
   i18n-upload-client-ui-files:
     name: Client
     runs-on: ubuntu-24.04
+    if: github.repository == 'freeCodeCamp/freeCodeCamp'
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/crowdin-upload.curriculum.yml
+++ b/.github/workflows/crowdin-upload.curriculum.yml
@@ -18,6 +18,7 @@ jobs:
   i18n-upload-curriculum-files:
     name: Learn
     runs-on: ubuntu-24.04
+    if: github.repository == 'freeCodeCamp/freeCodeCamp'
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/docker-docr-cleanup.yml
+++ b/.github/workflows/docker-docr-cleanup.yml
@@ -8,6 +8,7 @@ jobs:
   remove:
     name: Delete Old Images
     runs-on: ubuntu-latest
+    if: github.repository == 'freeCodeCamp/freeCodeCamp'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
 Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

### Description of changes

This pull request adds repository guards (`if: github.repository == 'freeCodeCamp/freeCodeCamp'`) to all scheduled workflows. 

Currently, scheduled jobs run automatically on forks of the repository. Because forks do not have access to upstream secrets (e.g., `CROWDIN_CAMPERBOT_SERVICE_TOKEN`, `DIGITALOCEAN_ACCESS_TOKEN`), these jobs fail every day and send automated failure emails to fork owners. 

Adding this condition ensures these scheduled workflows are skipped on forks, while still running as expected on the main `freeCodeCamp/freeCodeCamp` upstream repository.