### PR TITLE
fix(curriculum): clarify winner message format for tic-tac-toe lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
+++ b/curriculum/challenges/english/blocks/lab-tic-tac-toe/67e3a6b7f60b4085588189e6.md
@@ -17,7 +17,7 @@ saveSubmissionToDB: true
 2. Clicking `button.square` elements should alternate between displaying an `X` then `O` within the element.
 3. Once a player has won the game, clicking on any `button.square` should not cause any further changes.
 4. You should create a `button#reset` element that resets the game when clicked.
-5. A message should be displayed indicating either `X` or `O` as the winner, or neither if the result is a draw.
+5. A message should be displayed indicating the winner in the format `Winner: X` or `Winner: O`, or neither if the result is a draw.
 
 # --before-all--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68095 

<!-- Feel free to add any additional description of changes below this line -->
I have updated the markdown file for the lab to explicitly mention the required Winner: X and Winner: O format. This should make the user story much clearer and prevent unnecessary confusion for students passing the challenge.