### PR TITLE
fix(client, i18n): fix portuguese and italian i18n tests not passing

### DIFF
--- a/client/turbo.json
+++ b/client/turbo.json
@@ -28,6 +28,9 @@
     "develop": {
       "env": ["FCC_*"]
     },
+    "test": {
+      "env": ["FCC_*", "CLIENT_LOCALE", "CURRICULUM_LOCALE"]
+    },
     "setup": {
       "env": [
         "FCC_*",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

This is a suggestion to fix the fact that i18n - curriculum Portuguese and Italian tests are not passing because they are expecting English text on intro.json and are receiving results as per locale. This implementation should make turbo test as per the correct locale instead.