### PR TITLE
fix(curriculum): remove dot notation hints in wildlife tracker steps 8 and 9

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ad1cdc249e185aaeedbd.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ad1cdc249e185aaeedbd.md
@@ -53,12 +53,6 @@ const regex = __helpers.functionRegex('addHabitat', ['animal', 'habitat']);
 assert.match(__helpers.removeJSComments(code), regex);
 ```
 
-`addHabitat` should use dot notation to add the `habitat` property.
-
-```js
-assert.match(code, /animal\.habitat\s*=\s*habitat/);
-```
-
 The `addHabitat` function should return the updated `animal` object.
 
 ```js

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999adc72c02812a28c01e31.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999adc72c02812a28c01e31.md
@@ -47,12 +47,6 @@ const regex = __helpers.functionRegex('updateAge', ['animal', 'newAge']);
 assert.match(__helpers.removeJSComments(code), regex);
 ```
 
-`updateAge` should use dot notation to update the `age` property.
-
-```js
-assert.match(code, /animal\.age\s*=\s*newAge/);
-```
-
 The `updateAge` function should return the updated `animal` object.
 
 ```js


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68544

Remove the dot-notation-specific regex assertions from steps 8 and 9 of the Wildlife Tracker workshop. The hints were rejecting valid bracket notation solutions (e.g. `animal["habitat"] = habitat`), even though the instructions never specify which notation to use. The remaining `deepEqual`, `strictEqual`, and `propertyVal` assertions already fully validate that the property is set correctly.