### PR TITLE
fix(client): correct Map format output and add Set/Map test coverage

### DIFF
--- a/client/src/utils/format.js
+++ b/client/src/utils/format.js
@@ -9,7 +9,7 @@ export function format(x) {
     return `Map(${x.size}) {${Array.from(
       x.entries(),
       ([k, v]) => `${k} => ${v}`
-    ).join(', ')}})`;
+    ).join(', ')}}`;
   } else if (typeof x === 'bigint') {
     return x.toString() + 'n';
   } else if (typeof x === 'symbol') {

--- a/client/src/utils/format.test.ts
+++ b/client/src/utils/format.test.ts
@@ -43,4 +43,16 @@ describe('format', () => {
   it(`outputs NaN as 'NaN'`, () => {
     expect(format(NaN)).toBe('NaN');
   });
+  it('formats Set correctly', () => {
+    expect(format(new Set([1, 2, 3]))).toBe('Set(3) {1, 2, 3}');
+    expect(format(new Set())).toBe('Set(0) {}');
+  });
+  it('formats Map correctly', () => {
+    const map = new Map([
+      ['a', 1],
+      ['b', 2]
+    ]);
+    expect(format(map)).toBe('Map(2) {a => 1, b => 2}');
+    expect(format(new Map())).toBe('Map(0) {}');
+  });
 });

--- a/tools/client-plugins/browser-scripts/utils/format.js
+++ b/tools/client-plugins/browser-scripts/utils/format.js
@@ -12,7 +12,7 @@ export function format(x) {
     return `Map(${x.size}) {${Array.from(
       x.entries(),
       ([k, v]) => `${k} => ${v}`
-    ).join(', ')}})`;
+    ).join(', ')}}`;
   } else if (typeof x === 'bigint') {
     return x.toString() + 'n';
   } else if (typeof x === 'symbol') {


### PR DESCRIPTION
The Map formatting in the format utility produced an extra closing parenthesis, outputting 'Map(2) {a => 1, b => 2})' instead of 'Map(2) {a => 1, b => 2}'. This was a one-character bug present in both the client and tools copies of the function.

Also adds test cases for Set and Map formatting to the existing format.test.ts, which previously had no coverage for these types.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68494
 
## Description
 
The [format](cci:1://file:///home/m-h-jishan/freecodecamp/tools/client-plugins/browser-scripts/utils/format.js:5:0-21:1) utility function (used to mimic `console.log` output for the challenge runner) had a one-character bug in its Map formatting. It produced an extra closing parenthesis:
 
**Before:** `Map(2) {a => 1, b => 2})`
**After:** `Map(2) {a => 1, b => 2}`
 
This was present in both copies of the function:
- [client/src/utils/format.js](cci:7://file:///home/m-h-jishan/freecodecamp/client/src/utils/format.js:0:0-0:0)
- [tools/client-plugins/browser-scripts/utils/format.js](cci:7://file:///home/m-h-jishan/freecodecamp/tools/client-plugins/browser-scripts/utils/format.js:0:0-0:0)
 
The existing test suite ([format.test.ts](cci:7://file:///home/m-h-jishan/freecodecamp/client/src/utils/format.test.ts:0:0-0:0)) had no test coverage for `Set` or `Map` formatting, which is why this bug went unnoticed. This PR adds test cases for both types to prevent regressions.
 
### Changes
- Removed extra `)` in Map template literal in [client/src/utils/format.js](cci:7://file:///home/m-h-jishan/freecodecamp/client/src/utils/format.js:0:0-0:0)
- Removed extra `)` in Map template literal in [tools/client-plugins/browser-scripts/utils/format.js](cci:7://file:///home/m-h-jishan/freecodecamp/tools/client-plugins/browser-scripts/utils/format.js:0:0-0:0)
- Added `Set` and `Map` test cases to [client/src/utils/format.test.ts](cci:7://file:///home/m-h-jishan/freecodecamp/client/src/utils/format.test.ts:0:0-0:0)
 
### Testing
Ran `vitest run src/utils/format.test.ts` — all 9 tests pass (7 existing + 2 new).
