### PR TITLE
fix(curriculum): correct grammar in push local repository lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829079ab2abe728a822cc1.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829079ab2abe728a822cc1.md
@@ -9,7 +9,7 @@ dashedName: how-do-you-push-a-local-repository-to-github
 
 In a previous lesson, you learned how to create a new repository on GitHub. But what if you had an existing project locally that you want to add to GitHub? In this lesson, you will learn how to push existing local repositories to GitHub and pull changes down from remote repositories.
 
-Start by creating a new repository on GitHub without any files. When done correctly, you should be redirected a page that includes the URL needed to clone your repository.
+Start by creating a new repository on GitHub without any files. When done correctly, you should be redirected to a page that includes the URL needed to clone your repository.
 
 Now navigate to your terminal and select an existing project you wish to add to GitHub. In this lesson, I am choosing a local project called `super-awesome-game` with the following files inside:
 
@@ -18,7 +18,7 @@ jessicawilkins super-awesome-game >> ls
 README.md  index.html script.js  styles.css
 ```
 
-To setup version control for this project using Git, you will need to run the `git init` command in the project directory. This will initialize an empty Git repository so Git can begin tracking changes for this project. When done correctly you should see a similar output in the terminal:
+To set up version control for this project using Git, you will need to run the `git init` command in the project directory. This will initialize an empty Git repository so Git can begin tracking changes for this project. When done correctly you should see a similar output in the terminal:
 
 ```sh
 jessicawilkins super-awesome-game >> git init
@@ -94,7 +94,7 @@ git commit -m "fix(auth): correct token expiration time"
 git commit -m "refactor: simplify login flow logic"
 ```
 
-The `feat(api)` and `fix(auth)` follows the Conventional Commits style which is used to provide context on the types of changes in that commit.
+The `feat(api)` and `fix(auth)` follow the Conventional Commits style which is used to provide context on the types of changes in that commit.
 
 After you have committed your work, and run `git status` again, you should see the following output in the terminal:
 
@@ -105,7 +105,7 @@ nothing to commit, working tree clean
 
 To view all of your prior commits for this project you can run the `git log` command. This will list all prior commits with helpful information like the author, date of commit, commit message and commit hash. The commit hash is a long string which serves as a unique identifier for a commit.
 
-Once you are done committing your work, you can now push your changes to GitHub. You will first need to setup the remote connection to your remote repo. You learned about this in the previous lesson, but here is a reminder using SSH:
+Once you are done committing your work, you can now push your changes to GitHub. You will first need to set up the remote connection to your remote repo. You learned about this in the previous lesson, but here is a reminder using SSH:
 
 ```sh
 git remote add origin git@github.com:your-github-username/name-of-repo.git
@@ -197,7 +197,7 @@ Refer back to the section discussing commits.
 
 ---
 
-It commits your changes and omits the message your provides.
+It commits your changes and omits the message you provide.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829079ab2abe728a822cc1.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829079ab2abe728a822cc1.md
@@ -25,7 +25,7 @@ jessicawilkins super-awesome-game >> git init
 Initialized empty Git repository in /Users/jessicawilkins/workspace/freeCodeCamp/super-awesome-game/.git/
 ```
 
-When you initialize an empty Git repository to a project, a new `.git` hidden directory will be added. To view the addition of the directory you can run the `ls -a` command which lists all files and directories, including hidden ones:
+When you initialize an empty Git repository in a project, a new `.git` hidden directory will be added. To view the addition of the directory you can run the `ls -a` command which lists all files and directories, including hidden ones:
 
 ```sh
 jessicawilkins super-awesome-game >> ls -a


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68294

### Description
This PR fixes multiple grammar, typos, and syntax errors in the "How do you push a local repository to GitHub" lecture file.

### Changes Made
* Fixed missing preposition by changing "redirected a page" to "redirected to a page".
* Corrected "setup" to "set up" (verb phrase) when introducing `git init`.
* Fixed wrong preposition by changing "repository to a project" to "repository in a project".
* Fixed subject-verb agreement ("follows" -> "follow") and wrapped `feat(api)` and `fix(auth)` in backticks for proper code formatting.
* Corrected the second instance of "setup" to "set up" regarding remote connections.
* Fixed a grammar error in a multiple-choice option from "your provides" to "you provide".