### PR TITLE
fix(curriculum): use AST Explorer in N-th Fibonacci Lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-nth-fibonacci-number-js/7a97b79c096ecb000d03bd36.md
+++ b/curriculum/challenges/english/blocks/lab-nth-fibonacci-number-js/7a97b79c096ecb000d03bd36.md
@@ -28,8 +28,9 @@ assert.isFunction(fibonacci);
 Your `fibonacci` function should take a single parameter.
 
 ```js
-const params = __helpers.getFunctionParams(fibonacci.toString());
-assert.equal(params.length, 1);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.fibonacci.parameters;
+assert.lengthOf(parameters, 1);
 ```
 
 You should have an array named `sequence` within the `fibonacci` function initialized to `[0, 1]`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes part of #68417

### Description of changes
This PR updates the parameter count check in the N-th Fibonacci Number JavaScript lab to use the TypeScript AST helper `__helpers.Explorer` instead of the regex-based `getFunctionParams` check. This enables the test suite to correctly parse and accept arrow function definitions for the `fibonacci` function.
