### PR TITLE
fix(curriculum): teach toLocaleTimeString in JS Dates Review

### DIFF
--- a/curriculum/challenges/english/blocks/review-javascript-dates/6723ced0ba0b42c2a0ac14d2.md
+++ b/curriculum/challenges/english/blocks/review-javascript-dates/6723ced0ba0b42c2a0ac14d2.md
@@ -100,6 +100,17 @@ console.log(date.toLocaleDateString("en-GB", options)); // "Wednesday, 15 Octobe
 
 :::
 
+- **`toLocaleTimeString()` Method**: This method is used to format the time portion of a date based on the user's locale. Similar to the `toLocaleDateString()` method, it accepts optional `locales` and `options` parameters. If no parameters are provided, it will use the default system locale and its time formatting conventions.
+
+:::interactive_editor
+
+```js
+const date = new Date("2014-10-15T10:30:15");
+console.log(date.toLocaleTimeString("en-US")); // "10:30:15 AM"
+```
+
+:::
+
 # --assignment--
 
 Review the JavaScript Dates topics and concepts.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68420

<!-- Feel free to add any additional description of changes below this line -->
This PR resolves an issue in the JavaScript curriculum where `.toLocaleTimeString()` was being asked in the "JavaScript Dates Quiz" without ever being taught beforehand. I've added a new section to the `JavaScript Dates Review` file that explains `.toLocaleTimeString()` and provides an interactive example.
