### PR TITLE
fix(curriculum): add subheadings to whitespace lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
+++ b/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
@@ -7,7 +7,7 @@ dashedName: what-is-the-importance-of-whitespace-in-design
 
 # --description--
 
-## What is white space?
+## What Is White Space?
 
 White space refers to any type of space around elements like images, text, and buttons. White space is important in design because it helps to create a balance between the elements on the page.
 

--- a/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
+++ b/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
@@ -7,11 +7,15 @@ dashedName: what-is-the-importance-of-whitespace-in-design
 
 # --description--
 
+## What is white space?
+
 White space refers to any type of space around elements like images, text, and buttons. White space is important in design because it helps to create a balance between the elements on the page.
 
 Let's take a look at some examples of how white space can be used effectively in design.
 
-For example, let's consider a call-to-action (CTA) button. CTAs are used to encourage users to take a specific action like signing up for a newsletter or making a purchase. 
+## Enhancing CTAs
+
+Let's consider a call-to-action (CTA) button. CTAs are used to encourage users to take a specific action like signing up for a newsletter or making a purchase.
 
 On the freeCodeCamp homepage, the CTA button is visually separated from other elements. The image below shows this button, with a certain amount of space around it.
 
@@ -19,21 +23,22 @@ On the freeCodeCamp homepage, the CTA button is visually separated from other el
 
 By using white space effectively, we can help to make a CTA button more prominent and encourage users to click on it.
 
+## Types of white space
+
 Now let's take a closer look at the different types of white space.
 
-This first example uses both macro and active white space. Macro white space is the space between larger elements like images, text blocks, and buttons.
-
-Active white space is the space that is intentionally created to help guide the user's eye and draw attention to certain elements on the page.
-
-In contrast to active white space, there is also passive white space. Passive white space is the space that is left over after all the elements on a page have been placed.
-
-Another type of whitespace would be micro white space. This is the space between individual characters in a line of text.
+- **Macro** white space is the space between larger elements like images, text blocks, and buttons.
+- **Active** white space is the space that is intentionally created to help guide the user's eye and draw attention to certain elements on the page.
+- **Passive** white space is the space that is left over after all the elements on a page have been placed.
+- **Micro** white space is the space between individual characters in a line of text.
 
 The image below shows the Frequently Asked Questions section on the freeCodeCamp homepage, where this spacing allows you to read each question and answer easily.
 
 <img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/what-is-the-importance-of-whitespace-in-design-2.png" alt="The Frequently Asked Questions section on the freeCodeCamp homepage, with text spaced sufficiently between each letter.">
 
 Micro white space is important because it helps to improve readability and legibility, making it easier for users to scan and understand the content.
+
+## The law of proximity
 
 When designing your web pages, you always want to be mindful of the law of proximity. This law states that elements that are close together are perceived as being related, while elements that are far apart are perceived as being unrelated.
 

--- a/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
+++ b/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
@@ -38,7 +38,7 @@ The image below shows the Frequently Asked Questions section on the freeCodeCamp
 
 Micro white space is important because it helps to improve readability and legibility, making it easier for users to scan and understand the content.
 
-## The law of proximity
+## The Law of Proximity
 
 When designing your web pages, you always want to be mindful of the law of proximity. This law states that elements that are close together are perceived as being related, while elements that are far apart are perceived as being unrelated.
 

--- a/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
+++ b/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672baacb7f2f446728e77efe.md
@@ -23,7 +23,7 @@ On the freeCodeCamp homepage, the CTA button is visually separated from other el
 
 By using white space effectively, we can help to make a CTA button more prominent and encourage users to click on it.
 
-## Types of white space
+## Types of White Space
 
 Now let's take a closer look at the different types of white space.
 


### PR DESCRIPTION
  Checklist:

  - [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
 - [x] I have read and followed the [how to open a pull request
  guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

  Closes #67947

  The "What Is the Importance of Whitespace in Design?" lecture had a wall of text with no visual hierarchy, making it
   hard to scan or reference later.

  Changes to `# --description--` only (questions section untouched):
  - Added four `##` subheadings: "What is white space?", "Enhancing CTAs", "Types of white space", and "The law of
  proximity"
  - Consolidated the four whitespace type paragraphs into a bullet list with keyword-only bolding (e.g. **Macro**
  white space...)
  - Removed the redundant "For example," opener and the "This first example uses both macro and active white space."
  transition sentence