### PR TITLE
fix(curriculum): correct grammar in WAI-ARIA accessibility feedback

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a53cf67140d8cd85d4b0f.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a53cf67140d8cd85d4b0f.md
@@ -108,7 +108,7 @@ To change the visual appearance of elements.
 
 ### --feedback--
 
-Focus on how WAI-ARIA enhances HTML elements accessibility.
+Focus on how WAI-ARIA enhances the accessibility of HTML elements.
 
 ---
 
@@ -120,7 +120,7 @@ To display tooltips on elements.
 
 ### --feedback--
 
-Focus on how WAI-ARIA enhances HTML elements accessibility.
+Focus on how WAI-ARIA enhances the accessibility of HTML elements.
 
 ---
 
@@ -128,7 +128,7 @@ To add animations to elements.
 
 ### --feedback--
 
-Focus on how WAI-ARIA enhances HTML elements accessibility.
+Focus on how WAI-ARIA enhances the accessibility of HTML elements.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #68234 

Fixes a grammar issue in the wrong-answer feedback for the first question in the WAI-ARIA introduction lecture. The phrase "HTML elements accessibility" was a noun pile-up missing a preposition. Changed it to "the accessibility of HTML elements" in all three places it appears (the feedback text repeats identically three times).