### PR TITLE
Fix typo in recipe1 property assignment

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-recipe-tracker/66fbcf750a62784cf11f5635.md
+++ b/curriculum/challenges/english/blocks/workshop-recipe-tracker/66fbcf750a62784cf11f5635.md
@@ -31,7 +31,7 @@ You should access the `difficultyLevel` property of `recipe1`.
 assert.isNotEmpty(recipe1.difficultyLevel);
 ```
 
-You should assign the result of calling `getDifficultyLevel` with `recipe1.cookingTime` to the `cookingTime` property of `recipe1`.
+You should assign the result of calling `getDifficultyLevel` with `recipe1.cookingTime` to the `difficultyLevel` property of `recipe1`.
 
 ```js
 assert.strictEqual(recipe1.difficultyLevel, getDifficultyLevel(recipe1.cookingTime));


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes

Fixed a typo in the instruction text. Changed cookingTime to difficultyLevel to match the actual challenge requirement.
