### PR TITLE
fix(curriculum): correct RegExp constructor name in regex lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5dc74176e4c496d09e6.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5dc74176e4c496d09e6.md
@@ -103,7 +103,7 @@ console.log(
 
 :::
 
-Remember that `Regex.prototype.test` only confirms whether a string matches the regular expression. Let's use our negative lookbehind with `String.prototype.match` to see how assertions affect that:
+Remember that `RegExp.prototype.test` only confirms whether a string matches the regular expression. Let's use our negative lookbehind with `String.prototype.match` to see how assertions affect that:
 
 ```js
 const regex = /(?<!free)code/i;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68156

This fixes a technical-accuracy typo in the **"What Are Lookahead and Lookbehind Assertions, and How Do They Work?"** lecture. `Regex` is not a JavaScript object; the regular expression constructor is `RegExp`.

- Changed `Regex.prototype.test` to `RegExp.prototype.test`.

This is a text-only change to the lecture content; no code or tests are affected. Verified locally with Prettier (`prettier --check`) — the file matches Prettier code style.