### PR TITLE
fix: add backticks to Iterator and replace dashes with colons

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
@@ -95,7 +95,7 @@ And our result:
 // freeCodeCamp is the best we love freeCodeCamp
 ```
 
-Good news! Our `replaceAll()` worked exactly as we wanted – it replaced all occurrences of the lowercased `freecodecamp` with the properly camelCased version.
+Good news! Our `replaceAll()` worked exactly as we wanted: it replaced all occurrences of the lowercased `freecodecamp` with the properly camelCased version.
 
 But what is that empty object? Well, `matchAll()` returns a special type of object called an `Iterator`, which the freeCodeCamp console isn't prepared to handle.
 
@@ -174,7 +174,7 @@ As long as it finds a match, it isn't `done`. Once it fails to find a match and 
 
 If your example is less so, like ours, you can skip that feature and extract all of the matches at once by converting it to an array. This is achieved by calling `Array.from()` and passing your iterator as the argument.
 
-Let's update our code to use that – we'll go ahead and clean up our `replaceAll` calls since we know that works:
+Let's update our code to use that: we'll go ahead and clean up our `replaceAll` calls since we know that works:
 
 ```js
 const regex = /freecodecamp/g;
@@ -307,7 +307,7 @@ By spreading the result into an array literal.
 
 ### --feedback--
 
-The lesson demonstrates a specific method to convert the Iterator to an array.
+The lesson demonstrates a specific method to convert the `Iterator` to an array.
 
 ## --video-solution--
 


### PR DESCRIPTION
Updated punctuation to replace en dashes with colons for improved sentence structure and wrapped Iterator in backticks for consistency in the "Working with Regular Expressions" lecture.

Checklist:

<!--Updated punctuation to replace en dashes with colons for improved sentence structure and wrapped Iterator in backticks for consistency in the "Working with Regular Expressions" lecture.. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.



Closes #68157
