### PR TITLE
fix(curriculum): fix typos and formatting in semantic-html lecture block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,9 @@ curriculum/dist
 curriculum/build
 curriculum/src/test/blocks-generated
 
+### Nested repo clone (should not be committed) ###
+freeCodeCamp/
+
 ### Playwright ###
 
 /playwright

--- a/curriculum/challenges/english/blocks/lecture-importance-of-semantic-html/67298243760ae980de5266db.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-semantic-html/67298243760ae980de5266db.md
@@ -22,7 +22,7 @@ Most elements have semantic meaning. The `div` element is one of the very few th
 
 First and foremost, using proper semantic HTML will ensure the best experience for users with assistive technology like screen readers. But also, semantic HTML can improve your search rankings. This is referred to as search engine optimization, or SEO.
 
-Finally, using correct semantic elements can improve your development experience. Rather than having to sift through a bunch of developments to find your navigation bar, you can edit the `nav` element directly and know what you're changing. Throughout this section, you will learn more about these topics, how to use semantic elements, and why semantic HTML is so important.
+Finally, using correct semantic elements can improve your development experience. Rather than having to sift through a bunch of `div`s to find your navigation bar, you can edit the `nav` element directly and know what you're changing. Throughout this section, you will learn more about these topics, how to use semantic elements, and why semantic HTML is so important.
 
 # --questions--
 
@@ -32,7 +32,7 @@ What does semantic refer to?
 
 ## --answers--
 
-Nit picking the code.
+Nitpicking the code.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-importance-of-semantic-html/672990ecf71a852804ababe7.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-semantic-html/672990ecf71a852804ababe7.md
@@ -195,7 +195,7 @@ Think about which element describes the meaning of the content.
 
 ---
 
-Using the `nav` element to represent a navigation section
+Using the `nav` element to represent a navigation section.
 
 ---
 


### PR DESCRIPTION
## Description
Fixes typos and formatting issues in two curriculum files for the `lecture-importance-of-semantic-html` block.

### Changes:
- **why-should-you-care-about-semantic-html**: Replaced incorrect word `developments` with `` `div`s `` in the description; fixed `Nit picking` -> `Nitpicking` in quiz answer
- - **what-is-the-difference-between-presentational-and-semantic-html**: Added missing period to quiz answer option
Closes #68126