### PR TITLE
fix(curriculum): use functionRegex for calorie counter step 57

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-calorie-counter/63c21d4f48267a47c2946788.md
+++ b/curriculum/challenges/english/blocks/workshop-calorie-counter/63c21d4f48267a47c2946788.md
@@ -30,7 +30,7 @@ assert.isFunction(getCaloriesFromInputs);
 Your `getCaloriesFromInputs` function should take a parameter called `list`.
 
 ```js
-assert.match(getCaloriesFromInputs?.toString(), /\(\s*list\s*\)/);
+assert.match(code, __helpers.functionRegex('getCaloriesFromInputs', ['list']));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68332

Step 57 of the Calorie Counter workshop rejected arrow function definitions (`(list) => {}` and `list => {}`) because the third hint used a raw regex `/\(\s*list\s*\)/` on `.toString()`, which requires parentheses around the parameter. Replaced it with `__helpers.functionRegex('getCaloriesFromInputs', ['list'])` tested against `code`, which correctly matches function declarations, function expressions, and both arrow function forms.