### PR TITLE
fix(curriculum): correct punctuation in regex quantifiers lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5e54e3a154c8078ed48.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5e54e3a154c8078ed48.md
@@ -15,7 +15,7 @@ Consider a scenario where you want to match a four-digit identification code. Yo
 const regex = /^\d\d\d\d$/;
 ```
 
-And this does work – it will match four numerical characters. But rather than having to write out the same class multiple times, you can give it a quantifier.
+And this does work: it will match four numerical characters. But rather than having to write out the same class multiple times, you can give it a quantifier.
 
 Quantifiers are defined by curly braces containing one or two numbers. Let's use a quantifier in our pattern:
 
@@ -82,7 +82,7 @@ console.log(regex.test("1234567")); // false
 
 :::
 
-Note that you cannot use this syntax to set a maximum alone – you must always set a minimum. But if you set the minimum to `1`, you can effectively achieve the same result.
+Note that you cannot use this syntax to set a maximum alone: you must always set a minimum. But if you set the minimum to `1`, you can effectively achieve the same result.
 
 We've received updated requirements from our users. Identifiers can now optionally start with a letter. We already know the character class for this, so let's add that to our regular expression:
 
@@ -98,7 +98,7 @@ You could use the quantifier syntax with `0` as the minimum and `1` as the maxim
 const regex = /^[a-zA-Z]{0,1}\d{4,6}$/;
 ```
 
-But there's actually a special shorthand quantifier for a single optional character – the question mark (`?`). Let's replace our quantifier with the question mark:
+But there's actually a special shorthand quantifier for a single optional character, the question mark (`?`). Let's replace our quantifier with the question mark:
 
 ```js
 const regex = /^[a-zA-Z]?\d{4,6}$/;
@@ -128,7 +128,7 @@ Unfortunately, we've just realized we read the requirements wrong. We need to al
 const regex = /^[a-zA-Z]{0,}\d{4,6}$/;
 ```
 
-But our pattern is getting long again. Thankfully, there's another short-hand for "match the previous character zero or more times" –  the asterisk (`*`) symbol. Let's replace our quantifier with that in the pattern, and test it:
+But our pattern is getting long again. Thankfully, there's another short-hand for "match the previous character zero or more times", the asterisk (`*`) symbol. Let's replace our quantifier with that in the pattern, and test it:
 
 :::interactive_editor
 
@@ -144,9 +144,9 @@ console.log(regex.test("1234567")); // false
 
 :::
 
-Now we successfully match any identifier with zero or more letters followed by four to six numbers. But it turns out this is crashing our system – we actually have to require at least one letter.
+Now we successfully match any identifier with zero or more letters followed by four to six numbers. But it turns out this is crashing our system: we actually have to require at least one letter.
 
-Again, we could use a quantifier with a minimum of one and no defined maximum, or we could use yet another special syntax – the plus (`+`) symbol:
+Again, we could use a quantifier with a minimum of one and no defined maximum, or we could use yet another special syntax, the plus (`+`) symbol:
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #68160

Fixes six punctuation issues in the "What Are Regex Quantifiers, and How Do They Work?" lesson, where a spaced en dash was used where a colon or comma fits better:

- Changed "work – it" to "work: it" (colon joining two independent clauses).
- Changed "alone – you" to "alone: you" (colon joining two independent clauses).
- Changed "character – the" to "character, the" (comma before an appositive).
- Changed "times\" – the" to "times\", the" (comma before an appositive, also removed an extra space).
- Changed "system – we" to "system: we" (colon joining two independent clauses).
- Changed "syntax – the" to "syntax, the" (comma before an appositive).