### PR TITLE
test: move progress reset modal coverage to client

### DIFF
--- a/client/src/components/settings/reset-modal.test.tsx
+++ b/client/src/components/settings/reset-modal.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ResetModal from './reset-modal';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      options: { verifyText?: string } | undefined = undefined
+    ) => (options?.verifyText ? `${key} ${options.verifyText}` : key)
+  })
+}));
+
+const verifyResetText = 'settings.danger.verify-reset-text';
+
+function renderResetModal(
+  props: Partial<React.ComponentProps<typeof ResetModal>> = {}
+) {
+  return render(
+    <ResetModal reset={vi.fn()} onHide={vi.fn()} show={true} {...props} />
+  );
+}
+
+describe('<ResetModal />', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class ResizeObserver {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+      }
+    );
+  });
+
+  it('renders the reset progress warning and disabled confirmation button', () => {
+    renderResetModal();
+
+    expect(
+      screen.getByRole('dialog', { name: 'settings.danger.reset-heading' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('settings.danger.reset-p1')).toBeInTheDocument();
+    expect(
+      screen.getByText('settings.danger.reset-item-1')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('settings.danger.reset-item-2')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('settings.danger.reset-item-3')
+    ).toBeInTheDocument();
+    expect(screen.getByText('settings.danger.reset-p2')).toBeInTheDocument();
+    expect(screen.getByText('settings.danger.reset-p3')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'settings.danger.nevermind-2' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'settings.danger.reset-confirm' })
+    ).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
+  it('closes when the cancel button is clicked', () => {
+    const onHide = vi.fn();
+    renderResetModal({ onHide });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'settings.danger.nevermind-2' })
+    );
+
+    expect(onHide).toHaveBeenCalled();
+  });
+
+  it('keeps the confirmation button disabled for incorrect verification text', () => {
+    renderResetModal();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'incorrect text' }
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'settings.danger.reset-confirm' })
+    ).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('enables reset when the verification text matches', () => {
+    const reset = vi.fn();
+    renderResetModal({ reset });
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: verifyResetText }
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'settings.danger.reset-confirm' })
+    );
+
+    expect(reset).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/settings/reset-modal.test.tsx
+++ b/client/src/components/settings/reset-modal.test.tsx
@@ -4,15 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ResetModal from './reset-modal';
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (
-      key: string,
-      options: { verifyText?: string } | undefined = undefined
-    ) => (options?.verifyText ? `${key} ${options.verifyText}` : key)
-  })
-}));
-
 const verifyResetText = 'settings.danger.verify-reset-text';
 
 function renderResetModal(

--- a/e2e/progress-reset-modal.spec.ts
+++ b/e2e/progress-reset-modal.spec.ts
@@ -5,125 +5,16 @@ import translations from '../client/i18n/locales/english/translations.json';
 
 const execP = promisify(exec);
 
-test.beforeEach(async ({ page }) => {
-  await page.goto('/settings');
-});
-
 test.afterEach(async () => {
   await execP('node ../tools/scripts/seed/seed-demo-user --certified-user');
 });
 
 test.describe('Progress reset modal', () => {
-  test('should display the content properly', async ({ page }) => {
-    await page
-      .getByRole('button', { name: 'Reset all of my progress' })
-      .click();
-
-    await expect(
-      page.getByRole('dialog', { name: 'Reset My Progress' })
-    ).toBeVisible();
-
-    await expect(
-      page.getByText(
-        'This will permanently delete and reset all of the following:'
-      )
-    ).toBeVisible();
-
-    await expect(
-      page.getByText(
-        'Your progress through each step/challenge (all completed challenges will be lost)'
-      )
-    ).toBeVisible();
-
-    await expect(
-      page.getByText(
-        'Any saved code, including partially completed challenges, and certification project code'
-      )
-    ).toBeVisible();
-
-    await expect(
-      page.getByText('All completed and claimed certifications')
-    ).toBeVisible();
-
-    await expect(
-      page.getByText(
-        'You will effectively be set back to the very first day you signed up.'
-      )
-    ).toBeVisible();
-
-    await expect(
-      page.getByText(
-        "We won't be able to recover any of it for you later, even if you change your mind."
-      )
-    ).toBeVisible();
-
-    await expect(
-      page.getByRole('button', {
-        name: "Nevermind, I don't want to delete all of my progress"
-      })
-    ).toBeVisible();
-
-    await expect(
-      page.getByRole('button', {
-        name: 'Reset everything. I want to start from the beginning'
-      })
-    ).toBeVisible();
-
-    await expect(
-      page.getByRole('button', {
-        name: 'Reset everything. I want to start from the beginning'
-      })
-    ).toBeDisabled();
-  });
-
-  test('should close the dialog if the user clicks the cancel button', async ({
-    page
-  }) => {
-    await page
-      .getByRole('button', { name: 'Reset all of my progress' })
-      .click();
-
-    await expect(
-      page.getByRole('dialog', { name: 'Reset My Progress' })
-    ).toBeVisible();
-
-    await page
-      .getByRole('button', {
-        name: "Nevermind, I don't want to delete all of my progress"
-      })
-      .click();
-
-    await expect(
-      page.getByRole('dialog', { name: 'Reset My Progress' })
-    ).toBeHidden();
-  });
-
-  test('Reset progress button should be disabled if user incorrectly fills verify input text', async ({
-    page
-  }) => {
-    await page
-      .getByRole('button', { name: 'Reset all of my progress' })
-      .click();
-
-    await expect(
-      page.getByRole('dialog', { name: 'Reset My Progress' })
-    ).toBeVisible();
-
-    const verifyResetInput = page.getByRole('textbox', {
-      exact: true
-    });
-    await verifyResetInput.fill('incorrect text');
-
-    await expect(
-      page.getByRole('button', {
-        name: 'Reset everything. I want to start from the beginning'
-      })
-    ).toBeDisabled();
-  });
-
   test('should reset the progress if the user fills the verify input text and clicks the reset button', async ({
     page
   }) => {
+    await page.goto('/settings');
+
     await page
       .getByRole('button', { name: 'Reset all of my progress' })
       .click();


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves the progress reset modal rendering checks out of Playwright and into the client test layer. The old e2e spec opened the modal from `/settings` and asserted its content, cancel behavior, wrong verify text disabled state, and correct verify text enabled state. The new unit test covers these directly against the `ResetModal` component. The remaining e2e coverage keeps only the server-backed full account reset journey: filling the verify input, clicking reset, confirming the success flash, and verifying certifications are gone from `/settings`.