### PR TITLE
fix: correct GNU capitalization in lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/6882904fd7063f7258c0aef3.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/6882904fd7063f7258c0aef3.md
@@ -9,7 +9,7 @@ dashedName: how-do-you-handle-security-requirements-like-ssh-and-gpg-keys
 
 Before you can push your repository to GitHub, you will need to be authenticated. Both SSH and GPG keys use a public-private pair. This means that you keep a private key on your local machine, which you use to authenticate yourself. You share a public key with the people or services that need to validate your auth. In other words, the private key is required to perform an action, and the public key is used to verify the action.
 
-GPG, or Gnu Privacy Guard, keys are typically used to sign files or commits. Someone can then use your public GPG key to verify that the file signature is from your key and that the contents of the file have not been modified or tampered with. SSH, or Secure SHell, keys are typically used to authenticate a remote connection to a server - via the `ssh` utility. However, as you'll learn in this lesson, you can also use an SSH key to sign commits.
+GPG, or GNU Privacy Guard, keys are typically used to sign files or commits. Someone can then use your public GPG key to verify that the file signature is from your key and that the contents of the file have not been modified or tampered with. SSH, or Secure SHell, keys are typically used to authenticate a remote connection to a server - via the `ssh` utility. However, as you'll learn in this lesson, you can also use an SSH key to sign commits.
 
 To generate a GPG key, you'll need to run:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68292

<!-- Feel free to add any additional description of changes below this line -->

Changed "Gnu Privacy Guard" to "GNU Privacy Guard" to match the correct capitalization.

This improves accuracy in the curriculum lesson.