### PR TITLE
fix(curriculum): correct wording in React exports lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
@@ -77,7 +77,7 @@ export default function App() {
 }
 ```
 
-This file is usually located in the `src` directory of your project. You’ll learn more about common project layouts in a future lesson.
+This file is usually located in the `src` directory of your project. You'll learn more about common project layouts in a future lesson.
 
 To use the `Cat` component inside the root `App` component, you will need to import it like this:
 
@@ -106,7 +106,7 @@ export default function App() {
 This approach works well when a file is responsible for exporting a single main component, keeping the import syntax simple and easy to read. Remember, a file can only have one default export, which makes it ideal for a file that primarily contains a single component.
 
 
-Now that you know how to use default exports, let's look at named exports. Named exports allow a file to share multiple components or functions. Unlike default exports, these must be imported using the exact name they were exported with (unless you rename them using `as` term). 
+Now that you know how to use default exports, let's look at named exports. Named exports allow a file to share multiple components or functions. Unlike default exports, these must be imported using the exact name they were exported with (unless you rename them using the `as` keyword).
 
 This is useful when a file serves as a library of components. For example, here is a file containing two components, Cat and Dog:
 
@@ -137,7 +137,7 @@ export default function App() {
 }
 ```
 
-The `{ Cat, Dog }` syntax tells JavaScript to import the specific named exports from the `Animals.jsx` file. The names inside the curly braces must match the exported names exactly. If you need to avoid naming conflicts, or if you prefer a different name in the current file, you can rename a component during import using the as keyword.
+The `{ Cat, Dog }` syntax tells JavaScript to import the specific named exports from the `Animals.jsx` file. The names inside the curly braces must match the exported names exactly. If you need to avoid naming conflicts, or if you prefer a different name in the current file, you can rename a component during import using the `as` keyword.
 
 ```jsx
 import { Cat as Kitty } from "./Animals";


### PR DESCRIPTION
## Description

This PR fixes a few wording and formatting issues in the React exports lecture.

### Changes made

- Replace the curly apostrophe (`’`) with a straight apostrophe (`'`) in "You'll".
- Change "using `as` term" to "using the `as` keyword".
- Add backticks around `as` in "using the `as` keyword".

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68483
