### PR TITLE
feat(curriculum): add return to step 26 instructions for workshop-music-player

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
@@ -9,7 +9,9 @@ dashedName: step-26
 
 Now that you know how to find the next song to play, create a function named `playNextSong`. Inside the `playNextSong` function, create an `if` statement to check if the `currentSong` of `userData` is strictly equal to `null`. This will check if there's no current song playing in the `userData` object.
 
-If the condition is true, call the `playSong` function with the `id` of the first song in the `userData.songs` array as an argument. Then add a `return` statement to the end of the `if` block.
+If the condition is true, call the `playSong` function with the `id` of the first song in the `userData.songs` array as an argument.
+
+Then add a `return` statement to the end of the `if` block.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
+++ b/curriculum/challenges/english/blocks/workshop-music-player/674f50cce486fb404751a29c.md
@@ -9,7 +9,7 @@ dashedName: step-26
 
 Now that you know how to find the next song to play, create a function named `playNextSong`. Inside the `playNextSong` function, create an `if` statement to check if the `currentSong` of `userData` is strictly equal to `null`. This will check if there's no current song playing in the `userData` object.
 
-If the condition is true, call the `playSong` function with the `id` of the first song in the `userData.songs` array as an argument.
+If the condition is true, call the `playSong` function with the `id` of the first song in the `userData.songs` array as an argument. Then add a `return` statement to the end of the `if` block.
 
 # --hints--
 
@@ -38,6 +38,15 @@ assert.isUndefined(userData.currentSong);
 userData.currentSong = null;
 playNextSong();
 assert.strictEqual(userData.currentSong.id, 0);
+```
+
+You should have a `return` statement at the end of the `if` block.
+
+```js
+assert.match(
+  playNextSong.toString(),
+  /if\s*\(\s*userData\.currentSong\s*===\s*null\s*\)\s*\{[\s\S]*playSong\(\s*userData\.songs\s*\[\s*0\s*\]\.id\s*\)[^}]*return/
+);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

This PR was requested by a reviewer on my previous PR #68107, who noted that the instruction change and corresponding test should be submitted separately from the audit PR.

- Added an instruction for campers to include a `return` statement before the end of the `if` block
- Added a test that ensures the camper included a return statement after `playSong(userData.songs[0].id)` and before the closing `}` of the `if` block
- Added a hint to display when the test fails