### PR TITLE
fix(curriculum): capitalize Vite challenge title for consistency

### DIFF
--- a/curriculum/structure/blocks/lecture-introduction-to-javascript-libraries-and-frameworks.json
+++ b/curriculum/structure/blocks/lecture-introduction-to-javascript-libraries-and-frameworks.json
@@ -26,7 +26,7 @@
     },
     {
       "id": "6734e88cc46e6dc679420040",
-      "title": "What is Vite, and How Can It Be Used to Set Up a New React Project?"
+      "title": "What Is Vite, and How Can It Be Used to Set Up a New React Project?"
     }
   ],
   "helpCategory": "JavaScript"


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68484

## Description

Fixes inconsistent capitalization in the Vite challenge title. Changed "What is Vite..." to "What Is Vite..." in line 29 of `curriculum/structure/blocks/lecture-introduction-to-javascript-libraries-and-frameworks.json` to match title case used in other challenges.

## Changes
- Updated line 29: `"title": "What is Vite..."` → `"title": "What Is Vite..."`

## Why
- Maintains consistent title case across the block
- Follows the established naming convention

This is my first contribution to freeCodeCamp.