### PR TITLE
test: move flash rendering coverage to client

### DIFF
--- a/client/src/components/Flash/flash.test.tsx
+++ b/client/src/components/Flash/flash.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FlashMessages } from './redux/flash-messages';
+import Flash from '.';
+
+describe('<Flash />', () => {
+  it('renders a flash message and dismisses it', async () => {
+    const user = userEvent.setup();
+    const removeFlashMessage = vi.fn();
+
+    render(
+      <Flash
+        flashMessage={{
+          id: 'flash-id',
+          type: 'danger',
+          message: FlashMessages.UserFetchError
+        }}
+        removeFlashMessage={removeFlashMessage}
+      />
+    );
+
+    expect(screen.getByText('flash.user-fetch-error')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'buttons.close' }));
+
+    expect(removeFlashMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/e2e/flash.spec.ts
+++ b/e2e/flash.spec.ts
@@ -40,20 +40,4 @@ test.describe('Flash Message component E2E test', () => {
       translations.flash['updated-sound']
     );
   });
-
-  test('should be visible when a network error occurs', async ({ page }) => {
-    await page.route('*/**/user/session-user', async route => {
-      await route.fulfill({
-        status: 500,
-        contentType: 'application/json',
-        body: JSON.stringify({ user: {}, result: '' })
-      });
-    });
-
-    await page.goto('/');
-    await checkFlashMessageVisibility(
-      page,
-      translations.flash['user-fetch-error']
-    );
-  });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves the mocked user-fetch-error flash rendering check from Playwright to `flash.test.tsx`. The client test covers rendering the flash message and dismissing it through the close button.

The settings night-mode and sound-mode flash checks stay in Playwright because they still prove the settings page interaction produces the visible flash.
