### PR TITLE
test: move multiple choice question coverage to client

### DIFF
--- a/client/src/templates/Challenges/components/multiple-choice-questions.test.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { createStore } from '../../../redux/create-store';
+import MultipleChoiceQuestions from './multiple-choice-questions';
+
+vi.mock('../../../utils/get-words');
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+beforeAll(() => {
+  globalThis.ResizeObserver = ResizeObserverMock;
+});
+
+afterAll(() => {
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+const questionsWithAudio = [
+  {
+    text: '<p>Repeat the sentence.</p>',
+    solution: 1,
+    answers: [
+      {
+        answer: '<p>First spoken answer.</p>',
+        feedback: null,
+        audioId: 'first-answer'
+      },
+      {
+        answer: '<p>Second spoken answer.</p>',
+        feedback: null,
+        audioId: 'second-answer'
+      }
+    ]
+  }
+];
+
+const questionsWithoutAudio = Array.from({ length: 3 }, (_, questionIndex) => ({
+  text: `<p>Question ${questionIndex + 1}</p>`,
+  solution: 1,
+  answers: Array.from({ length: 4 }, (_, answerIndex) => ({
+    answer: `<p>Question ${questionIndex + 1} answer ${answerIndex + 1}</p>`,
+    feedback: null,
+    audioId: null
+  }))
+}));
+
+function renderQuestions({
+  questions = questionsWithAudio,
+  selectedOptions = questions.map(() => null),
+  submittedMcqAnswers = questions.map(() => null),
+  showFeedback = false
+}: Partial<React.ComponentProps<typeof MultipleChoiceQuestions>> = {}) {
+  const store = createStore();
+  const handleOptionChange = vi.fn();
+
+  render(
+    <Provider store={store}>
+      <MultipleChoiceQuestions
+        questions={questions}
+        selectedOptions={selectedOptions}
+        handleOptionChange={handleOptionChange}
+        submittedMcqAnswers={submittedMcqAnswers}
+        showFeedback={showFeedback}
+        superBlock={SuperBlocks.B1English}
+      />
+    </Provider>
+  );
+
+  return { handleOptionChange, store };
+}
+
+describe('MultipleChoiceQuestions', () => {
+  it('renders speaking controls for answers with audio', async () => {
+    const user = userEvent.setup();
+    const { store } = renderQuestions();
+
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+
+    const speakingButtons = screen.getAllByRole('button', {
+      name: 'speaking-modal.speaking-button'
+    });
+    expect(speakingButtons).toHaveLength(2);
+
+    expect(speakingButtons[0]).toHaveAttribute(
+      'aria-describedby',
+      'mc-question-0-answer-0-label'
+    );
+    expect(speakingButtons[1]).toHaveAttribute(
+      'aria-describedby',
+      'mc-question-0-answer-1-label'
+    );
+
+    await user.click(speakingButtons[0]);
+
+    expect(store.getState().challenge.modal.speaking).toBe(true);
+  });
+
+  it('does not render speaking controls for answers without audio', () => {
+    renderQuestions({ questions: questionsWithoutAudio });
+
+    expect(screen.getAllByRole('radio')).toHaveLength(12);
+    expect(
+      screen.queryByRole('button', {
+        name: 'speaking-modal.speaking-button'
+      })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/e2e/multiple-choice-question-challenge.spec.ts
+++ b/e2e/multiple-choice-question-challenge.spec.ts
@@ -3,8 +3,6 @@ import translations from '../client/i18n/locales/english/translations.json';
 
 const pageWithSpeaking =
   '/learn/b1-english-for-developers/learn-about-adverbial-phrases/task-19';
-const pageWithoutSpeaking =
-  '/learn/responsive-web-design-v9/lecture-what-is-css/what-is-the-basic-anatomy-of-a-css-rule';
 
 test.describe('Multiple Choice Question Challenge - With Speaking Modal', () => {
   test.beforeEach(async ({ page }) => {
@@ -20,30 +18,14 @@ test.describe('Multiple Choice Question Challenge - With Speaking Modal', () => 
       'Skip on Firefox - speech recognition unsupported'
     );
 
-    const speakingButtons = page.getByRole('button', {
-      name: translations['speaking-modal']['speaking-button']
-    });
-    await expect(speakingButtons).toHaveCount(2);
+    const speakingButton = page
+      .getByRole('button', {
+        name: translations['speaking-modal']['speaking-button']
+      })
+      .first();
+    await expect(speakingButton).toBeVisible();
 
-    await expect(page.getByRole('radio')).toHaveCount(2);
-
-    for (let i = 0; i < 2; i++) {
-      const btn = speakingButtons.nth(i);
-      await expect(btn).toBeVisible();
-
-      const describedBy = await btn.getAttribute('aria-describedby');
-      expect(describedBy).toBeTruthy();
-
-      // Ensure aria-describedby points to an existing element
-      await expect(page.locator(`#${describedBy}`)).toBeVisible();
-
-      await expect(btn).toHaveAttribute(
-        'aria-label',
-        translations['speaking-modal']['speaking-button']
-      );
-    }
-
-    await speakingButtons.first().click();
+    await speakingButton.click();
 
     await expect(page.getByRole('dialog')).toBeVisible();
 
@@ -87,23 +69,5 @@ test.describe('Multiple Choice Question Challenge - With Speaking Modal', () => 
         translations['speaking-modal']['speech-recognition-not-supported']
       )
     ).toBeVisible();
-  });
-});
-
-test.describe('Multiple Choice Question Challenge - Without Speaking Modal', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(pageWithoutSpeaking);
-  });
-
-  test('should not show speaking controls on a challenge without speaking', async ({
-    page
-  }) => {
-    await expect(page.getByRole('radio')).toHaveCount(12);
-
-    await expect(
-      page.getByRole('button', {
-        name: translations['speaking-modal']['speaking-button']
-      })
-    ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This keeps the browser-dependent speech-recognition checks in Playwright, but moves the rendering-shaped multiple choice question coverage into a client test. The client test covers speaking button rendering, accessible description wiring, the no-audio case, and the Redux modal dispatch with the real store. The e2e spec stays focused on the real challenge route opening the speaking modal and Firefox showing the unsupported speech-recognition path.