### PR TITLE
test: move interactive editor layout coverage to client

### DIFF
--- a/client/src/templates/Challenges/components/interactive-editor.test.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.test.tsx
@@ -1,66 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import InteractiveEditor, { type InteractiveFile } from './interactive-editor';
-
-vi.mock('@codesandbox/sandpack-react', async () => {
-  const React = await import('react');
-
-  const Panel = ({
-    children,
-    fallbackTestId
-  }: {
-    children?: React.ReactNode;
-    fallbackTestId: string;
-  }) => React.createElement('div', { 'data-testid': fallbackTestId }, children);
-
-  return {
-    FileTabs: () => React.createElement('div', { 'data-testid': 'file-tabs' }),
-    SandpackConsole: ({
-      children,
-      ...props
-    }: {
-      children?: React.ReactNode;
-      'data-playwright-test-label'?: string;
-    }) =>
-      React.createElement(
-        Panel,
-        { fallbackTestId: props['data-playwright-test-label'] ?? 'sp-console' },
-        children
-      ),
-    SandpackLayout: ({ children }: { children?: React.ReactNode }) =>
-      React.createElement(
-        Panel,
-        { fallbackTestId: 'sandpack-layout' },
-        children
-      ),
-    SandpackPreview: ({
-      children,
-      ...props
-    }: {
-      children?: React.ReactNode;
-      'data-playwright-test-label'?: string;
-    }) =>
-      React.createElement(
-        Panel,
-        { fallbackTestId: props['data-playwright-test-label'] ?? 'sp-preview' },
-        children
-      ),
-    SandpackProvider: ({ children }: { children?: React.ReactNode }) =>
-      React.createElement(
-        Panel,
-        { fallbackTestId: 'sandpack-provider' },
-        children
-      ),
-    SandpackStack: ({ children }: { children?: React.ReactNode }) =>
-      React.createElement(React.Fragment, null, children)
-  };
-});
-
-vi.mock('./custom-monaco-editor', () => ({
-  default: () => <div data-testid='custom-monaco-editor' />
-}));
 
 const htmlFile: InteractiveFile = {
   ext: 'html',

--- a/client/src/templates/Challenges/components/interactive-editor.test.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import InteractiveEditor, { type InteractiveFile } from './interactive-editor';
+
+vi.mock('@codesandbox/sandpack-react', async () => {
+  const React = await import('react');
+
+  const Panel = ({
+    children,
+    fallbackTestId
+  }: {
+    children?: React.ReactNode;
+    fallbackTestId: string;
+  }) => React.createElement('div', { 'data-testid': fallbackTestId }, children);
+
+  return {
+    FileTabs: () => React.createElement('div', { 'data-testid': 'file-tabs' }),
+    SandpackConsole: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      'data-playwright-test-label'?: string;
+    }) =>
+      React.createElement(
+        Panel,
+        { fallbackTestId: props['data-playwright-test-label'] ?? 'sp-console' },
+        children
+      ),
+    SandpackLayout: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(
+        Panel,
+        { fallbackTestId: 'sandpack-layout' },
+        children
+      ),
+    SandpackPreview: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      'data-playwright-test-label'?: string;
+    }) =>
+      React.createElement(
+        Panel,
+        { fallbackTestId: props['data-playwright-test-label'] ?? 'sp-preview' },
+        children
+      ),
+    SandpackProvider: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(
+        Panel,
+        { fallbackTestId: 'sandpack-provider' },
+        children
+      ),
+    SandpackStack: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children)
+  };
+});
+
+vi.mock('./custom-monaco-editor', () => ({
+  default: () => <div data-testid='custom-monaco-editor' />
+}));
+
+const htmlFile: InteractiveFile = {
+  ext: 'html',
+  name: 'index',
+  contents: '<h1>Hello</h1>',
+  contentsHtml: '<h1>Hello</h1>'
+};
+
+const jsFile: InteractiveFile = {
+  ext: 'js',
+  name: 'script',
+  contents: 'console.log("Hello");',
+  contentsHtml: 'console.log("Hello");'
+};
+
+describe('<InteractiveEditor />', () => {
+  it('shows preview and console panels for HTML with JavaScript', () => {
+    render(<InteractiveEditor files={[htmlFile, jsFile]} />);
+
+    expect(screen.getByTestId('sp-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('sp-console')).toBeInTheDocument();
+  });
+
+  it('shows only the console panel for JavaScript-only files', () => {
+    render(<InteractiveEditor files={[jsFile]} />);
+
+    expect(screen.getByTestId('sp-console')).toBeInTheDocument();
+    expect(screen.queryByTestId('sp-preview')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/templates/Challenges/components/interactive-editor.tsx
+++ b/client/src/templates/Challenges/components/interactive-editor.tsx
@@ -67,7 +67,7 @@ const InteractiveEditor = ({ files }: Props) => {
   return (
     <div
       className='interactive-editor-wrapper'
-      data-playwright-test-label='sp-interactive-editor'
+      data-testid='sp-interactive-editor'
     >
       <SandpackProvider
         template={
@@ -103,11 +103,11 @@ const InteractiveEditor = ({ files }: Props) => {
               showConsole ? (
                 <>
                   <SandpackPreview
-                    data-playwright-test-label='sp-preview'
+                    data-testid='sp-preview'
                     style={{ flex: 1.5 }}
                   />
                   <SandpackConsole
-                    data-playwright-test-label='sp-console'
+                    data-testid='sp-console'
                     style={{
                       flex: 1,
                       overflow: 'scroll'
@@ -118,10 +118,7 @@ const InteractiveEditor = ({ files }: Props) => {
                 <SandpackPreview />
               )
             ) : (
-              <SandpackConsole
-                data-playwright-test-label='sp-console'
-                standalone={true}
-              />
+              <SandpackConsole data-testid='sp-console' standalone={true} />
             )}
           </SandpackStack>
         </SandpackLayout>

--- a/e2e/interactive-editor.spec.ts
+++ b/e2e/interactive-editor.spec.ts
@@ -38,7 +38,9 @@ test.describe('Interactive Editor', () => {
     await expect(page.getByText(html.paragraphOneText)).toBeVisible();
 
     // Initially, interactive editor should be hidden, static code view should be visible
-    await expect(page.getByTestId('sp-interactive-editor')).not.toBeVisible();
+    await expect(
+      page.locator('[data-testid="sp-interactive-editor"]')
+    ).not.toBeVisible();
     await expect(
       page.locator('pre code').filter({ hasText: html.codeSnippet })
     ).toHaveCount(1);
@@ -51,7 +53,7 @@ test.describe('Interactive Editor', () => {
 
     // Interactive editor should be visible, static code view hidden
     await expect(
-      page.getByTestId('sp-interactive-editor').first()
+      page.locator('[data-testid="sp-interactive-editor"]').first()
     ).toBeVisible();
     await expect(page.locator('pre code')).not.toBeVisible();
 
@@ -59,7 +61,9 @@ test.describe('Interactive Editor', () => {
     await toggleButton.click();
 
     // Interactive editor should be hidden, static code view visible again
-    await expect(page.getByTestId('sp-interactive-editor')).not.toBeVisible();
+    await expect(
+      page.locator('[data-testid="sp-interactive-editor"]')
+    ).not.toBeVisible();
     await expect(
       page.locator('pre code').filter({ hasText: html.codeSnippet })
     ).toBeVisible();
@@ -71,7 +75,9 @@ test.describe('Interactive Editor', () => {
     await page.goto(html.challengePath);
 
     // Initially, the interactive editor should be hidden
-    await expect(page.getByTestId('sp-interactive-editor')).not.toBeVisible();
+    await expect(
+      page.locator('[data-testid="sp-interactive-editor"]')
+    ).not.toBeVisible();
 
     await page
       .getByRole('button', {
@@ -80,13 +86,13 @@ test.describe('Interactive Editor', () => {
       .click();
 
     await expect(
-      page.getByTestId('sp-interactive-editor').first()
+      page.locator('[data-testid="sp-interactive-editor"]').first()
     ).toBeVisible();
 
     // Reload the page and check that the interactive editor is still shown
     await page.reload();
     await expect(
-      page.getByTestId('sp-interactive-editor').first()
+      page.locator('[data-testid="sp-interactive-editor"]').first()
     ).toBeVisible();
   });
 });

--- a/e2e/interactive-editor.spec.ts
+++ b/e2e/interactive-editor.spec.ts
@@ -9,11 +9,6 @@ const html = {
   codeSnippet: '<h1>Heading 1</h1>'
 };
 
-const js = {
-  challengePath:
-    '/learn/javascript-v9/lecture-introduction-to-javascript/what-is-a-data-type'
-};
-
 test.describe('Interactive Editor', () => {
   // skipping because I don't know of a page with paragraph nodules that doesn't also have an interactive editor toggle
   test.skip('should render paragraph nodules as text and not show the interactive editor toggle', async ({
@@ -93,29 +88,5 @@ test.describe('Interactive Editor', () => {
     await expect(
       page.getByTestId('sp-interactive-editor').first()
     ).toBeVisible();
-  });
-
-  test('should hide the preview panel in JS-only interactive editors and just show the console', async ({
-    page
-  }) => {
-    await page.goto(js.challengePath);
-
-    // Click the toggle button to show interactive editor
-    await page
-      .getByRole('button', {
-        name: /interactive editor/i
-      })
-      .click();
-
-    // Check that the consoles are visible
-    const consoles = page.getByTestId('sp-console');
-    await expect(consoles).toHaveCount(4);
-    for (const console of await consoles.all()) {
-      await expect(console).toBeVisible();
-    }
-
-    // Check that the preview is not visible
-    const previews = page.getByTestId('sp-preview');
-    await expect(previews).not.toBeVisible();
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves the local interactive editor panel-selection coverage into a focused client test.

The Playwright spec still keeps the real challenge-route behavior: toggling from static code to the live Sandpack editor and preserving that preference after reload.