### PR TITLE
fix(curriculum): fix grammatically incorrect feedback in WAI-ARIA lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a53cf67140d8cd85d4b0f.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a53cf67140d8cd85d4b0f.md
@@ -108,7 +108,7 @@ To change the visual appearance of elements.
 
 ### --feedback--
 
-Focus on how WAI-ARIA enhances HTML elements accessibility.
+Focus on how WAI-ARIA enhances the accessibility of HTML elements.
 
 ---
 
@@ -120,7 +120,7 @@ To display tooltips on elements.
 
 ### --feedback--
 
-Focus on how WAI-ARIA enhances HTML elements accessibility.
+Focus on how WAI-ARIA enhances the accessibility of HTML elements.
 
 ---
 
@@ -128,7 +128,7 @@ To add animations to elements.
 
 ### --feedback--
 
-Focus on how WAI-ARIA enhances HTML elements accessibility.
+Focus on how WAI-ARIA enhances the accessibility of HTML elements.
 
 ## --video-solution--
 


### PR DESCRIPTION
Fixes #68234

Changes "HTML elements accessibility" to "the accessibility of HTML elements" in three feedback locations.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.