### PR TITLE
fix(curriculum): correct grammar and reframe checkValidity question in form validation quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-form-validation-with-javascript/66edd3403d7077eece6dc4b6.md
+++ b/curriculum/challenges/english/blocks/quiz-form-validation-with-javascript/66edd3403d7077eece6dc4b6.md
@@ -105,7 +105,7 @@ The browser stops the form submission if required fields are empty.
 
 #### --text--
 
-Which actions does not cause an HTML form to be checked for errors?
+Which action does not cause an HTML form to be checked for errors?
 
 #### --distractors--
 
@@ -193,7 +193,7 @@ The invalid field is highlighted and a message appears.
 
 #### --text--
 
-Which action will make `checkValidity()` run?
+Which action triggers the browser's built-in form validation?
 
 #### --distractors--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68406 

 ### Description of Changes
This pull request addresses two issues in the Form Validation with JavaScript quiz challenge (`66edd3403d7077eece6dc4b6.md`):
     1. Grammatical Fix (Subject-Verb Agreement): Corrects the question stem "Which actions does not cause..." to "Which action does not cause..." to resolve the subject verb disagreement.
      2. Clarifying Misleading Question Stem: Reframes the question "Which action will make
          `checkValidity()` run?" to "Which action triggers the browser's built-in form validation?".
          Submitting the form triggers the browser's native/built-in constraint validation algorithm, not the
          developer-callable `checkValidity()` JS method itself.
