### PR TITLE
fix(client): move course progress steps into main module button for screen reader accessibility

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -32,6 +32,7 @@
 .super-block-accordion .module-header-wrapper .module-button-main {
   flex: 1;
   min-width: 0;
+  justify-content: space-between;
 }
 
 .super-block-accordion .chapter-header-wrapper .chapter-button-toggle,

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -145,9 +145,9 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    const moduleSteps = within(moduleRight).getByText(
+    // The module-button now contains the progress steps inline
+    const moduleButton = screen.getByTestId('module-button');
+    const moduleSteps = within(moduleButton).getByText(
       /learn\.steps-completed/i
     );
     expect(moduleSteps).toBeInTheDocument();
@@ -185,8 +185,8 @@ describe('SuperBlockAccordion', () => {
     );
 
     // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
+    const moduleButton = screen.getByTestId('module-button');
+    expect(within(moduleButton).queryByText(/steps/i)).not.toBeInTheDocument();
   });
 
   // Modules with zero total steps should not display any progress text.
@@ -220,8 +220,8 @@ describe('SuperBlockAccordion', () => {
     );
 
     // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
+    const moduleButton = screen.getByTestId('module-button');
+    expect(within(moduleButton).queryByText(/steps/i)).not.toBeInTheDocument();
   });
 
   describe('Reset Button', () => {
@@ -548,8 +548,12 @@ describe('SuperBlockAccordion', () => {
     );
 
     // When expandAll=true, both chapters are open so their module main buttons are visible
-    expect(screen.getByRole('button', { name: 'mod-one' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'mod-two' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-one/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-two/i })
+    ).toBeInTheDocument();
   });
 
   it('should not render a module when all its challenges are filtered out', () => {
@@ -577,11 +581,13 @@ describe('SuperBlockAccordion', () => {
     );
 
     // mod-one has a challenge — its main module button should render
-    expect(screen.getByRole('button', { name: 'mod-one' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-one/i })
+    ).toBeInTheDocument();
 
     // mod-two has no challenges — its main module button should not render
     expect(
-      screen.queryByRole('button', { name: 'mod-two' })
+      screen.queryByRole('button', { name: /^mod-two/i })
     ).not.toBeInTheDocument();
   });
 });

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -207,9 +207,9 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    const moduleSteps = within(moduleRight).getByText(
+    // The module-button now contains the progress steps inline
+    const moduleButton = screen.getByTestId('module-button');
+    const moduleSteps = within(moduleButton).getByText(
       /learn\.steps-completed/i
     );
     expect(moduleSteps).toBeInTheDocument();
@@ -246,9 +246,8 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
+    const moduleButton = screen.getByTestId('module-button');
+    expect(within(moduleButton).queryByText(/steps/i)).not.toBeInTheDocument();
   });
 
   // Modules with zero total steps should not display any progress text.
