### PR TITLE
feat(client): loop daily challenges

### DIFF
--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
@@ -290,7 +290,6 @@ describe('/daily-coding-challenge', () => {
     });
 
     it('should return a day once real time has passed the entire original run, even for days that were never released relative to the mocked "today" above', async () => {
-      // well after 2026-08-10, so every day has been released at least once
       vi.setSystemTime(addDays(todayUsCentral, 365));
 
       const res = await superRequest('/daily-coding-challenge/day/10-03', {
@@ -316,7 +315,6 @@ describe('/daily-coding-challenge', () => {
         data: [feb28Challenge]
       });
 
-      // well after Feb 28, 2026, so it's already been released
       vi.setSystemTime(new Date(Date.UTC(2028, 1, 29, 6)));
 
       const res = await superRequest('/daily-coding-challenge/day/02-29', {
@@ -606,8 +604,6 @@ describe('/daily-coding-challenge', () => {
 
       expect(res.status).toBe(200);
 
-      // All 3 mock challenges are now in the past (including tomorrow's,
-      // since a year has elapsed), newest first
       const expectedResponse = [
         {
           id: tomorrowsChallenge.id,

--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
@@ -189,6 +189,148 @@ describe('/daily-coding-challenge', () => {
     });
   });
 
+  describe('GET /daily-coding-challenge/day/:day', () => {
+    beforeEach(async () => {
+      await fastifyTestInstance.prisma.dailyCodingChallenges.createMany({
+        data: mockChallenges
+      });
+    });
+
+    afterEach(async () => {
+      await fastifyTestInstance.prisma.dailyCodingChallenges.deleteMany();
+    });
+
+    it('should return 400 for an invalid day format', async () => {
+      const invalidFormats = [
+        'invalid-format',
+        '2025-10-02',
+        '010-02',
+        '2025-10',
+        '10-2',
+        '1-02',
+        '13-45',
+        '04-31',
+        '00-15'
+      ];
+
+      for (const invalidFormat of invalidFormats) {
+        const res = await superRequest(
+          `/daily-coding-challenge/day/${invalidFormat}`,
+          {
+            method: 'GET'
+          }
+        ).send({});
+
+        expect(res.status).toBe(400);
+        expect(res.body).toEqual({
+          type: 'error',
+          message: 'Invalid date format. Please use MM-DD.'
+        });
+      }
+    });
+
+    it('should return 404 for a day without a challenge', async () => {
+      const count = vi.fn();
+      const originalSentry = fastifyTestInstance.Sentry;
+      fastifyTestInstance.Sentry = {
+        ...originalSentry,
+        metrics: { ...originalSentry.metrics, count }
+      };
+
+      const res = await superRequest('/daily-coding-challenge/day/09-30', {
+        method: 'GET'
+      }).send({});
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({
+        type: 'error',
+        message: 'Challenge not found.'
+      });
+      expect(count).toHaveBeenCalledWith('dcc.challenge_not_found', 1, {
+        attributes: { route: '/daily-coding-challenge/day/:day' }
+      });
+
+      fastifyTestInstance.Sentry = originalSentry;
+    });
+
+    it('should return a challenge for a valid day request', async () => {
+      const count = vi.fn();
+      const originalSentry = fastifyTestInstance.Sentry;
+      fastifyTestInstance.Sentry = {
+        ...originalSentry,
+        metrics: { ...originalSentry.metrics, count }
+      };
+
+      const res = await superRequest('/daily-coding-challenge/day/10-02', {
+        method: 'GET'
+      }).send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        ...todaysChallenge,
+        date: todaysChallenge.date.toISOString()
+      });
+      expect(count).toHaveBeenCalledWith('dcc.challenge_viewed', 1, {
+        attributes: { route: '/daily-coding-challenge/day/:day' }
+      });
+
+      fastifyTestInstance.Sentry = originalSentry;
+    });
+
+    it("should not return a day's challenge if it hasn't been released even once yet (temporary, until the original run finishes on 2026-08-10)", async () => {
+      const res = await superRequest('/daily-coding-challenge/day/10-03', {
+        method: 'GET'
+      }).send({});
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({
+        type: 'error',
+        message: 'Challenge not found.'
+      });
+    });
+
+    it('should return a day once real time has passed the entire original run, even for days that were never released relative to the mocked "today" above', async () => {
+      // well after 2026-08-10, so every day has been released at least once
+      vi.setSystemTime(addDays(todayUsCentral, 365));
+
+      const res = await superRequest('/daily-coding-challenge/day/10-03', {
+        method: 'GET'
+      }).send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        ...tomorrowsChallenge,
+        date: tomorrowsChallenge.date.toISOString()
+      });
+    });
+
+    it('should map a Feb 29 day request to the Feb 28 challenge', async () => {
+      await fastifyTestInstance.prisma.dailyCodingChallenges.deleteMany();
+
+      const feb28UtcMidnight = new Date(Date.UTC(2026, 1, 28));
+      const feb28Challenge = {
+        ...todaysChallenge,
+        date: feb28UtcMidnight
+      };
+      await fastifyTestInstance.prisma.dailyCodingChallenges.createMany({
+        data: [feb28Challenge]
+      });
+
+      // well after Feb 28, 2026, so it's already been released
+      vi.setSystemTime(new Date(Date.UTC(2028, 1, 29, 6)));
+
+      const res = await superRequest('/daily-coding-challenge/day/02-29', {
+        method: 'GET'
+      }).send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        ...feb28Challenge,
+        date: feb28UtcMidnight.toISOString()
+      });
+    });
+  });
+
   describe('GET /daily-coding-challenge/today', () => {
     beforeEach(async () => {
       await fastifyTestInstance.prisma.dailyCodingChallenges.createMany({
@@ -248,6 +390,20 @@ describe('/daily-coding-challenge', () => {
       });
 
       fastifyTestInstance.Sentry = originalSentry;
+    });
+
+    it("should loop back to last year's challenge on the same month/day, returning the source date rather than a real requested year", async () => {
+      vi.setSystemTime(addDays(todayUsCentral, 365));
+
+      const res = await superRequest('/daily-coding-challenge/today', {
+        method: 'GET'
+      }).send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        ...todaysChallenge,
+        date: todaysChallenge.date.toISOString()
+      });
     });
   });
 
@@ -439,6 +595,42 @@ describe('/daily-coding-challenge', () => {
       });
 
       fastifyTestInstance.Sentry = originalSentry;
+    });
+
+    it('should include every challenge once real time has passed all of their release dates', async () => {
+      vi.setSystemTime(addDays(todayUsCentral, 365));
+
+      const res = await superRequest('/daily-coding-challenge/all', {
+        method: 'GET'
+      }).send({});
+
+      expect(res.status).toBe(200);
+
+      // All 3 mock challenges are now in the past (including tomorrow's,
+      // since a year has elapsed), newest first
+      const expectedResponse = [
+        {
+          id: tomorrowsChallenge.id,
+          challengeNumber: tomorrowsChallenge.challengeNumber,
+          date: tomorrowsChallenge.date.toISOString(),
+          title: tomorrowsChallenge.title
+        },
+        {
+          id: todaysChallenge.id,
+          challengeNumber: todaysChallenge.challengeNumber,
+          date: todaysChallenge.date.toISOString(),
+          title: todaysChallenge.title
+        },
+        {
+          id: yesterdaysChallenge.id,
+          challengeNumber: yesterdaysChallenge.challengeNumber,
+          date: yesterdaysChallenge.date.toISOString(),
+          title: yesterdaysChallenge.title
+        }
+      ];
+
+      expect(res.body).toHaveLength(3);
+      expect(res.body).toEqual(expectedResponse);
     });
   });
 

