### PR TITLE
fix: Fix recipe tracker hint

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-recipe-tracker/66fbcf750a62784cf11f5635.md
+++ b/curriculum/challenges/english/blocks/workshop-recipe-tracker/66fbcf750a62784cf11f5635.md
@@ -31,7 +31,7 @@ You should access the `difficultyLevel` property of `recipe1`.
 assert.isNotEmpty(recipe1.difficultyLevel);
 ```
 
-You should assign the result of calling `getDifficultyLevel` with `recipe1.cookingTime` to the `difficultyLevel` property of `recipe1`..
+You should assign the result of calling `getDifficultyLevel` with `recipe1.cookingTime` to the `difficultyLevel` property of `recipe1`.
 
 ```js
 assert.strictEqual(recipe1.difficultyLevel, getDifficultyLevel(recipe1.cookingTime));

--- a/curriculum/challenges/english/blocks/workshop-recipe-tracker/66fbcf750a62784cf11f5635.md
+++ b/curriculum/challenges/english/blocks/workshop-recipe-tracker/66fbcf750a62784cf11f5635.md
@@ -31,7 +31,7 @@ You should access the `difficultyLevel` property of `recipe1`.
 assert.isNotEmpty(recipe1.difficultyLevel);
 ```
 
-You should assign the result of calling `getDifficultyLevel` with `recipe1.cookingTime` to the `cookingTime` property of `recipe1`.
+You should assign the result of calling `getDifficultyLevel` with `recipe1.cookingTime` to the `difficultyLevel` property of `recipe1`..
 
 ```js
 assert.strictEqual(recipe1.difficultyLevel, getDifficultyLevel(recipe1.cookingTime));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ X] My pull request targets the `main` branch of freeCodeCamp.
- [ X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68456

<!-- Feel free to add any additional description of changes below this line -->
This PR corrects the hint in the Recipe Tracker workshop.

The hint incorrectly instructed learners to assign the result of `getDifficultyLevel(recipe1.cookingTime)` to the `cookingTime` property. It now correctly refers to the `difficultyLevel` property, matching the workshop instructions and tests.