### PR TITLE
test: move interactive editor and internet coverage to client

### DIFF
--- a/client/src/components/profile/components/internet.test.tsx
+++ b/client/src/components/profile/components/internet.test.tsx
@@ -1,0 +1,103 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { User } from '../../../redux/prop-types';
+import Internet from './internet';
+
+const baseUser = {
+  githubProfile: '',
+  linkedin: '',
+  twitter: '',
+  bluesky: '',
+  website: ''
+} as User;
+
+const socialFields = [
+  {
+    label: 'GitHub',
+    url: 'https://github.com/certified-user',
+    checkTestId: 'internet-github-check'
+  },
+  {
+    label: 'LinkedIn',
+    url: 'https://www.linkedin.com/in/certified-user',
+    checkTestId: 'internet-linkedin-check'
+  },
+  {
+    label: 'X',
+    url: 'https://x.com/certified-user',
+    checkTestId: 'internet-twitter-check'
+  },
+  {
+    label: 'Bluesky',
+    url: 'https://bsky.app/profile/certified-user.bsky.social',
+    checkTestId: 'internet-bluesky-check'
+  },
+  {
+    label: 'settings.labels.personal',
+    url: 'https://certified-user.com',
+    checkTestId: 'internet-website-check'
+  }
+];
+
+function makeStore() {
+  return configureStore({
+    reducer: (state: Record<string, never> = {}) => state
+  });
+}
+
+function renderInternet(userOverrides: Partial<User> = {}) {
+  const store = makeStore();
+
+  return render(
+    <Provider store={store}>
+      <Internet
+        setIsEditing={vi.fn()}
+        user={{ ...baseUser, ...userOverrides }}
+      />
+    </Provider>
+  );
+}
+
+function queryCheckmark(container: HTMLElement, testId: string) {
+  return container.querySelector(`[data-playwright-test-label="${testId}"]`);
+}
+
+describe('<Internet />', () => {
+  it('renders the internet presence form with a disabled save button', () => {
+    const { container } = renderInternet();
+
+    expect(
+      screen.getByRole('heading', { name: 'settings.headings.internet' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('group', { name: 'settings.headings.internet' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /buttons\.save/ })
+    ).toHaveAttribute('aria-disabled', 'true');
+
+    socialFields.forEach(({ checkTestId }) => {
+      expect(queryCheckmark(container, checkTestId)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows a checkmark for each valid social URL', async () => {
+    const user = userEvent.setup();
+    const { container } = renderInternet();
+
+    for (const { label, url, checkTestId } of socialFields) {
+      await user.type(screen.getByRole('textbox', { name: label }), url);
+
+      expect(queryCheckmark(container, checkTestId)).toBeInTheDocument();
+    }
+
+    expect(
+      screen.getByRole('button', { name: /buttons\.save/ })
+    ).not.toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/client/src/templates/Challenges/components/interactive-editor.test.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import InteractiveEditor, { type InteractiveFile } from './interactive-editor';
+
+vi.mock('@codesandbox/sandpack-react', async () => {
+  const React = await import('react');
+
+  const Panel = ({
+    children,
+    fallbackTestId
+  }: {
+    children?: React.ReactNode;
+    fallbackTestId: string;
+  }) => React.createElement('div', { 'data-testid': fallbackTestId }, children);
+
+  return {
+    FileTabs: () => React.createElement('div', { 'data-testid': 'file-tabs' }),
+    SandpackConsole: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      'data-playwright-test-label'?: string;
+    }) =>
+      React.createElement(
+        Panel,
+        { fallbackTestId: props['data-playwright-test-label'] ?? 'sp-console' },
+        children
+      ),
+    SandpackLayout: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(
+        Panel,
+        { fallbackTestId: 'sandpack-layout' },
+        children
+      ),
+    SandpackPreview: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      'data-playwright-test-label'?: string;
+    }) =>
+      React.createElement(
+        Panel,
+        { fallbackTestId: props['data-playwright-test-label'] ?? 'sp-preview' },
+        children
+      ),
+    SandpackProvider: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(
+        Panel,
+        { fallbackTestId: 'sandpack-provider' },
+        children
+      ),
+    SandpackStack: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children)
+  };
+});
+
+vi.mock('./custom-monaco-editor', () => ({
+  default: () => <div data-testid='custom-monaco-editor' />
+}));
+
+const htmlFile: InteractiveFile = {
+  ext: 'html',
+  name: 'index',
+  contents: '<h1>Hello</h1>',
+  contentsHtml: '<h1>Hello</h1>'
+};
+
+const jsFile: InteractiveFile = {
+  ext: 'js',
+  name: 'script',
+  contents: 'console.log("Hello");',
+  contentsHtml: 'console.log("Hello");'
+};
+
+describe('<InteractiveEditor />', () => {
+  it('shows preview and console panels for HTML with JavaScript', () => {
+    render(<InteractiveEditor files={[htmlFile, jsFile]} />);
+
+    expect(screen.getByTestId('sp-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('sp-console')).toBeInTheDocument();
+  });
+
+  it('shows only the console panel for JavaScript-only files', () => {
+    render(<InteractiveEditor files={[jsFile]} />);
+
+    expect(screen.getByTestId('sp-console')).toBeInTheDocument();
+    expect(screen.queryByTestId('sp-preview')).not.toBeInTheDocument();
+  });
+});

--- a/e2e/interactive-editor.spec.ts
+++ b/e2e/interactive-editor.spec.ts
@@ -9,11 +9,6 @@ const html = {
   codeSnippet: '<h1>Heading 1</h1>'
 };
 
-const js = {
-  challengePath:
-    '/learn/javascript-v9/lecture-introduction-to-javascript/what-is-a-data-type'
-};
-
 test.describe('Interactive Editor', () => {
   // skipping because I don't know of a page with paragraph nodules that doesn't also have an interactive editor toggle
   test.skip('should render paragraph nodules as text and not show the interactive editor toggle', async ({
@@ -93,29 +88,5 @@ test.describe('Interactive Editor', () => {
     await expect(
       page.getByTestId('sp-interactive-editor').first()
     ).toBeVisible();
-  });
-
-  test('should hide the preview panel in JS-only interactive editors and just show the console', async ({
-    page
-  }) => {
-    await page.goto(js.challengePath);
-
-    // Click the toggle button to show interactive editor
-    await page
-      .getByRole('button', {
-        name: /interactive editor/i
-      })
-      .click();
-
-    // Check that the consoles are visible
-    const consoles = page.getByTestId('sp-console');
-    await expect(consoles).toHaveCount(4);
-    for (const console of await consoles.all()) {
-      await expect(console).toBeVisible();
-    }
-
-    // Check that the preview is not visible
-    const previews = page.getByTestId('sp-preview');
-    await expect(previews).not.toBeVisible();
   });
 });

--- a/e2e/internet-presence-settings.spec.ts
+++ b/e2e/internet-presence-settings.spec.ts
@@ -3,15 +3,10 @@ import { test, expect } from '@playwright/test';
 import translations from '../client/i18n/locales/english/translations.json';
 
 const settingsPageElement = {
-  githubInput: 'internet-github-input',
-  githubCheckmark: 'internet-github-check',
-  linkedinCheckmark: 'internet-linkedin-check',
-  twitterCheckmark: 'internet-twitter-check',
-  blueskyCheckmark: 'internet-bluesky-check',
-  personalWebsiteCheckmark: 'internet-website-check',
-  flashMessageAlert: 'flash-message',
   internetPresenceForm: 'internet-presence'
 } as const;
+
+const githubUrl = 'https://github.com/certified-user';
 
 test.beforeEach(async ({ page }) => {
   // Reset input values
@@ -24,7 +19,8 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Your Internet Presence', () => {
   test.skip(({ browserName }) => browserName === 'webkit', 'flaky on Safari');
-  test('should display the section with save button being disabled', async ({
+
+  test('should save a social link and keep it after reload', async ({
     page
   }) => {
     await expect(
@@ -34,69 +30,24 @@ test.describe('Your Internet Presence', () => {
       })
     ).toBeVisible();
 
-    await expect(
-      page
-        .getByTestId(settingsPageElement.internetPresenceForm)
-        .getByRole('button', { name: translations.buttons.save })
-    ).toBeVisible();
-  });
+    const socialInput = page.getByRole('textbox', { name: 'GitHub' });
+    await expect(socialInput).toBeVisible();
+    await socialInput.fill(githubUrl);
 
-  const socials = [
-    {
-      name: 'github',
-      url: 'https://github.com/certified-user',
-      label: 'GitHub',
-      checkTestId: settingsPageElement.githubCheckmark
-    },
-    {
-      name: 'linkedin',
-      url: 'https://www.linkedin.com/in/certified-user',
-      label: 'LinkedIn',
-      checkTestId: settingsPageElement.linkedinCheckmark
-    },
-    {
-      name: 'twitter',
-      url: 'https://x.com/certified-user',
-      label: 'X',
-      checkTestId: settingsPageElement.twitterCheckmark
-    },
-    {
-      name: 'bluesky',
-      url: 'https://bsky.app/profile/certified-user.bsky.social',
-      label: 'Bluesky',
-      checkTestId: settingsPageElement.blueskyCheckmark
-    },
-    {
-      name: 'website',
-      url: 'https://certified-user.com',
-      label: translations.settings.labels.personal,
-      checkTestId: settingsPageElement.personalWebsiteCheckmark
-    }
-  ];
+    const saveButton = page
+      .getByTestId(settingsPageElement.internetPresenceForm)
+      .getByRole('button', { name: translations.buttons.save });
 
-  socials.forEach(social => {
-    test(`should hide ${social.name} checkmark by default`, async ({
-      page
-    }) => {
-      await expect(page.getByTestId(social.checkTestId)).toBeHidden();
-    });
+    await expect(saveButton).toBeVisible();
+    await saveButton.click();
+    await expect(page.getByRole('alert').first()).toContainText(
+      'We have updated your social links'
+    );
 
-    test(`should update ${social.name} URL`, async ({ page }) => {
-      const socialInput = page.getByRole('textbox', { name: social.label });
-      await expect(socialInput).toBeVisible();
-      await socialInput.fill(social.url);
-      const socialCheckmark = page.getByTestId(social.checkTestId);
-      await expect(socialCheckmark).toBeVisible();
-
-      const saveButton = page
-        .getByTestId(settingsPageElement.internetPresenceForm)
-        .getByRole('button', { name: translations.buttons.save });
-
-      await expect(saveButton).toBeVisible();
-      await saveButton.click();
-      await expect(page.getByRole('alert').first()).toContainText(
-        'We have updated your social links'
-      );
-    });
+    await page.reload();
+    await page.getByRole('button', { name: 'Edit my profile' }).click();
+    await expect(page.getByRole('textbox', { name: 'GitHub' })).toHaveValue(
+      githubUrl
+    );
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves two component-shaped Playwright checks into focused client tests: interactive editor panel selection and internet presence form/checkmark behavior.

The remaining Playwright coverage stays focused on true browser journeys: route-level interactive editor toggle/reload persistence, and saving an internet presence link through settings with flash/reload persistence.