### PR TITLE
fix(curriculum): clarify ancestor definition in CSS combinators lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
@@ -11,7 +11,7 @@ CSS combinators are used to define the relationship between selectors in CSS. Th
 
 We will discuss some primary CSS combinators and their use cases, starting with the descendant combinator.
 
-A descendant combinator is used to target elements matched by the second selector if they are nested within an ancestor element that matches the first selector. An ancestor can be a parent element or a parent's parent.
+A descendant combinator is used to target elements matched by the second selector if they are nested within an ancestor element that matches the first selector. An ancestor can be a parent, grandparent, or any other element higher in the document hierarchy.
 
 To better understand how this works, let's take a look at an example.
 


### PR DESCRIPTION
## Description

Clarified the definition of an ancestor in the CSS combinators lecture.

The previous wording suggested that an ancestor could only be a parent or grandparent. The updated wording explains that an ancestor can be any element higher in the document hierarchy.

Closes #68371