### PR TITLE
fix: correct grammar in Debug Camperbot's Profile Page user stories

### DIFF
--- a/curriculum/challenges/english/blocks/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
+++ b/curriculum/challenges/english/blocks/lab-debug-camperbots-profile-page/6823f9df49cc206af5471a30.md
@@ -14,9 +14,9 @@ Your job is to fix all of Camperbot's errors so they can continue building their
 
 **User Stories:**
 
-1. Camperbot is trying to use a `heading2` element, but that element does not exist. Fix those tags so it uses a correct second-level heading element.
+1. Camperbot is trying to use a `heading2` element, but that element does not exist. Fix those tags so they use a correct second-level heading element.
 2. Camperbot is trying to add two paragraphs with `pp`, but those don't exist either. Fix them so they use correct paragraph tags.
-3. Camperbot is using an `h3` element for the `Background and Interests` subheading but it has a syntax error. Spot the issue and resolve it.
+3. Camperbot is using an `h3` element for the `Background and Interests` subheading, but it has a syntax error. Spot the issue and resolve it.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68521 

<!-- Feel free to add any additional description of changes below this line -->
