### PR TITLE
fix(curriculum): align CSS Colors review with lecture content

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -93,7 +93,7 @@ div {
 
 :::
 
-- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. Hex codes can be written in a six-character form, such as `#FFFFFF`, or a three-character shorthand form, such as `#FFF`, when each pair of characters is identical.
+- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. Hex codes can be 6 characters long `#F498A2`, or 3 characters long equivalent to a 6 character one where each pair has the same digit twice, like `#2FB` is equivalent to `#22FFBB`.
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -58,7 +58,7 @@ div {
 
 :::
 
-- **`hsl()` Function**: HSL stands for Hue, Saturation, and Lightness — three key components that define a color. 
+- **`hsl()` Function**: HSL stands for Hue, Saturation, and Lightness — three key components that define a color. Modern `hsl()` syntax also supports an optional alpha value using a `/` separator.
 
 :::interactive_editor
 
@@ -75,7 +75,7 @@ p {
 
 :::
 
-- **`hsla()` Function**: The `hsla()` function was the original way to include transparency in HSL colors using comma-separated values. Modern CSS prefers the `hsl()` function with a `/` separator for alpha values, though `hsla()` remains supported as legacy syntax.
+- **`hsla()` Function**: The `hsla()` function is a legacy way to add transparency to HSL colors. Modern CSS prefers `hsl()` with a `/` separator for alpha values.
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -93,7 +93,7 @@ div {
 
 :::
 
-- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. Hex codes can be 6 characters long `#F498A2`, or 3 characters long equivalent to a 6 character one where each pair has the same digit twice, like `#2FB` is equivalent to `#22FFBB`.
+- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. Hex codes can be 6 characters long, like `#F498A2`, or a 3-character shorthand, which works when each pair in the full form uses the same character twice. For example, #2FB is equivalent to #22FFBB.
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -69,7 +69,7 @@ div {
 
 ```css
 p {
-  color: hsl(120 100% 50%);
+  color: hsl(120 100% 50% / 0.8);
 }
 ```
 
@@ -87,13 +87,13 @@ p {
 
 ```css
 div {
-  background-color: hsl(0 100% 50% / 0.5);
+  background-color: hsla(0, 100%, 50%, 0.5);
 }
 ```
 
 :::
 
-- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. Hex codes can be 6 characters long, like `#F498A2`, or a 3-character shorthand, which works when each pair in the full form uses the same character twice. For example, #2FB is equivalent to #22FFBB.
+- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. Hex codes can be 6 characters long, like `#F498A2`, or a 3-character shorthand, which works when each pair in the full form uses the same character twice. For example, `#2FB` is equivalent to `#22FFBB`.
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -65,10 +65,15 @@ div {
 ```html
 <link rel="stylesheet" href="styles.css">
 <p>HSL Color</p>
+<p class="alpha">HSL Color with Alpha</p>
 ```
 
 ```css
 p {
+  color: hsl(120 100% 50%);
+}
+
+.alpha {
   color: hsl(120 100% 50% / 0.8);
 }
 ```

--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -69,13 +69,13 @@ div {
 
 ```css
 p {
-  color: hsl(120, 100%, 50%);
+  color: hsl(120 100% 50%);
 }
 ```
 
 :::
 
-- **`hsla()` Function**: This function adds a fourth value, alpha, that controls the opacity of the color.
+- **`hsla()` Function**: The `hsla()` function was the original way to include transparency in HSL colors using comma-separated values. Modern CSS prefers the `hsl()` function with a `/` separator for alpha values, though `hsla()` remains supported as legacy syntax.
 
 :::interactive_editor
 
@@ -87,13 +87,13 @@ p {
 
 ```css
 div {
-  background-color: hsla(0, 100%, 50%, 0.5);
+  background-color: hsl(0 100% 50% / 0.5);
 }
 ```
 
 :::
 
-- **Hexadecimal**: A hex code (short for hexadecimal code) is a six-character string used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. 
+- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. Hex codes can be written in a six-character form, such as `#FFFFFF`, or a three-character shorthand form, such as `#FFF`, when each pair of characters is identical.
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68514 

Aligned the CSS Colors review with the lecture content by adding hex shorthand examples and updated HSL/HSLA syntax to use the modern format.