### PR TITLE
fix(curriculum): fixed workshop name casing and missing semicolons in the Build a Wildlife Tracker workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6998b99a8e195cd0c1f211df.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6998b99a8e195cd0c1f211df.md
@@ -7,7 +7,7 @@ dashedName: step-1
 
 # --description--
 
-In this workshop, you will build a simple wildlife tracker using JavaScript objects.
+In this workshop, you will build a simple Wildlife Tracker using JavaScript objects.
 
 Here is an example of an object:
 

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ad1cdc249e185aaeedbd.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ad1cdc249e185aaeedbd.md
@@ -19,7 +19,7 @@ const cat = {
 const addColor = (pet, color) => {
   pet.color = color; // add new property using dot notation
   return pet; // return the updated object
-}
+};
 
 console.log(addColor(cat, "White")); 
 // {

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999adc72c02812a28c01e31.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999adc72c02812a28c01e31.md
@@ -19,7 +19,7 @@ const dog = {
 const changeAge = (pet, updatedAge) => {
   pet.age = updatedAge; // update existing property using dot notation
   return pet; // return the updated object
-}
+};
 
 console.log(changeAge(dog, 6)); // { age: 6 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
@@ -18,7 +18,7 @@ const cat = {
 
 const getAnimalAge = (pet) => {
   return pet.age; // access age using dot notation
-}
+};
 
 console.log(getAnimalAge(cat)); // 3
 ```


### PR DESCRIPTION
Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68543 

In Step 1, changed wildlife tracker to Wildlife Tracker.
In Step 7, added a semicolon after the closing brace of the getAnimalAge function so } becomes };.
In Step 8, added a semicolon after the closing brace of the addColor function so } becomes };.
In Step 9, added a semicolon after the closing brace of the changeAge function so } becomes };.

Closes #68543 