### PR TITLE
fix(curriculum): editing regex from workshop-colored-markers to allow modern syntax

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-colored-markers/61a489b8579e87364b2d2cdb.md
+++ b/curriculum/challenges/english/blocks/workshop-colored-markers/61a489b8579e87364b2d2cdb.md
@@ -20,7 +20,10 @@ In the `.red` CSS rule, change the `background-color` property to `background`.
 Your `.red` CSS rule should have a `background` property with the value `rgb(255, 0, 0)`.
 
 ```js
-assert.match(__helpers.removeWhiteSpace(code), /\.red\{.*?background:rgb\(255,0,0\)/);
+assert.match(
+  code,
+  /\.red\s*\{\s*background:\s*rgb\(\s*255(,\s*|\s+)0(?:\1)0\s*\)/
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-colored-markers/61a5ca57f50ded36d33eef96.md
+++ b/curriculum/challenges/english/blocks/workshop-colored-markers/61a5ca57f50ded36d33eef96.md
@@ -16,7 +16,10 @@ In the `.blue` CSS rule, change the `background-color` property to `background`.
 Your `.blue` CSS rule should have a `background` property with the value `hsl(240, 100%, 50%)`.
 
 ```js
-assert.match(__helpers.removeWhiteSpace(code), /\.blue\{.*?background:hsl\(240,100%,50%\)/);
+assert.match(
+  code,
+  /\.blue\s*\{\s*background:\s*hsl\(\s*240(,\s*|\s+)100%(?:\1)50%\s*\)/
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-colored-markers/61a5d594b887335228ee6533.md
+++ b/curriculum/challenges/english/blocks/workshop-colored-markers/61a5d594b887335228ee6533.md
@@ -14,7 +14,10 @@ Use the `linear-gradient` function, and pass in the `hsl` function with the valu
 Your `.blue` CSS rule should have a `background` property with the value `linear-gradient(hsl(186, 76%, 16%))`.
 
 ```js
-assert.match(__helpers.removeWhiteSpace(code), /\.blue\{.*?background:linear-gradient\(hsl\(186,76%,16%\)\)/);
+assert.match(
+  code,
+  /\.blue\s*\{\s*background:\s*linear-gradient\(hsl\(\s*186(,\s*|\s+)76%(?:\1)16%\s*\)\)/
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-colored-markers/61b095989e7fc020b43b1bb9.md
+++ b/curriculum/challenges/english/blocks/workshop-colored-markers/61b095989e7fc020b43b1bb9.md
@@ -16,7 +16,10 @@ In the `linear-gradient` function, use the `rgb` function to set the first color
 Your `.red` CSS rule should have a `background` property with the value `linear-gradient(90deg, rgb(255, 0, 0))`.
 
 ```js
-assert.match(__helpers.removeWhiteSpace(code), /\.red\{.*?background:linear-gradient\(90deg,rgb\(255,0,0\)\)/);
+assert.match(
+  code,
+  /\.red\s*\{\s*background:\s*linear-gradient\(90deg,\s*rgb\(\s*255(,\s*|\s+)0(?:\1)0\s*\)\)/
+);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68068

<!-- Feel free to add any additional description of changes below this line -->
This PR is part of Naomi's Sprints, Responsive Web Design Certification. In this workshop, some steps (44, 46, 61, 62) rejected valid solutions with modern syntax and only accepts the legacy one. This PR addresses the restriction.