### PR TITLE
fix(client): render FaqItem as a React component

### DIFF
--- a/client/src/components/Donation/donation-text-components.tsx
+++ b/client/src/components/Donation/donation-text-components.tsx
@@ -74,25 +74,27 @@ const OtherWaysToSupport = (): JSX.Element => {
   );
 };
 
-const FaqItem = (
-  title: string,
-  text: JSX.Element,
-  key: number
-): JSX.Element => {
+type FaqItemProps = {
+  title: string;
+  text: JSX.Element;
+  index: number;
+};
+
+const FaqItem = ({ title, text, index }: FaqItemProps): JSX.Element => {
   const [isExpanded, setExpanded] = useState(false);
   return (
-    <div className={`faq-item ${isExpanded ? 'open' : ''}`} key={key}>
+    <div className={`faq-item ${isExpanded ? 'open' : ''}`}>
       <button
         className='map-title'
         onClick={() => setExpanded(!isExpanded)}
         aria-expanded={isExpanded}
-        aria-controls={`donate-faq-content-${key}`}
+        aria-controls={`donate-faq-content-${index}`}
       >
         <Caret />
         <h3>{title}</h3>
       </button>
       {isExpanded && (
-        <div className='map-challenges-ul' id={`donate-faq-content-${key}`}>
+        <div className='map-challenges-ul' id={`donate-faq-content-${index}`}>
           {text}
         </div>
       )}
@@ -240,7 +242,9 @@ export const DonationFaqText = (): JSX.Element => {
     <>
       <h2 data-playwright-test-label='faq-head'>{t('donate.faq')}</h2>
       <Spacer size='xs' />
-      {faqItems.map((item, iterator) => FaqItem(item.Q, item.A, iterator))}
+      {faqItems.map((item, iterator) => (
+        <FaqItem key={iterator} title={item.Q} text={item.A} index={iterator} />
+      ))}
     </>
   );
 };


### PR DESCRIPTION
  **Checklist:**                                                                                                          
                                                                                                                      
  - [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).                  
  - [x] I have read and followed the [how to open a pull request                                                   guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).                                            
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

  Closes #68170

  `FaqItem` calls `useState` internally, making it a React component, but it was being called as a plain function
  (`FaqItem(item.Q, item.A, iterator)`). This violates the rules of hooks — React doesn't manage a proper component
  instance for direct function calls, which can cause state to behave unpredictably.

 **Changes:**
  - Added a `FaqItemProps` type with `title`, `text`, and `index` fields
  - Changed `FaqItem` to accept a single props object (standard React component pattern)
  - Renamed `key` → `index` inside the component, since `key` is a reserved React prop and cannot be passed through to
   the component
  - Updated the call site to use JSX: `<FaqItem key={iterator} title={item.Q} text={item.A} index={iterator} />`

  No HTML structure, class names, or aria attributes were changed.
