### PR TITLE
fix(curriculum): method parentheses, ValidityState example, and phrasing fixes in validate forms lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
@@ -347,7 +347,7 @@ input.addEventListener("input", (e) => {
 
 And as a result, you will see the browser's error message "Please match the requested format."
 
-It reports the invalid state immediately, instead of waiting for us to submit the form. But it's still using the default message. This is because the `reportValidity` method only tells the browser that the input is invalid. The browser still chooses how to display why it's invalid. That's where the `setCustomValidity` method comes in.
+It reports the invalid state immediately, instead of waiting for us to submit the form. But it's still using the default message. This is because the `reportValidity()` method only tells the browser that the input is invalid. The browser still chooses how to display why it's invalid. That's where the `setCustomValidity()` method comes in.
 
 :::interactive_editor
 
@@ -535,13 +535,13 @@ ValidityState {
   tooShort: false,
   typeMismatch: true,
   valueMissing: false,
-  valid: true
+  valid: false
 }
 ```
 
-There are several helpful properties which all hold the value of a boolean of `true` or `false`.
+There are several helpful properties which all hold a boolean value of `true` or `false`.
 
-Some of these helpful properties that you can explore more on your own would be the `valueMissing` property which is `true` when a required input field is left empty. Or the `patternMismatch` which is `true` if the value doesn't match the specified regular expression pattern.
+Some of these helpful properties that you can explore more on your own would be the `valueMissing` property which is `true` when a required input field is left empty, or the `patternMismatch` property, which is `true` if the value doesn't match the specified regular expression pattern.
 
 After this lesson, I encourage you to play around with the examples given in this lesson and explore more about the different validity properties.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68430

This PR addresses the issues described in #68430 by:

- adding missing parentheses to `reportValidity` and `setCustomValidity` methods
- fixing the inconsistent ValidityState example
- improving awkward phrasing
- fixing sentence fragment and making property names consistent