### PR TITLE
fix(curriculum): make step 47 target handling consistent

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68f1e7ab1db80271d5fed0dd.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68f1e7ab1db80271d5fed0dd.md
@@ -556,8 +556,8 @@ class Game {
   
   showFortune(e: Event) {
     const target = e.target
-    if(!(target instanceof  HTMLElement)){
-      throw new Error("target element is not correct");
+    if (!(target instanceof HTMLElement)) {
+      return;
     }
     
     const cardElement = target?.closest(".card_container")


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68541

<!-- Feel free to add any additional description of changes below this line -->

## Description

This PR fixes an inconsistency in the Fortune Teller App workshop.

In Step 46, an invalid `EventTarget` is handled using an early return:

```ts
if (!(target instanceof HTMLElement)) {
  return;
}