### PR TITLE
fix(curriculum): remove "or set" from validity property description

### DIFF
--- a/curriculum/challenges/english/blocks/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
+++ b/curriculum/challenges/english/blocks/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
@@ -74,7 +74,7 @@ dashedName: review-form-validation-with-javascript
 
 :::
 
-- **`validity` Property**: This property is used to get or set the validity state of form controls (like `<input>`, `<select>`, etc.) and provides information about whether the user input meets the constraints defined for that element (e.g., `required` fields, pattern constraints, maximum length, etc.).
+- **`validity` Property**: This property is used to get the validity state of form controls (like `<input>`, `<select>`, etc.) and provides information about whether the user input meets the constraints defined for that element (e.g., `required` fields, pattern constraints, maximum length, etc.).
 
 :::interactive_editor
 


### PR DESCRIPTION
### Description:

This pull request fixes an incorrect description of the `validity` property by:

- Removing "or set" from the description, as the `validity` property is read-only and cannot be used to set the validity state.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68277 

<!-- Feel free to add any additional description of changes below this line -->
