### PR TITLE
fix(curriculum): explicitly mention + operator in steps

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6ea530e19a9c48c59f0.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6ea530e19a9c48c59f0.md
@@ -9,8 +9,7 @@ dashedName: step-3
 
 If you concatenate two strings like `'John' + 'Doe'`, the result is `'JohnDoe'` with no space. To fix this, you need to concatenate a string containing a space (`' '`) between them.
 
-
-Update your `full_name` variable so it concatenates `first_name`, a space, and `last_name`.
+Update your `full_name` variable so it concatenates the `first_name` variable, a space (`' '`), and the `last_name` variable, in that order, using the `+` operator.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f2.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f2.md
@@ -7,7 +7,7 @@ dashedName: step-11
 
 # --description--
 
-Now complete the sentence by updating the `employee_info` assignment to also concatenate the string ` years old` at the end. Remember to include a space at the beginning of your string.
+Now complete the sentence by updating the `employee_info` assignment to also concatenate the string ` years old` at the end, using the `+` operator. Remember to include a space at the beginning of your string.
 
 Finally, print `employee_info`.
 

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f3.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f3.md
@@ -11,7 +11,7 @@ Now you're going to use the `str()` function one more time. Just like with age, 
 
 Create a variable named `experience_years` and assign it the integer `5`.
 
-Then, create a variable `experience_info`. Assign it a string formed by concatenating `'Experience: '`, the `experience_years` variable (converted to a string), and `' years'` using the `+` operator. Print the result to the terminal.
+Then, create a variable `experience_info`. Assign it a string formed by concatenating `'Experience: '`, the `experience_years` variable (converted to a string), and `' years'`, using the `+` operator. Print the result to the terminal.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f3.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f3.md
@@ -11,7 +11,7 @@ Now you're going to use the `str()` function one more time. Just like with age, 
 
 Create a variable named `experience_years` and assign it the integer `5`.
 
-Then, create a variable `experience_info`. Assign it a string formed by concatenating `'Experience: '`, the `experience_years` variable (converted to a string), and `' years'`. Print the result to the terminal.
+Then, create a variable `experience_info`. Assign it a string formed by concatenating `'Experience: '`, the `experience_years` variable (converted to a string), and `' years'` using the `+` operator. Print the result to the terminal.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f5.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f5.md
@@ -72,6 +72,7 @@ position = 'Data Analyst'
 salary = 75000
 employee_card = f'Employee: {full_name} | Age: {employee_age} | Position: {position} | Salary: ${salary}'
 print(employee_card)
+
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f5.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f5.md
@@ -72,7 +72,6 @@ position = 'Data Analyst'
 salary = 75000
 employee_card = f'Employee: {full_name} | Age: {employee_age} | Position: {position} | Salary: ${salary}'
 print(employee_card)
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/695df6480de23758af5a29cd.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/695df6480de23758af5a29cd.md
@@ -9,7 +9,7 @@ dashedName: step-8
 
 Now, you want to create a string that displays the employee's age.
 
-Start by creating a variable `employee_info` and assign it the result of concatenating:
+Start by creating a variable `employee_info` and assign it the result of concatenating, using the `+` operator:
 
 - the `full_name` variable.
 - a string consisting of the characters `is` preceded and followed by a space.

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/695fd3dde03273875e5d6709.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/695fd3dde03273875e5d6709.md
@@ -7,7 +7,7 @@ dashedName: step-9
 
 # --description--
 
-Update the `employee_info` assignment to also concatenate `employee_age` at the end.
+Update the `employee_info` assignment to also concatenate `employee_age` at the end, using the `+` operator.
 
 Once you've done so, you'll see a `TypeError` in the terminal. In the next step, you'll work on fixing it.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68464

<!-- Feel free to add any additional description of changes below this line -->

> if it is more clear there are other steps in this workshop that have campers confused in the same way

I found the same issue in other steps and have listed them below, but if these steps don't require changes, do let me know and I can revert them back. Also, if there any other steps that need the same change, let me know.

Additionally, I found step 16 had an extra line, so I removed it. If it is out of scope for this PR, please point it out and I'll revert it. 

Updated following steps:

- Step 8
- Step 9
- Step 11
- Step 12
- Step 16 - Removed one extra line from here to maintain consistency throughout the steps. 