### PR TITLE
fix(curriculum): update steps to remove the need of useEffect

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd57e96257ed1fabbe4879.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd57e96257ed1fabbe4879.md
@@ -7,20 +7,64 @@ dashedName: step-10
 
 # --description--
 
-**NOTE**: A `useEffect` hook was added to call the `handleToggleVisibility` function when the component renders. You will learn more about the `useEffect` hook in a future lesson and workshop. 
+Now it is time to use your `handleToggleVisibility` function. 
 
-Now would be a good time to see the updated `isVisible` value.
+In prior lessons, you learned about React's Synthetic Event System and how to work with attributes like `onClick` and `onSubmit`.
 
-Below the `setIsVisible(!isVisible);`, log the `isVisible` state variable to the console. 
+Remember that you can pass a function reference to an `onClick` attribute like this:
 
-Open up the console and you will notice that the value is not what you expected it to be. 
+```jsx
+function handleClick() {
+  console.log("Button clicked!");
+}
+
+<button onClick={handleClick}>Click Me</button>;
+```
+
+Update your existing `button` element to add an `onClick` attribute and pass in a `handleToggleVisibility` function reference. 
+
+Now, when you click on the button, you will see the visibility of the paragraph text toggle between hidden and shown on the page. 
 
 # --hints--
 
-You should use `console.log` to log the `isVisible` state variable to the console. 
+When the `toggle-button` is clicked, the message `"I love freeCodeCamp!"` should appear on the screen.
 
 ```js
-assert.match(code, /console\.log\(\s*isVisible\s*\)/);
+  const abuseState = __helpers.spyOn(React, "useState");
+  const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText.replace("_React.useState", "abuseState");
+
+  const exports = {};
+  const a = eval(script);
+
+  const s = await __helpers.prepTestComponent(exports.ToggleApp);
+
+  const btn = s.querySelector('#toggle-button');
+  assert.exists(btn);
+  
+  await React.act(async () => {
+    const ev = new MouseEvent("click", { bubbles: true, cancelable: true });
+    btn.dispatchEvent(ev);
+  });
+
+  const alteredStates = abuseState.returns;
+  const initialStates = alteredStates.splice(0, abuseState.returns.length / 2);
+
+  const stateChanged = initialStates.some((s, i) => {
+    try {
+      assert.deepEqual(s[0], alteredStates[i][0]);
+      return false; 
+    } catch (e) {
+      return true; 
+    }
+  });
+ 
+  const msg = s.querySelector("#message");
+
+  assert.exists(msg)
+  assert.equal(msg.textContent, "I love freeCodeCamp!");
+
+  abuseState.restore();
+  assert.isTrue(stateChanged);
 ```
 
 # --seed--
