### PR TITLE
fix: HTML lecture grammar

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-html-attributes/66f6db08d55022680a3cfbc9.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-html-attributes/66f6db08d55022680a3cfbc9.md
@@ -7,7 +7,7 @@ dashedName: what-is-html
 
 # --interactive--
 
-HTML, which stands for Hypertext Markup Language, is a markup language for creating web pages. When you visit a website and see content like paragraphs, headings, links, images, and videos; that's HTML. 
+HTML, which stands for HyperText Markup Language, is a markup language for creating web pages. When you visit a website and see content like paragraphs, headings, links, images, and videos, that's HTML. 
 
 Here is a small example using HTML elements. Try editing some of the text in the editor and see the changes update in the preview window.
 
@@ -61,11 +61,11 @@ Sometimes you will see void elements that use a `/` before the `>` like this:
 <img />
 ```
 
-While many code formatters like Prettier, will choose to include the `/` in void elements, the HTML spec states that the presence of the `/` "does not mark the start tag as self-closing but instead is unnecessary and has no effect of any kind".
+While many code formatters like Prettier will choose to include the `/` in void elements, the HTML spec states that the presence of the `/` "does not mark the start tag as self-closing but instead is unnecessary and has no effect of any kind".
 
-In real world development, you will see both forms so it is important to be familiar with both.
+In real-world development, you will see both forms, so it is important to be familiar with both.
 
-If you wanted to display an image, you will need to include a couple of attributes inside your image element. An attribute is a special value used to adjust the behavior for an HTML element. 
+If you wanted to display an image, you will need to include a couple of attributes inside your image element. An attribute is a special value used to adjust the behavior of an HTML element. 
 
 Here is an example of an image element with a `src` attribute. Update the value of the `src` attribute to `"https://cdn.freecodecamp.org/curriculum/cat-photo-app/cats.jpg"` and you will see the image change to two cats peacefully sleeping.
 
@@ -93,7 +93,7 @@ So, you might be wondering if HTML by itself is enough to build a website. Well,
 
 HTML is for the content and structure. CSS is for styling. JavaScript is for adding interactivity to your web pages. A good analogy for this is to compare HTML, CSS, and JavaScript with a complete building. 
 
-HTML represents the blocks, concrete, and irons that make up the walls. It's the foundation that makes the building strong. CSS represents the interior and exterior design that makes the house look beautiful. JavaScript represents the electrical and water system that ensures uninterrupted access to water and electricity.
+HTML represents the blocks, concrete, and iron that make up the walls. It's the foundation that makes the building strong. CSS represents the interior and exterior design that makes the building look beautiful. JavaScript represents the electrical and water system that ensures uninterrupted access to water and electricity.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Fixed grammar and punctuation issues in the HTML lecture content.

Changes include:
- Fixed semicolon usage
- Corrected comma placement
- Fixed preposition (for → of)
- Standardized real-world hyphenation
- Fixed analogy consistency (irons → iron, house → building)

No logic or educational meaning was changed.
Only writing and grammar improvements were made for clarity and correctness.


Closes #68564
