### PR TITLE
fix(curriculum): correct RegExp constructor typo

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5dc74176e4c496d09e6.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5dc74176e4c496d09e6.md
@@ -103,7 +103,7 @@ console.log(
 
 :::
 
-Remember that `Regex.prototype.test` only confirms whether a string matches the regular expression. Let's use our negative lookbehind with `String.prototype.match` to see how assertions affect that:
+Remember that `RegExp.prototype.test` only confirms whether a string matches the regular expression. Let's use our negative lookbehind with `String.prototype.match` to see how assertions affect that:
 
 ```js
 const regex = /(?<!free)code/i;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

### What is changed

Corrected `Regex.prototype.test` to `RegExp.prototype.test` in the Lookahead and Lookbehind Assertions lecture.

### Why

JavaScript exposes the regular expression constructor as `RegExp`; `Regex` is not a built-in JavaScript object. The typo made the lesson technically inaccurate.

### Validation

 I ran the documented challenge-scoped curriculum test locally:

```sh
CURRICULUM_LOCALE=english FCC_CHALLENGE_ID=6733c5dc74176e4c496d09e6 pnpm run test-curriculum-content
```

Result: 1 test file passed, 3 tests passed.

Closes #68156
