### PR TITLE
fix(gha): relax linked-issue check for assignees and Naomi's Sprints

### DIFF
--- a/.github/scripts/pr-guidelines/check-linked-issue.js
+++ b/.github/scripts/pr-guidelines/check-linked-issue.js
@@ -56,18 +56,23 @@ module.exports = async ({ github, context, core, isAllowListed }) => {
   }
 
   const prAuthor = context.payload.pull_request.user.login;
-  const isNaomiSprintAssignee = linkedIssues.some(
-    issue =>
-      issue.labels.nodes.some(l => l.name === "Naomi's Sprints") &&
-      issue.assignees.nodes.some(a => a.login === prAuthor)
+  const isAuthorAssignee = linkedIssues.some(issue =>
+    issue.assignees.nodes.some(a => a.login === prAuthor)
   );
-  if (isNaomiSprintAssignee) {
+  const hasNaomiSprintsLabel = linkedIssues.some(issue =>
+    issue.labels.nodes.some(l => l.name === "Naomi's Sprints")
+  );
+
+  if (hasNaomiSprintsLabel) {
     await github.rest.issues.addLabels({
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: context.payload.pull_request.number,
       labels: ["Naomi's Sprints"]
     });
+  }
+
+  if (isAuthorAssignee || hasNaomiSprintsLabel) {
     return;
   }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR relaxes check-linked-issue.js so PRs aren't deprioritized in two cases:
- The PR author is an assignee on the linked issue.
- The linked issue carries the `Naomi's Sprints` label. This also adds the `Naomi's Sprints` label to the PR.
  - We originally required both `hasLabel` and `isAssignee` to prevent spam, but that `isAssignee` restriction has generated noise recently so this PR removes it.

<!-- Feel free to add any additional description of changes below this line -->
