### PR TITLE
fix: Fix binary search lesson typos

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-common-searching-and-sorting-algorithms/69691f96a3a2f3f6c220ab52.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-common-searching-and-sorting-algorithms/69691f96a3a2f3f6c220ab52.md
@@ -40,7 +40,7 @@ Binary search is a more efficient algorithm for searching through a large list o
 
 Binary search works by dividing the list in half and checking if the target value is in the middle of the list. If the target value is in the middle of the list, the index of the target value is returned. Otherwise, the algorithm checks if the target value is in the left or right half of the list.
 
-It continues to divide the remaining parts of the list into halves until the target value is found. If the target value is not in the list, it returns `-1`
+It continues to divide the remaining parts of the list into halves until the target value is found. If the target value is not in the list, it returns `-1`.
 
 Here is what the code looks like for binary search:
 
@@ -71,9 +71,9 @@ We then check the condition of `low` being less than or equal to `high`. If `low
 
 If the `low` index is less than or equal to the `high` index, we calculate the middle index of the list, `mid`. We then check if the target value is at the middle index. If it is, we return the middle index.
 
-Otherwise, we check if the value at the midpoint is less than the target. If it is, we update the low index to be the middle index plus one. This means we will search the right half of the list.
+Otherwise, we check if the value at the midpoint is less than the target. If it is, we update the `low` index to be the middle index plus one. This means we will search the right half of the list.
 
-Lastly, if none of the other conditions are `True`, we update the `high` index to be the middle index minus one. This means we will search the left half of the list.
+Lastly, if none of the other conditions are `true`, we update the `high` index to be the middle index minus one. This means we will search the left half of the list.
 
 We continue to repeat this process until we find the target or determine that the target is not in the list.
 
@@ -192,4 +192,3 @@ Reflect on what the function is designed to do when the target is absent.
 ## --video-solution--
 
 2
-


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team has all the context they need to review your changes. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68285

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes three small text issues in the binary search lesson:

- Adds the missing period after `-1`.
- Changes `True` to `true` to match JavaScript.
- Wraps `low` in backticks for consistency with the rest of the lesson.
