### PR TITLE
fix(curriculum): correct brand casing and grammar in git and github lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/688290189fecfe7206d22833.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/688290189fecfe7206d22833.md
@@ -7,13 +7,13 @@ dashedName: what-is-the-purpose-of-sites-like-github-and-gitlab
 
 # --description--
 
-In a previous lesson, we briefly mentioned GitHub. Both GitHub and Gitlab are version control providers. This means they are cloud-based solutions that offer storage of version-controlled projects in something called "repositories", and enable collaboration features to use with those projects.
+In a previous lesson, we briefly mentioned GitHub. Both GitHub and GitLab are version control providers. This means they are cloud-based solutions that offer storage of version-controlled projects in something called "repositories", and enable collaboration features to use with those projects.
 
-Before we dive in to the features these platforms offer, we need to discuss the different types of projects. Many projects are considered "open-source", which means people can see the code you publish, propose changes, report issues, and even run a modified version.
+Before we dive into the features these platforms offer, we need to discuss the different types of projects. Many projects are considered "open-source", which means people can see the code you publish, propose changes, report issues, and even run a modified version.
 
 But sometimes you may only want your teammates to see and work on the code. You can also publish a project as "closed-source", meaning the only people who can see and interact with the project are the people you explicitly authorize.
 
-Regardless of which approach your project takes, sites like GitHub and Gitlab can massively level up your team's collaboration.
+Regardless of which approach your project takes, sites like GitHub and GitLab can massively level up your team's collaboration.
 
 For example, a teammate working on a feature might be stuck and have questions. Rather than having to copy-paste the code into Discord for you to read, or hop on a call to screen share their work, they can upload the changes directly to GitHub. From there, you can view the changes in your browser or even download the changes to run and debug locally.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #68290


Corrected the brand casing from "Gitlab" to "GitLab" and fixed the phrasal verb spacing from "dive in to" to "dive into" to ensure consistency across the Relational Databases lecture content.