### PR TITLE
fix(curriculum): replace getFunctionParams with functionRegex in Linked List Step 13

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a030fbe487f185f55b8627.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a030fbe487f185f55b8627.md
@@ -22,8 +22,12 @@ assert.isFunction(remove)
 Your `remove` function should have `list` and `element` parameters.
 
 ```js
-const regex = __helpers.functionRegex('remove', ['list', 'element']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const removeFunc = explorer.allFunctions.remove;
+assert.exists(removeFunc);
+assert.lengthOf(removeFunc.parameters, 2);
+assert.isTrue(removeFunc.parameters[0].matches("list"));
+assert.isTrue(removeFunc.parameters[1].matches("element"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a030fbe487f185f55b8627.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a030fbe487f185f55b8627.md
@@ -22,10 +22,8 @@ assert.isFunction(remove)
 Your `remove` function should have `list` and `element` parameters.
 
 ```js
-const removeParams = __helpers.getFunctionParams(remove.toString());
-const removeParamsNames = removeParams.map(param => param.name)
-assert.include(removeParamsNames, "list");
-assert.include(removeParamsNames, "element");
+const regex = __helpers.functionRegex('remove', ['list', 'element']);
+assert.match(__helpers.removeJSComments(code), regex);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68379

<!-- Feel free to add any additional description of changes below this line -->

## Description
This PR replaces `getFunctionParams(remove.toString())` with `__helpers.functionRegex` in the Linked List Step 13 challenge hint. 

This allows campers to use arrow function syntax (e.g. `const remove = (list, element) => {}`) without getting false test failures.