@@ -281,9 +280,8 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
-    const moduleRight = screen.getByTestId('module-button-right');
-    expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
+    const moduleButton = screen.getByTestId('module-button');
+    expect(within(moduleButton).queryByText(/steps/i)).not.toBeInTheDocument();
   });
 
   describe('Reset Button', () => {
@@ -610,8 +608,12 @@ describe('SuperBlockAccordion', () => {
     );
 
     // When expandAll=true, both chapters are open so their module main buttons are visible
-    expect(screen.getByRole('button', { name: 'mod-one' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'mod-two' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-one/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-two/i })
+    ).toBeInTheDocument();
   });
 
   it('should not render a module when all its challenges are filtered out', () => {
@@ -639,11 +641,13 @@ describe('SuperBlockAccordion', () => {
     );
 
     // mod-one has a challenge — its main module button should render
-    expect(screen.getByRole('button', { name: 'mod-one' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-one/i })
+    ).toBeInTheDocument();
 
     // mod-two has no challenges — its main module button should not render
     expect(
-      screen.queryByRole('button', { name: 'mod-two' })
+      screen.queryByRole('button', { name: /^mod-two/i })
     ).not.toBeInTheDocument();
   });
 

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -691,12 +691,11 @@ describe('SuperBlockAccordion', () => {
     // The collapsed chapter's module is not rendered; the expanded chapter
     // reveals its module, which is expanded as well
     expect(
-      screen.queryByRole('button', { name: 'mod-one' })
+      screen.queryByRole('button', { name: 'mod-one learn.steps-completed' })
     ).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'mod-two' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    );
+    expect(
+      screen.getByRole('button', { name: 'mod-two learn.steps-completed' })
+    ).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('links directly to the full-stack exam when the exam challenge is available', () => {

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -255,9 +255,6 @@ const Module = ({
   const panelId = `module-panel-${dashedName}`;
   const isComplete = totalSteps === 0 ? false : completedSteps === totalSteps;
   const moduleLabel = t(`intro:${superBlock}.modules.${dashedName}`);
-  const toggleLabel = open
-    ? t('intro:misc-text.collapse')
-    : t('intro:misc-text.expand');
   const { note, intro } = t(`intro:${superBlock}.module-intros.${dashedName}`, {
     returnObjects: true
   }) as {
@@ -301,6 +298,7 @@ const Module = ({
           className='module-button module-button-main'
           onClick={toggleOpen}
           type='button'
+          data-testid='module-button'
         >
           <div className='module-button-left'>
             <span className='dropdown-wrap'>
@@ -311,28 +309,16 @@ const Module = ({
             </span>
             {moduleLabel}
           </div>
+          {!comingSoon && !!totalSteps && (
+            <span className='module-steps'>
+              {t('learn.steps-completed', {
+                completed: completedSteps,
+                total: totalSteps
+              })}
+            </span>
+          )}
         </button>
         {resetButton}
-        <button
-          aria-controls={panelId}
-          aria-expanded={open}
-          aria-label={`${toggleLabel} ${moduleLabel}`}
-          className='module-button module-button-toggle'
-          data-testid='module-button-right'
-          onClick={toggleOpen}
-          type='button'
-        >
-          <div className='module-button-right'>
-            {!comingSoon && !!totalSteps && (
-              <span className='module-steps'>
-                {t('learn.steps-completed', {
-                  totalSteps,
-                  completedSteps
-                })}
-              </span>
-            )}
-          </div>
-        </button>
       </div>
       {open && (
         <ul className='module-panel' id={panelId}>

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -255,9 +255,6 @@ const Module = ({
   const panelId = `module-panel-${dashedName}`;
   const isComplete = totalSteps === 0 ? false : completedSteps === totalSteps;
   const moduleLabel = t(`intro:${superBlock}.modules.${dashedName}`);
-  const toggleLabel = open
-    ? t('intro:misc-text.collapse')
-    : t('intro:misc-text.expand');
   const { note, intro } = t(`intro:${superBlock}.module-intros.${dashedName}`, {
     returnObjects: true
   }) as {
@@ -301,6 +298,7 @@ const Module = ({
           className='module-button module-button-main'
           onClick={toggleOpen}
           type='button'
+          data-testid='module-button'
         >
           <div className='module-button-left'>
             <span className='dropdown-wrap'>
@@ -311,28 +309,16 @@ const Module = ({
             </span>
             {moduleLabel}
           </div>
+          {!comingSoon && !!totalSteps && (
+            <span className='module-steps'>
+              {t('learn.steps-completed', {
+                completedSteps,
+                totalSteps
+              })}
+            </span>
+          )}
         </button>
         {resetButton}
-        <button
-          aria-controls={panelId}
-          aria-expanded={open}
-          aria-label={`${toggleLabel} ${moduleLabel}`}
-          className='module-button module-button-toggle'
-          data-testid='module-button-right'
-          onClick={toggleOpen}
-          type='button'
-        >
-          <div className='module-button-right'>
-            {!comingSoon && !!totalSteps && (
-              <span className='module-steps'>
-                {t('learn.steps-completed', {
-                  totalSteps,
-                  completedSteps
-                })}
-              </span>
-            )}
-          </div>
-        </button>
       </div>
       {open && (
         <ul className='module-panel' id={panelId}>

--- a/e2e/super-block-page.spec.ts
+++ b/e2e/super-block-page.spec.ts
@@ -332,7 +332,7 @@ test.describe('Super Block Page - Search Lessons', () => {
       page.getByRole('heading', { name: 'Build a Greeting Bot' })
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/i })
     ).not.toBeVisible();
     await expect(
       page.getByText(

--- a/e2e/super-block-page.spec.ts
+++ b/e2e/super-block-page.spec.ts
@@ -321,7 +321,7 @@ test.describe('Super Block Page - Search Lessons', () => {
     await page.goto('/learn/javascript-v9/');
 
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/i })
     ).toBeVisible();
 
     await page
@@ -343,7 +343,7 @@ test.describe('Super Block Page - Search Lessons', () => {
     await page.getByRole('button', { name: 'Clear search terms' }).click();
 
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/i })
     ).toBeVisible();
   });
 });

--- a/e2e/super-block-page.spec.ts
+++ b/e2e/super-block-page.spec.ts
@@ -217,7 +217,7 @@ test.describe('Super Block Page - Search Lessons', () => {
     await page.goto('/learn/javascript-v9/');
 
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/i })
     ).toBeVisible();
 
     await page
@@ -228,7 +228,7 @@ test.describe('Super Block Page - Search Lessons', () => {
       page.getByRole('heading', { name: 'Build a Greeting Bot' })
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/i })
     ).not.toBeVisible();
     await expect(
       page.getByText(
@@ -239,7 +239,7 @@ test.describe('Super Block Page - Search Lessons', () => {
     await page.getByRole('button', { name: 'Clear search terms' }).click();
 
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/i })
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67770  

<!-- Feel free to add any additional description of changes below this line -->

### Problem
Course progress steps (e.g. "X/Y steps completed") in the super-block accordion were rendered inside a separate toggle button (module-button-right), making them inaccessible to screen reader users. Screen readers couldn't associate the progress information with the module, since it lived in a visually-only secondary button outside the primary interactive element.

### Solution
Moved the progress steps from the separate module-button-right toggle button directly into the main module-button-main button
Removed the redundant secondary toggle button (module-button-right) entirely, since it duplicated the expand/collapse behaviour and added unnecessary DOM complexity
Added justify-content: space-between to .module-button-main so the module label and progress steps are visually spaced correctly within the single button
Updated tests to query by module-button (the main button) instead of module-button-right, and switched exact name matches to regex (/^mod-one/i) to account for the progress text now being part of the button's accessible name

### Testing
All existing tests updated and passing. No behaviour change for sighted users; screen reader users will now hear progress information as part of the button's accessible name when navigating the accordion.