### PR TITLE
chore: update turbo to 2.10.0

### DIFF
--- a/api/turbo.json
+++ b/api/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://v2-8-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-0.turborepo.dev/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/client/turbo.json
+++ b/client/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://v2-8-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-0.turborepo.dev/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/curriculum/turbo.json
+++ b/curriculum/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://v2-8-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-0.turborepo.dev/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "prettier": "3.8.2",
     "stylelint": "16.26.1",
     "tsx": "4.21.0",
-    "turbo": "^2.8.7",
+    "turbo": "2.10.0",
     "typescript": "5.9.3",
     "webpack-bundle-analyzer": "4.10.2",
     "yargs": "17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: 4.21.0
         version: 4.21.0
       turbo:
-        specifier: ^2.8.7
-        version: 2.9.8
+        specifier: 2.10.0
+        version: 2.10.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -921,7 +921,7 @@ importers:
         version: 7.16.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-turbo:
         specifier: ^2.8.3
-        version: 2.9.7(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8)
+        version: 2.9.7(eslint@9.39.4(jiti@2.6.1))(turbo@2.10.0)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -4472,33 +4472,33 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
-  '@turbo/darwin-64@2.9.8':
-    resolution: {integrity: sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA==}
+  '@turbo/darwin-64@2.10.0':
+    resolution: {integrity: sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.8':
-    resolution: {integrity: sha512-nKRFI5ZhCGUi4eXNlrojzWcT/CehMj0raot1WE4lw5qf66ZxZHbRbBqcwNEy+ZLY7RkJJRY+TaU89fuj3BcgGg==}
+  '@turbo/darwin-arm64@2.10.0':
+    resolution: {integrity: sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.8':
-    resolution: {integrity: sha512-Wf/kQpVDCaWM3P5d6lKvJnqjYn/ofUBGbT4h4vRFrdC4N6B/nsun03S2kQNJJMXpXg39woeS4CI367RMU3/OAg==}
+  '@turbo/linux-64@2.10.0':
+    resolution: {integrity: sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.8':
-    resolution: {integrity: sha512-v6S3HuKVoa9CEx16IxKj1i/+crxXx22A9O80zW1350zyUlcX0T/zLOxVf1k+ruK/7ssXnDJVg8uSYOxlYRedlA==}
+  '@turbo/linux-arm64@2.10.0':
+    resolution: {integrity: sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.8':
-    resolution: {integrity: sha512-JaefWOJNBazDylAn3f+lLB34XMNu8nEBbgPRP/Ewysg81cBubGfcyyyzpQOGVuMwfaqdNAE/kitG7w3AbJn9/g==}
+  '@turbo/windows-64@2.10.0':
+    resolution: {integrity: sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.8':
-    resolution: {integrity: sha512-Or6ljjB4TiiwCdVKDYWew0SokQ9kep5zruL8P3nbum9WdkH5XA41rQID4Ulc215Z+R3DrB+qXSHPsJjU3/n2ng==}
+  '@turbo/windows-arm64@2.10.0':
+    resolution: {integrity: sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A==}
     cpu: [arm64]
     os: [win32]
 
@@ -11739,8 +11739,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.9.8:
-    resolution: {integrity: sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A==}
+  turbo@2.10.0:
+    resolution: {integrity: sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -17435,22 +17435,22 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
-  '@turbo/darwin-64@2.9.8':
+  '@turbo/darwin-64@2.10.0':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.8':
+  '@turbo/darwin-arm64@2.10.0':
     optional: true
 
-  '@turbo/linux-64@2.9.8':
+  '@turbo/linux-64@2.10.0':
     optional: true
 
-  '@turbo/linux-arm64@2.9.8':
+  '@turbo/linux-arm64@2.10.0':
     optional: true
 
-  '@turbo/windows-64@2.9.8':
+  '@turbo/windows-64@2.10.0':
     optional: true
 
-  '@turbo/windows-arm64@2.9.8':
+  '@turbo/windows-arm64@2.10.0':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -20576,11 +20576,11 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-turbo@2.9.7(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8):
+  eslint-plugin-turbo@2.9.7(eslint@9.39.4(jiti@2.6.1))(turbo@2.10.0):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.39.4(jiti@2.6.1)
-      turbo: 2.9.8
+      turbo: 2.10.0
 
   eslint-scope@5.1.1:
     dependencies:
@@ -26469,14 +26469,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.9.8:
+  turbo@2.10.0:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.8
-      '@turbo/darwin-arm64': 2.9.8
-      '@turbo/linux-64': 2.9.8
-      '@turbo/linux-arm64': 2.9.8
-      '@turbo/windows-64': 2.9.8
-      '@turbo/windows-arm64': 2.9.8
+      '@turbo/darwin-64': 2.10.0
+      '@turbo/darwin-arm64': 2.10.0
+      '@turbo/linux-64': 2.10.0
+      '@turbo/linux-arm64': 2.10.0
+      '@turbo/windows-64': 2.10.0
+      '@turbo/windows-arm64': 2.10.0
 
   type-check@0.4.0:
     dependencies:

--- a/tools/challenge-helper-scripts/turbo.json
+++ b/tools/challenge-helper-scripts/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://v2-8-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-0.turborepo.dev/schema.json",
   "extends": ["//"],
   "tasks": {
     "test": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://v2-8-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-0.turborepo.dev/schema.json",
   "globalPassThroughEnv": ["MONGOHQ_URL"],
   "tasks": {
     "build": { "dependsOn": ["setup"], "outputs": ["dist/**"] },


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I'm trying to rule out "old turbo version" as a cause for the issue that Huyen ran into in https://github.com/freeCodeCamp/freeCodeCamp/blob/main/.github/workflows/node.js-tests.yml#L244-L254

e.g. https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/28549079542/job/84645563023

I tested locally and was able to build the curriculum-data folder in English and then Italian (it updated both times) then I could switch back and forth getting the correct (cached) version each time.

```
# set CURRICULUM_LOCALE to english
turbo -F=@freecodecamp/client setup
# see English in client/static/curriculum-data
# set CURRICULUM_LOCALE to italian
turbo -F=@freecodecamp/client setup
# see Italian in client/static/curriculum-data
# repeat (set to english, run setup, set to italian, run setup 
# see italian again. 
```

This may not be the root cause - I'll keep digging.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/68433

<!-- Feel free to add any additional description of changes below this line -->
