### PR TITLE
fix(curriculum): accept arrow function syntax in linked list step 2

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a00cd4ec513345d40e95ec.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a00cd4ec513345d40e95ec.md
@@ -22,8 +22,8 @@ assert.isFunction(isEmpty)
 Your `isEmpty` function should have a `list` parameter.
 
 ```js
-const isEmptyParams = __helpers.getFunctionParams(isEmpty.toString());
-assert.deepEqual(isEmptyParams[0].name, "list");
+const regex = __helpers.functionRegex('isEmpty', ['list']);
+assert.match(__helpers.removeJSComments(code), regex);
 ```
 
 Your `isEmpty` function should return `list.length === 0`.


### PR DESCRIPTION
### Checklist:

  - [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
  - [x] I have read and followed the [how to open a pull request
  guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

  Closes #68338

  Replaces `getFunctionParams` with `functionRegex` in the linked list workshop step 2 hint, so that arrow function
  syntax is accepted alongside traditional function declarations.

  The instructions never specify how `isEmpty` should be declared, but the old `getFunctionParams` helper rejected
  arrow syntax (`const isEmpty = list => {}`). The `functionRegex` helper matches any valid JS function syntax with
  the correct name and parameter. This is the same fix applied in #68263 for the binary search workshop and in the
  merge sort workshop step 1.

  Note: the issue title says "Merge sort workshop step 2" but the affected page is actually
  `workshop-linked-list-js/step-2` — the bug is in the linked list workshop.
