### PR TITLE
fix(curriculum): improve wording in submit event forms lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
@@ -15,7 +15,7 @@ The second is when the user presses the Enter key on any editable input field in
 
 The third is through a JavaScript call to the `requestSubmit()` or `submit()` methods of the form element.
 
-But what happens when a form is submitted? There's a few things that happen, and the behavior of the form depends on its attributes.
+But what happens when a form is submitted? There are a few things that happen, and the behavior of the form depends on its attributes.
 
 The first attribute that we need to look at is the `action` attribute. The `action` attribute should contain either a URL or a relative path for the current domain. This value determines where the form attempts to send data. If you do not set an `action` attribute, the form will send data to the current page's URL. Here is an example of a form with an `action` attribute set to a specific URL:
 
@@ -53,7 +53,7 @@ This is great for something like a search form, where your user is querying data
 
 Let's set the `method` attribute to the value of `POST`:
 
-```xml
+```html
 <form action="/data" method="POST">
   <input type="number" id="input" placeholder="Enter a number" name="number" />
   <button type="submit">Submit</button>
@@ -176,7 +176,7 @@ The lesson mentions a specific `enctype` for handling forms with file uploads.
 
 ### --feedback--
 
-The lesson mentions a specific enctype for handling forms with file uploads.
+The lesson mentions a specific `enctype` for handling forms with file uploads.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68428

<!-- Feel free to add any additional description of changes below this line -->

This PR addresses three issues found in [this page](https://www.freecodecamp.org/learn/javascript-v9/lecture-understanding-form-validation/how-does-the-submit-event-work-with-forms):
- Updated text from "There's a few things that happen" to "There are a few things that happen".
- Changed the code fence block language from `xml` to `html`.
- Added backticks around enctype so that "The lesson mentions a specific enctype..." became "The lesson mentions a specific `enctype`...".
