### PR TITLE
fix(curriculum): update css grid quiz distractor

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
+++ b/curriculum/challenges/english/blocks/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
@@ -857,7 +857,7 @@ Creates columns that are exactly `1fr` wide regardless of content.
 
 ---
 
-Creates a maximum of one column per `150px` of available width.
+Fills each row with as many `150px` columns as possible, reserving empty tracks when there are not enough items to fill them.
 
 #### --answer--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68520


<!-- Feel free to add any additional description of changes below this line -->

This PR replaces a technically correct distractor in the CSS Grid Quiz. 

**Changes:**
- Replaced `Creates a maximum of one column per 150px of available width.` with `Fills each row with as many 150px columns as possible, reserving empty tracks when there are not enough items to fill them.`
- The new distractor describes `auto-fill` behavior (which preserves empty tracks) rather than the `auto-fit` behavior in the quiz question (which collapses them), making it a plausible but incorrect option.
Local verification (`pnpm run audit-challenges`) and the pre-commit linting hook both passed successfully.