### PR TITLE
fix(curriculum): correct typo in pull request instructions

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/688290da3736c273009129d0.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/688290da3736c273009129d0.md
@@ -15,7 +15,7 @@ Let's head over to our repository on GitHub again.
 
 Now, after you pushed your new branch, you should see a fancy banner that says you've pushed to a branch, and a button you can click to create a pull request. This button skips a couple of steps and streamlines the process, so we're going to ignore it for now. That way you are prepared for cases where the banner does not appear.
 
-Click on the pull requests tab at the top the repository page, then ignore the banner again and click "New Pull Request". You'll be taken to a UI to prepare your request.
+Click on the pull requests tab at the top of the repository page, then ignore the banner again and click "New Pull Request". You'll be taken to a UI to prepare your request.
 
 Now, there are some terms we need to go over here. First, we have the "base" and "compare" drop downs. The "base" is your target for the merge. Since we want to merge into `main`, we can leave this alone.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5c549775c4be710237c.md
@@ -267,7 +267,7 @@ The lesson describes a special type of object returned by `matchAll()`.
 
 ---
 
-There is no difference, they are interchangeable
+There is no difference, they are interchangeable.
 
 ### --feedback--
 
@@ -283,7 +283,7 @@ How can you convert the result of `matchAll()` into an array containing all matc
 
 ## --answers--
 
-By using a `for...of` loop
+By using a `for...of` loop.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68297


<!-- Feel free to add any additional description of changes below this line -->
