### PR TITLE
fix: replace deprecated grid-gap with gap

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-grid/672aa8ac4631d1623ec5cd86.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-grid/672aa8ac4631d1623ec5cd86.md
@@ -52,7 +52,7 @@ If you wanted to style those elements in a grid format, you can set the `display
 .container {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-gap: 20px;
+  gap: 20px;
 }
 
 .item {

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-grid/673226b97d4a731e0577ae93.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-grid/673226b97d4a731e0577ae93.md
@@ -70,7 +70,7 @@ Here's an example for the holy grail layout:
     'header header header'
     'sidebar-left main sidebar-right'
     'footer footer footer';
-  grid-gap: 10px;
+  gap: 10px;
   background-color: #2196F3;
   padding: 10px;
 }

--- a/curriculum/challenges/english/blocks/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
+++ b/curriculum/challenges/english/blocks/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
@@ -139,7 +139,7 @@ What is the shorthand for the `column-gap` and `row-gap` properties?
 
 ---
 
-`grid-gap`
+`grid-space`
 
 #### --answer--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Closes #68523 

## Description

This PR updates the CSS Grid curriculum by:

- Replacing the deprecated `grid-gap` property with `gap` in the "What Is CSS Grid, and How Does It Differ from Flexbox?" lecture.
- Replacing the deprecated `grid-gap` property with `gap` in the "How Can You Position Items on the Grid Using the `grid-template-areas` Property?" lecture.
- Updating the CSS Grid quiz by replacing `grid-gap` as a distractor, ensuring `gap` is the only correct shorthand answer.
