### PR TITLE
fix(curriculum): audit editable regions in space mission roster workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c9c186c089f7bdff0f3c6.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c9c186c089f7bdff0f3c6.md
@@ -102,8 +102,8 @@ const firstAstronaut = {
 };
 
 function addCrewMember(crew, astronaut) {
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ca14c8ef00056ad146e51.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ca14c8ef00056ad146e51.md
@@ -92,8 +92,8 @@ function addCrewMember(crew, astronaut) {
       return;
     }
   }
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8c16f3672c498d4656ac.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8c16f3672c498d4656ac.md
@@ -178,8 +178,8 @@ for (let i = 0; i < remainingCrew.length; i++) {
 }
 
 function swapCrewMembers(crew, fromIndex, toIndex) {
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
@@ -85,8 +85,8 @@ function swapCrewMembers(crew, fromIndex, toIndex) {
     return;
   }
   
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddd106340237efb0c80.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddd106340237efb0c80.md
@@ -117,8 +117,8 @@ function swapCrewMembers(crew, fromIndex, toIndex) {
   }
 
   const updatedCrew = crew.slice();
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d98a87c2a7a33ca92cfa9.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d98a87c2a7a33ca92cfa9.md
@@ -129,8 +129,8 @@ function swapCrewMembers(crew, fromIndex, toIndex) {
 
   const updatedCrew = crew.slice();
   updatedCrew[fromIndex] = updatedCrew.splice(toIndex, 1, updatedCrew[fromIndex])[0];
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
@@ -116,8 +116,8 @@ function swapCrewMembers(crew, fromIndex, toIndex) {
 const updatedSquad = swapCrewMembers(squad, 2, 5);
 
 function getEVAReadyCrew(crew) {
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eeb57faae3b2331add3e7.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eeb57faae3b2331add3e7.md
@@ -105,9 +105,9 @@ function getEVAReadyCrew(crew) {
   for (const astronaut of crew) {
     if (astronaut.isEVAEligible) eligible.push(astronaut);
   }
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 
   return eligible;
 }

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
@@ -104,6 +104,7 @@ function getEVAReadyCrew(crew) {
     if (astronaut.isEVAEligible) eligible.push(astronaut);
   }
   sortByPriorityDescending(eligible); 
+
   return eligible;
 }
 

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f7cae8b5aa1f91cb33c8b.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f7cae8b5aa1f91cb33c8b.md
@@ -180,8 +180,8 @@ function getEVAReadyCrew(crew) {
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
 
 function chunkCrew(crew, size) {
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
@@ -171,8 +171,8 @@ function chunkCrew(crew, size) {
     return;
   }
   
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504c249850e861921dca82.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504c249850e861921dca82.md
@@ -156,6 +156,7 @@ function getEVAReadyCrew(crew) {
 }
 
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
+
 function chunkCrew(crew, size) {
   if (size < 1) {
     console.log("Chunk size must be >= 1");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/6951cfd4955dbb84cb9b8b22.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/6951cfd4955dbb84cb9b8b22.md
@@ -41,9 +41,9 @@ function addCrewMember(crew, astronaut) {
     }
   }
   crew.push(astronaut);
---fcc-editable-region--
-console.log(`Added ${astronaut.name} as ${astronaut.role}`);
---fcc-editable-region--
+  --fcc-editable-region--
+  console.log(`Added ${astronaut.name} as ${astronaut.role}`);
+  --fcc-editable-region--
 }
 addCrewMember(squad, firstAstronaut);
 

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/6951cfd4955dbb84cb9b8b22.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/6951cfd4955dbb84cb9b8b22.md
@@ -33,6 +33,7 @@ const firstAstronaut = {
   isEVAEligible: true,
   priority: 3
 };
+
 function addCrewMember(crew, astronaut) {
   for (let i = 0; i < crew.length; i++) {
     if (crew[i].id === astronaut.id) {
@@ -45,6 +46,7 @@ function addCrewMember(crew, astronaut) {
   console.log(`Added ${astronaut.name} as ${astronaut.role}`);
   --fcc-editable-region--
 }
+
 addCrewMember(squad, firstAstronaut);
 
 const remainingCrew = [

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/6951d46955d890de029fdc30.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/6951d46955d890de029fdc30.md
@@ -75,11 +75,11 @@ function swapCrewMembers(crew, fromIndex, toIndex) {
 
   const updatedCrew = crew.slice();
   updatedCrew[fromIndex] = updatedCrew.splice(toIndex, 1, updatedCrew[fromIndex])[0];
---fcc-editable-region--
-for (let i = 0; i < updatedCrew.length; i++) {
-  console.log(updatedCrew[i].name);
-}
---fcc-editable-region--
+  --fcc-editable-region--
+  for (let i = 0; i < updatedCrew.length; i++) {
+    console.log(updatedCrew[i].name);
+  }
+  --fcc-editable-region--
 
   return updatedCrew; 
 }

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a43cc94b29c92227efd46.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a43cc94b29c92227efd46.md
@@ -104,6 +104,7 @@ function getEVAReadyCrew(crew) {
 }
 
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
+
 function chunkCrew(crew, size) {
   if (size < 1) {
     console.log("Chunk size must be >= 1");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
@@ -109,6 +109,7 @@ function getEVAReadyCrew(crew) {
 }
 
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
+
 function chunkCrew(crew, size) {
   if (size < 1) {
     console.log("Chunk size must be >= 1");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
@@ -110,6 +110,7 @@ function getEVAReadyCrew(crew) {
 }
 
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
+
 function chunkCrew(crew, size) {
   if (size < 1) {
     console.log("Chunk size must be >= 1");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
@@ -127,8 +127,8 @@ function chunkCrew(crew, size) {
 const EVAChunks = chunkCrew(EVAReadySquad, 3);
 
 function printCrewSummary(crew) {
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4a70d5843b7f18c1050f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4a70d5843b7f18c1050f.md
@@ -125,8 +125,8 @@ const EVAChunks = chunkCrew(EVAReadySquad, 3);
 
 function printCrewSummary(crew) {
   const sorted = crew.slice();
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4a70d5843b7f18c1050f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4a70d5843b7f18c1050f.md
@@ -107,6 +107,7 @@ function getEVAReadyCrew(crew) {
 }
 
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
+
 function chunkCrew(crew, size) {
   if (size < 1) {
     console.log("Chunk size must be >= 1");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4b4afad548377ea2f146.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4b4afad548377ea2f146.md
@@ -149,6 +149,7 @@ function getEVAReadyCrew(crew) {
 }
 
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
+
 function chunkCrew(crew, size) {
   if (size < 1) {
     console.log("Chunk size must be >= 1");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4b4afad548377ea2f146.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4b4afad548377ea2f146.md
@@ -168,8 +168,8 @@ const EVAChunks = chunkCrew(EVAReadySquad, 3);
 function printCrewSummary(crew) {
   const sorted = crew.slice();
   sortByPriorityDescending(sorted); 
---fcc-editable-region--
-
---fcc-editable-region--
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4c4742aa88ce805940ac.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4c4742aa88ce805940ac.md
@@ -123,6 +123,7 @@ function getEVAReadyCrew(crew) {
 }
 
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
+
 function chunkCrew(crew, size) {
   if (size < 1) {
     console.log("Chunk size must be >= 1");
@@ -235,6 +236,7 @@ function getEVAReadyCrew(crew) {
 }
 
 const EVAReadySquad = getEVAReadyCrew(updatedSquad);
+
 function chunkCrew(crew, size) {
   if (size < 1) {
     console.log("Chunk size must be >= 1");


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Reference to https://github.com/freeCodeCamp/freeCodeCamp/issues/67721

This PR is part of Naomi's sprint for editable regions in workshops.

This PR fixes editable region in space mission roster workshop

<!-- Feel free to add any additional description of changes below this line -->
