### PR TITLE
fix(curriculum): audit editable regions for workshop-countup

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-countup/694870bcf3c6874112b6f951.md
+++ b/curriculum/challenges/english/blocks/workshop-countup/694870bcf3c6874112b6f951.md
@@ -43,8 +43,7 @@ function countup(number) {
   if (number < 1) {
     return [];
 --fcc-editable-region--
-  }
-  
+  } 
 --fcc-editable-region--
 }
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Part of #67721

<!-- Feel free to add any additional description of changes below this line -->

This PR completes the editable region audit for workshop-countup.

Changes:

- Remove extra blank line in editable region
- Add a space after the closing brace in the editable region