### PR TITLE
fix(client): correct spelling errors in code comments

### DIFF
--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -61,7 +61,7 @@ class Header extends React.Component<Props, { displayMenu: boolean }> {
       // the search bar should not toggle the menu
       this.searchBarRef.current &&
       !this.searchBarRef.current.contains(eventTarget) &&
-      // don't count clicks on searcn bar inputs reset button
+      // don't count clicks on search bar inputs reset button
       !eventTarget.closest('.ais-SearchBox-reset') &&
       // don't count clicks on disabled elements
       !eventTarget.closest('[aria-disabled="true"]')

--- a/client/src/components/search/with-instant-search.tsx
+++ b/client/src/components/search/with-instant-search.tsx
@@ -21,7 +21,7 @@ import {
 const mockSearchClient = {
   // When Algolia is not configured, the client will still render,
   // the result query is returned to the search component as a mock
-  //(mainly for testing without relying on Playwright fuffill route as
+  //(mainly for testing without relying on Playwright fulfill route as
   // there is no request made without a key).
   search: (request: Array<{ indexName: string; params: SearchOptions }>) => {
     return Promise.resolve({

--- a/client/src/redux/failed-updates-epic.js
+++ b/client/src/redux/failed-updates-epic.js
@@ -53,7 +53,7 @@ function failedUpdateEpic(action$, state$) {
 
       let submitableFailures = failures.filter(isSubmitable);
 
-      // delete unsubmitable failed challenges
+      // delete unsubmittable failed challenges
       store.set(key, submitableFailures);
       failures = submitableFailures;
 

--- a/client/src/utils/curriculum-layout.ts
+++ b/client/src/utils/curriculum-layout.ts
@@ -23,8 +23,8 @@ export const isProjectBased = (
   challengeType: number,
   blockDashedName: unknown = null
 ) => {
-  // Is project based but should be collapsable, this differs from the
-  // other projects which are not collapsable.
+  // Is project based but should be collapsible, this differs from the
+  // other projects which are not collapsible.
   if (blockDashedName === 'take-home-projects') return false;
 
   return projectBasedChallengeTypes.includes(challengeType);


### PR DESCRIPTION
Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68331

Fixed spelling errors in code comments across 4 client-side files:

- collapsable → collapsible (curriculum-layout.ts)
- unsubmitable → unsubmittable (failed-updates-epic.js)
- searcn → search (Header/index.tsx)
- fuffill → fulfill (with-instant-search.tsx)
