### PR TITLE
fix(curriculum): correct regex character class description

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5d0048bb74c18431296.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5d0048bb74c18431296.md
@@ -45,9 +45,9 @@ The `\w` class, which is a backslash followed by a `w`, represents any word char
 const regex = /\w/;
 ```
 
-A word character is defined as any letter, from `a` to `z`, or a number from `0` to `9`, or the underscore (`_`) character.
+A word character is defined as any letter, from `a` to `z` or `A` to `Z`, or a number from `0` to `9`, or the underscore (`_`) character.
 
-The inclusion of the underscore might seem strange, but consider the naming conventions for variables – variable names can often include underscores, so `\w` is designed to match that as well.
+The inclusion of the underscore might seem strange, but consider the naming conventions for variables: variable names can often include underscores, so `\w` is designed to match that as well.
 
 There is one more special character class to consider: the whitespace class `\s`, represented by a backslash followed by an `s`. This character class will match any whitespace, including new lines, spaces, tabs, and special unicode space characters.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68155

Updated `6733c5d0048bb74c18431296.md` to include the uppercase letter range `A` to `Z` in the `\w` character class description and replaced an en dash with a colon for correct punctuation.