### PR TITLE
fix(curriculum): correct linebreaks spelling in regex modifiers lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -381,7 +381,7 @@ The `m` modifier enables matching at the start and end of lines in multi-line st
 
 ---
 
-It allows the regular expression to match linebreaks.
+It allows the regular expression to match line breaks.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68252

Corrects an inconsistent spelling in the "What Are Some Common Regular Expression Modifiers Used for Searching?" lesson.

The third answer's feedback for the multi-line (`m`) modifier question used "linebreaks" as one word, while the rest of this block (and the related wildcard lesson) uses "line breaks" as two words.

```diff
-It allows the regular expression to match linebreaks.
+It allows the regular expression to match line breaks.
```

Thanks for reviewing.
