### PR TITLE
fix(curriculum): fixing missing word and fix hyphenation in Merge Sort lecture (Python v9)

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-searching-and-sorting-algorithms/68910fc037a90c285107af04.md
+++ b/curriculum/challenges/english/blocks/lecture-searching-and-sorting-algorithms/68910fc037a90c285107af04.md
@@ -27,7 +27,7 @@ Then we need to look at the left side of the list:
 42 37
 ```
 
-We take that sub list and divide in half again until each sub list has only one item in it:
+We take that sub list and divide it in half again until each sub list has only one item in it:
 
 ```md
 42 | 37
@@ -113,7 +113,7 @@ Review the beginning of the lesson.
 
 ---
 
-A technique for recursively breaking down problems into smaller sub problems.
+A technique for recursively breaking down problems into smaller sub-problems.
 
 ---
 


### PR DESCRIPTION

## Description

Fixes two minor text issues in the **"What Is Divide and Conquer, and How Does Merge Sort Work?"** lecture in the Python v9 curriculum.

Closes #68303

---

## Changes Made

**1. Missing word — added `it` after `divide`**

The sentence was grammatically incomplete — `divide in half` is missing its object.

- **Before:** `We take that sub list and divide in half again until each sub list has only one item in it:`
- **After:** `We take that sub list and divide it in half again until each sub list has only one item in it:`

This is also consistent with the earlier sentence in the same description (`divide that list in half`) and the code comment (`# divide the list in half`).

---

**2. Inconsistent hyphenation — standardized to `sub-problems`**

The description introduces the concept as `sub-problems` (hyphenated), but the correct quiz answer uses `sub problems` (unhyphenated). They should match.

- **Before:** `A technique for recursively breaking down problems into smaller sub problems.`
- **After:** `A technique for recursively breaking down problems into smaller sub-problems.`

---


## Checklist
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces