### PR TITLE
fix(curriculum): corrected name recipe

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-recipe-tracker/670e4f45f7116c0f216a5177.md
+++ b/curriculum/challenges/english/blocks/workshop-recipe-tracker/670e4f45f7116c0f216a5177.md
@@ -38,7 +38,7 @@ You should create a `recipe1Name` variable.
 assert.isDefined(recipe1Name);
 ```
 
-You should assign the value of the `name` property of `recipe1` to your `recipe1name` variable.
+You should assign the value of the `name` property of `recipe1` to your `recipe1Name` variable.
 
 ```js
 assert.strictEqual(recipe1Name, recipe1.name);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68454

<!-- Feel free to add any additional description of changes below this line -->

## Description

This pull request fixes the incorrect variable casing in the Recipe Tracker Step 6 hint.

### Changes made

- Updated the variable name from `recipe1name` to `recipe1Name`.
- Ensured the variable name is consistent with the rest of the lesson and follows the expected camelCase naming convention.

This change improves consistency and prevents confusion for learners following the workshop.