### PR TITLE
fix(curriculum): use AST Explorer in Shortest Path Step 3

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shortest-path-algorithm-js/69c918841987bf16c1d1babb.md
+++ b/curriculum/challenges/english/blocks/workshop-shortest-path-algorithm-js/69c918841987bf16c1d1babb.md
@@ -24,11 +24,11 @@ assert.isFunction(shortestPath);
 Your `shortestPath` function should have the parameters `matrix`, `startNode`, and `targetNode`.
 
 ```js
-const params = __helpers.getFunctionParams(shortestPath.toString());
-const names = params.map(p => p.name);
-assert.include(names, 'matrix');
-assert.include(names, 'startNode');
-assert.include(names, 'targetNode');
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.shortestPath.parameters;
+assert.equal(parameters[0].toString(), "matrix");
+assert.equal(parameters[1].toString(), "startNode");
+assert.equal(parameters[2].toString(), "targetNode");
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68353

### Description of changes
This PR updates the test for Step 3 of the JavaScript Shortest Path Algorithm workshop to use the TypeScript AST helper `__helpers.Explorer` instead of the regex-based `functionRegex` check. This allows the test suite to correctly parse and accept arrow function declarations for the `shortestPath` function.
