### PR TITLE
Update Bubble Sort implementation instructions

### DIFF
--- a/curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
+++ b/curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md
@@ -27,10 +27,11 @@ For this lab, you have been provided with all the HTML and CSS. You will use Jav
 1. You should have a function named `highlightCurrentEls` that takes an HTML element and a numeric index.
 1. The `highlightCurrentEls` function should set the `border` of the given element's child at the given index, and the child immediately after the index, to have a `dashed` style, a `red` color, and a width of your choice.
 1. When you click `#generate-btn` you should use the `fillArrContainer` function to fill `#starting-array` with five `span` elements, each with a random number as its text. If present, other elements should be removed from `#array-container`.
-1. You should implement the Bubble Sort algorithm so that after you click `#sort-btn`, `#array-container` contains a `div` element for each of the steps required by the Bubble Sort algorithm to sort the starting array, including the `div` representing the starting array and a `div` representing the sorted array. The functions you have created so far can be useful here.
+1. You should implement the Bubble Sort algorithm inside a function named `bubbleSort` so that after you click `#sort-btn` and execute it, `#array-container` contains a `div` element for each of the steps required by the Bubble Sort algorithm to sort the starting array, including the `div` representing the starting array and a `div` representing the sorted array. The functions you have created so far can be useful here.
 1. Each `div` should contain five `span` elements, representing the array in its current state of being sorted.
 1. After you click `#sort-btn`, `#starting-array` should represent the starting step with the initial array and the first two integers highlighted.
 1. For each sorting step, you should use `highlightCurrentEls` to highlight the two numbers that are being compared, and swap them in the next step by using `swapElements`.
+
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Note: Left blank intentionally per freeCodeCamp documentation policy. Instruction updates do not require a pre-existing issue track. -->

---

### Description
In the **Sorting Visualizer** lab, the user stories instruct campers to implement the bubble sort algorithm after clicking the `#sort-btn`. However, none of the stories explicitly specify that this sorting logic must be wrapped inside a function named exactly `bubbleSort()`. 

Despite this missing instruction, test #20 uses a regular expression that explicitly validates and asserts the presence of a `bubbleSort` function call inside the click event listener callback. Campers who implement a valid sorting routine using alternative architectures or unnamed closures face unexpected test failures.

### Changes Proposed
* Updated User Story #12 in `curriculum/challenges/english/blocks/lab-sorting-visualizer/6716249b5405164036fd0b0d.md` to explicitly state that the Bubble Sort algorithm must be implemented inside a function named `bubbleSort`.
* Fixed markdown list numbering format to use standard `1.` increments to preserve clean auto-generation.
