### PR TITLE
fix(curriculum): allow all function syntaxes in leap year lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -37,7 +37,7 @@ assert.isFunction(isLeapYear);
 The `isLeapYear` function should take a number as an argument.
 
 ```js
-assert.match(isLeapYear.toString(), /\s*isLeapYear\(\s*\w+\s*\)/);
+assert.match(__helpers.removeJSComments(code), /(?:function\s+isLeapYear\s*\(\s*\w+\s*\)|isLeapYear\s*=\s*(?:function\s*\(\s*\w+\s*\)|\(?\s*\w+\s*\)?\s*=>))/);
 ```
 
 You should declare a variable `year` and assign it a value to check if it is a leap year.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68193

<!-- Feel free to add any additional description of changes below this line -->

In the Leap Year Calculator lab, test #2 was overly strict by expecting `isLeapYear.toString()` to match a specific regex. This failed for valid function expressions and arrow functions because their `.toString()` representation does not contain the function name.

**Changes Made:**
- Updated the regex assertion in `66c06fad3475cd92421b9ac2.md` to check `__helpers.removeJSComments(code)` instead.
- The new regex gracefully supports function declarations, function expressions, and arrow functions.

---
*Authored by **Subbareddy Palagiri**.*