### PR TITLE
fix(curriculum): allow all function syntaxes in leap year lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -37,7 +37,7 @@ assert.isFunction(isLeapYear);
 The `isLeapYear` function should take a number as an argument.
 
 ```js
-assert.match(isLeapYear.toString(), /\s*isLeapYear\(\s*\w+\s*\)/);
+assert.match(__helpers.removeJSComments(code), /(?:function\s+isLeapYear\s*\(\s*\w+\s*\)|isLeapYear\s*=\s*(?:function\s*\(\s*\w+\s*\)|\(?\s*\w+\s*\)?\s*=>))/);
 ```
 
 You should declare a variable `year` and assign it a value to check if it is a leap year.


### PR DESCRIPTION
## Overview
This pull request addresses and resolves **Issue #68193**.

In the Leap Year Calculator lab, test #2 was overly strict by expecting `isLeapYear.toString()` to match a specific regex `/\s*isLeapYear\(\s*\w+\s*\)/`. This failed for valid function expressions and arrow functions because their `.toString()` representation does not contain the function name.

## Changes Made
- Updated the regex assertion in `66c06fad3475cd92421b9ac2.md` to check `__helpers.removeJSComments(code)` instead.
- The new regex gracefully supports function declarations, function expressions, and arrow functions `(?:function\s+isLeapYear\s*\(\s*\w+\s*\)|isLeapYear\s*=\s*(?:function\s*\(\s*\w+\s*\)|\(?\s*\w+\s*\)?\s*=>))`.

## Validation
- [x] Tested the regex against standard `function()`, `const = () =>`, and `let = function()` definitions.
- [x] Verified functionality matches the expected behavior for the curriculum.

Thank you for reviewing this contribution!

---
*Authored by **Subbareddy Palagiri**.*