### PR TITLE
fix(curriculum): improve wording in character classes lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5d0048bb74c18431296.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5d0048bb74c18431296.md
@@ -93,7 +93,7 @@ Remember that regular expressions are case-sensitive by default. This means our 
 const regex = /[a-zA-Z]/;
 ```
 
-You can also mix digits and numbers in your character class. For example, if you wanted the behavior of the `\w` class without the underscore, you could construct your own:
+You can also mix letters and numbers in your character class. For example, if you wanted the behavior of the `\w` class without the underscore, you could construct your own:
 
 ```js
 const regex = /[a-zA-Z0-9]/;
@@ -125,7 +125,7 @@ Which character class matches any single character EXCEPT line breaks?
 
 ### --feedback--
 
-The lesson mentions a "wild card" class represented by a specific symbol.
+The lesson mentions a "wildcard" class represented by a specific symbol.
 
 ---
 
@@ -133,7 +133,7 @@ The lesson mentions a "wild card" class represented by a specific symbol.
 
 ### --feedback--
 
-The lesson mentions a "wild card" class represented by a specific symbol.
+The lesson mentions a "wildcard" class represented by a specific symbol.
 
 ---
 
@@ -141,7 +141,7 @@ The lesson mentions a "wild card" class represented by a specific symbol.
 
 ### --feedback--
 
-The lesson mentions a "wild card" class represented by a specific symbol.
+The lesson mentions a "wildcard" class represented by a specific symbol.
 
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68250

## Summary

- Changed "digits and numbers" to "letters and numbers" for accuracy.
- Updated "wild card" to "wildcard" in the lesson feedback for consistency.