### PR TITLE
test: move quincy email sign-up rendering coverage to client

### DIFF
--- a/client/src/components/email-options.test.tsx
+++ b/client/src/components/email-options.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import EmailOptions from './email-options';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}));
+
+vi.mock('../../config/env.json', () => ({
+  apiLocation: 'http://localhost:3000'
+}));
+
+function renderEmailOptions(isSignedIn: boolean) {
+  return render(
+    <EmailOptions
+      isSignedIn={isSignedIn}
+      updateQuincyEmail={vi.fn()}
+      isPage={true}
+    />
+  );
+}
+
+describe('<EmailOptions />', () => {
+  it('renders the signed-out state with heading, copy, and sign-in button', () => {
+    renderEmailOptions(false);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'misc.email-signup' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('misc.email-blast')).toBeInTheDocument();
+    expect(
+      screen.getByText('misc.email-signup-not-signed-in')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'buttons.sign-in' })
+    ).toHaveAttribute('href', 'http://localhost:3000/signin');
+  });
+
+  it('renders the signed-in state with heading, copy, and yes/no buttons', () => {
+    renderEmailOptions(true);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'misc.email-signup' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('misc.email-blast')).toBeInTheDocument();
+    expect(screen.getByText('misc.quincy')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'buttons.yes-please' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'buttons.no-thanks' })
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/components/email-options.test.tsx
+++ b/client/src/components/email-options.test.tsx
@@ -4,16 +4,6 @@ import { describe, it, expect, vi } from 'vitest';
 
 import EmailOptions from './email-options';
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key
-  })
-}));
-
-vi.mock('../../config/env.json', () => ({
-  apiLocation: 'http://localhost:3000'
-}));
-
 function renderEmailOptions(isSignedIn: boolean) {
   return render(
     <EmailOptions

--- a/e2e/quincy-email-sign-up.spec.ts
+++ b/e2e/quincy-email-sign-up.spec.ts
@@ -15,38 +15,14 @@ test.describe('Email sign-up page when user is not signed in', () => {
     await page.goto('/email-sign-up');
   });
 
-  test('should display the content correctly', async ({ page }) => {
-    await expect(
-      page.getByRole('heading', {
-        level: 1,
-        name: translations.misc['email-signup']
-      })
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.misc['email-blast'])
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.misc['email-signup-not-signed-in'])
-    ).toBeVisible();
-    await expect(page.getByTestId('email-signup-sign-in-btn')).toBeVisible();
-  });
-
   test("should not enable Quincy's weekly newsletter when the user clicks the sign up button", async ({
     page
   }) => {
-    await expect(page).toHaveTitle('Email Sign Up | freeCodeCamp.org');
-    await expect(
-      page.getByText(translations.misc['email-blast'])
-    ).toBeVisible();
-
     const signupLink = page.getByTestId('email-signup-sign-in-btn');
 
-    await expect(signupLink).toBeVisible();
     await expect(signupLink).toHaveAttribute('href', `${apiLocation}/signin`);
     await signupLink.click();
 
-    // The user is signed in and automatically redirected to /learn after clicking the button.
-    // We wait for this navigation to complete before moving onto the next.
     await page.waitForURL(allowTrailingSlash('/learn'));
     await expect(
       page.getByRole('heading', { name: 'Welcome back, Full Stack User' })
@@ -67,45 +43,19 @@ test.describe('Email sign-up page when user is not signed in', () => {
 
 test.describe('Email sign-up page when user is signed in', () => {
   test.beforeEach(async ({ page }) => {
-    // It's necessary to seed with a user that has not selected an email newsletter option.
     execSync('node ../tools/scripts/seed/seed-demo-user --certified-user');
-
     await page.goto('/email-sign-up');
-  });
-
-  test('should display the content correctly', async ({ page }) => {
-    await expect(
-      page.getByText(translations.misc['email-signup'])
-    ).toBeVisible();
-    await expect(
-      page.getByText(translations.misc['email-blast'])
-    ).toBeVisible();
-    await expect(page.getByText(translations.misc['quincy'])).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: translations.buttons['yes-please'] })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: translations.buttons['no-thanks'] })
-    ).toBeVisible();
   });
 
   test("should disable Quincy's weekly newsletter if the user clicks No", async ({
     page
   }) => {
-    await expect(page).toHaveTitle('Email Sign Up | freeCodeCamp.org');
-    await expect(
-      page.getByText(translations.misc['email-blast'])
-    ).toBeVisible();
-
     const noThanksButton = page.getByRole('button', {
       name: translations.buttons['no-thanks']
     });
 
-    await expect(noThanksButton).toBeVisible();
     await noThanksButton.click();
 
-    // The user is signed in and automatically redirected to /learn after clicking the button.
-    // We wait for the navigation to complete.
     await page.waitForURL('/learn');
     await expect(
       page.getByRole('heading', { name: 'Welcome back, Full Stack User' })
@@ -126,20 +76,12 @@ test.describe('Email sign-up page when user is signed in', () => {
   test("should enable Quincy's weekly newsletter if the user clicks Yes", async ({
     page
   }) => {
-    await expect(page).toHaveTitle('Email Sign Up | freeCodeCamp.org');
-    await expect(
-      page.getByText(translations.misc['email-blast'])
-    ).toBeVisible();
-
     const signupButton = page.getByRole('button', {
       name: translations.buttons['yes-please']
     });
 
-    await expect(signupButton).toBeVisible();
     await signupButton.click();
 
-    // The user is signed in and automatically redirected to /learn after clicking the button.
-    // We wait for the navigation to complete.
     await page.waitForURL('/learn');
     await expect(
       page.getByRole('heading', { name: 'Welcome back, Full Stack User' })


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This moves the email sign-up page rendering checks out of Playwright and into the client test layer. The old e2e spec asserted the signed-out state (heading, copy, sign-in link) and the signed-in state (heading, copy, yes/no buttons) by loading the real route. The new unit test covers both states directly against the `EmailOptions` component. The remaining e2e coverage keeps only the three server-backed journeys: clicking the sign-in link does not enable the newsletter, clicking No saves the preference and redirects, and clicking Yes saves the preference and redirects.