### PR TITLE
fix(curriculum): use early return in fortune teller step 47

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68f1e7ab1db80271d5fed0dd.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68f1e7ab1db80271d5fed0dd.md
@@ -554,21 +554,21 @@ class Game {
       .join("");
   }
   
-  showFortune(e: Event) {
+    showFortune(e: Event) {
     const target = e.target
     if(!(target instanceof  HTMLElement)){
-      throw new Error("target element is not correct");
+      return;
     }
-    
-    const cardElement = target?.closest(".card_container")
+
+  const cardElement = target?.closest(".card_container")
     if(!(cardElement instanceof HTMLElement)){
       return;
     }
-    
---fcc-editable-region--
-    
---fcc-editable-region--
-  }
+
+  //--fcc-editable-region--
+
+  //--fcc-editable-region--
+}
   
   newReading() {  
     


### PR DESCRIPTION

This PR updates Step 47 of the Fortune Teller workshop by replacing the `throw new Error(...)` statement with an early `return`.

This keeps the implementation consistent with the previous and subsequent workshop steps, which also use an early return when the target is not a valid `HTMLElement`.

Closes #68541