### PR TITLE
fix(curriculum): arrow function syntax in linked list step 13

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-linked-list-js/69a030fbe487f185f55b8627.md
+++ b/curriculum/challenges/english/blocks/workshop-linked-list-js/69a030fbe487f185f55b8627.md
@@ -22,10 +22,12 @@ assert.isFunction(remove)
 Your `remove` function should have `list` and `element` parameters.
 
 ```js
-const removeParams = __helpers.getFunctionParams(remove.toString());
-const removeParamsNames = removeParams.map(param => param.name)
-assert.include(removeParamsNames, "list");
-assert.include(removeParamsNames, "element");
+const explorer = await __helpers.Explorer(code);
+const allFuncs = explorer.allFunctions;
+const params = explorer.parameters("remove");
+assert.exists(allFuncs.remove);
+assert.equal(params[0], "list");
+assert.equal(params[1], "element");
 ```
 
 # --seed--


### PR DESCRIPTION
## Description

The test in Step 13 of the Linked List JS workshop only accepted traditional `function` declaration syntax. When a learner used arrow function syntax (`const remove = (list, element) => {}`), the test incorrectly failed even though the instructions never specified which syntax to use.

## Changes Made

Replaced the regex-based test with AST-based helpers (`Explorer`, `allFunctions`, `parameters`) so both `function` declarations and arrow functions are accepted.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68379 

<!-- Feel free to add any additional description of changes below this line -->