@@ -98,25 +142,20 @@ body {
 ```
 
 ```jsx
-const { useState, useEffect } = React;
+const { useState } = React;
 
 export const ToggleApp = () => {
   const [isVisible, setIsVisible] = useState(false);
   
   const handleToggleVisibility = () => {
     setIsVisible(!isVisible);
-  --fcc-editable-region--
-    
-  --fcc-editable-region--
   }
-  
-  useEffect(() => {
-    handleToggleVisibility(); 
-  }, [])
   
   return (
     <div id="toggle-container">
+      --fcc-editable-region--
       <button id="toggle-button">Message</button>
+      --fcc-editable-region--
       {isVisible && <p id="message">I love freeCodeCamp!</p>}
     </div>
   );

--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd59f6581d3a20c9cc6460.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd59f6581d3a20c9cc6460.md
@@ -7,18 +7,18 @@ dashedName: step-11
 
 # --description--
 
-If you looked at the console, you might have been surprised to see the value of `false` instead of `true`. This is happening because React doesn't immediately update state. The state will only be updated on the next render cycle. 
+Now would be a good time to see the updated `isVisible` value.
 
-It is a common mistake for developers new to React to place console statements right after a set function. So this is something to be aware when you are building out your React applications.
+Below the `setIsVisible(!isVisible);`, log the `isVisible` state variable to the console. 
 
-Since the `console.log()` is no longer needed, remove it from your `handleToggleVisibility` function.
+Open up the console and you will notice that the value is not what you expected it to be. 
 
 # --hints--
 
-You should no longer have the `console.log(isVisible);` in your code.
+You should use `console.log` to log the `isVisible` state variable to the console. 
 
 ```js
-assert.notMatch(code, /console\.log\s*\(\s*isVisible\s*\)\s*;?/);
+assert.match(code, /console\.log\(\s*isVisible\s*\)/);
 ```
 
 # --seed--
@@ -96,7 +96,7 @@ body {
 ```
 
 ```jsx
-const { useState, useEffect } = React;
+const { useState } = React;
 
 export const ToggleApp = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -104,17 +104,15 @@ export const ToggleApp = () => {
   const handleToggleVisibility = () => {
     setIsVisible(!isVisible);
   --fcc-editable-region--
-    console.log(isVisible);
+    
   --fcc-editable-region--
   }
   
-  useEffect(() => {
-    handleToggleVisibility(); 
-  }, [])
-  
   return (
     <div id="toggle-container">
-      <button id="toggle-button">Message</button>
+      <button onClick={handleToggleVisibility} id="toggle-button">
+        Message
+      </button>
       {isVisible && <p id="message">I love freeCodeCamp!</p>}
     </div>
   );

--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd5bace629fa219a70aa6d.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd5bace629fa219a70aa6d.md
@@ -7,64 +7,18 @@ dashedName: step-12
 
 # --description--
 
-Now it is time to use your `handleToggleVisibility` function. 
+If you looked at the console, you might have been surprised to see the value of `false` instead of `true`. This is happening because React doesn't immediately update state. The state will only be updated on the next render cycle. 
 
-In prior lessons, you learned about React's Synthetic Event System and how to work with attributes like `onClick` and `onSubmit`.
+It is a common mistake for developers new to React to place console statements right after a set function. So this is something to be aware when you are building out your React applications.
 
-Remember that you can pass a function reference to an `onClick` attribute like this:
-
-```jsx
-function handleClick() {
-  console.log("Button clicked!");
-}
-
-<button onClick={handleClick}>Click Me</button>;
-```
-
-Update your existing `button` element to add an `onClick` attribute and pass in a `handleToggleVisibility` function reference. 
-
-Now, when you click on the button, you will see the visibility of the paragraph text toggle between hidden and shown on the page. 
+Since the `console.log()` is no longer needed, remove it from your `handleToggleVisibility` function.
 
 # --hints--
 
-When the `toggle-button` is clicked, the message `"I love freeCodeCamp!"` should appear on the screen.
+You should no longer have the `console.log(isVisible);` in your code.
 
 ```js
-  const abuseState = __helpers.spyOn(React, "useState");
-  const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText.replace("_React.useState", "abuseState");
-
-  const exports = {};
-  const a = eval(script);
-
-  const s = await __helpers.prepTestComponent(exports.ToggleApp);
-
-  const btn = s.querySelector('#toggle-button');
-  assert.exists(btn);
-  
-  await React.act(async () => {
-    const ev = new MouseEvent("click", { bubbles: true, cancelable: true });
-    btn.dispatchEvent(ev);
-  });
-
-  const alteredStates = abuseState.returns;
-  const initialStates = alteredStates.splice(0, abuseState.returns.length / 2);
-
-  const stateChanged = initialStates.some((s, i) => {
-    try {
-      assert.deepEqual(s[0], alteredStates[i][0]);
-      return false; 
-    } catch (e) {
-      return true; 
-    }
-  });
- 
-  const msg = s.querySelector("#message");
-
-  assert.exists(msg)
-  assert.equal(msg.textContent, "I love freeCodeCamp!");
-
-  abuseState.restore();
-  assert.isTrue(stateChanged);
+assert.notMatch(code, /console\.log\s*\(\s*isVisible\s*\)\s*;?/);
 ```
 
 # --seed--
@@ -149,13 +103,16 @@ export const ToggleApp = () => {
   
   const handleToggleVisibility = () => {
     setIsVisible(!isVisible);
+  --fcc-editable-region--
+    console.log(isVisible);
+  --fcc-editable-region--
   }
   
   return (
     <div id="toggle-container">
-      --fcc-editable-region--
-      <button id="toggle-button">Message</button>
-      --fcc-editable-region--
+      <button onClick={handleToggleVisibility} id="toggle-button">
+        Message
+      </button>
       {isVisible && <p id="message">I love freeCodeCamp!</p>}
     </div>
   );

--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
@@ -155,9 +155,11 @@ export const ToggleApp = () => {
   
   return (
     <div id="toggle-container">
+      <button onClick={handleToggleVisibility} id="toggle-button">
     --fcc-editable-region--
-      <button onClick={handleToggleVisibility} id="toggle-button">Message</button>
+        Message
     --fcc-editable-region--
+      </button>
       {isVisible && <p id="message">I love freeCodeCamp!</p>}
     </div>
   );

--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
@@ -258,5 +258,3 @@ export const ToggleApp = () => {
   );
 };
 ```
-
-


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68153 

<!-- Feel free to add any additional description of changes below this line -->

The PR is to update the steps 10,11,12,13 of workshop toggle text app. It fixes the disappearing of useEffect from the code without any explanation and updates the steps to remove the need of useEffect entirely from the workshop.

The steps now wires the `onClick` function to the button first as proposed in the issue and then uses `console.log` to show the value of `isVisible`.