### PR TITLE
fix(curriculum): correct form validation quiz questions

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-form-validation-with-javascript/66edd3403d7077eece6dc4b6.md
+++ b/curriculum/challenges/english/blocks/quiz-form-validation-with-javascript/66edd3403d7077eece6dc4b6.md
@@ -105,7 +105,7 @@ The browser stops the form submission if required fields are empty.
 
 #### --text--
 
-Which actions does not cause an HTML form to be checked for errors?
+Which action does not cause an HTML form to be checked for errors?
 
 #### --distractors--
 
@@ -193,7 +193,7 @@ The invalid field is highlighted and a message appears.
 
 #### --text--
 
-Which action will make `checkValidity()` run?
+Which action triggers the browser's built-in form validation?
 
 #### --distractors--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68406

### Description of changes
This PR corrects two issues in the Form Validation with JavaScript quiz:
1. Fixes a subject-verb agreement error in the question stem: *"Which actions does not..."* -> *"Which action does not..."*.
2. Clarifies that form submission triggers the browser's built-in (interactive) form validation rather than invoking the `checkValidity()` method directly.
