### PR TITLE
fix(curriculum): correct contributing lecture text

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/688290b7f7f46f72d3d4e73d.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/688290b7f7f46f72d3d4e73d.md
@@ -21,7 +21,7 @@ Click "Create fork" and your new repository will be created, and you'll automati
 
 Next, clone it to your local computer just like you would do with your own repository, using SSH or the GitHub CLI.
 
-Now, let's take a look at the remotes your local clone has configured. Open a terminal in the local repository directory and run `git remote -v` to get a full list, it should look something like this:
+Now, let's take a look at the remotes your local clone has configured. Open a terminal in the local repository directory and run `git remote -v` to get a full list. It should look something like this:
 
 ```sh
 origin git@github.com:your-username/your-repo-name.git (fetch)
@@ -33,7 +33,7 @@ By cloning a repository from GitHub, Git has automatically configured your fork 
 To do this, let's add the original repository as another remote. Return to the page where you forked the repository from, click the "Code" button, and grab the SSH URL. Then run the command to create a new upstream remote:
 
 ```sh
-git remote add upstream git@github.com:original-repo-username/repo-name.git
+git remote add upstream git@github.com:original-repo-username/your-repo-name.git
 ```
 
 `upstream` is the name of the remote - you can name it something else, but `upstream` tends to be the convention. If you look at your remotes again, you will see your new upstream remote:
@@ -49,7 +49,7 @@ With the `upstream` remote you'll be able to do things like `git fetch upstream`
 
 A fork is still a repository, and you create commits and push changes in the same way. However, before diving into that, you should understand that there are certain strategies that you should follow when making changes to someone else's project. You'll learn more about these strategies in upcoming lessons.
 
-Projects which make their source code available to the public, allow you to modify the code, and accept code contributions are called "open source" projects. There are a lot of benefits to open source, such as allowing the community to help you identify and fix bugs, learning from the contributions people make to your work, and fostering a community of developers that you can turn in to a network.
+Projects which make their source code available to the public, allow you to modify the code, and accept code contributions are called "open source" projects. There are a lot of benefits to open source, such as allowing the community to help you identify and fix bugs, learning from the contributions people make to your work, and fostering a community of developers that you can turn into a network.
 
 When you make changes to someone's project, you are considered an "open source contributor". Contributing to open source projects can be an excellent preview of what working on a professional developer team is like. And some of the strategies here will help you do just that, and carry over into your first paid role.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68295

This corrects three text issues in the contributing lecture:
- Splits a comma splice into two sentences.
- Makes the upstream remote command match the following remote output.
- Changes 'turn in to' to 'turn into'.

Validation:
- git diff --check
- pnpm dlx prettier@3.8.2 --check curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/688290b7f7f46f72d3d4e73d.md