### PR TITLE
fix(curriculum): use sentence case for Vite lecture title

### DIFF
--- a/curriculum/structure/blocks/lecture-introduction-to-javascript-libraries-and-frameworks.json
+++ b/curriculum/structure/blocks/lecture-introduction-to-javascript-libraries-and-frameworks.json
@@ -26,7 +26,7 @@
     },
     {
       "id": "6734e88cc46e6dc679420040",
-      "title": "What is Vite, and How Can It Be Used to Set Up a New React Project?"
+      "title": "What Is Vite, and How Can It Be Used to Set Up a New React Project?"
     }
   ],
   "helpCategory": "JavaScript"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68484

<!-- Feel free to add any additional description of changes below this line -->

Changed the Vite lecture title to sentence case as described in the issue.