### PR TITLE
fix(curriculum): correct comma splice and verb form in git lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829061f03543726ea6f318.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829061f03543726ea6f318.md
@@ -15,7 +15,7 @@ Visit <a href="https://github.com" target="_blank">GitHub's website</a>, make su
 
 The first option you'll see there is the ability to choose a template. You likely do not have one of these set up yet, but a template is a special kind of repository that you can use as a springboard for your new repositories. These are helpful for including documentation or issue templates in all of your projects.
 
-Your next option is to select an owner, you can choose your user account or any organizations you own or have access to. Then you can name the repository - in general, you'll want to use a name that succinctly describes the project you are building. As a general best practice, you want to avoid spaces in your repo name. GitHub will automatically replace them with hyphens.
+Your next option is to select an owner. You can choose your user account or any organizations you own or have access to. Then you can name the repository - in general, you'll want to use a name that succinctly describes the project you are building. As a general best practice, you want to avoid spaces in your repo name. GitHub will automatically replace them with hyphens.
 
 Next, you can optionally add a description which will appear on the repository's home page.
 
@@ -29,7 +29,7 @@ From here, you can click the "Code" button to get options to clone your reposito
 
 You can ignore the "Codespaces" and "Copilot" tabs for this lesson. Instead, we are going to focus on the three options in the "Local" tab. The first two, HTTPS and SSH, are used in the same way. You use the `git clone` command with the URL provided in the box to clone the remote repository to your computer. The difference between these two is the connection and authentication methods.
 
-For cloning a public repository, you won't actually need to authenticate. But to clone a private repository, or to push to either public or private repositories, you will have to be authenticated. An HTTPS remote URL used to authenticate you via your GitHub username and password. However, due to security concerns this is no longer supported, and you are instead required to use a username and access token. Even then, it's a much less secure method than SSH, which uses your private and public keys. This has an added benefit of automatically signing you in, rather than having to provide a token every time. There will be a separate lesson diving deeper into SSH and how it works but you can also read through the GitHub documentation on how to setup SSH.
+For cloning a public repository, you won't actually need to authenticate. But to clone a private repository, or to push to either public or private repositories, you will have to be authenticated. An HTTPS remote URL used to authenticate you via your GitHub username and password. However, due to security concerns this is no longer supported, and you are instead required to use a username and access token. Even then, it's a much less secure method than SSH, which uses your private and public keys. This has an added benefit of automatically signing you in, rather than having to provide a token every time. There will be a separate lesson diving deeper into SSH and how it works but you can also read through the GitHub documentation on how to set up SSH.
 
 To clone the repository, you can run this in the terminal:
 


### PR DESCRIPTION
Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68293

Fixed comma splice and setup verb form in the Git and GitHub lecture:
- Changed comma splice to two separate sentences.
- Changed 'setup' to 'set up'.