--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
@@ -4,7 +4,9 @@ import * as schemas from '../schemas/index.js';
 import {
   getNowUsCentral,
   getUtcMidnight,
-  dateStringToUtcMidnight
+  dateStringToUtcMidnight,
+  monthDayStringToUtcDate,
+  getSourceDate
 } from '../utils/helpers.js';
 
 /**
@@ -22,6 +24,7 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
   done
 ) => {
   fastify.get(
+    // Will stop returning challenges if param is after aug 10, 2026 - the last challenge date.
     '/daily-coding-challenge/date/:date',
     {
       schema: schemas.dailyCodingChallenge.date
@@ -83,6 +86,80 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
   );
 
   fastify.get(
+    '/daily-coding-challenge/day/:day',
+    {
+      schema: schemas.dailyCodingChallenge.day
+    },
+    async (req, reply) => {
+      req.log.info(
+        { day: req.params.day },
+        'Received request for daily coding challenge by day'
+      );
+
+      const { day } = req.params;
+
+      try {
+        const monthDay = monthDayStringToUtcDate(day);
+
+        if (!monthDay) {
+          req.log.warn({ day }, 'Invalid day format requested');
+          return reply.status(400).send({
+            type: 'error',
+            message: 'Invalid date format. Please use MM-DD.'
+          });
+        }
+
+        const sourceDate = getSourceDate(monthDay);
+
+        // TEMPORARY: blocks days for not yet released challenges
+        // Safe to delete after 2026-08-10 (all challenges released)
+        if (sourceDate > getUtcMidnight(getNowUsCentral())) {
+          req.log.warn({ day }, 'Challenge not found for day');
+          fastify.Sentry?.metrics?.count('dcc.challenge_not_found', 1, {
+            attributes: { route: '/daily-coding-challenge/day/:day' }
+          });
+          return reply
+            .status(404)
+            .send({ type: 'error', message: 'Challenge not found.' });
+        }
+
+        const challenge = await fastify.prisma.dailyCodingChallenges.findFirst({
+          where: {
+            date: sourceDate
+          }
+        });
+
+        if (!challenge) {
+          req.log.warn({ day }, 'Challenge not found for day');
+          fastify.Sentry?.metrics?.count('dcc.challenge_not_found', 1, {
+            attributes: { route: '/daily-coding-challenge/day/:day' }
+          });
+          return reply
+            .status(404)
+            .send({ type: 'error', message: 'Challenge not found.' });
+        }
+
+        fastify.Sentry?.metrics?.count('dcc.challenge_viewed', 1, {
+          attributes: { route: '/daily-coding-challenge/day/:day' }
+        });
+        return reply.send({
+          ...challenge,
+          date: challenge.date.toISOString()
+        });
+      } catch (error) {
+        req.log.error(error, 'Failed to get daily coding challenge by day.');
+        fastify.Sentry?.captureException(error);
+        fastify.Sentry?.metrics?.count('dcc.request_failed', 1, {
+          attributes: { route: '/daily-coding-challenge/day/:day' }
+        });
+        await reply
+          .status(500)
+          .send({ type: 'error', message: 'Internal server error.' });
+      }
+    }
+  );
+
+  fastify.get(
     '/daily-coding-challenge/today',
     {
       schema: schemas.dailyCodingChallenge.today
@@ -91,12 +168,13 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
       req.log.info("Received request for today's daily coding challenge");
 
       const today = getUtcMidnight(getNowUsCentral());
+      const sourceDate = getSourceDate(today);
 
       try {
         const todaysChallenge =
           await fastify.prisma.dailyCodingChallenges.findFirst({
             where: {
-              date: today
+              date: sourceDate
             }
           });
 

--- a/api/src/daily-coding-challenge/schemas/daily-coding-challenge.ts
+++ b/api/src/daily-coding-challenge/schemas/daily-coding-challenge.ts
@@ -46,6 +46,27 @@ const date = {
   }
 };
 
+const day = {
+  params: Type.Object({
+    day: Type.String({ pattern: '^\\d{2}-\\d{2}$' })
+  }),
+  response: {
+    200: singleChallengeResponse,
+    400: Type.Object({
+      type: Type.Literal('error'),
+      message: Type.Literal('Invalid date format. Please use MM-DD.')
+    }),
+    404: Type.Object({
+      type: Type.Literal('error'),
+      message: Type.Literal('Challenge not found.')
+    }),
+    500: Type.Object({
+      type: Type.Literal('error'),
+      message: Type.Literal('Internal server error.')
+    })
+  }
+};
+
 const today = {
   response: {
     200: singleChallengeResponse,
@@ -122,6 +143,7 @@ const newest = {
 
 export const dailyCodingChallenge = {
   date,
+  day,
   today,
   month,
   all,

--- a/api/src/daily-coding-challenge/utils/helpers.ts
+++ b/api/src/daily-coding-challenge/utils/helpers.ts
@@ -40,8 +40,7 @@ export function dateStringToUtcMidnight(dateStr: string): Date | null {
 }
 
 /**
- * Parses a date string in the format "MM-DD" and returns a UTC-midnight date
- * with a placeholder year.
+ * Parses a date string in the format "MM-DD" and returns a UTC-midnight date.
  * @param monthDayStr - Date string in "MM-DD" format.
  * @returns Date object set to UTC midnight (placeholder year) or null if invalid.
  */
