### PR TITLE
fix(curriculum): align CSS Colors review with lecture content

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -58,42 +58,52 @@ div {
 
 :::
 
-- **`hsl()` Function**: HSL stands for Hue, Saturation, and Lightness — three key components that define a color. 
+- **`hsl()` Function**: HSL stands for Hue, Saturation, and Lightness — three key components that define a color. The preferred modern syntax uses spaces to separate the values. You may also encounter the comma-separated syntax, which is considered legacy.
 
 :::interactive_editor
 
 ```html
 <link rel="stylesheet" href="styles.css">
-<p>HSL Color</p>
+<p class="modern">Modern HSL Color</p>
+<p class="legacy">Legacy HSL Color</p>
 ```
 
 ```css
-p {
+.modern {
+  color: hsl(120 100% 50%);
+}
+
+.legacy {
   color: hsl(120, 100%, 50%);
 }
 ```
 
 :::
 
-- **`hsla()` Function**: This function adds a fourth value, alpha, that controls the opacity of the color.
+- **`hsla()` Function**: This function adds a fourth value, alpha, that controls the opacity of the color. It is the legacy syntax. The preferred modern approach is to use hsl() with the / separator.
 
 :::interactive_editor
 
 ```html
 <link rel="stylesheet" href="styles.css">
-<div>HSLA Background</div>
+<div class="legacy-alpha"></div>
+<div class="modern-alpha"></div>
 ```
 
 
 ```css
-div {
+.legacy-alpha {
   background-color: hsla(0, 100%, 50%, 0.5);
+}
+
+.modern-alpha {
+  background-color: hsl(0 100% 50% / 0.5);
 }
 ```
 
 :::
 
-- **Hexadecimal**: A hex code (short for hexadecimal code) is a six-character string used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. 
+- **Hexadecimal**: A hex code (short for hexadecimal code) is a six-character string used to represent colors in the RGB color model. A three-character shorthand can also be used when each pair of digits is identical (for example, #FFFFFF can be written as #FFF). The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. 
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68514 

<!-- Feel free to add any additional description of changes below this line -->

## Description

This PR updates the CSS Colors review page to better align with the "Working with Colors in CSS" lecture.

### Changes made

- Updated the Hexadecimal section to acknowledge the three-character shorthand syntax alongside the six-character format.
- Updated the `hsl()` section to prioritize the modern space-separated syntax.
- Added examples demonstrating both the modern and legacy `hsl()` syntax.
- Updated the `hsla()` section to identify it as the legacy syntax and included the modern `hsl()` equivalent using the `/` separator.
