### PR TITLE
fix(curriculum): correct grammar in js regex review lecture

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -159,7 +159,7 @@ And the result is:
 
 - **`u` Flag**: This expands the functionality of a regular expression to allow it to match special unicode characters. The `u` flag gives you access to special classes like the `Extended_Pictographic` to match most emoji. There is also a `v` flag, which further expands the functionality of the unicode matching.
 - **`y` Flag**: The sticky modifier behaves very similarly to the global modifier, but with a few exceptions. The biggest one is that a global regular expression will start from lastIndex and search the entire remainder of the string for another match, but a sticky regular expression will return null and reset the lastIndex to 0 if there is not immediately a match at the previous lastIndex.
-- **`s` Flag**: The single-line modifier allows a wildcard character, represented by a `.` in regex, to match linebreaks - effectively treating the string as a single line of text.
+- **`s` Flag**: The single-line modifier allows a wildcard character, represented by a `.` in regex, to match line breaks - effectively treating the string as a single line of text.
 
 ## Character Classes
 
@@ -181,14 +181,14 @@ const regex = /\d/;
 const regex = /\w/;
 ```
 
-- **`\s`**: The white-space class `\s`, represented by a backslash followed by an `s`. This character class will match any white space, including new lines, spaces, tabs, and special unicode space characters.
+- **`\s`**: The white-space class `\s` is represented by a backslash followed by an `s`. This character class will match any white space, including new lines, spaces, tabs, and special unicode space characters.
 - **Negating Special Character Classes**: To negate one of these character classes, instead of using a lowercase letter after the backslash, you can use the uppercase equivalent. The following example does not match a numerical character. Instead, it matches any single character that is NOT a numerical character. 
 
 ```js
 const regex = /\D/;
 ```
 
-- **Custom Character Classes**: You can create custom character classes by placing the character you wish match inside a set of square brackets.
+- **Custom Character Classes**: You can create custom character classes by placing the character you wish to match inside a set of square brackets.
 
 ```js
 const regex = /[abcdf]/;


### PR DESCRIPTION
1. Change `linebreaks` to `line breaks`.
2. Change `The white-space class `\s`, represented by a backslash` to `The white-space class `\s` is represented by a backslash`.
3. Change `the character you wish match` to `the character you wish to match`.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68161