### PR TITLE
fix(curriculum): add missing terminal periods to two answer options

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
@@ -267,7 +267,7 @@ The lesson describes a special type of object returned by `matchAll()`.
 
 ---
 
-There is no difference, they are interchangeable
+There is no difference, they are interchangeable.
 
 ### --feedback--
 
@@ -283,7 +283,7 @@ How can you convert the result of `matchAll()` into an array containing all matc
 
 ## --answers--
 
-By using a `for...of` loop
+By using a `for...of` loop.
 
 ### --feedback--
 


### PR DESCRIPTION
Fixes #68251

Adds missing terminal periods to two answer options in the lecture on working with regular expressions.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.