### PR TITLE
fix(script): correct locale output in external curriculum build script

### DIFF
--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -125,9 +125,10 @@ describe('external curriculum data build', () => {
 
   test('block-based super blocks and blocks should have the correct data', async () => {
     const superBlocks = Object.values(SuperBlocks);
+    const localeDataPath = getCurriculumDataPath(getCurriculumLocale());
 
     const superBlockFiles = (
-      await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
+      await readdirp.promise(localeDataPath, {
         directoryFilter: ['!challenges'],
         fileFilter: entry => {
           // The directory contains super block files and other curriculum-related files.
@@ -150,7 +151,7 @@ describe('external curriculum data build', () => {
 
     superBlockFiles.forEach(file => {
       const fileContentJson = fs.readFileSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/${file}`,
+        `${localeDataPath}/${file}`,
         'utf-8'
       );
 
@@ -179,9 +180,10 @@ describe('external curriculum data build', () => {
 
   test('chapter-based super blocks and blocks should have the correct data', async () => {
     const superBlocks = Object.values(SuperBlocks);
+    const localeDataPath = getCurriculumDataPath(getCurriculumLocale());
 
     const superBlockFiles = (
-      await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
+      await readdirp.promise(localeDataPath, {
         directoryFilter: ['!challenges'],
         fileFilter: entry => {
           // The directory contains super block files and other curriculum-related files.
@@ -204,7 +206,7 @@ describe('external curriculum data build', () => {
 
     superBlockFiles.forEach(file => {
       const fileContentJson = fs.readFileSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/${file}`,
+        `${localeDataPath}/${file}`,
         'utf-8'
       );
 

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -10,7 +10,7 @@ import {
   SuperBlockStage,
   superBlockStages
 } from '@freecodecamp/shared/config/curriculum';
-import { Languages } from '@freecodecamp/shared/config/i18n';
+import { availableLangs, Languages } from '@freecodecamp/shared/config/i18n';
 import {
   superblockSchemaValidator,
   availableSuperBlocksValidator
@@ -24,7 +24,9 @@ import {
   orderedSuperBlockInfo,
   OrderedSuperBlocks,
   readCurriculumIntros,
-  getCurriculumLocale
+  getCurriculumLocale,
+  getCurriculumDataPath,
+  getLegacyCurriculumDataPath
 } from './build-external-curricula-data-v2';
 
 const VERSION = 'v2';
@@ -321,6 +323,18 @@ describe('external curriculum data build', () => {
     });
     expect(spanishOrderedSuperBlockInfo.core[0]?.title).not.toEqual(
       englishIntros[SuperBlocks.RespWebDesignV9].title
+    );
+  });
+
+  test('curriculum data path helpers should include lang segments and preserve legacy English path', () => {
+    availableLangs.curriculum.forEach(lang => {
+      expect(getCurriculumDataPath(lang)).toBe(
+        `${clientStaticPath}/curriculum-data/${VERSION}/${lang}`
+      );
+    });
+
+    expect(getLegacyCurriculumDataPath()).toBe(
+      `${clientStaticPath}/curriculum-data/${VERSION}`
     );
   });
 });

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { omit } from 'lodash';
+import { config } from 'dotenv';
 import { submitTypes } from '@freecodecamp/shared/config/challenge-types';
 import { type ChallengeNode } from '../../src/redux/prop-types';
 import {
@@ -113,6 +114,8 @@ export type OrderedSuperBlocks = Record<
   string,
   Array<{ dashedName: SuperBlocks; public: boolean; title: string }>
 >;
+
+config({ path: resolve(__dirname, '../../../.env') });
 
 const ver = 'v2';
 

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.ts
@@ -120,8 +120,7 @@ config({ path: resolve(__dirname, '../../../.env') });
 const ver = 'v2';
 
 const staticFolderPath = resolve(__dirname, '../../../client/static');
-const dataPath = `${staticFolderPath}/curriculum-data/`;
-const intros = readCurriculumIntros(getCurriculumLocale());
+const dataPath = `${staticFolderPath}/curriculum-data`;
 
 export function getCurriculumLocale(): Languages {
   const { CURRICULUM_LOCALE } = process.env;
@@ -129,6 +128,17 @@ export function getCurriculumLocale(): Languages {
   return availableLangs.curriculum.includes(CURRICULUM_LOCALE as Languages)
     ? (CURRICULUM_LOCALE as Languages)
     : Languages.English;
+}
+
+export function getCurriculumDataPath(
+  lang: Languages = getCurriculumLocale()
+): string {
+  return `${dataPath}/${ver}/${lang}`;
+}
+
+// TODO: Remove this once mobile has been updated to use the new curriculum data path.
+export function getLegacyCurriculumDataPath(): string {
+  return `${dataPath}/${ver}`;
 }
 
 export function readCurriculumIntros(lang: Languages): CurriculumIntros {
@@ -337,7 +347,11 @@ export const superBlockDashedNames = (() => {
 export function buildExtCurriculumDataV2(
   curriculum: Curriculum<CurriculumProps>
 ): void {
-  mkdirSync(dataPath, { recursive: true });
+  const curriculumLocale = getCurriculumLocale();
+  const localeDataPath = getCurriculumDataPath(curriculumLocale);
+  const intros = readCurriculumIntros(curriculumLocale);
+
+  mkdirSync(localeDataPath, { recursive: true });
 
   parseCurriculumData();
   getSubmitTypes();
@@ -459,16 +473,20 @@ export function buildExtCurriculumDataV2(
   }
 
   function writeToFile(fileName: string, data: Record<string, unknown>): void {
-    const filePath = `${dataPath}/${ver}/${fileName}.json`;
+    const filePath = `${localeDataPath}/${fileName}.json`;
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, JSON.stringify(data, null, 2));
+
+    // TODO: Remove this once mobile has been updated to use the new curriculum data path.
+    if (curriculumLocale === Languages.English) {
+      const legacyFilePath = `${dataPath}/${ver}/${fileName}.json`;
+      mkdirSync(dirname(legacyFilePath), { recursive: true });
+      writeFileSync(legacyFilePath, JSON.stringify(data, null, 2));
+    }
   }
 
   function getSubmitTypes() {
-    writeFileSync(
-      `${dataPath}/${ver}/submit-types.json`,
-      JSON.stringify(submitTypes, null, 2)
-    );
+    writeToFile('submit-types', submitTypes);
   }
 
   function getSceneAssets() {
@@ -481,9 +499,6 @@ export function buildExtCurriculumDataV2(
       characterAssets
     };
 
-    writeFileSync(
-      `${dataPath}/${ver}/scene-assets.json`,
-      JSON.stringify(sceneAssets, null, 2)
-    );
+    writeToFile('scene-assets', sceneAssets);
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## Problem

A test case in `build-external-curricula-data-v2.test.ts` is failing. It expects the intro string to be Portuguese/Italian but receives English instead.

You won't see this failure on normal PRs because it only triggers on submodule update PRs: https://github.com/freeCodeCamp/freeCodeCamp/blob/main/.github/workflows/node.js-tests.yml#L244-L254.

My previous attempt (#68001) didn't resolve the issue, as the same failure occurred again in #68216.

## Investigation

I looked into the script and found that `CURRICULUM_LOCALE` was `undefined` because Node wasn't loading the environment variables. As a result, the build fell back to English.

The fix is to load the environment variables with `dotenv`. After making this change, the build correctly generated the output for the selected language.

While testing the fix, I also noticed that the output directory was always `curriculum-data/v2/`, causing each language build to overwrite the previous one. So I'm changing the output paths to:
- Write localized output to `/curriculum-data/v2/${lang}`
- Keep writing English output to `/curriculum-data/v2/` for backward compatibility with the mobile app.
  - We will remove this path once mobile is updated to consume the new path

## Testing

Steps to test:
- Try changing `CURRICULUM_LOCALE` in `.env`
- cd to the client and run `pnpm create:external-curriculum`

<details>

  <summary>Screenshot of the output, including the previous structure, and the new `english` and `portuguese` directories</summary>



<img width="272" height="248" alt="Screenshot 2026-07-01 at 17 15 43" src="https://github.com/user-attachments/assets/758fb6e3-ccdb-418a-8e58-4c78b2ba0bc8" />

</details>

<details>

  <summary>Screenshot of an English superblock file</summary>

<img width="738" height="206" alt="Screenshot 2026-07-01 at 17 16 00" src="https://github.com/user-attachments/assets/0459a1a4-46af-4137-b500-ba750d29e81e" />

</details>

<details>

  <summary>Screenshot of a Portuguese superblock file</summary>

<img width="644" height="165" alt="Screenshot 2026-07-01 at 17 16 16" src="https://github.com/user-attachments/assets/68e01dfd-c3ac-4333-beb1-4edd9ce542ca" />

</details>



<!-- Feel free to add any additional description of changes below this line -->
