### PR TITLE
fix(curriculum): add const check for getWeather in weather app lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
+++ b/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
@@ -75,7 +75,7 @@ You will use a weather API. The output data has the following format:
 
    - You should have an element with the id `location` for displaying the current location.
 
-1. You should have an asynchronous function named `getWeather` that fetches the weather information from the `https://weather-proxy.freecodecamp.rocks/api/city/<CITY>` API and returns it. Note that this API returns data using the metric system, that means m/s for wind speed, and Celsius for the temperature.
+1. You should have an asynchronous function named `getWeather` that fetches the weather information from the `https://weather-proxy.freecodecamp.rocks/api/city/<CITY>` API and returns it. Note that this API returns data using the metric system, that means m/s for wind speed, and Celsius for the temperature. If you use an arrow function, do not declare it with `const`, as the tests require the ability to reassign it.
 
 1. The `getWeather` asynchronous function should accept a city as its argument.
 
@@ -429,6 +429,12 @@ You should have a `getWeather` function.
 
 ```js
 assert.isFunction(getWeather);
+```
+
+If you are using an arrow function for `getWeather`, it should not be declared with `const`.
+
+```js
+assert.doesNotThrow(() => { getWeather = getWeather; }, TypeError);
 ```
 
 The `getWeather` function should accept a city as its only argument and return the JSON from the Weather API.


### PR DESCRIPTION
The showWeather tests reassign getWeather to a mock function, which fails if getWeather is declared with const. Added a new test that checks getWeather is not declared with const, and updated the description to explicitly tell campers not to use const for getWeather if they use an arrow function.

Fixes #68309

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68309

<!-- Feel free to add any additional description of changes below this line -->
