### PR TITLE
fix(curriculum): editable regions in workshop error message component

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-error-message-component/684cca09aac0fc035db4099f.md
+++ b/curriculum/challenges/english/blocks/workshop-error-message-component/684cca09aac0fc035db4099f.md
@@ -46,11 +46,11 @@ assert.isTrue(pElement?.textContent.trim().endsWith(remainingText));
   </head>
   <body>
     <div>
-      --fcc-editable-region--
       <p>
-
-      </p>
       --fcc-editable-region--
+        
+      --fcc-editable-region--
+      </p>
     </div>
   </body>
 </html>

--- a/curriculum/challenges/english/blocks/workshop-error-message-component/684ccbdc1ef89e042b744e09.md
+++ b/curriculum/challenges/english/blocks/workshop-error-message-component/684ccbdc1ef89e042b744e09.md
@@ -74,7 +74,7 @@ assert.equal(spanEl?.innerHTML, "×");
         <strong>Error!</strong> Something went wrong. Please try again.
       </p>
       --fcc-editable-region--
-
+      
       --fcc-editable-region--
     </div>
   </body>

--- a/curriculum/challenges/english/blocks/workshop-error-message-component/684d1942a1904a14a3709c6c.md
+++ b/curriculum/challenges/english/blocks/workshop-error-message-component/684d1942a1904a14a3709c6c.md
@@ -64,7 +64,7 @@ assert.isTrue(divEl.classList.contains("items-center"));
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>  
-    <div class="bg-red-100 border-2 border-red-300 rounded-md md:w-1/2 p-4 mt-4 mx-auto flex gap-4 justify-center items-center">
+    <div class="bg-red-100 border-2 border-red-300 rounded-md md:w-1/2 p-4 mt-4 md:mx-auto flex gap-4 justify-center items-center">
       <p class="text-red-700 text-xl">
         <strong>Error!</strong> Something went wrong. Please try again.
       </p>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

References to: #67721

<!-- Feel free to add any additional description of changes below this line -->

This PR is part of Naomi's sprint for editable regions in workshops.

This PR fixes editable regions in workshop error message component.