### PR TITLE
fix(client): refactor FaqItem to proper React component

### DIFF
--- a/client/src/components/Donation/donation-text-components.tsx
+++ b/client/src/components/Donation/donation-text-components.tsx
@@ -74,25 +74,31 @@ const OtherWaysToSupport = (): JSX.Element => {
   );
 };
 
-const FaqItem = (
-  title: string,
-  text: JSX.Element,
-  key: number
-): JSX.Element => {
+type FaqItemProps = {
+  title: string;
+  text: JSX.Element;
+  index: number;
+};
+
+const FaqItem = ({ title, text, index }: FaqItemProps): JSX.Element => {
   const [isExpanded, setExpanded] = useState(false);
+  const contentId = `donate-faq-content-${index}`;
+
   return (
-    <div className={`faq-item ${isExpanded ? 'open' : ''}`} key={key}>
-      <button
-        className='map-title'
-        onClick={() => setExpanded(!isExpanded)}
-        aria-expanded={isExpanded}
-        aria-controls={`donate-faq-content-${key}`}
-      >
-        <Caret />
-        <h3>{title}</h3>
-      </button>
+    <div className={`faq-item ${isExpanded ? 'open' : ''}`}>
+      <h3>
+        <button
+          className='map-title'
+          onClick={() => setExpanded(!isExpanded)}
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+        >
+          <Caret />
+          {title}
+        </button>
+      </h3>
       {isExpanded && (
-        <div className='map-challenges-ul' id={`donate-faq-content-${key}`}>
+        <div className='map-challenges-ul' id={contentId}>
           {text}
         </div>
       )}
@@ -240,7 +246,9 @@ export const DonationFaqText = (): JSX.Element => {
     <>
       <h2 data-playwright-test-label='faq-head'>{t('donate.faq')}</h2>
       <Spacer size='xs' />
-      {faqItems.map((item, iterator) => FaqItem(item.Q, item.A, iterator))}
+      {faqItems.map((item, iterator) => (
+        <FaqItem key={iterator} title={item.Q} text={item.A} index={iterator} />
+      ))}
     </>
   );
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68170

<!-- Feel free to add any additional description of changes below this line -->

I refactored the `FaqItem` to function as a proper React component with typed props instead of a standard function call, which resolves the React Hook rule violation. I also inverted the `<button>` and `<h3>` tags to ensure proper semantic HTML and accessibility.
