### PR TITLE
fix(curriculum): correct typos and punctuation in JavaScript review lecture

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -267,7 +267,7 @@ console.log(poem);
 
 :::
 
-- **Escaping Strings**: You can escape characters in a string by placing backlashes (`\`) in front of the quotes.
+- **Escaping Strings**: You can escape characters in a string by placing backslashes (`\`) in front of the quotes.
 
 :::interactive_editor
 
@@ -448,14 +448,14 @@ const answer = window.prompt("What's your favorite animal?"); // This will chang
 - **Addition Operator**: This operator (`+`) is used to calculate the sum of two or more numbers. 
 - **Subtraction Operator**: This operator (`-`) is used to calculate the difference between two numbers.
 - **Multiplication Operator**: This operator (`*`) is used to calculate the product of two or more numbers. 
-- **Division Operator**: This operator (`/`) is used to calculate the quotient between two numbers
+- **Division Operator**: This operator (`/`) is used to calculate the quotient between two numbers.
 - **Division By Zero**: If you try to divide by zero, JavaScript will return `Infinity`.
-- **Remainder Operator**: This operator(`%`) returns the remainder of a division. 
+- **Remainder Operator**: This operator (`%`) returns the remainder of a division. 
 - **Exponentiation Operator**: This operator (`**`) raises one number to the power of another.
 
 ## Calculations with Numbers and Strings 
 
-- **Explanation**: When you use the `+` operator with a number and a string, JavaScript will coerce the number into a string and concatenate the two values.  When you use the `-`, `*` or `/` operators with a string and number, JavaScript will coerce the string into a number and the result will be a number. For `null` and `undefined`, JavaScript treats `null` as 0 and undefined as `NaN` in mathematical operations.
+- **Explanation**: When you use the `+` operator with a number and a string, JavaScript will coerce the number into a string and concatenate the two values.  When you use the `-`, `*` or `/` operators with a string and number, JavaScript will coerce the string into a number and the result will be a number. For `null` and `undefined`, JavaScript treats `null` as 0 and `undefined` as `NaN` in mathematical operations.
 
 :::interactive_editor
 
@@ -1206,7 +1206,7 @@ console.log(person.hasOwnProperty("job")); // false
 
 :::
 
-- **`Object.hasOwn()` Method**: This is the modern, recommended way to check if an object has a property as its own (not inherited). The syntax is `Object.hasOwn(object, propertyName)`. It returns `true` if the property exists on the object and `false` if it does not — regardless of what value the property holds. This makes it safer than checking `if (obj.prop)` when values can be `0`, `false`, `null`, or `undefined`.
+- **`Object.hasOwn()` Method**: This is the modern, recommended way to check if an object has a property as its own (not inherited). The syntax is `Object.hasOwn(object, propertyName)`. It returns `true` if the property exists on the object and `false` if it does not, regardless of what value the property holds. This makes it safer than checking `if (obj.prop)` when values can be `0`, `false`, `null`, or `undefined`.
 
 :::interactive_editor
 
@@ -1862,7 +1862,7 @@ console.log(fruits); // ["Apple", "Banana", "Mango", "Orange"]
 
 :::
 
-If you need to sort numbers, then you will need to pass in a compare function. The `sort` method converts the elements to strings and then compares their sequences of UTF-16 code units values. UTF-16 code units are the numeric values that represent the characters in the string. Examples of UTF-16 code units are the numbers 65, 66, and 67 which represent the characters "A", "B", and "C" respectively. So the number 200 appears before the number 3 in an array, because the string "200" comes before the string "3" when comparing their UTF-16 code units.
+If you need to sort numbers, then you will need to pass in a compare function. The `sort` method converts the elements to strings and then compares their sequences of UTF-16 code unit values. UTF-16 code units are the numeric values that represent the characters in the string. Examples of UTF-16 code units are the numbers 65, 66, and 67 which represent the characters "A", "B", and "C" respectively. So the number 200 appears before the number 3 in an array, because the string "200" comes before the string "3" when comparing their UTF-16 code units.
 
 :::interactive_editor
 
@@ -2312,7 +2312,7 @@ const square = document.querySelector('#square');
 const animation = square.animate(
  [{ transform: 'translateX(0px)' }, { transform: 'translateX(100px)' }],
  {
-   duration: 2000, // makes animation lasts 2 seconds
+   duration: 2000, // makes the animation last 2 seconds
    iterations: Infinity, // loops indefinitely
    direction: 'alternate', // moves back and forth
    easing: 'ease-in-out', // smooth easing


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68163

Fixes the spelling, punctuation, and formatting issues listed in the issue, all within the JavaScript Review lecture:

1. `backlashes` → `backslashes` (Escaping Strings).
2. Added the missing terminal period to the Division Operator bullet, matching its siblings.
3. Added the missing space in `This operator(%)` → `This operator (%)` for the Remainder Operator.
4. Wrapped `undefined` in backticks to match `null` in the same sentence.
5. Replaced the em dash with a comma in the `Object.hasOwn()` description.
6. `UTF-16 code units values` → `UTF-16 code unit values`.
7. Corrected the code comment `// makes animation lasts 2 seconds` → `// makes the animation last 2 seconds`.

These are prose-only edits to a single challenge file with no change in meaning.