### PR TITLE
fix(#68236): improved aria-describedby lecture wording

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a551975938a916c74802c.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a551975938a916c74802c.md
@@ -13,7 +13,7 @@ The most common use for `aria-describedby` is to associate instructions and erro
 
 Let's take a look at a few examples to understand how it works. In this first example, we have a `form` element that accepts a password.
 
-Enable the interactive editor and type a few characters into the password input field. You will see that the password is masked in the preview window. You should also see that the `password-help` text remains red until you provide 8 or more characters into the input. 
+Enable the interactive editor and type a few characters into the password input field. You will see that the password is masked in the preview window. You should also see that the `password-help` text remains red until you type 8 or more characters into the input.
 
 NOTE: This interactive example is using CSS and JavaScript to dynamically update the color for the `password-help` text. Don't worry about trying to understand the JavaScript code because you will learn JavaScript in future modules.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68236)

<!-- Feel free to add any additional description of changes below this line -->

Replaced "provide 8 or more characters into the input" with
"type 8 or more characters into the input" for clearer and
more natural wording.