### PR TITLE
fix(curriculum): add missing periods to quiz answers

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
@@ -267,7 +267,7 @@ The lesson describes a special type of object returned by `matchAll()`.
 
 ---
 
-There is no difference, they are interchangeable
+There is no difference, they are interchangeable.
 
 ### --feedback--
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

### Description

This pull request adds the missing periods to two quiz answer options in the JavaScript v9 lesson **"How Can You Match and Replace All Occurrences in a String?"** to improve punctuation consistency.

Checklist: 

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68251

<!-- Feel free to add any additional description of changes below this line -->
