### PR TITLE
fix(curriculum): correct line breaks wording in regex lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -381,7 +381,7 @@ The `m` modifier enables matching at the start and end of lines in multi-line st
 
 ---
 
-It allows the regular expression to match linebreaks.
+It allows the regular expression to match line breaks.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68252 

<!-- Feel free to add any additional description of changes below this line -->
## Summary

- Changed "linebreaks" to "line breaks" in the Regular Expression Modifiers lesson for consistency.

Closes #68252 