### PR TITLE
fix(curriculum): correct consistency and punctuation in regex modifie…

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -66,7 +66,7 @@ console.log(regex.test("dO yOu LoVe fReEcOdEcAmP?")); // true
 
 There are quite a few other flags that you can use. The `g` flag, or global modifier, allows your regular expression to match a pattern more than once. 
 
-Let's see how that affects our code. You'll notice we kept the `i` flag – a regular expression can use multiple flags (as many as needed) to achieve your desired behavior:
+Let's see how that affects our code. You'll notice we kept the `i` flag: a regular expression can use multiple flags (as many as needed) to achieve your desired behavior:
 
 ```js
 const regex = /freeCodeCamp/gi;
@@ -260,9 +260,9 @@ The second is the sticky modifier, or the `y` flag. The sticky modifier behaves 
 
 The biggest one is that a global regular expression will start from `lastIndex` and search the entire remainder of the string for another match, but a sticky regular expression will return `null` and reset the `lastIndex` to `0` if there is not immediately a match at the previous `lastIndex`.
 
-And the last is the single-line modifier, or the `s` flag. Remember that the multiline modifier allows start and end anchors to match the start and end of a line, instead of the entire string. 
+And the last is the single-line modifier, or the `s` flag. Remember that the multi-line modifier allows start and end anchors to match the start and end of a line, instead of the entire string. 
 
-The single-line modifier allows a wildcard character, represented by a period (`.`) in regex, to match linebreaks – effectively treating the string as a single line of text.
+The single-line modifier allows a wildcard character, represented by a period (`.`) in regex, to match line breaks, effectively treating the string as a single line of text.
 
 There are quite a few of these modifiers, but the `i` and `g` flags are the ones you'll use most frequently, and are the most important to remember.
 


### PR DESCRIPTION
Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #68159

Fixes three consistency and punctuation issues in the "What Are Some Common Regular Expression Modifiers Used for Searching?" lesson:

- Changed "multiline" to "multi-line" to match the hyphenated spelling used elsewhere in the lesson and in a related quiz.
- Changed "linebreaks" to "line breaks" and replaced a spaced en dash with a comma.
- Replaced a spaced en dash with a colon, since it joins two independent clauses.