### PR TITLE
fix(curriculum): clarify descendant combinator ancestor definition

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
@@ -11,7 +11,7 @@ CSS combinators are used to define the relationship between selectors in CSS. Th
 
 We will discuss some primary CSS combinators and their use cases, starting with the descendant combinator.
 
-A descendant combinator is used to target elements matched by the second selector if they are nested within an ancestor element that matches the first selector. An ancestor can be a parent element or a parent's parent.
+A descendant combinator is used to target elements matched by the second selector if they are nested within an ancestor element that matches the first selector. An ancestor can be a parent, grandparent, or any ancestor further up the document tree.
 
 To better understand how this works, let's take a look at an example.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68371

<!-- Feel free to add any additional description of changes below this line -->

## Description
This PR updates the explanation of a descendant combinator in the CSS Combinators lecture challenge. 

It clarifies that an ancestor can be any ancestor further up the document tree, rather than implying it is limited to a grandparent level, as recommended in the issue.
