### PR TITLE
fix(api): validate coderoad tokens before querying db

### DIFF
--- a/api/src/routes/protected/challenge.test.ts
+++ b/api/src/routes/protected/challenge.test.ts
@@ -57,6 +57,7 @@ import {
 import { Answer } from '../../utils/exam-types.js';
 import type { getSessionUser } from '../../schemas/user/get-session-user.js';
 import { verifyTrophyWithMicrosoft } from '../helpers/challenge-helpers.js';
+import { encodeUserToken } from '../../utils/tokens.js';
 
 const mockVerifyTrophyWithMicrosoft = vi.mocked(verifyTrophyWithMicrosoft);
 
@@ -260,9 +261,45 @@ describe('challengeRoutes', () => {
         expect(response.status).toBe(400);
       });
 
-      test('should return 400 if invalid user token', async () => {
+      test('should return 400 if the token is valid, but has no userToken property', async () => {
+        // @ts-expect-error TS is trying to protect us, but we need to test this
+        // edge case.
+        const emptyToken = encodeUserToken(undefined);
+
+        const response = await superPost('/coderoad-challenge-completed')
+          .set('coderoad-user-token', emptyToken)
+          .send({
+            tutorialId:
+              'freeCodeCamp/learn-bash-by-building-a-boilerplate:v1.0.0'
+          });
+
+        expect(response.body).toEqual({
+          msg: 'invalid user token',
+          type: 'error'
+        });
+        expect(response.status).toBe(400);
+      });
+
+      test('should return 400 for invalid user tokens', async () => {
         const response = await superPost('/coderoad-challenge-completed')
           .set('coderoad-user-token', 'invalid')
+          .send({
+            tutorialId:
+              'freeCodeCamp/learn-bash-by-building-a-boilerplate:v1.0.0'
+          });
+        expect(response.body).toEqual({
+          msg: 'invalid user token',
+          type: 'error'
+        });
+        expect(response.status).toBe(400);
+      });
+
+      test('should return 400 for nonsensical user tokens', async () => {
+        // @ts-expect-error TS is trying to protect us, but we need to test this
+        // edge case.
+        const weirdToken = encodeUserToken({});
+        const response = await superPost('/coderoad-challenge-completed')
+          .set('coderoad-user-token', weirdToken)
           .send({
             tutorialId:
               'freeCodeCamp/learn-bash-by-building-a-boilerplate:v1.0.0'

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -947,6 +947,7 @@ async function postCoderoadChallengeCompleted(
   try {
     const payload = jwt.verify(encodedUserToken, JWT_SECRET) as JwtPayload;
     userToken = payload.userToken;
+    if (!userToken || typeof userToken !== 'string') throw Error();
   } catch {
     logger.warn('Invalid user token');
     void reply.code(400);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I'm not sure why we're getting empty tokens, but the api shouldn't throw when it encounters them. See: https://freecodecamp.sentry.io/issues/7110742359/events/f32c10240c0142b1901eb8bbb6eb3101/

<!-- Feel free to add any additional description of changes below this line -->
