### PR TITLE
fix: correct ARIA terminology and grammar

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a549231b8728f7171ed9d.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a549231b8728f7171ed9d.md
@@ -33,7 +33,7 @@ But non-semantic elements don't have a role. For example, screen readers will no
 </div>
 ```
 
-To specify the ARIA role of an element, you just need to add the `role` attribute, like this `role="ARIA role"`, where value is the name of a role in the ARIA specification.
+To specify the ARIA role of an element, you just need to add the `role` attribute, like this `role="ARIA role"`, where the value is the name of a role in the ARIA specification.
 
 Here is an example of using the `role` attribute with a value of `"alert"`:
 
@@ -308,7 +308,7 @@ button.addEventListener("click", () => {
 
 :::
 
-Window roles define sub-windows, like pop up modal dialogues. These roles include `alertdialog` and `dialog`. Please note that it is now considered a best practice to use the HTML `dialog` element and its associated JavaScript methods instead of manually creating a dialog.
+Window roles define sub-windows, like pop-up modal dialogs. These roles include `alertdialog` and `dialog`. Please note that it is now considered a best practice to use the HTML `dialog` element and its associated JavaScript methods instead of manually creating a dialog.
 
 Here is an example of using a `dialog` role for a custom dialog:
 
@@ -451,7 +451,7 @@ Think about how ARIA roles help assistive technologies understand the content.
 
 ## --text--
 
-Which category of ARIA roles is used to define the purpose and behavior of sub-windows, like pop-up modal dialogues?
+Which category of ARIA roles is used to define the purpose and behavior of sub-windows, like pop-up modal dialogs?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:
- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68235

This PR fixes grammar and terminology issues in the "What Are ARIA Roles?" lecture by:

* Adding the missing article in "where the value is the name..."
* Changing "pop up" to "pop-up"
* Changing "dialogues" to "dialogs" in the lesson text and quiz text.

