### PR TITLE
fix(curriculum): straight apostrophes and code block in step 24

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
@@ -347,7 +347,7 @@ input.addEventListener("input", (e) => {
 
 And as a result, you will see the browser's error message "Please match the requested format."
 
-It reports the invalid state immediately, instead of waiting for us to submit the form. But it's still using the default message. This is because the `reportValidity()` method only tells the browser that the input is invalid. The browser still chooses how to display why it's invalid. That's where the `setCustomValidity()` method comes in.
+It reports the invalid state immediately, instead of waiting for us to submit the form. But it's still using the default message. This is because the `reportValidity` method only tells the browser that the input is invalid. The browser still chooses how to display why it's invalid. That's where the `setCustomValidity` method comes in.
 
 :::interactive_editor
 
@@ -535,13 +535,13 @@ ValidityState {
   tooShort: false,
   typeMismatch: true,
   valueMissing: false,
-  valid: false
+  valid: true
 }
 ```
 
-There are several helpful properties which all hold a boolean value of `true` or `false`.
+There are several helpful properties which all hold the value of a boolean of `true` or `false`.
 
-Some of these helpful properties that you can explore more on your own would be the `valueMissing` property which is `true` when a required input field is left empty, or the `patternMismatch` property, which is `true` if the value doesn't match the specified regular expression pattern.
+Some of these helpful properties that you can explore more on your own would be the `valueMissing` property which is `true` when a required input field is left empty. Or the `patternMismatch` which is `true` if the value doesn't match the specified regular expression pattern.
 
 After this lesson, I encourage you to play around with the examples given in this lesson and explore more about the different validity properties.
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
@@ -347,7 +347,7 @@ input.addEventListener("input", (e) => {
 
 And as a result, you will see the browser's error message "Please match the requested format."
 
-It reports the invalid state immediately, instead of waiting for us to submit the form. But it's still using the default message. This is because the `reportValidity` method only tells the browser that the input is invalid. The browser still chooses how to display why it's invalid. That's where the `setCustomValidity` method comes in.
+It reports the invalid state immediately, instead of waiting for us to submit the form. But it's still using the default message. This is because the `reportValidity()` method only tells the browser that the input is invalid. The browser still chooses how to display why it's invalid. That's where the `setCustomValidity()` method comes in.
 
 :::interactive_editor
 
@@ -535,13 +535,13 @@ ValidityState {
   tooShort: false,
   typeMismatch: true,
   valueMissing: false,
-  valid: true
+  valid: false
 }
 ```
 
-There are several helpful properties which all hold the value of a boolean of `true` or `false`.
+There are several helpful properties which all hold a boolean value of `true` or `false`.
 
-Some of these helpful properties that you can explore more on your own would be the `valueMissing` property which is `true` when a required input field is left empty. Or the `patternMismatch` which is `true` if the value doesn't match the specified regular expression pattern.
+Some of these helpful properties that you can explore more on your own would be the `valueMissing` property which is `true` when a required input field is left empty, or the `patternMismatch` property, which is `true` if the value doesn't match the specified regular expression pattern.
 
 After this lesson, I encourage you to play around with the examples given in this lesson and explore more about the different validity properties.
 

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63efdbc22a0c56070beabed7.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63efdbc22a0c56070beabed7.md
@@ -7,22 +7,22 @@ dashedName: step-24
 
 # --description--
 
-You’re on the right track! However, let’s take a moment to address a common issue when working with objects in JavaScript.
+You're on the right track! However, let's take a moment to address a common issue when working with objects in JavaScript.
 
-When you try to access an object property that doesn’t exist, JavaScript returns `undefined`. If you then attempt to perform arithmetic operations on `undefined`, it can lead to unexpected results, such as `NaN`.
+When you try to access an object property that doesn't exist, JavaScript returns `undefined`. If you then attempt to perform arithmetic operations on `undefined`, it can lead to unexpected results, such as `NaN`.
 
 To prevent this, you can use the `||` (logical OR) operator to provide a default value.
 
 ```js
-  let scores = {}; 
-  let players = ["Alice", "Bob", "Charlie"];
+let scores = {};
+let players = ["Alice", "Bob", "Charlie"];
 
-  players.forEach(player => {
-    scores[player] = scores[player] || 0;
-  });
+players.forEach(player => {
+  scores[player] = scores[player] || 0;
+});
 ```
 
-Now, let’s apply this concept to your `totalCountPerProduct` object in the `forEach` callback. Make sure that each `dessert.id` property is initialized properly.
+Now, let's apply this concept to your `totalCountPerProduct` object in the `forEach` callback. Make sure that each `dessert.id` property is initialized properly.
 
 Initialize `totalCountPerProduct[dessert.id]` with a default value of `0` using the `||` operator.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68444

This PR addresses the issues described in #68444 by:

- Replaced curly apostrophes (`’`) with straight apostrophes (`'`) in three sentences (`You're`, `let's`, `doesn't`)
- Removed two-space indentation from top-level lines in the example code block
- Removed trailing whitespace from the first line of the example

Closes #68444