### PR TITLE
feat(client): warn before leaving unsaved projects

### DIFF
--- a/client/src/templates/Challenges/classic/exit-project-modal.test.tsx
+++ b/client/src/templates/Challenges/classic/exit-project-modal.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ExitProjectModal } from './exit-project-modal';
+
+describe('<ExitProjectModal />', () => {
+  beforeAll(() => {
+    type ResizeObserverMockInstance = {
+      observe: ResizeObserver['observe'];
+      unobserve: ResizeObserver['unobserve'];
+      disconnect: ResizeObserver['disconnect'];
+    };
+    Object.defineProperty(window, 'ResizeObserver', {
+      writable: true,
+      value: vi.fn(function (this: ResizeObserverMockInstance) {
+        this.observe = vi.fn();
+        this.unobserve = vi.fn();
+        this.disconnect = vi.fn();
+      })
+    });
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <ExitProjectModal isOpen={false} onClose={vi.fn()} onExit={vi.fn()} />
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('lets the camper cancel or confirm navigation', () => {
+    const onClose = vi.fn();
+    const onExit = vi.fn();
+    render(
+      <ExitProjectModal isOpen={true} onClose={onClose} onExit={onExit} />
+    );
+
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'misc.navigation-warning'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'buttons.cancel' }));
+    expect(onClose).toHaveBeenCalledOnce();
+
+    const exitButtons = screen.getAllByRole('button', {
+      name: 'buttons.exit'
+    });
+    fireEvent.click(exitButtons[exitButtons.length - 1]);
+    expect(onExit).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/templates/Challenges/classic/exit-project-modal.tsx
+++ b/client/src/templates/Challenges/classic/exit-project-modal.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, Modal, Spacer } from '@freecodecamp/ui';
+
+interface ExitProjectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExit: () => void;
+}
+
+export const ExitProjectModal = ({
+  isOpen,
+  onClose,
+  onExit
+}: ExitProjectModalProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal onClose={onClose} open={isOpen} variant='danger'>
+      <Modal.Header closeButtonClassNames='close'>
+        {t('buttons.exit')}
+      </Modal.Header>
+      <Modal.Body alignment='center'>{t('misc.navigation-warning')}</Modal.Body>
+      <Modal.Footer>
+        <Button block variant='primary' onClick={onClose}>
+          {t('buttons.cancel')}
+        </Button>
+        <Spacer size='xxs' />
+        <Button block variant='danger' onClick={onExit}>
+          {t('buttons.exit')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+ExitProjectModal.displayName = 'ExitProjectModal';

--- a/client/src/templates/Challenges/classic/saved-challenges.test.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.test.ts
@@ -3,7 +3,10 @@ import type {
   ChallengeFile,
   SavedChallengeFile
 } from '../../../redux/prop-types';
-import { mergeChallengeFiles } from './saved-challenges';
+import {
+  hasUnsavedChallengeFiles,
+  mergeChallengeFiles
+} from './saved-challenges';
 
 const jsChallenge = {
   contents: 'js contents',
@@ -55,6 +58,34 @@ const savedHtmlChallenge: SavedChallengeFile = {
   name: 'name',
   ext: 'html' as const
 };
+
+describe('hasUnsavedChallengeFiles', () => {
+  it('returns false when no challenge files have changed', () => {
+    expect(
+      hasUnsavedChallengeFiles([
+        { ...jsChallenge, contents: 'saved', seed: 'saved' }
+      ])
+    ).toBe(false);
+  });
+
+  it('returns true when a challenge file has changed', () => {
+    expect(
+      hasUnsavedChallengeFiles([
+        { ...jsChallenge, contents: 'changed', seed: 'saved' }
+      ])
+    ).toBe(true);
+  });
+
+  it('ignores files without an initialized seed', () => {
+    expect(
+      hasUnsavedChallengeFiles([{ ...jsChallenge, seed: undefined }])
+    ).toBe(false);
+  });
+
+  it('returns false when challenge files are unavailable', () => {
+    expect(hasUnsavedChallengeFiles(null)).toBe(false);
+  });
+});
 
 describe('mergeChallengeFiles', () => {
   it('should return files if savedChallengeFiles is undefined', () => {

--- a/client/src/templates/Challenges/classic/saved-challenges.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.ts
@@ -1,4 +1,15 @@
-import { ChallengeFile, SavedChallengeFile } from '../../../redux/prop-types';
+import type {
+  ChallengeFile,
+  ChallengeFiles,
+  SavedChallengeFile
+} from '../../../redux/prop-types';
+
+export const hasUnsavedChallengeFiles = (
+  challengeFiles: ChallengeFiles
+): boolean =>
+  challengeFiles?.some(
+    ({ contents, seed }) => typeof seed === 'string' && contents !== seed
+  ) ?? false;
 
 export function mergeChallengeFiles(
   files?: ChallengeFile[] | null,

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -1,5 +1,5 @@
-import { graphql } from 'gatsby';
-import React, { useState, useEffect, useRef } from 'react';
+import { graphql, navigate } from 'gatsby';
+import React, { useCallback, useState, useEffect, useRef } from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -43,6 +43,7 @@ import Preview, { type PreviewProps } from '../components/preview';
 import ProjectPreviewModal from '../components/project-preview-modal';
 import SidePanel from '../components/side-panel';
 import VideoModal from '../components/video-modal';
+import { usePageLeave } from '../hooks';
 import {
   cancelTests,
   challengeMounted,
@@ -74,7 +75,11 @@ import { XtermTerminal } from './xterm';
 import MultifileEditor from './multifile-editor';
 import DesktopLayout from './desktop-layout';
 import MobileLayout from './mobile-layout';
-import { mergeChallengeFiles } from './saved-challenges';
+import { ExitProjectModal } from './exit-project-modal';
+import {
+  hasUnsavedChallengeFiles,
+  mergeChallengeFiles
+} from './saved-challenges';
 
 import './classic.css';
 import '../components/test-frame.css';
@@ -244,6 +249,41 @@ function ShowClassic({
   const isMobile = useMediaQuery({
     query: `(max-width: ${MAX_MOBILE_WIDTH}px)`
   });
+  const [isExitProjectModalOpen, setIsExitProjectModalOpen] = useState(false);
+  const [exitPathname, setExitPathname] = useState('');
+  const exitConfirmed = useRef(false);
+
+  const hasUnsavedChanges =
+    !!saveSubmissionToDB && hasUnsavedChallengeFiles(challengeFiles);
+
+  const onWindowClose = useCallback((event: BeforeUnloadEvent) => {
+    event.preventDefault();
+    event.returnValue = true;
+  }, []);
+
+  const onHistoryChange = useCallback((targetPathname: string): boolean => {
+    if (exitConfirmed.current) return false;
+
+    setExitPathname(targetPathname);
+    setIsExitProjectModalOpen(true);
+    return true;
+  }, []);
+
+  usePageLeave({
+    onWindowClose,
+    onHistoryChange,
+    enabled: hasUnsavedChanges
+  });
+
+  const handleExitProject = () => {
+    exitConfirmed.current = true;
+    setIsExitProjectModalOpen(false);
+    if (exitPathname) {
+      void navigate(exitPathname, { replace: true });
+    } else {
+      window.history.back();
+    }
+  };
 
   const guideUrl = getGuideUrl({ forumTopicId, title });
 
@@ -550,6 +590,13 @@ function ShowClassic({
         />
         <ShortcutsModal />
         <MobileAppModal superBlock={superBlock} />
+        {saveSubmissionToDB && (
+          <ExitProjectModal
+            isOpen={isExitProjectModalOpen}
+            onClose={() => setIsExitProjectModalOpen(false)}
+            onExit={handleExitProject}
+          />
+        )}
       </LearnLayout>
     </Hotkeys>
   );

--- a/client/src/templates/Challenges/hooks/use-page-leave.test.tsx
+++ b/client/src/templates/Challenges/hooks/use-page-leave.test.tsx
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { usePageLeave } from './use-page-leave';
+
+vi.mock('@gatsbyjs/reach-router', () => ({
+  useLocation: () => ({ pathname: '/learn/test-project' })
+}));
+
+describe('usePageLeave', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not register navigation handlers when disabled', () => {
+    const addWindowListener = vi.spyOn(window, 'addEventListener');
+    const pushState = vi.spyOn(window.history, 'pushState');
+
+    renderHook(() =>
+      usePageLeave({
+        enabled: false,
+        onWindowClose: vi.fn(),
+        onHistoryChange: vi.fn()
+      })
+    );
+
+    expect(addWindowListener).not.toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function)
+    );
+    expect(pushState).not.toHaveBeenCalled();
+  });
+
+  it('registers and removes navigation handlers when enabled', () => {
+    const addWindowListener = vi.spyOn(window, 'addEventListener');
+    const removeWindowListener = vi.spyOn(window, 'removeEventListener');
+    const pushState = vi.spyOn(window.history, 'pushState');
+    const onWindowClose = vi.fn();
+    const onHistoryChange = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      usePageLeave({ onWindowClose, onHistoryChange })
+    );
+
+    expect(addWindowListener).toHaveBeenCalledWith(
+      'beforeunload',
+      onWindowClose
+    );
+    expect(pushState).toHaveBeenCalledWith({}, '/learn/test-project');
+
+    unmount();
+
+    expect(removeWindowListener).toHaveBeenCalledWith(
+      'beforeunload',
+      onWindowClose
+    );
+  });
+});

--- a/client/src/templates/Challenges/hooks/use-page-leave.ts
+++ b/client/src/templates/Challenges/hooks/use-page-leave.ts
@@ -4,12 +4,19 @@ import { useLocation } from '@gatsbyjs/reach-router';
 interface Props {
   onWindowClose: (event: BeforeUnloadEvent) => void;
   onHistoryChange: (targetPathname: string) => boolean;
+  enabled?: boolean;
 }
 
-export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
+export const usePageLeave = ({
+  onWindowClose,
+  onHistoryChange,
+  enabled = true
+}: Props) => {
   const curLocation = useLocation();
 
   useEffect(() => {
+    if (!enabled) return;
+
     window.addEventListener('beforeunload', onWindowClose);
     // Push a dummy state so that navigating back will restore the current page,
     // allowing us to manually handle navigation.
@@ -45,5 +52,5 @@ export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
       window.removeEventListener('popstate', handlePopState);
       document.removeEventListener('click', handleLinkClick, true);
     };
-  }, [onWindowClose, onHistoryChange, curLocation]);
+  }, [onWindowClose, onHistoryChange, curLocation, enabled]);
 };


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

### What changed

- Detect unsaved certification-project files by comparing their current contents with the last saved baseline.
- Warn before internal navigation, browser-back navigation, refresh, or tab close only while changes are unsaved.
- Stop warning after a successful save resets the file baseline.
- Add a confirmation modal and focused tests for dirty-state detection, modal actions, and page-leave handler registration.

### Validation

- 14 focused Vitest tests pass.
- Full client TypeScript check passes.
- ESLint passes for all changed files.
- `git diff --check` passes.

Rendered browser QA could not run because the local Gatsby server fails during its existing `createPages` setup with a missing `allSuperBlockStructure` GraphQL field, before any page is served.

Closes #54796
