### PR TITLE
test: use fixtures for curriculum-data tests

### DIFF
--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -1,8 +1,16 @@
+import os from 'os';
 import path from 'path';
 import fs from 'fs';
 
-import readdirp from 'readdirp';
-import { afterEach, describe, test, expect, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  test,
+  expect,
+  vi
+} from 'vitest';
 
 import {
   chapterBasedSuperBlocks,
@@ -11,256 +19,308 @@ import {
   superBlockStages
 } from '@freecodecamp/shared/config/curriculum';
 import {
-  superblockSchemaValidator,
-  availableSuperBlocksValidator
+  availableSuperBlocksValidator,
+  superblockSchemaValidator
 } from './external-data-schema-v2';
 import {
   type Curriculum,
-  type GeneratedCurriculumProps,
+  type CurriculumIntros,
+  type CurriculumProps,
   type GeneratedBlockBasedCurriculumProps,
   type GeneratedChapterBasedCurriculumProps,
-  type ChapterBasedCurriculumIntros,
+  type OrderedSuperBlocks,
+  buildExtCurriculumDataV2,
   orderedSuperBlockInfo,
-  OrderedSuperBlocks,
-  readCurriculumIntros,
-  getCurriculumLocale,
-  CurriculumIntros
 } from './build-external-curricula-data-v2';
+import { getSuperblockStructure } from '@freecodecamp/curriculum/file-handler';
+
+vi.mock('@freecodecamp/curriculum/file-handler');
 
 const VERSION = 'v2';
-const intros = readCurriculumIntros(getCurriculumLocale());
+const BLOCK_BASED_SB = SuperBlocks.CodingInterviewPrep;
+const CHAPTER_BASED_SB = SuperBlocks.RespWebDesignV9;
 
 const dummyIntro = Object.values(SuperBlocks)
   .map(s => ({ [s]: { title: s } }))
   .reduce((prev, curr) => ({ ...prev, ...curr }), {}) as CurriculumIntros;
 
-describe('external curriculum data build', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
+function buildFixtureIntros(): CurriculumIntros {
+  const stub: Record<string, unknown> = {};
+  for (const sb of Object.values(SuperBlocks)) {
+    if (chapterBasedSuperBlocks.includes(sb)) {
+      stub[sb] = {
+        title: sb,
+        intro: ['stub intro'],
+        chapters: {},
+        modules: {},
+        blocks: {}
+      };
+    } else {
+      stub[sb] = { title: sb, intro: ['stub intro'], blocks: {} };
+    }
+  }
+
+  stub[BLOCK_BASED_SB] = {
+    title: 'Coding Interview Prep',
+    intro: ['Prepare for coding interviews.'],
+    blocks: {
+      'test-block': {
+        title: 'Test Block Title',
+        intro: ['Block intro paragraph.']
+      }
+    }
+  };
+
+  stub[CHAPTER_BASED_SB] = {
+    title: 'Responsive Web Design V9',
+    intro: ['Learn responsive web design.'],
+    chapters: {
+      'test-chapter': 'Test Chapter Name',
+      'coming-soon-chapter': 'Coming Soon Chapter'
+    },
+    modules: { 'test-module': 'Test Module Name' },
+    blocks: {
+      'test-chapter-block': {
+        title: 'Chapter Block Title',
+        intro: ['Chapter block intro.']
+      }
+    }
+  };
+
+  return stub as CurriculumIntros;
+}
+
+function buildFixtureCurriculum(): Curriculum<CurriculumProps> {
+  const stub: Record<string, unknown> = {};
+  for (const sb of Object.values(SuperBlocks)) {
+    stub[sb] = { intro: ['stub'], blocks: {} };
+  }
+
+  stub[BLOCK_BASED_SB] = {
+    intro: ['unused'],
+    blocks: {
+      'test-block': {
+        desc: ['desc'],
+        intro: ['unused'],
+        challenges: [{ id: 'challenge-1', title: 'Test Challenge' }],
+        meta: {
+          name: 'Original Name',
+          isUpcomingChange: false,
+          dashedName: 'test-block',
+          helpCategory: 'JavaScript',
+          order: 0,
+          superBlock: BLOCK_BASED_SB,
+          blockLayout: 'challenge-list',
+          challengeOrder: [{ id: 'challenge-1', title: 'Test Challenge' }]
+        }
+      }
+    }
+  };
+
+  stub[CHAPTER_BASED_SB] = {
+    intro: ['unused'],
+    blocks: {
+      'test-chapter-block': {
+        desc: ['desc'],
+        intro: ['unused'],
+        challenges: [{ id: 'chapter-challenge-1', title: 'Chapter Challenge' }],
+        meta: {
+          name: 'Original',
+          isUpcomingChange: false,
+          dashedName: 'test-chapter-block',
+          helpCategory: 'HTML-CSS',
+          order: 0,
+          superBlock: CHAPTER_BASED_SB,
+          blockLayout: 'challenge-list',
+          blockLabel: 'lecture',
+          chapter: 'test-chapter',
+          module: 'test-module',
+          challengeOrder: [
+            { id: 'chapter-challenge-1', title: 'Chapter Challenge' }
+          ]
+        }
+      }
+    }
+  };
+
+  return stub as unknown as Curriculum<CurriculumProps>;
+}
+
+describe('buildExtCurriculumDataV2', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ext-curriculum-test-'));
+
+    vi.mocked(getSuperblockStructure).mockImplementation(key => {
+      if (key === (CHAPTER_BASED_SB as string)) {
+        return {
+          chapters: [
+            {
+              dashedName: 'test-chapter',
+              modules: [
+                {
+                  dashedName: 'test-module',
+                  blocks: ['test-chapter-block']
+                }
+              ]
+            },
+            {
+              dashedName: 'coming-soon-chapter',
+              comingSoon: true,
+              modules: []
+            }
+          ]
+        };
+      }
+      return { chapters: [] };
+    });
+
+    buildExtCurriculumDataV2(buildFixtureCurriculum(), {
+      dataPath: tmpDir,
+      intros: buildFixtureIntros()
+    });
   });
-  const clientStaticPath = path.resolve(__dirname, '../../../client/static');
 
-  const validateSuperBlock = superblockSchemaValidator();
-
-  test("the external curriculum data should be in the client's static directory", () => {
-    expect(
-      fs.existsSync(`${clientStaticPath}/curriculum-data/${VERSION}`)
-    ).toBe(true);
-
-    expect(
-      fs.readdirSync(`${clientStaticPath}/curriculum-data/${VERSION}`).length
-    ).toBeGreaterThan(0);
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
   });
 
-  test('there should be an endpoint to request submit types from', () => {
-    expect(
-      fs.existsSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/submit-types.json`
-      )
-    ).toBe(true);
-  });
+  test('available-superblocks.json passes schema validation', () => {
+    const filePath = path.join(tmpDir, VERSION, 'available-superblocks.json');
+    expect(fs.existsSync(filePath)).toBe(true);
 
-  test('the available-superblocks file should have the correct structure', async () => {
-    const filteredSuperBlockStages: string[] = Object.keys(SuperBlockStage)
-      .filter(key => isNaN(Number(key))) // Filter out numeric keys to get only the names
-      .filter(
-        name => name !== 'Upcoming' && name !== 'Next' && name !== 'Catalog'
-      ) // Filter out 'Upcoming', 'Next', and 'Catalog'
-      .map(name => name.toLowerCase());
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as {
+      superblocks: OrderedSuperBlocks;
+    };
+    const validate = availableSuperBlocksValidator();
+    const result = validate(data);
 
-    const validateAvailableSuperBlocks = availableSuperBlocksValidator();
-    const availableSuperblocks = JSON.parse(
-      await fs.promises.readFile(
-        `${clientStaticPath}/curriculum-data/${VERSION}/available-superblocks.json`,
-        'utf-8'
-      )
-    ) as { superblocks: OrderedSuperBlocks };
-
-    const result = validateAvailableSuperBlocks(availableSuperblocks);
-
-    expect(Object.keys(availableSuperblocks.superblocks)).toHaveLength(
-      filteredSuperBlockStages.length
-    );
-
-    expect(Object.keys(availableSuperblocks.superblocks)).toEqual(
-      expect.arrayContaining(filteredSuperBlockStages)
-    );
-
-    expect(result.error?.details).toBeUndefined();
     expect(result.error).toBeFalsy();
   });
 
-  test('the super block files generated should have the correct schema', async () => {
-    const superBlocks = Object.values(SuperBlocks);
+  test('superblock files pass schema validation', () => {
+    const validateSuperBlock = superblockSchemaValidator();
 
-    const fileArray = (
-      await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
-        directoryFilter: ['!challenges'],
-        fileFilter: entry => {
-          // The directory contains super block files and other curriculum-related files.
-          // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
-          );
-
-          return isSuperBlock;
-        }
-      })
-    ).map(file => file.path);
-
-    expect(fileArray.length).toBeGreaterThan(0);
-
-    fileArray.forEach(fileInArray => {
-      const fileContent = fs.readFileSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/${fileInArray}`,
-        'utf-8'
-      );
-
-      const result = validateSuperBlock(
-        JSON.parse(fileContent) as Record<string, unknown>
-      );
+    for (const sb of [BLOCK_BASED_SB, CHAPTER_BASED_SB]) {
+      const filePath = path.join(tmpDir, VERSION, `${sb}.json`);
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+      const result = validateSuperBlock(data);
 
       expect(result.error?.details).toBeUndefined();
       expect(result.error).toBeFalsy();
+    }
+  });
+
+  test('block-based superblock file has correct intro and meta.name', () => {
+    const filePath = path.join(tmpDir, VERSION, `${BLOCK_BASED_SB}.json`);
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<
+      string,
+      GeneratedBlockBasedCurriculumProps
+    >;
+
+    expect(data[BLOCK_BASED_SB]).toMatchObject({
+      intro: ['Prepare for coding interviews.'],
+      blocks: [
+        {
+          intro: ['Block intro paragraph.'],
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          meta: expect.objectContaining({
+            name: 'Test Block Title',
+            dashedName: 'test-block'
+          })
+        }
+      ]
     });
   });
 
-  test('block-based super blocks and blocks should have the correct data', async () => {
-    const superBlocks = Object.values(SuperBlocks);
+  test('chapter-based superblock file has correct structure with comingSoon filtered', () => {
+    const filePath = path.join(tmpDir, VERSION, `${CHAPTER_BASED_SB}.json`);
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<
+      string,
+      GeneratedChapterBasedCurriculumProps
+    >;
 
-    const superBlockFiles = (
-      await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
-        directoryFilter: ['!challenges'],
-        fileFilter: entry => {
-          // The directory contains super block files and other curriculum-related files.
-          // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
-          );
-
-          const isChapterBasedSuperBlock = chapterBasedSuperBlocks.some(
-            chapterBasedSuperBlock =>
-              entry.basename.includes(chapterBasedSuperBlock)
-          );
-
-          return isSuperBlock && !isChapterBasedSuperBlock;
-        }
-      })
-    ).map(file => file.path);
-
-    expect(superBlockFiles.length).toBeGreaterThan(0);
-
-    superBlockFiles.forEach(file => {
-      const fileContentJson = fs.readFileSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/${file}`,
-        'utf-8'
-      );
-
-      const fileContent = JSON.parse(
-        fileContentJson
-      ) as Curriculum<GeneratedCurriculumProps>;
-
-      const superBlock = Object.keys(fileContent)[0] as SuperBlocks;
-      const superBlockData = fileContent[
-        superBlock
-      ] as GeneratedBlockBasedCurriculumProps;
-
-      expect(superBlockData.intro).toEqual(intros[superBlock].intro);
-      const blocks = superBlockData.blocks;
-
-      for (const block of blocks) {
-        expect(block.intro).toEqual(
-          intros[superBlock].blocks[block.meta.dashedName as string].intro
-        );
-        expect(block.meta.name).toEqual(
-          intros[superBlock].blocks[block.meta.dashedName as string].title
-        );
-      }
+    expect(data[CHAPTER_BASED_SB]).toMatchObject({
+      intro: ['Learn responsive web design.'],
+      chapters: [
+        {
+          name: 'Test Chapter Name',
+          modules: [
+            {
+              name: 'Test Module Name',
+              blocks: [
+                {
+                  intro: ['Chapter block intro.'],
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                  meta: expect.objectContaining({
+                    name: 'Chapter Block Title',
+                    dashedName: 'test-chapter-block'
+                  })
+                }
+              ]
+            }
+          ]
+        },
+        { comingSoon: true, modules: [] }
+      ]
     });
+
+    // chapter and module fields should be omitted from block meta
+    const blockMeta =
+      data[CHAPTER_BASED_SB].chapters[0].modules[0].blocks[0].meta;
+    expect(blockMeta).not.toHaveProperty('chapter');
+    expect(blockMeta).not.toHaveProperty('module');
   });
 
-  test('chapter-based super blocks and blocks should have the correct data', async () => {
-    const superBlocks = Object.values(SuperBlocks);
+  test('challenge files are written at the correct paths', () => {
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          VERSION,
+          'challenges',
+          BLOCK_BASED_SB,
+          'test-block',
+          'challenge-1.json'
+        )
+      )
+    ).toBe(true);
 
-    const superBlockFiles = (
-      await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
-        directoryFilter: ['!challenges'],
-        fileFilter: entry => {
-          // The directory contains super block files and other curriculum-related files.
-          // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
-          );
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          VERSION,
+          'challenges',
+          CHAPTER_BASED_SB,
+          'test-chapter-block',
+          'chapter-challenge-1.json'
+        )
+      )
+    ).toBe(true);
+  });
 
-          const isChapterBasedSuperBlock = chapterBasedSuperBlocks.some(
-            chapterBasedSuperBlock =>
-              entry.basename.includes(chapterBasedSuperBlock)
-          );
+  test('submit-types.json is written', () => {
+    expect(fs.existsSync(path.join(tmpDir, VERSION, 'submit-types.json'))).toBe(
+      true
+    );
+  });
 
-          return isSuperBlock && isChapterBasedSuperBlock;
-        }
-      })
-    ).map(file => file.path);
+  test('scene-assets.json is written', () => {
+    expect(fs.existsSync(path.join(tmpDir, VERSION, 'scene-assets.json'))).toBe(
+      true
+    );
+  });
+});
 
-    expect(superBlockFiles.length).toBeGreaterThan(0);
-
-    superBlockFiles.forEach(file => {
-      const fileContentJson = fs.readFileSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/${file}`,
-        'utf-8'
-      );
-
-      const fileContent = JSON.parse(
-        fileContentJson
-      ) as Curriculum<GeneratedCurriculumProps>;
-
-      const superBlock = Object.keys(fileContent)[0] as SuperBlocks;
-      const superBlockData = fileContent[
-        superBlock
-      ] as GeneratedChapterBasedCurriculumProps;
-
-      const superBlockIntros = intros[
-        superBlock
-      ] as ChapterBasedCurriculumIntros[SuperBlocks];
-
-      // Check super block data
-      expect(superBlockData.intro).toEqual(superBlockIntros.intro);
-
-      // Loop through all chapters
-      superBlockData.chapters
-        .filter(({ comingSoon }) => !comingSoon)
-        .forEach(chapter => {
-          expect(chapter.name).toEqual(
-            superBlockIntros.chapters[chapter.dashedName]
-          );
-
-          // Loop through all modules in the chapter
-          chapter.modules
-            .filter(({ comingSoon }) => !comingSoon)
-            .forEach(module => {
-              expect(module.name).toEqual(
-                superBlockIntros.modules[module.dashedName]
-              );
-            });
-        });
-
-      for (const chapter of superBlockData.chapters) {
-        if (chapter.comingSoon) continue;
-
-        for (const module of chapter.modules) {
-          if (module.comingSoon) continue;
-
-          for (const block of module.blocks) {
-            expect(block.intro).toEqual(
-              superBlockIntros.blocks[block.meta.dashedName as string].intro
-            );
-            expect(block.meta.name).toEqual(
-              superBlockIntros.blocks[block.meta.dashedName as string].title
-            );
-          }
-        }
-      }
-    });
+describe('orderedSuperBlockInfo', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test('All public SuperBlocks should be present in the SuperBlock object', () => {
@@ -298,18 +358,6 @@ describe('external curriculum data build', () => {
         superBlockStages[stageValueInNum].length
       );
     }
-  });
-
-  test('challenge files should be created and in the correct directory', () => {
-    expect(
-      fs.existsSync(`${clientStaticPath}/curriculum-data/${VERSION}/challenges`)
-    ).toBe(true);
-
-    expect(
-      fs.readdirSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/challenges`
-      ).length
-    ).toBeGreaterThan(0);
   });
 
   test('orderedSuperBlockInfo should use intro argument', () => {

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -30,7 +30,7 @@ import {
   type GeneratedChapterBasedCurriculumProps,
   type OrderedSuperBlocks,
   buildExtCurriculumDataV2,
-  orderedSuperBlockInfo,
+  orderedSuperBlockInfo
 } from './build-external-curricula-data-v2';
 import { getSuperblockStructure } from '@freecodecamp/curriculum/file-handler';
 

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -37,7 +37,7 @@ import {
   catalogCourses,
   fillIntrosFromEnglish,
   buildExtCurriculumDataV2,
-  orderedSuperBlockInfo,
+  orderedSuperBlockInfo
 } from './build-external-curricula-data-v2';
 import { getSuperblockStructure } from '@freecodecamp/curriculum/file-handler';
 

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -1,8 +1,16 @@
+import os from 'os';
 import path from 'path';
 import fs from 'fs';
 
-import readdirp from 'readdirp';
-import { afterEach, describe, test, expect, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  test,
+  expect,
+  vi
+} from 'vitest';
 
 import {
   chapterBasedSuperBlocks,
@@ -12,95 +20,235 @@ import {
 } from '@freecodecamp/shared/config/curriculum';
 import { catalog } from '@freecodecamp/shared/config/catalog';
 import {
-  superblockSchemaValidator,
+  catalogValidator,
   availableSuperBlocksValidator,
-  catalogValidator
+  superblockSchemaValidator
 } from './external-data-schema-v2';
 import {
   type Curriculum,
-  type GeneratedCurriculumProps,
+  type CurriculumIntros,
+  type CurriculumProps,
   type GeneratedBlockBasedCurriculumProps,
   type GeneratedChapterBasedCurriculumProps,
-  type ChapterBasedCurriculumIntros,
+  type GeneratedCurriculumProps,
   type CatalogCourse,
-  orderedSuperBlockInfo,
-  OrderedSuperBlocks,
+  type OrderedSuperBlocks,
+  type SuperBlockIntro,
   catalogCourses,
-  readCurriculumIntros,
-  getCurriculumLocale,
-  CurriculumIntros,
   fillIntrosFromEnglish,
-  type SuperBlockIntro
+  buildExtCurriculumDataV2,
+  orderedSuperBlockInfo,
 } from './build-external-curricula-data-v2';
+import { getSuperblockStructure } from '@freecodecamp/curriculum/file-handler';
+
+vi.mock('@freecodecamp/curriculum/file-handler');
 
 const VERSION = 'v2';
-const intros = readCurriculumIntros(getCurriculumLocale());
+const BLOCK_BASED_SB = SuperBlocks.CodingInterviewPrep;
+const CHAPTER_BASED_SB = SuperBlocks.RespWebDesignV9;
+const CATALOG_SB = SuperBlocks.LearnPythonForBeginners;
 
 const dummyIntro = Object.values(SuperBlocks)
   .map(s => ({ [s]: { title: s } }))
   .reduce((prev, curr) => ({ ...prev, ...curr }), {}) as CurriculumIntros;
 
-describe('external curriculum data build', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
+function buildFixtureIntros(): CurriculumIntros {
+  const stub: Record<string, unknown> = {};
+  for (const sb of Object.values(SuperBlocks)) {
+    if (chapterBasedSuperBlocks.includes(sb)) {
+      stub[sb] = {
+        title: sb,
+        intro: ['stub intro'],
+        chapters: {},
+        modules: {},
+        blocks: {}
+      };
+    } else {
+      stub[sb] = { title: sb, intro: ['stub intro'], blocks: {} };
+    }
+  }
+
+  stub[BLOCK_BASED_SB] = {
+    title: 'Coding Interview Prep',
+    intro: ['Prepare for coding interviews.'],
+    blocks: {
+      'test-block': {
+        title: 'Test Block Title',
+        intro: ['Block intro paragraph.']
+      }
+    }
+  };
+
+  stub[CHAPTER_BASED_SB] = {
+    title: 'Responsive Web Design V9',
+    intro: ['Learn responsive web design.'],
+    chapters: {
+      'test-chapter': 'Test Chapter Name',
+      'coming-soon-chapter': 'Coming Soon Chapter'
+    },
+    modules: { 'test-module': 'Test Module Name' },
+    blocks: {
+      'test-chapter-block': {
+        title: 'Chapter Block Title',
+        intro: ['Chapter block intro.']
+      }
+    }
+  };
+
+  stub[CATALOG_SB] = {
+    title: "Learn Python for Beginners",
+    intro: ["Learn python"],
+    blocks: {
+      'test-catalog-block': {
+        title: 'Catalog block title',
+        intro: ['Catalog block intro.']
+      }
+
+
+    }
+  }
+
+  return stub as CurriculumIntros;
+}
+
+function buildFixtureCurriculum(): Curriculum<CurriculumProps> {
+  const stub: Record<string, unknown> = {};
+  for (const sb of Object.values(SuperBlocks)) {
+    stub[sb] = { intro: ['stub'], blocks: {} };
+  }
+
+  stub[BLOCK_BASED_SB] = {
+    intro: ['unused'],
+    blocks: {
+      'test-block': {
+        desc: ['desc'],
+        intro: ['unused'],
+        challenges: [{ id: 'challenge-1', title: 'Test Challenge' }],
+        meta: {
+          name: 'Original Name',
+          isUpcomingChange: false,
+          dashedName: 'test-block',
+          helpCategory: 'JavaScript',
+          order: 0,
+          superBlock: BLOCK_BASED_SB,
+          blockLayout: 'challenge-list',
+          challengeOrder: [{ id: 'challenge-1', title: 'Test Challenge' }]
+        }
+      }
+    }
+  };
+
+  stub[CHAPTER_BASED_SB] = {
+    intro: ['unused'],
+    blocks: {
+      'test-chapter-block': {
+        desc: ['desc'],
+        intro: ['unused'],
+        challenges: [{ id: 'chapter-challenge-1', title: 'Chapter Challenge' }],
+        meta: {
+          name: 'Original',
+          isUpcomingChange: false,
+          dashedName: 'test-chapter-block',
+          helpCategory: 'HTML-CSS',
+          order: 0,
+          superBlock: CHAPTER_BASED_SB,
+          blockLayout: 'challenge-list',
+          blockLabel: 'lecture',
+          chapter: 'test-chapter',
+          module: 'test-module',
+          challengeOrder: [
+            { id: 'chapter-challenge-1', title: 'Chapter Challenge' }
+          ]
+        }
+      }
+    }
+  };
+
+
+  stub[CATALOG_SB] = {
+    intro: ['unused'],
+    blocks: {
+      'test-catalog-block': {
+        desc: ['desc'],
+        intro: ['unused'],
+        challenges: [{ id: 'challenge-1', title: 'Test Challenge' }],
+        meta: {
+          name: 'Original Name',
+          isUpcomingChange: false,
+          dashedName: 'test-catalog-block',
+          helpCategory: 'JavaScript',
+          order: 0,
+          superBlock: BLOCK_BASED_SB,
+          blockLayout: 'challenge-list',
+          challengeOrder: [{ id: 'challenge-1', title: 'Test Challenge' }]
+        }
+      }
+    }
+  };
+
+  return stub as unknown as Curriculum<CurriculumProps>;
+}
+
+describe('buildExtCurriculumDataV2', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ext-curriculum-test-'));
+
+    vi.mocked(getSuperblockStructure).mockImplementation(key => {
+      if (key === (CHAPTER_BASED_SB as string)) {
+        return {
+          chapters: [
+            {
+              dashedName: 'test-chapter',
+              modules: [
+                {
+                  dashedName: 'test-module',
+                  blocks: ['test-chapter-block']
+                }
+              ]
+            },
+            {
+              dashedName: 'coming-soon-chapter',
+              comingSoon: true,
+              modules: []
+            }
+          ]
+        };
+      }
+      return { chapters: [] };
+    });
+
+    buildExtCurriculumDataV2(buildFixtureCurriculum(), {
+      dataPath: tmpDir,
+      intros: buildFixtureIntros()
+    });
   });
-  const clientStaticPath = path.resolve(__dirname, '../../../client/static');
 
-  const validateSuperBlock = superblockSchemaValidator();
-
-  test("the external curriculum data should be in the client's static directory", () => {
-    expect(
-      fs.existsSync(`${clientStaticPath}/curriculum-data/${VERSION}`)
-    ).toBe(true);
-
-    expect(
-      fs.readdirSync(`${clientStaticPath}/curriculum-data/${VERSION}`).length
-    ).toBeGreaterThan(0);
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
   });
 
-  test('there should be an endpoint to request submit types from', () => {
-    expect(
-      fs.existsSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/submit-types.json`
-      )
-    ).toBe(true);
-  });
+  test('available-superblocks.json passes schema validation', () => {
+    const filePath = path.join(tmpDir, VERSION, 'available-superblocks.json');
+    expect(fs.existsSync(filePath)).toBe(true);
 
-  test('the available-superblocks file should have the correct structure', async () => {
-    const filteredSuperBlockStages: string[] = Object.keys(SuperBlockStage)
-      .filter(key => isNaN(Number(key))) // Filter out numeric keys to get only the names
-      .filter(
-        name => name !== 'Upcoming' && name !== 'Next' && name !== 'Catalog'
-      ) // Filter out 'Upcoming', 'Next', and 'Catalog'
-      .map(name => name.toLowerCase());
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as {
+      superblocks: OrderedSuperBlocks;
+    };
+    const validate = availableSuperBlocksValidator();
+    const result = validate(data);
 
-    const validateAvailableSuperBlocks = availableSuperBlocksValidator();
-    const availableSuperblocks = JSON.parse(
-      await fs.promises.readFile(
-        `${clientStaticPath}/curriculum-data/${VERSION}/available-superblocks.json`,
-        'utf-8'
-      )
-    ) as { superblocks: OrderedSuperBlocks };
-
-    const result = validateAvailableSuperBlocks(availableSuperblocks);
-
-    expect(Object.keys(availableSuperblocks.superblocks)).toHaveLength(
-      filteredSuperBlockStages.length
-    );
-
-    expect(Object.keys(availableSuperblocks.superblocks)).toEqual(
-      expect.arrayContaining(filteredSuperBlockStages)
-    );
-
-    expect(result.error?.details).toBeUndefined();
     expect(result.error).toBeFalsy();
   });
 
   test('the catalog file should have the correct structure and data', async () => {
+    const filePath = path.join(tmpDir, VERSION, 'catalog.json');
     const validateCatalog = catalogValidator();
     const catalogFile = JSON.parse(
       await fs.promises.readFile(
-        `${clientStaticPath}/curriculum-data/${VERSION}/catalog.json`,
+        filePath,
         'utf-8'
       )
     ) as { catalog: CatalogCourse[] };
@@ -117,8 +265,8 @@ describe('external curriculum data build', () => {
 
       expect(course).toEqual({
         dashedName: superBlock,
-        title: intros[superBlock].title,
-        summary: intros[superBlock].summary,
+        title: superBlock,
+        summary: [],
         level,
         hours,
         topic
@@ -126,33 +274,33 @@ describe('external curriculum data build', () => {
     });
   });
 
-  test('every catalog course should have its blocks and challenges generated', () => {
+  test.only('catalog courses should have their blocks and challenges generated', () => {
     catalog.forEach(({ superBlock }) => {
-      const superBlockPath = `${clientStaticPath}/curriculum-data/${VERSION}/${superBlock}.json`;
+      const filePath = path.join(tmpDir, VERSION, `${superBlock}.json`);
 
-      expect(fs.existsSync(superBlockPath)).toBe(true);
+      expect(fs.existsSync(filePath)).toBe(true);
 
       const fileContent = JSON.parse(
-        fs.readFileSync(superBlockPath, 'utf-8')
+        fs.readFileSync(filePath, 'utf-8')
       ) as Curriculum<GeneratedCurriculumProps>;
       const superBlockData = fileContent[superBlock];
 
       const blocks = chapterBasedSuperBlocks.includes(superBlock)
         ? (
-            superBlockData as GeneratedChapterBasedCurriculumProps
-          ).chapters.flatMap(chapter =>
-            chapter.modules.flatMap(module => module.blocks)
-          )
+          superBlockData as GeneratedChapterBasedCurriculumProps
+        ).chapters.flatMap(chapter =>
+          chapter.modules.flatMap(module => module.blocks)
+        )
         : (superBlockData as GeneratedBlockBasedCurriculumProps).blocks;
 
       blocks.forEach(block => {
         const challengeOrder = block.meta.challengeOrder as { id: string }[];
 
+        expect(challengeOrder.length).toBeGreaterThan(0)
+
         challengeOrder.forEach(({ id }) => {
           expect(
-            fs.existsSync(
-              `${clientStaticPath}/curriculum-data/${VERSION}/challenges/${superBlock}/${block.meta.dashedName as string}/${id}.json`
-            )
+            fs.existsSync(path.join(tmpDir, VERSION, 'challenges', superBlock, block.meta.dashedName as string, `${id}.json`))
           ).toBe(true);
         });
       });
@@ -169,177 +317,127 @@ describe('external curriculum data build', () => {
     });
   });
 
-  test('the super block files generated should have the correct schema', async () => {
-    const superBlocks = Object.values(SuperBlocks);
+  test('superblock files pass schema validation', () => {
+    const validateSuperBlock = superblockSchemaValidator();
 
-    const fileArray = (
-      await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
-        directoryFilter: ['!challenges'],
-        fileFilter: entry => {
-          // The directory contains super block files and other curriculum-related files.
-          // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
-          );
-
-          return isSuperBlock;
-        }
-      })
-    ).map(file => file.path);
-
-    expect(fileArray.length).toBeGreaterThan(0);
-
-    fileArray.forEach(fileInArray => {
-      const fileContent = fs.readFileSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/${fileInArray}`,
-        'utf-8'
-      );
-
-      const result = validateSuperBlock(
-        JSON.parse(fileContent) as Record<string, unknown>
-      );
+    for (const sb of [BLOCK_BASED_SB, CHAPTER_BASED_SB]) {
+      const filePath = path.join(tmpDir, VERSION, `${sb}.json`);
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+      const result = validateSuperBlock(data);
 
       expect(result.error?.details).toBeUndefined();
       expect(result.error).toBeFalsy();
+    }
+  });
+
+  test('block-based superblock file has correct intro and meta.name', () => {
+    const filePath = path.join(tmpDir, VERSION, `${BLOCK_BASED_SB}.json`);
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<
+      string,
+      GeneratedBlockBasedCurriculumProps
+    >;
+
+    expect(data[BLOCK_BASED_SB]).toMatchObject({
+      intro: ['Prepare for coding interviews.'],
+      blocks: [
+        {
+          intro: ['Block intro paragraph.'],
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          meta: expect.objectContaining({
+            name: 'Test Block Title',
+            dashedName: 'test-block'
+          })
+        }
+      ]
     });
   });
 
-  test('block-based super blocks and blocks should have the correct data', async () => {
-    const superBlocks = Object.values(SuperBlocks);
+  test('chapter-based superblock file has correct structure with comingSoon filtered', () => {
+    const filePath = path.join(tmpDir, VERSION, `${CHAPTER_BASED_SB}.json`);
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<
+      string,
+      GeneratedChapterBasedCurriculumProps
+    >;
 
-    const superBlockFiles = (
-      await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
-        directoryFilter: ['!challenges'],
-        fileFilter: entry => {
-          // The directory contains super block files and other curriculum-related files.
-          // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
-          );
-
-          const isChapterBasedSuperBlock = chapterBasedSuperBlocks.some(
-            chapterBasedSuperBlock =>
-              entry.basename.includes(chapterBasedSuperBlock)
-          );
-
-          return isSuperBlock && !isChapterBasedSuperBlock;
-        }
-      })
-    ).map(file => file.path);
-
-    expect(superBlockFiles.length).toBeGreaterThan(0);
-
-    superBlockFiles.forEach(file => {
-      const fileContentJson = fs.readFileSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/${file}`,
-        'utf-8'
-      );
-
-      const fileContent = JSON.parse(
-        fileContentJson
-      ) as Curriculum<GeneratedCurriculumProps>;
-
-      const superBlock = Object.keys(fileContent)[0] as SuperBlocks;
-      const superBlockData = fileContent[
-        superBlock
-      ] as GeneratedBlockBasedCurriculumProps;
-
-      expect(superBlockData.intro).toEqual(intros[superBlock].intro);
-      const blocks = superBlockData.blocks;
-
-      for (const block of blocks) {
-        expect(block.intro).toEqual(
-          intros[superBlock].blocks[block.meta.dashedName as string].intro
-        );
-        expect(block.meta.name).toEqual(
-          intros[superBlock].blocks[block.meta.dashedName as string].title
-        );
-      }
+    expect(data[CHAPTER_BASED_SB]).toMatchObject({
+      intro: ['Learn responsive web design.'],
+      chapters: [
+        {
+          name: 'Test Chapter Name',
+          modules: [
+            {
+              name: 'Test Module Name',
+              blocks: [
+                {
+                  intro: ['Chapter block intro.'],
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                  meta: expect.objectContaining({
+                    name: 'Chapter Block Title',
+                    dashedName: 'test-chapter-block'
+                  })
+                }
+              ]
+            }
+          ]
+        },
+        { comingSoon: true, modules: [] }
+      ]
     });
+
+    // chapter and module fields should be omitted from block meta
+    const blockMeta =
+      data[CHAPTER_BASED_SB].chapters[0].modules[0].blocks[0].meta;
+    expect(blockMeta).not.toHaveProperty('chapter');
+    expect(blockMeta).not.toHaveProperty('module');
   });
 
-  test('chapter-based super blocks and blocks should have the correct data', async () => {
-    const superBlocks = Object.values(SuperBlocks);
+  test('challenge files are written at the correct paths', () => {
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          VERSION,
+          'challenges',
+          BLOCK_BASED_SB,
+          'test-block',
+          'challenge-1.json'
+        )
+      )
+    ).toBe(true);
 
-    const superBlockFiles = (
-      await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`, {
-        directoryFilter: ['!challenges'],
-        fileFilter: entry => {
-          // The directory contains super block files and other curriculum-related files.
-          // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
-          );
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          VERSION,
+          'challenges',
+          CHAPTER_BASED_SB,
+          'test-chapter-block',
+          'chapter-challenge-1.json'
+        )
+      )
+    ).toBe(true);
+  });
 
-          const isChapterBasedSuperBlock = chapterBasedSuperBlocks.some(
-            chapterBasedSuperBlock =>
-              entry.basename.includes(chapterBasedSuperBlock)
-          );
+  test('submit-types.json is written', () => {
+    expect(fs.existsSync(path.join(tmpDir, VERSION, 'submit-types.json'))).toBe(
+      true
+    );
+  });
 
-          return isSuperBlock && isChapterBasedSuperBlock;
-        }
-      })
-    ).map(file => file.path);
+  test('scene-assets.json is written', () => {
+    expect(fs.existsSync(path.join(tmpDir, VERSION, 'scene-assets.json'))).toBe(
+      true
+    );
+  });
+});
 
-    expect(superBlockFiles.length).toBeGreaterThan(0);
-
-    superBlockFiles.forEach(file => {
-      const fileContentJson = fs.readFileSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/${file}`,
-        'utf-8'
-      );
-
-      const fileContent = JSON.parse(
-        fileContentJson
-      ) as Curriculum<GeneratedCurriculumProps>;
-
-      const superBlock = Object.keys(fileContent)[0] as SuperBlocks;
-      const superBlockData = fileContent[
-        superBlock
-      ] as GeneratedChapterBasedCurriculumProps;
-
-      const superBlockIntros = intros[
-        superBlock
-      ] as ChapterBasedCurriculumIntros[SuperBlocks];
-
-      // Check super block data
-      expect(superBlockData.intro).toEqual(superBlockIntros.intro);
-
-      // Loop through all chapters
-      superBlockData.chapters
-        .filter(({ comingSoon }) => !comingSoon)
-        .forEach(chapter => {
-          expect(chapter.name).toEqual(
-            superBlockIntros.chapters[chapter.dashedName]
-          );
-
-          // Loop through all modules in the chapter
-          chapter.modules
-            .filter(({ comingSoon }) => !comingSoon)
-            .forEach(module => {
-              expect(module.name).toEqual(
-                superBlockIntros.modules[module.dashedName]
-              );
-            });
-        });
-
-      for (const chapter of superBlockData.chapters) {
-        if (chapter.comingSoon) continue;
-
-        for (const module of chapter.modules) {
-          if (module.comingSoon) continue;
-
-          for (const block of module.blocks) {
-            expect(block.intro).toEqual(
-              superBlockIntros.blocks[block.meta.dashedName as string].intro
-            );
-            expect(block.meta.name).toEqual(
-              superBlockIntros.blocks[block.meta.dashedName as string].title
-            );
-          }
-        }
-      }
-    });
+describe('orderedSuperBlockInfo', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test('All public SuperBlocks should be present in the SuperBlock object', () => {
@@ -377,18 +475,6 @@ describe('external curriculum data build', () => {
         superBlockStages[stageValueInNum].length
       );
     }
-  });
-
-  test('challenge files should be created and in the correct directory', () => {
-    expect(
-      fs.existsSync(`${clientStaticPath}/curriculum-data/${VERSION}/challenges`)
-    ).toBe(true);
-
-    expect(
-      fs.readdirSync(
-        `${clientStaticPath}/curriculum-data/${VERSION}/challenges`
-      ).length
-    ).toBeGreaterThan(0);
   });
 
   test('orderedSuperBlockInfo should use intro argument', () => {

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -188,9 +188,13 @@ function buildFixtureCurriculum(): Curriculum<CurriculumProps> {
 
 describe('buildExtCurriculumDataV2', () => {
   let tmpDir: string;
+  let fixtureIntros: CurriculumIntros;
+  let fixtureCurriculum: Curriculum<CurriculumProps>;
 
   beforeAll(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ext-curriculum-test-'));
+    fixtureIntros = buildFixtureIntros();
+    fixtureCurriculum = buildFixtureCurriculum();
 
     vi.mocked(getSuperblockStructure).mockImplementation(key => {
       if (key === (CHAPTER_BASED_SB as string)) {
@@ -216,9 +220,9 @@ describe('buildExtCurriculumDataV2', () => {
       return { chapters: [] };
     });
 
-    buildExtCurriculumDataV2(buildFixtureCurriculum(), {
+    buildExtCurriculumDataV2(fixtureCurriculum, {
       dataPath: tmpDir,
-      intros: buildFixtureIntros()
+      intros: fixtureIntros
     });
   });
 
@@ -258,7 +262,7 @@ describe('buildExtCurriculumDataV2', () => {
       const { superBlock, level, hours, topic } = catalog[index];
       expect(course).toEqual({
         dashedName: superBlock,
-        title: superBlock,
+        title: fixtureIntros[superBlock].title,
         summary: [],
         level,
         hours,

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -96,17 +96,15 @@ function buildFixtureIntros(): CurriculumIntros {
   };
 
   stub[CATALOG_SB] = {
-    title: "Learn Python for Beginners",
-    intro: ["Learn python"],
+    title: 'Learn Python for Beginners',
+    intro: ['Learn python'],
     blocks: {
       'test-catalog-block': {
         title: 'Catalog block title',
         intro: ['Catalog block intro.']
       }
-
-
     }
-  }
+  };
 
   return stub as CurriculumIntros;
 }
@@ -163,7 +161,6 @@ function buildFixtureCurriculum(): Curriculum<CurriculumProps> {
       }
     }
   };
-
 
   stub[CATALOG_SB] = {
     intro: ['unused'],
@@ -247,10 +244,7 @@ describe('buildExtCurriculumDataV2', () => {
     const filePath = path.join(tmpDir, VERSION, 'catalog.json');
     const validateCatalog = catalogValidator();
     const catalogFile = JSON.parse(
-      await fs.promises.readFile(
-        filePath,
-        'utf-8'
-      )
+      await fs.promises.readFile(filePath, 'utf-8')
     ) as { catalog: CatalogCourse[] };
 
     const result = validateCatalog(catalogFile);
@@ -262,7 +256,6 @@ describe('buildExtCurriculumDataV2', () => {
 
     catalogFile.catalog.forEach((course, index) => {
       const { superBlock, level, hours, topic } = catalog[index];
-
       expect(course).toEqual({
         dashedName: superBlock,
         title: superBlock,
@@ -274,7 +267,7 @@ describe('buildExtCurriculumDataV2', () => {
     });
   });
 
-  test.only('catalog courses should have their blocks and challenges generated', () => {
+  test('catalog courses should have their blocks and challenges generated', () => {
     catalog.forEach(({ superBlock }) => {
       const filePath = path.join(tmpDir, VERSION, `${superBlock}.json`);
 
@@ -287,20 +280,29 @@ describe('buildExtCurriculumDataV2', () => {
 
       const blocks = chapterBasedSuperBlocks.includes(superBlock)
         ? (
-          superBlockData as GeneratedChapterBasedCurriculumProps
-        ).chapters.flatMap(chapter =>
-          chapter.modules.flatMap(module => module.blocks)
-        )
+            superBlockData as GeneratedChapterBasedCurriculumProps
+          ).chapters.flatMap(chapter =>
+            chapter.modules.flatMap(module => module.blocks)
+          )
         : (superBlockData as GeneratedBlockBasedCurriculumProps).blocks;
 
       blocks.forEach(block => {
         const challengeOrder = block.meta.challengeOrder as { id: string }[];
 
-        expect(challengeOrder.length).toBeGreaterThan(0)
+        expect(challengeOrder.length).toBeGreaterThan(0);
 
         challengeOrder.forEach(({ id }) => {
           expect(
-            fs.existsSync(path.join(tmpDir, VERSION, 'challenges', superBlock, block.meta.dashedName as string, `${id}.json`))
+            fs.existsSync(
+              path.join(
+                tmpDir,
+                VERSION,
+                'challenges',
+                superBlock,
+                block.meta.dashedName as string,
+                `${id}.json`
+              )
+            )
           ).toBe(true);
         });
       });

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.ts
@@ -116,9 +116,12 @@ export type OrderedSuperBlocks = Record<
 
 const ver = 'v2';
 
-const staticFolderPath = resolve(__dirname, '../../../client/static');
-const dataPath = `${staticFolderPath}/curriculum-data/`;
-const intros = readCurriculumIntros(getCurriculumLocale());
+export interface BuildOptions {
+  /** Directory to write output into (default: client/static/curriculum-data) */
+  dataPath?: string;
+  /** Pre-loaded intro data (default: read from disk for current locale) */
+  intros?: CurriculumIntros;
+}
 
 export function getCurriculumLocale(): Languages {
   const { CURRICULUM_LOCALE } = process.env;
@@ -332,8 +335,14 @@ export const superBlockDashedNames = (() => {
 })();
 
 export function buildExtCurriculumDataV2(
-  curriculum: Curriculum<CurriculumProps>
+  curriculum: Curriculum<CurriculumProps>,
+  options: BuildOptions = {}
 ): void {
+  const dataPath =
+    options.dataPath ??
+    resolve(__dirname, '../../../client/static/curriculum-data/');
+  const intros = options.intros ?? readCurriculumIntros(getCurriculumLocale());
+
   mkdirSync(dataPath, { recursive: true });
 
   parseCurriculumData();

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.ts
@@ -132,9 +132,12 @@ export interface CatalogCourse {
 
 const ver = 'v2';
 
-const staticFolderPath = resolve(__dirname, '../../../client/static');
-const dataPath = `${staticFolderPath}/curriculum-data/`;
-const intros = readCurriculumIntros(getCurriculumLocale());
+export interface BuildOptions {
+  /** Directory to write output into (default: client/static/curriculum-data) */
+  dataPath?: string;
+  /** Pre-loaded intro data (default: read from disk for current locale) */
+  intros?: CurriculumIntros;
+}
 
 export function getCurriculumLocale(): Languages {
   const { CURRICULUM_LOCALE } = process.env;
@@ -438,8 +441,14 @@ export const superBlockDashedNames = (() => {
 export const catalogDashedNames = catalog.map(({ superBlock }) => superBlock);
 
 export function buildExtCurriculumDataV2(
-  curriculum: Curriculum<CurriculumProps>
+  curriculum: Curriculum<CurriculumProps>,
+  options: BuildOptions = {}
 ): void {
+  const dataPath =
+    options.dataPath ??
+    resolve(__dirname, '../../../client/static/curriculum-data/');
+  const intros = options.intros ?? readCurriculumIntros(getCurriculumLocale());
+
   mkdirSync(dataPath, { recursive: true });
 
   parseCurriculumData();


### PR DESCRIPTION
This makes the tests independent of the environment. Instead of relying on build artifacts, the tests now use their own fixtures.

While we're no longer testing the full process, I'd rather keep the tests isolated until we run into an error they can't prevent

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
