### PR TITLE
fix(curriculum): accept arrow function syntax in merge sort step 1

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-merge-sort-js/69b2713ff6c21fed2d3ad88b.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort-js/69b2713ff6c21fed2d3ad88b.md
@@ -17,9 +17,8 @@ You should declare a function named `mergeSort` with a single `array` parameter.
 
 ```js
 assert.isFunction(mergeSort);
-const params = __helpers.getFunctionParams(mergeSort.toString());
-assert.lengthOf(params, 1);
-assert.deepEqual(params[0].name, "array");
+const regex = __helpers.functionRegex('mergeSort', ['array']);
+assert.match(__helpers.removeJSComments(code), regex);
 ```
 
 # --seed--


### PR DESCRIPTION
### Checklist:

  - [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
  - [x] I have read and followed the [how to open a pull request
  guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

  Closes #68334

  Replaces `getFunctionParams` with `functionRegex` in the merge sort workshop step 1 hint, so that arrow function
  syntax is accepted alongside traditional function declarations.

  The instructions never specify how the function should be declared, but the old `getFunctionParams` helper parsed
  the function AST in a way that rejected arrow syntax (`const mergeSort = array => {}`). The `functionRegex` helper
  matches any valid JS function syntax with the correct name and parameter, which is the same fix applied in #68263
  for the binary search workshop.