### PR TITLE
fix(curriculum): improve e.preventDefault lecture wording

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733d3a33abdd27cd562bdf2.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733d3a33abdd27cd562bdf2.md
@@ -185,7 +185,7 @@ input.addEventListener("keydown", (e) => {
 
 `e.key` gives you the value of the key pressed, such as `a` for the `a` key or `Enter` for the `Enter` key.
 
-With the above code, when you type in the `input`, the character you type will be displayed in the `p` element. 
+With the above code, when you type in the `input`, the character you type will be displayed in the `p` element.
 
 This is great, but we don't want to show the characters in the `input` as well. This is where our `preventDefault()` method comes in. The default behavior of a `keydown` is to render the character in the input. Let's avoid that by calling `e.preventDefault()`:
 
@@ -255,7 +255,7 @@ input.addEventListener("keydown", (e) => {
 
 And just like that, you have prevented the default behavior to allow yourself to implement your own custom event handling.
 
-Another common example of when to use the `e.preventDefault` method has to deal with form submissions. By default, submitting a form sends data to the server and reloads the page. Using `e.preventDefault()` prevents this from happening.
+Another common example of when to use the `e.preventDefault()` method has to do with form submissions. By default, submitting a form sends data to the server and reloads the page. Using `e.preventDefault()` prevents this from happening.
 
 ```js
 const form = document.querySelector("form");
@@ -266,7 +266,7 @@ form.addEventListener("submit", (e) => {
 });
 ```
 
-Preventing the default behavior is great when you need more control over how a user interacts with the page, but it's important to keep things like accessibility in mind – your custom behavior should provide the same features as the default.
+Preventing the default behavior is great when you need more control over how a user interacts with the page, but it's important to keep things like accessibility in mind: your custom behavior should provide the same features as the default.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68429

<!-- Feel free to add any additional description of changes below this line -->


This PR addresses the issues described in #68429 by:

* removing the trailing whitespace
* updating `e.preventDefault` to `e.preventDefault()`
* changing "has to deal with" to "has to do with"
* replacing the en dash with a colon for improved readability

Closes #68429
