### PR TITLE
fix: warn before leaving projects with unsaved code

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -737,6 +737,11 @@
       "exit-modal-yes": "Yes, I want to leave the quiz",
       "exit-modal-no": "No, I would like to continue the quiz"
     },
+    "project": {
+      "exit-modal-header": "Leave Project",
+      "exit-modal-yes": "Yes, leave the project",
+      "exit-modal-no": "No, continue coding"
+    },
     "exam": {
       "qualified": "Congratulations, you have completed all the requirements to qualify for the exam.",
       "not-qualified": "You have not met the requirements to be eligible for the exam. To qualify, please complete the following challenges:",

--- a/client/src/templates/Challenges/classic/exit-project-modal.test.tsx
+++ b/client/src/templates/Challenges/classic/exit-project-modal.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createStore } from '../../../redux/create-store';
+import { render } from '../../../../utils/test-utils';
+import { openModal } from '../redux/actions';
+import ExitProjectModal from './exit-project-modal';
+
+vi.mock('../../../utils/get-words');
+
+globalThis.ResizeObserver = class ResizeObserver {
+  disconnect = vi.fn();
+  observe = vi.fn();
+  unobserve = vi.fn();
+};
+
+describe('<ExitProjectModal />', () => {
+  it('renders the project exit warning', () => {
+    const reduxStore = createStore();
+    reduxStore.dispatch(openModal('exitProject'));
+
+    render(<ExitProjectModal onExit={vi.fn()} />, reduxStore);
+
+    expect(
+      screen.getByText('learn.project.exit-modal-header')
+    ).toBeInTheDocument();
+    expect(screen.getByText('misc.navigation-warning')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'learn.project.exit-modal-no' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'learn.project.exit-modal-yes' })
+    ).toBeInTheDocument();
+  });
+
+  it('closes without exiting the project', async () => {
+    const user = userEvent.setup();
+    const onExit = vi.fn();
+    const reduxStore = createStore();
+    reduxStore.dispatch(openModal('exitProject'));
+
+    render(<ExitProjectModal onExit={onExit} />, reduxStore);
+
+    await user.click(
+      screen.getByRole('button', { name: 'learn.project.exit-modal-no' })
+    );
+
+    expect(onExit).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText('learn.project.exit-modal-header')
+    ).not.toBeInTheDocument();
+  });
+
+  it('confirms exiting the project', async () => {
+    const user = userEvent.setup();
+    const onExit = vi.fn();
+    const reduxStore = createStore();
+    reduxStore.dispatch(openModal('exitProject'));
+
+    render(<ExitProjectModal onExit={onExit} />, reduxStore);
+
+    await user.click(
+      screen.getByRole('button', { name: 'learn.project.exit-modal-yes' })
+    );
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/templates/Challenges/classic/exit-project-modal.tsx
+++ b/client/src/templates/Challenges/classic/exit-project-modal.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Button, Modal, Spacer } from '@freecodecamp/ui';
+
+import { closeModal } from '../redux/actions';
+import { isExitProjectModalOpenSelector } from '../redux/selectors';
+
+interface ExitProjectModalProps {
+  closeExitProjectModal: () => void;
+  isExitProjectModalOpen: boolean;
+  onExit: () => void;
+}
+
+const mapStateToProps = (state: unknown) => ({
+  isExitProjectModalOpen: isExitProjectModalOpenSelector(state) as boolean
+});
+
+const mapDispatchToProps = {
+  closeExitProjectModal: () => closeModal('exitProject')
+};
+
+const ExitProjectModal = ({
+  closeExitProjectModal,
+  isExitProjectModalOpen,
+  onExit
+}: ExitProjectModalProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      onClose={closeExitProjectModal}
+      open={isExitProjectModalOpen}
+      variant='danger'
+    >
+      <Modal.Header closeButtonClassNames='close'>
+        {t('learn.project.exit-modal-header')}
+      </Modal.Header>
+      <Modal.Body alignment='center'>{t('misc.navigation-warning')}</Modal.Body>
+      <Modal.Footer>
+        <Button block variant='primary' onClick={closeExitProjectModal}>
+          {t('learn.project.exit-modal-no')}
+        </Button>
+        <Spacer size='xxs' />
+        <Button block variant='danger' onClick={onExit}>
+          {t('learn.project.exit-modal-yes')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+ExitProjectModal.displayName = 'ExitProjectModal';
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExitProjectModal);

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -1,5 +1,5 @@
-import { graphql } from 'gatsby';
-import React, { useState, useEffect, useRef } from 'react';
+import { graphql, navigate } from 'gatsby';
+import React, { useCallback, useState, useEffect, useRef } from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -54,6 +54,7 @@ import {
   initVisibleEditors,
   previewMounted,
   updateChallengeMeta,
+  closeModal,
   openModal,
   setEditorFocusability,
   setIsAdvancing
@@ -70,11 +71,13 @@ import envData from '../../../../config/env.json';
 import ToolPanel from '../components/tool-panel';
 import { getChallengePaths } from '../utils/challenge-paths';
 import { challengeHasPreview, isJavaScriptChallenge } from '../utils/build';
+import { usePageLeave } from '../hooks';
 import { XtermTerminal } from './xterm';
 import MultifileEditor from './multifile-editor';
 import DesktopLayout from './desktop-layout';
 import MobileLayout from './mobile-layout';
 import { mergeChallengeFiles } from './saved-challenges';
+import ExitProjectModal from './exit-project-modal';
 
 import './classic.css';
 import '../components/test-frame.css';
@@ -99,6 +102,7 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
       executeChallenge,
       cancelTests,
       previewMounted,
+      closeExitProjectModal: () => closeModal('exitProject'),
       openModal,
       setEditorFocusability,
       setIsAdvancing
@@ -124,6 +128,7 @@ interface ShowClassicProps extends Pick<PreviewProps, 'previewMounted'> {
   pageContext: PageContext | DailyCodingChallengePageContext;
   updateChallengeMeta: (arg0: ChallengeMeta) => void;
   openModal: (modal: string) => void;
+  closeExitProjectModal: () => void;
   setDailyCodingChallengeLanguage: (
     language: DailyCodingChallengeLanguages
   ) => void;
@@ -145,6 +150,11 @@ interface RenderEditorArgs {
   isMobileLayout: boolean;
   isUsingKeyboardInTablist: boolean;
 }
+
+type ChallengeFileWithSeed = {
+  contents: string;
+  seed?: string;
+};
 
 const REFLEX_LAYOUT = 'challenge-layout';
 const BASE_LAYOUT = {
@@ -227,6 +237,7 @@ function ShowClassic({
   setDailyCodingChallengeLanguage,
   updateChallengeMeta,
   openModal,
+  closeExitProjectModal,
   setIsAdvancing,
   savedChallenges,
   isChallengeCompleted,
@@ -241,6 +252,10 @@ function ShowClassic({
   const editorRef = useRef<editor.IStandaloneCodeEditor>();
   const instructionsPanelRef = useRef<HTMLDivElement>(null);
   const xtermFitRef = useRef<FitAddon | null>(null);
+  const exitProjectConfirmed = useRef(false);
+  const [exitProjectPathname, setExitProjectPathname] = useState(
+    challengeMeta.prevChallengePath || '/learn'
+  );
   const isMobile = useMediaQuery({
     query: `(max-width: ${MAX_MOBILE_WIDTH}px)`
   });
@@ -312,8 +327,51 @@ function ShowClassic({
   const showIndependentLowerJaw = !isMobile;
 
   const showSidePanelTests = isMobile || !hasEditableBoundaries;
+  const hasUnsavedProjectFiles =
+    !!saveSubmissionToDB &&
+    challengeFiles?.some(file => {
+      const { contents, seed } = file as ChallengeFileWithSeed;
+      return seed !== undefined && contents !== seed;
+    });
+
+  const onWindowClose = useCallback(
+    (event: BeforeUnloadEvent) => {
+      if (!hasUnsavedProjectFiles || exitProjectConfirmed.current) return;
+
+      event.preventDefault();
+      event.returnValue = t('misc.navigation-warning');
+    },
+    [hasUnsavedProjectFiles, t]
+  );
+
+  const onHistoryChange = useCallback(
+    (targetPathname: string): boolean => {
+      if (!hasUnsavedProjectFiles || exitProjectConfirmed.current) {
+        return false;
+      }
+
+      setExitProjectPathname(
+        targetPathname || challengeMeta.prevChallengePath || '/learn'
+      );
+      openModal('exitProject');
+      return true;
+    },
+    [challengeMeta.prevChallengePath, hasUnsavedProjectFiles, openModal]
+  );
+
+  const exitProject = () => {
+    exitProjectConfirmed.current = true;
+    closeExitProjectModal();
+    void navigate(exitProjectPathname);
+  };
 
   // Show test
+
+  usePageLeave({
+    enabled: !!hasUnsavedProjectFiles,
+    onWindowClose,
+    onHistoryChange
+  });
 
   useEffect(() => {
     if (
@@ -548,6 +606,7 @@ function ShowClassic({
               : t('learn.project-preview-title')
           }
         />
+        <ExitProjectModal onExit={exitProject} />
         <ShortcutsModal />
         <MobileAppModal superBlock={superBlock} />
       </LearnLayout>

--- a/client/src/templates/Challenges/hooks/use-page-leave.ts
+++ b/client/src/templates/Challenges/hooks/use-page-leave.ts
@@ -4,12 +4,19 @@ import { useLocation } from '@gatsbyjs/reach-router';
 interface Props {
   onWindowClose: (event: BeforeUnloadEvent) => void;
   onHistoryChange: (targetPathname: string) => boolean;
+  enabled?: boolean;
 }
 
-export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
+export const usePageLeave = ({
+  onWindowClose,
+  onHistoryChange,
+  enabled = true
+}: Props) => {
   const curLocation = useLocation();
 
   useEffect(() => {
+    if (!enabled) return;
+
     window.addEventListener('beforeunload', onWindowClose);
     // Push a dummy state so that navigating back will restore the current page,
     // allowing us to manually handle navigation.
@@ -45,5 +52,5 @@ export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
       window.removeEventListener('popstate', handlePopState);
       document.removeEventListener('click', handleLinkClick, true);
     };
-  }, [onWindowClose, onHistoryChange, curLocation]);
+  }, [enabled, onWindowClose, onHistoryChange, curLocation]);
 };

--- a/client/src/templates/Challenges/redux/code-storage-epic.js
+++ b/client/src/templates/Challenges/redux/code-storage-epic.js
@@ -13,7 +13,7 @@ import {
   getDailyCodingChallengeLanguage
 } from '@freecodecamp/shared/config/challenge-types';
 import { actionTypes } from './action-types';
-import { noStoredCodeFound, updateFile } from './actions';
+import { createFiles, noStoredCodeFound, updateFile } from './actions';
 import { challengeFilesSelector, challengeMetaSelector } from './selectors';
 
 const legacyPrefixes = [
@@ -94,7 +94,8 @@ function saveCodeEpic(action$, state$) {
     // do not save challenge if code is locked
     map(action => {
       const state = state$.value;
-      const { id, challengeType } = challengeMetaSelector(state);
+      const { id, challengeType, saveSubmissionToDB } =
+        challengeMetaSelector(state);
       const challengeFiles = challengeFilesSelector(state);
       try {
         const isDailyCodingChallenge = getIsDailyCodingChallenge(challengeType);
@@ -114,21 +115,27 @@ function saveCodeEpic(action$, state$) {
         ) {
           throw Error('Failed to save to localStorage');
         }
-        return action;
+        return { ...action, challengeFiles, saveSubmissionToDB };
       } catch {
         return { ...action, error: true };
       }
     }),
     ofType(actionTypes.saveEditorContent),
-    switchMap(({ error }) =>
-      of(
-        createFlashMessage({
-          type: error ? 'warning' : 'success',
-          message: error
-            ? FlashMessages.LocalCodeSaveError
-            : FlashMessages.LocalCodeSaved
-        })
-      )
+    switchMap(({ challengeFiles, error, saveSubmissionToDB }) =>
+      error
+        ? of(
+            createFlashMessage({
+              type: 'warning',
+              message: FlashMessages.LocalCodeSaveError
+            })
+          )
+        : of(
+            ...(saveSubmissionToDB ? [createFiles(challengeFiles)] : []),
+            createFlashMessage({
+              type: 'success',
+              message: FlashMessages.LocalCodeSaved
+            })
+          )
     )
   );
 }

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -44,6 +44,7 @@ const initialState = {
     video: false,
     reset: false,
     exitExam: false,
+    exitProject: false,
     finishExam: false,
     exitQuiz: false,
     finishQuiz: false,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -42,6 +42,8 @@ export const isHelpModalOpenSelector = state => state[ns].modal.help;
 export const isVideoModalOpenSelector = state => state[ns].modal.video;
 export const isResetModalOpenSelector = state => state[ns].modal.reset;
 export const isExitExamModalOpenSelector = state => state[ns].modal.exitExam;
+export const isExitProjectModalOpenSelector = state =>
+  state[ns].modal.exitProject;
 export const isFinishExamModalOpenSelector = state =>
   state[ns].modal.finishExam;
 export const isSurveyModalOpenSelector = state => state[ns].modal.survey;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68332

## Summary

- add an exit confirmation modal for project pages with unsaved editor changes
- only enable the leave guard for project challenges that save submissions
- reset the dirty baseline after successful DB saves, and after local saves only for project pages, so saved code can be left without a warning
- add coverage for the new project exit modal

## Validation

- `pnpm --filter @freecodecamp/client lint src/templates/Challenges/redux/code-storage-epic.js src/templates/Challenges/classic/show.tsx src/templates/Challenges/hooks/use-page-leave.ts src/templates/Challenges/classic/exit-project-modal.tsx src/templates/Challenges/classic/exit-project-modal.test.tsx`
- `pnpm --filter @freecodecamp/client type-check`
- `pnpm --filter @freecodecamp/client test src/templates/Challenges/classic/exit-project-modal.test.tsx`
- `git diff --check`