@@ -52,12 +51,10 @@ export function monthDayStringToUtcDate(monthDayStr: string): Date | null {
 
   const [month, day] = monthDayStr.split('-').map(Number) as [number, number];
 
-  // 2000 is a leap year, so Date.UTC keeps "02-29" as Feb 29 instead of
-  // silently rolling it over to Mar 1 the way a non-leap year would.
+  // 2000 is a leap year, so Date.UTC keeps Feb 29 instead of rolling it over
   const date = new Date(Date.UTC(2000, month - 1, day));
 
-  // Date.UTC silently rolls over out-of-range values (e.g. month 13, or
-  // day 45) instead of rejecting them - this catches that.
+  // Date.UTC silently rolls over out-of-range values - this catches that.
   if (date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
     return null;
   }
@@ -65,15 +62,14 @@ export function monthDayStringToUtcDate(monthDayStr: string): Date | null {
   return date;
 }
 
-// A single year of challenges from 2025-08-11 - 2026-08-10 was created.
-const CYCLE_START_MONTH = 8; // August
-const CYCLE_START_DAY = 11;
-const CYCLE_START_YEAR = 2025; // Aug 11 - Dec 31 portion of the source range
-const CYCLE_END_YEAR = 2026; // Jan 1 - Aug 10 portion of the source range
+// A single year of challenges (2025-08-11 - 2026-08-10) was created.
+const ORIGINAL_START_MONTH = 8;
+const ORIGINAL_START_DAY = 11;
+const ORIGINAL_START_YEAR = 2025;
+const ORIGINAL_END_YEAR = 2026;
 
 /**
- * Maps any UTC-midnight date to the equivalent date within the real
- * challenge range (2025-08-11 - 2026-08-10), matching on month/day.
+ * Maps any UTC-midnight date to the original challenge date.
  * @param date - UTC-midnight date.
  * @returns UTC-midnight date within the source challenge range.
  */
@@ -81,17 +77,18 @@ export function getSourceDate(date: Date): Date {
   const month = date.getUTCMonth() + 1;
   let day = date.getUTCDate();
 
-  // Feb 29 doesn't exist in the source range (2026 is not a leap year).
-  // So we show the Feb 28 challenge for Feb 29 requests.
+  // Show the Feb 28 challenge for Feb 29 requests.
   if (month === 2 && day === 29) {
     day = 28;
   }
 
   const isOnOrAfterCycleStart =
-    month > CYCLE_START_MONTH ||
-    (month === CYCLE_START_MONTH && day >= CYCLE_START_DAY);
+    month > ORIGINAL_START_MONTH ||
+    (month === ORIGINAL_START_MONTH && day >= ORIGINAL_START_DAY);
 
-  const sourceYear = isOnOrAfterCycleStart ? CYCLE_START_YEAR : CYCLE_END_YEAR;
+  const sourceYear = isOnOrAfterCycleStart
+    ? ORIGINAL_START_YEAR
+    : ORIGINAL_END_YEAR;
 
   return new Date(Date.UTC(sourceYear, month - 1, day));
 }

--- a/api/src/daily-coding-challenge/utils/helpers.ts
+++ b/api/src/daily-coding-challenge/utils/helpers.ts
@@ -38,3 +38,60 @@ export function dateStringToUtcMidnight(dateStr: string): Date | null {
 
   return new Date(Date.UTC(year, month - 1, day));
 }
+
+/**
+ * Parses a date string in the format "MM-DD" and returns a UTC-midnight date
+ * with a placeholder year.
+ * @param monthDayStr - Date string in "MM-DD" format.
+ * @returns Date object set to UTC midnight (placeholder year) or null if invalid.
+ */
+export function monthDayStringToUtcDate(monthDayStr: string): Date | null {
+  if (!/^\d{2}-\d{2}$/.test(monthDayStr)) {
+    return null;
+  }
+
+  const [month, day] = monthDayStr.split('-').map(Number) as [number, number];
+
+  // 2000 is a leap year, so Date.UTC keeps "02-29" as Feb 29 instead of
+  // silently rolling it over to Mar 1 the way a non-leap year would.
+  const date = new Date(Date.UTC(2000, month - 1, day));
+
+  // Date.UTC silently rolls over out-of-range values (e.g. month 13, or
+  // day 45) instead of rejecting them - this catches that.
+  if (date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+    return null;
+  }
+
+  return date;
+}
+
+// A single year of challenges from 2025-08-11 - 2026-08-10 was created.
+const CYCLE_START_MONTH = 8; // August
+const CYCLE_START_DAY = 11;
+const CYCLE_START_YEAR = 2025; // Aug 11 - Dec 31 portion of the source range
+const CYCLE_END_YEAR = 2026; // Jan 1 - Aug 10 portion of the source range
+
+/**
+ * Maps any UTC-midnight date to the equivalent date within the real
+ * challenge range (2025-08-11 - 2026-08-10), matching on month/day.
+ * @param date - UTC-midnight date.
+ * @returns UTC-midnight date within the source challenge range.
+ */
+export function getSourceDate(date: Date): Date {
+  const month = date.getUTCMonth() + 1;
+  let day = date.getUTCDate();
+
+  // Feb 29 doesn't exist in the source range (2026 is not a leap year).
+  // So we show the Feb 28 challenge for Feb 29 requests.
+  if (month === 2 && day === 29) {
+    day = 28;
+  }
+
+  const isOnOrAfterCycleStart =
+    month > CYCLE_START_MONTH ||
+    (month === CYCLE_START_MONTH && day >= CYCLE_START_DAY);
+
+  const sourceYear = isOnOrAfterCycleStart ? CYCLE_START_YEAR : CYCLE_END_YEAR;
+
+  return new Date(Date.UTC(sourceYear, month - 1, day));
+}

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -132,7 +132,7 @@
     "title": "Daily Coding Challenges",
     "map-title": "Try the coding challenge of the day:",
     "not-found": "Daily Coding Challenge Not Found.",
-    "release-note": "New challenges are released at midnight US Central time."
+    "release-note": "The daily challenge changes at midnight US Central time."
   },
   "weekdays": {
     "short": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -132,7 +132,7 @@
     "title": "Daily Coding Challenges",
     "map-title": "Try the coding challenge of the day:",
     "not-found": "Daily Coding Challenge Not Found.",
-    "release-note": "The daily challenge changes at midnight US Central time."
+    "release-note": "The daily challenge updates at midnight US Central time."
   },
   "weekdays": {
     "short": {

--- a/client/src/client-only-routes/show-daily-coding-challenge.test.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.test.tsx
@@ -107,6 +107,32 @@ describe('<ShowDailyCodingChallenge />', () => {
     expect(showClassic).not.toHaveBeenCalled();
   });
 
+  it('fetches the challenge by year-agnostic month-day, not the full date', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: vi.fn().mockResolvedValue(mockDailyChallenge)
+    } as unknown as Response);
+
+    render(<ShowDailyCodingChallenge date='2026-06-22' />);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    const requestedUrl = fetchSpy.mock.calls[0]?.[0] as string;
+    expect(requestedUrl).toMatch(/\/daily-coding-challenge\/day\/06-22$/);
+  });
+
+  it('also accepts a bare "MM-DD" date prop, unchanged', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: vi.fn().mockResolvedValue(mockDailyChallenge)
+    } as unknown as Response);
+
+    render(<ShowDailyCodingChallenge date='06-22' />);
+
+    expect(await screen.findByText('classic challenge')).toBeInTheDocument();
+
+    const requestedUrl = fetchSpy.mock.calls[0]?.[0] as string;
+    expect(requestedUrl).toMatch(/\/daily-coding-challenge\/day\/06-22$/);
+  });
+
   it('formats valid API data before rendering the daily challenge', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       json: vi.fn().mockResolvedValue(mockDailyChallenge)

--- a/client/src/client-only-routes/show-daily-coding-challenge.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.tsx
@@ -9,7 +9,10 @@ import {
 } from '../redux/prop-types';
 import DailyCodingChallengeNotFound from '../components/daily-coding-challenge/not-found';
 import { apiLocation } from '../../config/env.json';
-import { isValidDateString } from '../components/daily-coding-challenge/helpers';
+import {
+  isValidDateOrMonthDayString,
+  toMonthDay
+} from '../components/daily-coding-challenge/helpers';
 import {
   validateDailyCodingChallengeSchema,
   type DailyCodingChallengeFromDb
@@ -151,8 +154,9 @@ function ShowDailyCodingChallenge({ date }: { date: string }): JSX.Element {
 
   const fetchChallenge = async (date: string) => {
     try {
+      const monthDay = toMonthDay(date);
       const response = await fetch(
-        `${apiLocation}/daily-coding-challenge/date/${date}`
+        `${apiLocation}/daily-coding-challenge/day/${monthDay}`
       );
       const challengeData = await response.json();
 
@@ -186,7 +190,7 @@ function ShowDailyCodingChallenge({ date }: { date: string }): JSX.Element {
 
   useEffect(() => {
     // If date is invalid, stop loading/fetching and show the not found page
-    if (!date || !isValidDateString(date)) {
+    if (!date || !isValidDateOrMonthDayString(date)) {
       setIsLoading(false);
       setChallengeFound(false);
       return;

--- a/client/src/components/Map/index.test.tsx
+++ b/client/src/components/Map/index.test.tsx
@@ -12,7 +12,10 @@ import introTranslations from '../../../i18n/locales/english/intro.json';
 import i18nTestConfig from '../../../i18n/config-for-tests';
 import translations from '../../../i18n/locales/english/translations.json';
 import { showUpcomingChanges } from '../../../config/env.json';
-import { getTodayUsCentral } from '../daily-coding-challenge/helpers';
+import {
+  getTodayUsCentral,
+  toMonthDay
+} from '../daily-coding-challenge/helpers';
 import Map from './index';
 
 vi.unmock('react-i18next');
@@ -101,7 +104,7 @@ describe('Map', () => {
       })
     ).toHaveAttribute(
       'href',
-      `/learn/daily-coding-challenge/${getTodayUsCentral()}`
+      `/learn/daily-coding-challenge/${toMonthDay(getTodayUsCentral())}`
     );
     expect(
       screen.getByRole('link', {

--- a/client/src/components/Map/index.test.tsx
+++ b/client/src/components/Map/index.test.tsx
@@ -12,10 +12,7 @@ import introTranslations from '../../../i18n/locales/english/intro.json';
 import i18nTestConfig from '../../../i18n/config-for-tests';
 import translations from '../../../i18n/locales/english/translations.json';
 import { showUpcomingChanges } from '../../../config/env.json';
-import {
-  getTodayUsCentral,
-  toMonthDay
-} from '../daily-coding-challenge/helpers';
+import { getMonthDayUsCentral } from '../daily-coding-challenge/helpers';
 import Map from './index';
 
 vi.unmock('react-i18next');
@@ -104,7 +101,7 @@ describe('Map', () => {
       })
     ).toHaveAttribute(
       'href',
-      `/learn/daily-coding-challenge/${toMonthDay(getTodayUsCentral())}`
+      `/learn/daily-coding-challenge/${getMonthDayUsCentral()}`
     );
     expect(
       screen.getByRole('link', {

--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -5,7 +5,7 @@ import GreenPass from '../../assets/icons/green-pass';
 import GreenNotCompleted from '../../assets/icons/green-not-completed';
 import JavaScriptIcon from '../../assets/icons/javascript';
 import PythonIcon from '../../assets/icons/python';
-import { formatDisplayDate, truncate } from './helpers';
+import { formatDisplayDate, toMonthDay, truncate } from './helpers';
 
 interface CalendarDayProps {
   dayNumber: number;
@@ -64,7 +64,7 @@ function DailyCodingChallengeCalendarDay({
   // isAvailable -> render link to challenge
   return (
     <Link
-      to={`/learn/daily-coding-challenge/${date}`}
+      to={`/learn/daily-coding-challenge/${date && toMonthDay(date)}`}
       className='calendar-day available'
       data-playwright-test-label='calendar-day'
       aria-label={`${date && formatDisplayDate(date)}`}

--- a/client/src/components/daily-coding-challenge/calendar-day.tsx
+++ b/client/src/components/daily-coding-challenge/calendar-day.tsx
@@ -9,7 +9,7 @@ import { formatDisplayDate, toMonthDay, truncate } from './helpers';
 
 interface CalendarDayProps {
   dayNumber: number;
-  date?: string;
+  date: string;
   challengeNumber?: number;
   completedLanguages?: string[];
   isAvailable?: boolean;
@@ -44,16 +44,13 @@ function DailyCodingChallengeCalendarDay({
   const { t } = useTranslation();
   const completed = completedLanguages.length > 0;
 
-  // dayNumber = 0 -> render nothing
-  if (dayNumber === 0) return <div></div>;
-
   if (!isAvailable)
     return (
       <button
         disabled
         className='calendar-day not-available'
         data-playwright-test-label='calendar-day'
-        aria-label={`${date && formatDisplayDate(date)}, (${t('aria.not-available')})`}
+        aria-label={`${formatDisplayDate(date)}, (${t('aria.not-available')})`}
       >
         <span className='calendar-day-number' aria-hidden='true'>
           {dayNumber}
@@ -64,10 +61,10 @@ function DailyCodingChallengeCalendarDay({
   // isAvailable -> render link to challenge
   return (
     <Link
-      to={`/learn/daily-coding-challenge/${date && toMonthDay(date)}`}
+      to={`/learn/daily-coding-challenge/${toMonthDay(date)}`}
       className='calendar-day available'
       data-playwright-test-label='calendar-day'
-      aria-label={`${date && formatDisplayDate(date)}`}
+      aria-label={formatDisplayDate(date)}
     >
       <span className='calendar-day-number' aria-hidden='true'>
         {dayNumber}

--- a/client/src/components/daily-coding-challenge/calendar.css
+++ b/client/src/components/daily-coding-challenge/calendar.css
@@ -1,12 +1,3 @@
-.calendar-weekday-labels {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  text-align: center;
-  margin: 0 auto;
-  max-width: 1500px;
-  padding: 0 20px;
-}
-
 .calendar-head {
   display: flex;
   justify-content: center;

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -141,7 +141,6 @@ function DailyCodingChallengeCalendar({
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
-  const [monthInfo, setMonthInfo] = useState<MonthInfo | null>(null);
   const [monthOffset, setMonthOffset] = useState(0);
   const [dailyChallengesMap, setDailyChallengesMap] = useState(
     () => new Map<string, DailyChallengeMap>()
@@ -170,18 +169,6 @@ function DailyCodingChallengeCalendar({
         });
 
         setDailyChallengesMap(newDailyChallengesMap);
-
-        // After getting the challenges and creating the map, set the initial month info -
-        // Display the month of the current US Central day because challenges are released
-        // at midnight US Central - so don't show the local month, show the US Central month
-        const [year, month] = todayUsCentral.split('-').map(Number);
-        const initialMonthInfo = getMonthInfo(
-          year,
-          month - 1, // Convert to 0-indexed month
-          newDailyChallengesMap
-        );
-
-        setMonthInfo(initialMonthInfo);
       } else {
         setError(true);
       }
@@ -198,27 +185,10 @@ function DailyCodingChallengeCalendar({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // we just need to change the month, the year can stay the same
-  // because it just rolls over, e.g. (index) 12, 2024 will be Jan, 2025
-  const nextMonth = () => {
-    if (lastDailyChallengeReleased) {
-      setMonthOffset(offset => Math.min(0, offset + 1));
-    } else {
-      setMonthInfo(
-        m => m && getMonthInfo(m.year, m.index + 1, dailyChallengesMap)
-      );
-    }
-  };
-
-  const prevMonth = () => {
-    if (lastDailyChallengeReleased) {
-      setMonthOffset(offset => Math.max(minMonthOffset, offset - 1));
-    } else {
-      setMonthInfo(
-        m => m && getMonthInfo(m.year, m.index - 1, dailyChallengesMap)
-      );
-    }
-  };
+  // The prev/next buttons are disabled outside the valid range, so these
+  // don't need to clamp the offset themselves
+  const nextMonth = () => setMonthOffset(offset => offset + 1);
+  const prevMonth = () => setMonthOffset(offset => offset - 1);
 
   const hasOlderChallenges = (
     map: DailyChallengesMap,
@@ -251,33 +221,26 @@ function DailyCodingChallengeCalendar({
   const isBoundaryMonth = minMonthOffset === -12 && monthOffset === -12;
 
   // After the last challenge is released, the current month only shows
-  // challenges through today
-  const evergreenMonthInfo = getMonthInfo(
+  // challenges through today, and the boundary month only shows the days
+  // still hidden in the current month
+  const displayedMonthInfo = getMonthInfo(
     todayYear,
     todayMonth - 1 + monthOffset,
     dailyChallengesMap,
-    monthOffset === 0 ? todayDay : undefined,
-    isBoundaryMonth ? todayDay : undefined
+    lastDailyChallengeReleased && monthOffset === 0 ? todayDay : undefined,
+    lastDailyChallengeReleased && isBoundaryMonth ? todayDay : undefined
   );
-
-  const displayedMonthInfo = lastDailyChallengeReleased
-    ? evergreenMonthInfo
-    : monthInfo;
 
   const showPrevButton = lastDailyChallengeReleased
     ? monthOffset > minMonthOffset
-    : monthInfo
-      ? hasOlderChallenges(dailyChallengesMap, monthInfo)
-      : false;
+    : hasOlderChallenges(dailyChallengesMap, displayedMonthInfo);
 
   const showNextButton = lastDailyChallengeReleased
     ? monthOffset < 0
-    : monthInfo
-      ? hasNewerChallenges(dailyChallengesMap, monthInfo)
-      : false;
+    : hasNewerChallenges(dailyChallengesMap, displayedMonthInfo);
 
   if (isLoading) return <Loader />;
-  if (error || !displayedMonthInfo) return <DailyCodingChallengeNotFound />;
+  if (error) return <DailyCodingChallengeNotFound />;
 
   return (
     <>

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -14,7 +14,12 @@ import { Loader } from '../helpers';
 import envData from '../../../config/env.json';
 import Login from '../Header/components/login';
 import CalendarDay from './calendar-day';
-import { getTodayUsCentral, formatDate } from './helpers';
+import {
+  getTodayUsCentral,
+  toMonthDay,
+  formatDate,
+  lastDailyChallengeIsReleased
+} from './helpers';
 
 import './calendar.css';
 import DailyCodingChallengeNotFound from './not-found';
@@ -60,11 +65,12 @@ interface MonthInfo {
 const getMonthInfo = (
   year: number,
   monthIndex: number,
-  dailyChallengesMap: DailyChallengesMap
+  dailyChallengesMap: DailyChallengesMap,
+  hideDaysAfter?: number,
+  hideDaysThrough?: number
 ) => {
   // Create date for first of the month (handles rollover automatically)
   const firstOfMonth = new Date(Date.UTC(year, monthIndex, 1));
-  const firstOfMonthWeekdayIndex = firstOfMonth.getUTCDay();
   const utcYear = firstOfMonth.getUTCFullYear();
   const utcMonthIndex = firstOfMonth.getUTCMonth();
 
@@ -75,11 +81,6 @@ const getMonthInfo = (
 
   const days: JSX.Element[] = [];
 
-  // push empty days to before the 1st of the month
-  for (let i = 0; i < firstOfMonthWeekdayIndex; i++) {
-    days.push(<CalendarDay key={`empty-${i}`} dayNumber={0} />);
-  }
-
   for (let day = 1; day <= numberOfDays; day++) {
     const formattedDate = formatDate({
       month: utcMonthIndex + 1, // Convert back to 1-indexed
@@ -87,10 +88,13 @@ const getMonthInfo = (
       year: utcYear
     });
 
-    const challengeData = dailyChallengesMap.get(formattedDate);
+    const challengeData = dailyChallengesMap.get(toMonthDay(formattedDate));
     const completedLanguages = challengeData?.completedLanguages || [];
     const title = challengeData?.title || '';
-    const isAvailable = challengeData !== undefined;
+    const isAvailable =
+      challengeData !== undefined &&
+      (hideDaysAfter === undefined || day <= hideDaysAfter) &&
+      (hideDaysThrough === undefined || day > hideDaysThrough);
     const challengeNumber = challengeData?.challengeNumber;
 
     days.push(
@@ -124,10 +128,21 @@ function DailyCodingChallengeCalendar({
   const { t } = useTranslation();
 
   const todayUsCentral = getTodayUsCentral();
+  const lastDailyChallengeReleased = lastDailyChallengeIsReleased();
+
+  const [todayYear, todayMonth, todayDay] = todayUsCentral
+    .split('-')
+    .map(Number);
+
+  const daysInCurrentMonth = new Date(
+    Date.UTC(todayYear, todayMonth, 0)
+  ).getUTCDate();
+  const minMonthOffset = todayDay === daysInCurrentMonth ? -11 : -12;
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
   const [monthInfo, setMonthInfo] = useState<MonthInfo | null>(null);
+  const [monthOffset, setMonthOffset] = useState(0);
   const [dailyChallengesMap, setDailyChallengesMap] = useState(
     () => new Map<string, DailyChallengeMap>()
   );
@@ -145,7 +160,7 @@ function DailyCodingChallengeCalendar({
         challenges.forEach(c => {
           const date = c.date.split('T')[0];
 
-          newDailyChallengesMap.set(date, {
+          newDailyChallengesMap.set(toMonthDay(date), {
             ...c,
             date,
             completedLanguages:
@@ -186,23 +201,31 @@ function DailyCodingChallengeCalendar({
   // we just need to change the month, the year can stay the same
   // because it just rolls over, e.g. (index) 12, 2024 will be Jan, 2025
   const nextMonth = () => {
-    setMonthInfo(
-      m => m && getMonthInfo(m.year, m.index + 1, dailyChallengesMap)
-    );
+    if (lastDailyChallengeReleased) {
+      setMonthOffset(offset => Math.min(0, offset + 1));
+    } else {
+      setMonthInfo(
+        m => m && getMonthInfo(m.year, m.index + 1, dailyChallengesMap)
+      );
+    }
   };
 
   const prevMonth = () => {
-    setMonthInfo(
-      m => m && getMonthInfo(m.year, m.index - 1, dailyChallengesMap)
-    );
+    if (lastDailyChallengeReleased) {
+      setMonthOffset(offset => Math.max(minMonthOffset, offset - 1));
+    } else {
+      setMonthInfo(
+        m => m && getMonthInfo(m.year, m.index - 1, dailyChallengesMap)
+      );
+    }
   };
 
   const hasOlderChallenges = (
     map: DailyChallengesMap,
     monthInfo: MonthInfo
   ): boolean => {
-    return Array.from(map.keys()).some(dateStr => {
-      const [year, month] = dateStr.split('-').map(Number);
+    return Array.from(map.values()).some(({ date }) => {
+      const [year, month] = date.split('-').map(Number);
       return (
         year < monthInfo.year ||
         (year === monthInfo.year && month - 1 < monthInfo.index)
@@ -214,8 +237,8 @@ function DailyCodingChallengeCalendar({
     map: DailyChallengesMap,
     monthInfo: MonthInfo
   ): boolean => {
-    return Array.from(map.keys()).some(dateStr => {
-      const [year, month] = dateStr.split('-').map(Number);
+    return Array.from(map.values()).some(({ date }) => {
+      const [year, month] = date.split('-').map(Number);
       return (
         year > monthInfo.year ||
         (year === monthInfo.year && month - 1 > monthInfo.index)
@@ -223,16 +246,38 @@ function DailyCodingChallengeCalendar({
     });
   };
 
-  const showPrevButton = monthInfo
-    ? hasOlderChallenges(dailyChallengesMap, monthInfo)
-    : false;
+  // The boundary month (the furthest back you can go) only shows the days
+  // still hidden in the current month - the rest is already visible there
+  const isBoundaryMonth = minMonthOffset === -12 && monthOffset === -12;
 
-  const showNextButton = monthInfo
-    ? hasNewerChallenges(dailyChallengesMap, monthInfo)
-    : false;
+  // After the last challenge is released, the current month only shows
+  // challenges through today
+  const evergreenMonthInfo = getMonthInfo(
+    todayYear,
+    todayMonth - 1 + monthOffset,
+    dailyChallengesMap,
+    monthOffset === 0 ? todayDay : undefined,
+    isBoundaryMonth ? todayDay : undefined
+  );
+
+  const displayedMonthInfo = lastDailyChallengeReleased
+    ? evergreenMonthInfo
+    : monthInfo;
+
+  const showPrevButton = lastDailyChallengeReleased
+    ? monthOffset > minMonthOffset
+    : monthInfo
+      ? hasOlderChallenges(dailyChallengesMap, monthInfo)
+      : false;
+
+  const showNextButton = lastDailyChallengeReleased
+    ? monthOffset < 0
+    : monthInfo
+      ? hasNewerChallenges(dailyChallengesMap, monthInfo)
+      : false;
 
   if (isLoading) return <Loader />;
-  if (error || !monthInfo) return <DailyCodingChallengeNotFound />;
+  if (error || !displayedMonthInfo) return <DailyCodingChallengeNotFound />;
 
   return (
     <>
@@ -245,7 +290,7 @@ function DailyCodingChallengeCalendar({
 
             <Button
               block={true}
-              href={`/learn/daily-coding-challenge/${todayUsCentral}`}
+              href={`/learn/daily-coding-challenge/${toMonthDay(todayUsCentral)}`}
             >
               {t('buttons.go-to-dcc-today')}
             </Button>
@@ -264,9 +309,7 @@ function DailyCodingChallengeCalendar({
           &lt;
         </Button>
 
-        <h2 className='text-center'>
-          {monthInfo.name} {monthInfo.year}
-        </h2>
+        <h2 className='text-center'>{displayedMonthInfo.name}</h2>
         <Button
           aria-label={t('aria.next-month')}
           disabled={!showNextButton}
@@ -277,33 +320,7 @@ function DailyCodingChallengeCalendar({
       </div>
 
       <Spacer size='m' />
-
-      <div className='calendar-weekday-labels'>
-        <div aria-label={t('weekdays.long.sunday')}>
-          {t('weekdays.short.sunday')}
-        </div>
-        <div aria-label={t('weekdays.long.monday')}>
-          {t('weekdays.short.monday')}
-        </div>
-        <div aria-label={t('weekdays.long.tuesday')}>
-          {t('weekdays.short.tuesday')}
-        </div>
-        <div aria-label={t('weekdays.long.wednesday')}>
-          {t('weekdays.short.wednesday')}
-        </div>
-        <div aria-label={t('weekdays.long.thursday')}>
-          {t('weekdays.short.thursday')}
-        </div>
-        <div aria-label={t('weekdays.long.friday')}>
-          {t('weekdays.short.friday')}
-        </div>
-        <div aria-label={t('weekdays.long.saturday')}>
-          {t('weekdays.short.saturday')}
-        </div>
-      </div>
-
-      <Spacer size='s' />
-      <div className='calendar-grid'>{monthInfo.days}</div>
+      <div className='calendar-grid'>{displayedMonthInfo.days}</div>
       <Spacer size='l' />
 
       {!isSignedIn && (

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -185,8 +185,6 @@ function DailyCodingChallengeCalendar({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // The prev/next buttons are disabled outside the valid range, so these
-  // don't need to clamp the offset themselves
   const nextMonth = () => setMonthOffset(offset => offset + 1);
   const prevMonth = () => setMonthOffset(offset => offset - 1);
 
@@ -216,13 +214,10 @@ function DailyCodingChallengeCalendar({
     });
   };
 
-  // The boundary month (the furthest back you can go) only shows the days
-  // still hidden in the current month - the rest is already visible there
+  // The furthest month back you can go only shows the days hidden in the current month
   const isBoundaryMonth = minMonthOffset === -12 && monthOffset === -12;
 
-  // After the last challenge is released, the current month only shows
-  // challenges through today, and the boundary month only shows the days
-  // still hidden in the current month
+  // The current month only shows challenges through today
   const displayedMonthInfo = getMonthInfo(
     todayYear,
     todayMonth - 1 + monthOffset,

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -62,6 +62,12 @@ interface MonthInfo {
   year: number;
 }
 
+// Cap Feb to 28 days regardless of which "year" is displayed
+const getDaysInMonth = (year: number, monthIndex: number): number => {
+  const realDays = new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+  return monthIndex === 1 ? 28 : realDays;
+};
+
 const getMonthInfo = (
   year: number,
   monthIndex: number,
@@ -73,11 +79,7 @@ const getMonthInfo = (
   const firstOfMonth = new Date(Date.UTC(year, monthIndex, 1));
   const utcYear = firstOfMonth.getUTCFullYear();
   const utcMonthIndex = firstOfMonth.getUTCMonth();
-
-  // Get number of days in the month (day 0 of next month = last day of current month)
-  const numberOfDays = new Date(
-    Date.UTC(utcYear, utcMonthIndex + 1, 0)
-  ).getUTCDate();
+  const numberOfDays = getDaysInMonth(utcYear, utcMonthIndex);
 
   const days: JSX.Element[] = [];
 
@@ -134,10 +136,8 @@ function DailyCodingChallengeCalendar({
     .split('-')
     .map(Number);
 
-  const daysInCurrentMonth = new Date(
-    Date.UTC(todayYear, todayMonth, 0)
-  ).getUTCDate();
-  const minMonthOffset = todayDay === daysInCurrentMonth ? -11 : -12;
+  const daysInCurrentMonth = getDaysInMonth(todayYear, todayMonth - 1);
+  const minMonthOffset = todayDay >= daysInCurrentMonth ? -11 : -12;
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -214,11 +214,11 @@ function DailyCodingChallengeCalendar({
     });
   };
 
-  // The furthest month back you can go only shows the days hidden in the current month
+  // The furthest month back only shows challenges after today
   const isBoundaryMonth = minMonthOffset === -12 && monthOffset === -12;
 
   // The current month only shows challenges through today
-  const displayedMonthInfo = getMonthInfo(
+  const monthInfo = getMonthInfo(
     todayYear,
     todayMonth - 1 + monthOffset,
     dailyChallengesMap,
@@ -228,11 +228,11 @@ function DailyCodingChallengeCalendar({
 
   const showPrevButton = lastDailyChallengeReleased
     ? monthOffset > minMonthOffset
-    : hasOlderChallenges(dailyChallengesMap, displayedMonthInfo);
+    : hasOlderChallenges(dailyChallengesMap, monthInfo);
 
   const showNextButton = lastDailyChallengeReleased
     ? monthOffset < 0
-    : hasNewerChallenges(dailyChallengesMap, displayedMonthInfo);
+    : hasNewerChallenges(dailyChallengesMap, monthInfo);
 
   if (isLoading) return <Loader />;
   if (error) return <DailyCodingChallengeNotFound />;
@@ -267,7 +267,7 @@ function DailyCodingChallengeCalendar({
           &lt;
         </Button>
 
-        <h2 className='text-center'>{displayedMonthInfo.name}</h2>
+        <h2 className='text-center'>{monthInfo.name}</h2>
         <Button
           aria-label={t('aria.next-month')}
           disabled={!showNextButton}
@@ -278,7 +278,7 @@ function DailyCodingChallengeCalendar({
       </div>
 
       <Spacer size='m' />
-      <div className='calendar-grid'>{displayedMonthInfo.days}</div>
+      <div className='calendar-grid'>{monthInfo.days}</div>
       <Spacer size='l' />
 
       {!isSignedIn && (

--- a/client/src/components/daily-coding-challenge/helpers.ts
+++ b/client/src/components/daily-coding-challenge/helpers.ts
@@ -59,6 +59,11 @@ export function toMonthDay(dateOrDayString: string) {
     : dateOrDayString;
 }
 
+// Get "MM-DD" today US Central
+export function getMonthDayUsCentral() {
+  return toMonthDay(getTodayUsCentral());
+}
+
 // Convert yyyy-MM-dd or MM-DD to display format (e.g: "January 1")
 export function formatDisplayDate(dateString: string) {
   const monthDay = toMonthDay(dateString);

--- a/client/src/components/daily-coding-challenge/helpers.ts
+++ b/client/src/components/daily-coding-challenge/helpers.ts
@@ -39,10 +39,9 @@ export function isValidMonthDayString(dayString: string) {
 
   const [month, day] = dayString.split('-').map(Number) as [number, number];
 
-  // Date.UTC silently rolls over values (e.g. month 13, or day
-  // 45) instead of rejecting them - this catches that.
   // 2000 is a leap year, so it keeps Feb 29 instead of rolling it over.
   const date = new Date(Date.UTC(2000, month - 1, day));
+  // Date.UTC silently rolls over out-of-range values - this catches that.
   return date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
 }
 

--- a/client/src/components/daily-coding-challenge/helpers.ts
+++ b/client/src/components/daily-coding-challenge/helpers.ts
@@ -18,6 +18,12 @@ export function getTodayUsCentral(dateObj: Date = new Date()) {
   return format(zonedDate, 'yyyy-MM-dd');
 }
 
+const LAST_DAY_OF_NEW_DAILY_CHALLENGES = '2026-08-10';
+
+export function lastDailyChallengeIsReleased() {
+  return getTodayUsCentral() > LAST_DAY_OF_NEW_DAILY_CHALLENGES;
+}
+
 // Validate that dateString is in the format yyyy-MM-dd
 // Leading zero's are accepted for single digit month/day
 export function isValidDateString(dateString: string) {
@@ -25,13 +31,44 @@ export function isValidDateString(dateString: string) {
   return isValid(parsedDate);
 }
 
-// Convert yyyy-MM-dd to display format (e.g: "January 1, 2025")
+// Check if string is valid "MM-DD"
+export function isValidMonthDayString(dayString: string) {
+  if (!/^\d{2}-\d{2}$/.test(dayString)) {
+    return false;
+  }
+
+  const [month, day] = dayString.split('-').map(Number) as [number, number];
+
+  // Date.UTC silently rolls over values (e.g. month 13, or day
+  // 45) instead of rejecting them - this catches that.
+  // 2000 is a leap year, so it keeps Feb 29 instead of rolling it over.
+  const date = new Date(Date.UTC(2000, month - 1, day));
+  return date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+// Validate is "yyyy-MM-dd" or "MM-DD"
+export function isValidDateOrMonthDayString(dateOrDayString: string) {
+  return (
+    isValidDateString(dateOrDayString) || isValidMonthDayString(dateOrDayString)
+  );
+}
+
+// Get "MM-DD" from "yyyy-MM-dd" or "MM-DD"
+export function toMonthDay(dateOrDayString: string) {
+  return isValidDateString(dateOrDayString)
+    ? dateOrDayString.slice(5)
+    : dateOrDayString;
+}
+
+// Convert yyyy-MM-dd or MM-DD to display format (e.g: "January 1")
 export function formatDisplayDate(dateString: string) {
-  const parsedDate = parse(dateString, 'yyyy-MM-dd', new Date());
+  const monthDay = toMonthDay(dateString);
+  // Reference year must be a leap year so "02-29" parses correctly
+  const parsedDate = parse(monthDay, 'MM-dd', new Date(Date.UTC(2000, 0, 1)));
   if (!isValid(parsedDate)) {
     return 'Invalid date';
   }
-  return format(parsedDate, 'MMMM d, yyyy');
+  return format(parsedDate, 'MMMM d');
 }
 
 export function truncate(str: string, maxLength = 35) {

--- a/client/src/components/daily-coding-challenge/helpers.ts
+++ b/client/src/components/daily-coding-challenge/helpers.ts
@@ -52,11 +52,12 @@ export function isValidDateOrMonthDayString(dateOrDayString: string) {
   );
 }
 
-// Get "MM-DD" from "yyyy-MM-dd" or "MM-DD"
+// Get "MM-DD" from "yyyy-MM-dd" or "MM-DD" + map Feb 29 to Feb 28
 export function toMonthDay(dateOrDayString: string) {
-  return isValidDateString(dateOrDayString)
+  const monthDay = isValidDateString(dateOrDayString)
     ? dateOrDayString.slice(5)
     : dateOrDayString;
+  return monthDay === '02-29' ? '02-28' : monthDay;
 }
 
 // Get "MM-DD" today US Central
@@ -67,8 +68,7 @@ export function getMonthDayUsCentral() {
 // Convert yyyy-MM-dd or MM-DD to display format (e.g: "January 1")
 export function formatDisplayDate(dateString: string) {
   const monthDay = toMonthDay(dateString);
-  // Reference year must be a leap year so "02-29" parses correctly
-  const parsedDate = parse(monthDay, 'MM-dd', new Date(Date.UTC(2000, 0, 1)));
+  const parsedDate = parse(monthDay, 'MM-dd', new Date(2000, 0, 1));
   if (!isValid(parsedDate)) {
     return 'Invalid date';
   }

--- a/client/src/components/daily-coding-challenge/not-found.tsx
+++ b/client/src/components/daily-coding-challenge/not-found.tsx
@@ -5,7 +5,7 @@ import { Button, Container, Col, Row, Spacer } from '@freecodecamp/ui';
 import { randomQuote } from '../../utils/get-words';
 import { Link } from '../helpers';
 import notFoundLogo from '../../assets/images/freeCodeCamp-404.svg';
-import { getTodayUsCentral } from './helpers';
+import { toMonthDay, getTodayUsCentral } from './helpers';
 
 import './not-found.css';
 
@@ -41,7 +41,7 @@ function DailyCodingChallengeNotFound(): JSX.Element {
           <div className='button-wrapper'>
             <Button
               block={true}
-              href={`/learn/daily-coding-challenge/${getTodayUsCentral()}`}
+              href={`/learn/daily-coding-challenge/${toMonthDay(getTodayUsCentral())}`}
             >
               {t(`buttons.go-to-dcc-today`)}
             </Button>

--- a/client/src/components/daily-coding-challenge/not-found.tsx
+++ b/client/src/components/daily-coding-challenge/not-found.tsx
@@ -5,7 +5,7 @@ import { Button, Container, Col, Row, Spacer } from '@freecodecamp/ui';
 import { randomQuote } from '../../utils/get-words';
 import { Link } from '../helpers';
 import notFoundLogo from '../../assets/images/freeCodeCamp-404.svg';
-import { toMonthDay, getTodayUsCentral } from './helpers';
+import { getMonthDayUsCentral } from './helpers';
 
 import './not-found.css';
 
@@ -41,7 +41,7 @@ function DailyCodingChallengeNotFound(): JSX.Element {
           <div className='button-wrapper'>
             <Button
               block={true}
-              href={`/learn/daily-coding-challenge/${toMonthDay(getTodayUsCentral())}`}
+              href={`/learn/daily-coding-challenge/${getMonthDayUsCentral()}`}
             >
               {t(`buttons.go-to-dcc-today`)}
             </Button>

--- a/client/src/components/daily-coding-challenge/widget.tsx
+++ b/client/src/components/daily-coding-challenge/widget.tsx
@@ -6,7 +6,7 @@ import { ButtonLink } from '../helpers';
 import DailyCodingChallengeIcon from '../../assets/icons/daily-coding-challenge';
 import LinkButton from '../../assets/icons/link-button';
 import CalendarIcon from '../../assets/icons/calendar';
-import { getTodayUsCentral } from './helpers';
+import { toMonthDay, getTodayUsCentral } from './helpers';
 
 import './widget.css';
 
@@ -29,7 +29,7 @@ function DailyCodingChallengeWidget({
           block
           size='large'
           className='map-superblock-link'
-          href={`/learn/daily-coding-challenge/${getTodayUsCentral()}`}
+          href={`/learn/daily-coding-challenge/${toMonthDay(getTodayUsCentral())}`}
         >
           <div className='daily-coding-challenge-button'>
             <DailyCodingChallengeIcon className='map-icon' />

--- a/client/src/components/daily-coding-challenge/widget.tsx
+++ b/client/src/components/daily-coding-challenge/widget.tsx
@@ -6,7 +6,7 @@ import { ButtonLink } from '../helpers';
 import DailyCodingChallengeIcon from '../../assets/icons/daily-coding-challenge';
 import LinkButton from '../../assets/icons/link-button';
 import CalendarIcon from '../../assets/icons/calendar';
-import { toMonthDay, getTodayUsCentral } from './helpers';
+import { getMonthDayUsCentral } from './helpers';
 
 import './widget.css';
 
@@ -29,7 +29,7 @@ function DailyCodingChallengeWidget({
           block
           size='large'
           className='map-superblock-link'
-          href={`/learn/daily-coding-challenge/${toMonthDay(getTodayUsCentral())}`}
+          href={`/learn/daily-coding-challenge/${getMonthDayUsCentral()}`}
         >
           <div className='daily-coding-challenge-button'>
             <DailyCodingChallengeIcon className='map-icon' />

--- a/client/src/pages/learn/daily-coding-challenge/[...].test.tsx
+++ b/client/src/pages/learn/daily-coding-challenge/[...].test.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable filenames-simple/naming-convention */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import DailyCodingChallengeAll from './[...]';
+
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock('gatsby', () => ({
+  navigate: navigateMock,
+  withPrefix: (path: string) => path
+}));
+
+vi.mock('../../../client-only-routes/show-daily-coding-challenge', () => ({
+  default: ({ date }: { date: string }) => (
+    <div data-testid='challenge'>{date}</div>
+  )
+}));
+
+vi.mock('../../../components/redirect-daily-challenge-archive', () => ({
+  default: () => <div data-testid='archive-redirect' />
+}));
+
+describe('DailyCodingChallengeAll', () => {
+  afterEach(() => {
+    navigateMock.mockClear();
+  });
+
+  it('redirects to the archive for an invalid param', () => {
+    render(<DailyCodingChallengeAll params={{ '*': 'not-a-date' }} />);
+
+    expect(screen.getByTestId('archive-redirect')).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects a full "yyyy-MM-dd" date to its year-agnostic "MM-DD" form', () => {
+    render(<DailyCodingChallengeAll params={{ '*': '2027-07-01' }} />);
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/learn/daily-coding-challenge/07-01',
+      { replace: true }
+    );
+    expect(screen.queryByTestId('challenge')).not.toBeInTheDocument();
+  });
+
+  it('renders the challenge directly for an already year-agnostic "MM-DD" param', () => {
+    render(<DailyCodingChallengeAll params={{ '*': '07-01' }} />);
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('challenge')).toHaveTextContent('07-01');
+  });
+});

--- a/client/src/pages/learn/daily-coding-challenge/[...].test.tsx
+++ b/client/src/pages/learn/daily-coding-challenge/[...].test.tsx
@@ -5,10 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import DailyCodingChallengeAll from './[...]';
 
-const navigateMock = vi.hoisted(() => vi.fn());
-
 vi.mock('gatsby', () => ({
-  navigate: navigateMock,
   withPrefix: (path: string) => path
 }));
 
@@ -23,31 +20,34 @@ vi.mock('../../../components/redirect-daily-challenge-archive', () => ({
 }));
 
 describe('DailyCodingChallengeAll', () => {
+  const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
   afterEach(() => {
-    navigateMock.mockClear();
+    replaceStateSpy.mockClear();
   });
 
   it('redirects to the archive for an invalid param', () => {
     render(<DailyCodingChallengeAll params={{ '*': 'not-a-date' }} />);
 
     expect(screen.getByTestId('archive-redirect')).toBeInTheDocument();
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
   });
 
-  it('redirects a full "yyyy-MM-dd" date to its year-agnostic "MM-DD" form', () => {
+  it('swaps a full "yyyy-MM-dd" date to its year-agnostic "MM-DD" form in the address bar', () => {
     render(<DailyCodingChallengeAll params={{ '*': '2027-07-01' }} />);
 
-    expect(navigateMock).toHaveBeenCalledWith(
-      '/learn/daily-coding-challenge/07-01',
-      { replace: true }
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      '',
+      '/learn/daily-coding-challenge/07-01'
     );
-    expect(screen.queryByTestId('challenge')).not.toBeInTheDocument();
+    expect(screen.getByTestId('challenge')).toHaveTextContent('07-01');
   });
 
   it('renders the challenge directly for an already year-agnostic "MM-DD" param', () => {
     render(<DailyCodingChallengeAll params={{ '*': '07-01' }} />);
 
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
     expect(screen.getByTestId('challenge')).toHaveTextContent('07-01');
   });
 });

--- a/client/src/pages/learn/daily-coding-challenge/[...].tsx
+++ b/client/src/pages/learn/daily-coding-challenge/[...].tsx
@@ -1,9 +1,14 @@
 /* eslint-disable filenames-simple/naming-convention */
 import React from 'react';
+import { navigate, withPrefix } from 'gatsby';
 
 import ShowDailyCodingChallenge from '../../../client-only-routes/show-daily-coding-challenge';
 import RedirectToArchive from '../../../components/redirect-daily-challenge-archive';
-import { isValidDateString } from '../../../components/daily-coding-challenge/helpers';
+import {
+  isValidDateOrMonthDayString,
+  isValidDateString,
+  toMonthDay
+} from '../../../components/daily-coding-challenge/helpers';
 
 interface Props {
   params: {
@@ -11,12 +16,25 @@ interface Props {
   };
 }
 
-function DailyCodingChallengeAll(props: Props): JSX.Element {
-  if (!isValidDateString(props.params['*'])) {
+function DailyCodingChallengeAll(props: Props): JSX.Element | null {
+  const param = props.params['*'];
+
+  if (!isValidDateOrMonthDayString(param)) {
     return <RedirectToArchive />;
   }
 
-  return <ShowDailyCodingChallenge date={props.params['*']} />;
+  // Redirect "YYYY-MM-DD" params to their "MM-DD" equivalent
+  if (isValidDateString(param)) {
+    if (typeof window !== 'undefined') {
+      void navigate(
+        withPrefix(`/learn/daily-coding-challenge/${toMonthDay(param)}`),
+        { replace: true }
+      );
+    }
+    return null;
+  }
+
+  return <ShowDailyCodingChallenge date={param} />;
 }
 
 DailyCodingChallengeAll.displayName = 'DailyCodingChallengeAll';

--- a/client/src/pages/learn/daily-coding-challenge/[...].tsx
+++ b/client/src/pages/learn/daily-coding-challenge/[...].tsx
@@ -1,12 +1,11 @@
 /* eslint-disable filenames-simple/naming-convention */
-import React from 'react';
-import { navigate, withPrefix } from 'gatsby';
+import React, { useEffect } from 'react';
+import { withPrefix } from 'gatsby';
 
 import ShowDailyCodingChallenge from '../../../client-only-routes/show-daily-coding-challenge';
 import RedirectToArchive from '../../../components/redirect-daily-challenge-archive';
 import {
   isValidDateOrMonthDayString,
-  isValidDateString,
   toMonthDay
 } from '../../../components/daily-coding-challenge/helpers';
 
@@ -18,23 +17,25 @@ interface Props {
 
 function DailyCodingChallengeAll(props: Props): JSX.Element | null {
   const param = props.params['*'];
+  const isValid = isValidDateOrMonthDayString(param);
+  const monthDay = isValid ? toMonthDay(param) : param;
 
-  if (!isValidDateOrMonthDayString(param)) {
+  // Swap "YYYY-MM-DD" links to their "MM-DD" equivalent in the address bar
+  useEffect(() => {
+    if (isValid && monthDay !== param) {
+      window.history.replaceState(
+        null,
+        '',
+        withPrefix(`/learn/daily-coding-challenge/${monthDay}`)
+      );
+    }
+  }, [isValid, monthDay, param]);
+
+  if (!isValid) {
     return <RedirectToArchive />;
   }
 
-  // Redirect "YYYY-MM-DD" params to their "MM-DD" equivalent
-  if (isValidDateString(param)) {
-    if (typeof window !== 'undefined') {
-      void navigate(
-        withPrefix(`/learn/daily-coding-challenge/${toMonthDay(param)}`),
-        { replace: true }
-      );
-    }
-    return null;
-  }
-
-  return <ShowDailyCodingChallenge date={param} />;
+  return <ShowDailyCodingChallenge date={monthDay} />;
 }
 
 DailyCodingChallengeAll.displayName = 'DailyCodingChallengeAll';

--- a/client/src/pages/learn/daily-coding-challenge/archive.test.tsx
+++ b/client/src/pages/learn/daily-coding-challenge/archive.test.tsx
@@ -12,7 +12,8 @@ import {
 } from '../../../../utils/test-utils';
 import {
   formatDate,
-  getTodayUsCentral
+  getTodayUsCentral,
+  toMonthDay
 } from '../../../components/daily-coding-challenge/helpers';
 import Archive from './archive';
 
@@ -100,7 +101,7 @@ describe('<DailyCodingChallengeArchive />', () => {
       screen.getByRole('link', { name: 'buttons.go-to-dcc-today' })
     ).toHaveAttribute(
       'href',
-      `/learn/daily-coding-challenge/${todayUsCentral}`
+      `/learn/daily-coding-challenge/${toMonthDay(todayUsCentral)}`
     );
 
     await waitFor(() => {

--- a/client/src/templates/Challenges/components/daily-challenge-bread-crumb.test.tsx
+++ b/client/src/templates/Challenges/components/daily-challenge-bread-crumb.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import DailyChallengeBreadCrumb from './daily-challenge-bread-crumb';
+
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string) => key
+  }
+}));
+
+describe('<DailyChallengeBreadCrumb />', () => {
+  it('renders nothing when there is no param', () => {
+    const { container } = render(<DailyChallengeBreadCrumb />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for an invalid param', () => {
+    const { container } = render(
+      <DailyChallengeBreadCrumb dailyChallengeParam='not-a-date' />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a shape-valid but semantically invalid month-day', () => {
+    const { container } = render(
+      <DailyChallengeBreadCrumb dailyChallengeParam='13-45' />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows only the month and day for a full "yyyy-MM-dd" date, with no year', () => {
+    render(<DailyChallengeBreadCrumb dailyChallengeParam='2026-07-15' />);
+
+    expect(
+      screen.getByRole('navigation', { name: 'aria.breadcrumb-nav' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('July 15')).toBeInTheDocument();
+    expect(screen.queryByText('2026')).not.toBeInTheDocument();
+  });
+
+  it('shows only the month and day for a year-agnostic "MM-DD" param', () => {
+    render(<DailyChallengeBreadCrumb dailyChallengeParam='07-15' />);
+
+    expect(screen.getByText('July 15')).toBeInTheDocument();
+  });
+});

--- a/client/src/templates/Challenges/components/daily-challenge-bread-crumb.tsx
+++ b/client/src/templates/Challenges/components/daily-challenge-bread-crumb.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../../components/helpers/index';
 
 import './challenge-title.css';
 import {
-  isValidDateString,
+  isValidDateOrMonthDayString,
   formatDisplayDate
 } from '../../../components/daily-coding-challenge/helpers';
 
@@ -16,7 +16,8 @@ function DailyChallengeBreadCrumb({
 }): JSX.Element | null {
   const { t } = useTranslation();
 
-  return dailyChallengeParam && isValidDateString(dailyChallengeParam) ? (
+  return dailyChallengeParam &&
+    isValidDateOrMonthDayString(dailyChallengeParam) ? (
     <nav
       className='challenge-title-breadcrumbs'
       aria-label={t('aria.breadcrumb-nav')}

--- a/e2e/daily-coding-challenge.spec.ts
+++ b/e2e/daily-coding-challenge.spec.ts
@@ -4,7 +4,7 @@ import {
   formatDisplayDate
 } from '../client/src/components/daily-coding-challenge/helpers';
 
-const dateRouteRe = /.*\/daily-coding-challenge\/date\/.*/;
+const dateRouteRe = /.*\/daily-coding-challenge\/day\/.*/;
 
 const todayUsCentral = getTodayUsCentral();
 


### PR DESCRIPTION
~~This was much easier than I thought - it's a simple way to transition the daily challenges after august 10th (the last challenge date). It just adds a check for the date and displays/removes certain things so it all makes sense. For now, I'd like to go with something like this.~~

<details><summary><s>Screenshots</s></summary>

~~Production on left, this PR on right...~~

~~#### Landing:~~

<img width="1080" height="630" alt="Screenshot 2026-06-22 at 11 56 49 AM" src="https://github.com/user-attachments/assets/a386c462-5451-46f6-92c1-25c73b569618" />

~~#### /learn:~~

<img width="1080" height="630" alt="Screenshot 2026-06-22 at 11 57 06 AM" src="https://github.com/user-attachments/assets/9faa9806-28d9-4644-beb3-bd5f7eb87cbe" />

~~#### archive/calendar:~~
<img width="1395" height="956" alt="Screenshot 2026-06-22 at 11 58 20 AM" src="https://github.com/user-attachments/assets/8f62c929-5deb-4dca-a575-a8283723fd5a" />

~~#### 404:~~
<img width="1395" height="956" alt="Screenshot 2026-06-22 at 11 59 09 AM" src="https://github.com/user-attachments/assets/96d3fcdd-3a25-4915-a149-245b8f1d4106" />

</details>

~~In another part of this transition, we can do a more permanent solution, something like - change the challenge parser to allow JS and Py and in a single challenge file and combine the challenge files - or maybe change it to combine the existing challenge files into one (basically what the seed script does now) - then we can have the challenges created at build - and delete the endpoints and database collection, etc.~~

Okay, ignore all of the above. The new goal is to make everything year agnostic. So this adds a `/day/:day` endpoint to get challenges using MM-DD - it always returns a challenge for a valid MM-DD. It just gets whatever challenge was on that MM-DD originally. (Feb 29 gets Feb 28ths challenge) - one caveat: it doesn't return unreleased challenges - after aug 10 all challenges will be released and it will always return a challenge.

And changes in the client - the URL to get to a challenge can just be MM-DD - e.g: `/learn/daily-coding-challenge/07-20` - dates that include the year will get redirected to the MM-DD URL. The year was removed from the breadcrumb and the calendar. The weekday labels were also removed from the calendar - and it now just shows the first of the month at the top left so it's just a grid.

That all changes immediately. After aug 10 (the last day with a new challenge), the calendar will have a year window of challenges it displays. Todays challenge will still appear as the newest challenge and you will be able to scroll back through the calendar to tomorrows challenge. So exactly every challenge will be shown on the calendar.

Ask me if you want a demo.

Mobile todo:

- switch to using the /day/:day endpoint. /date/:date will not return challenges after august 10th.
- make client changes. Everything should be year agnostic. Just a generic "Month Day" challenge. 

Note: The returned challenges on all endpoints has not changed - it still include the original release date.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
