### PR TITLE
fix(api): do not throw on second exam error

### DIFF
--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -237,6 +237,70 @@ describe('/exam-environment/', () => {
         expect(examModeration).not.toBeNull();
       });
 
+      it('should not error if an invalid attempt is submitted when the attempt is already linked to a moderation record', async () => {
+        const attempt =
+          await fastifyTestInstance.prisma.examEnvironmentExamAttempt.create({
+            data: { ...mock.examAttempt, userId: defaultUserId }
+          });
+
+        attempt.questionSets[0]!.id = mock.oid();
+
+        const body: Static<typeof examEnvironmentPostExamAttempt.body> = {
+          attempt
+        };
+
+        // First invalid submission creates moderation record, and links it to attempt
+        const firstRes = await superPost('/exam-environment/exam/attempt')
+          .set(
+            'exam-environment-authorization-token',
+            examEnvironmentAuthorizationToken
+          )
+          .send(body);
+
+        expect(firstRes.status).toBe(400);
+
+        const examModeration =
+          await fastifyTestInstance.prisma.examEnvironmentExamModeration.findUnique(
+            {
+              where: {
+                examAttemptId: attempt.id
+              }
+            }
+          );
+        expect(examModeration).not.toBeNull();
+
+        const linkedAttempt =
+          await fastifyTestInstance.prisma.examEnvironmentExamAttempt.findUnique(
+            {
+              where: { id: attempt.id }
+            }
+          );
+        expect(linkedAttempt?.examModerationId).toBe(examModeration!.id);
+
+        // Second invalid submission must not 500 trying to re-link the moderation record
+        const secondRes = await superPost('/exam-environment/exam/attempt')
+          .set(
+            'exam-environment-authorization-token',
+            examEnvironmentAuthorizationToken
+          )
+          .send(body);
+
+        expect(secondRes.body).toStrictEqual({
+          code: 'FCC_EINVAL_EXAM_ENVIRONMENT_EXAM_ATTEMPT',
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.any(String)
+        });
+        expect(secondRes.status).toBe(400);
+
+        const relinkedAttempt =
+          await fastifyTestInstance.prisma.examEnvironmentExamAttempt.findUnique(
+            {
+              where: { id: attempt.id }
+            }
+          );
+        expect(relinkedAttempt?.examModerationId).toBe(examModeration!.id);
+      });
+
       it('should return 200 if request is valid, and update attempt in database', async () => {
         const attempt =
           await fastifyTestInstance.prisma.examEnvironmentExamAttempt.create({

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -700,7 +700,7 @@ async function postExamAttemptHandler(
     });
 
     // Link attempt with moderation id if it has not already been done
-    await this.prisma.examEnvironmentExamAttempt.update({
+    await this.prisma.examEnvironmentExamAttempt.updateMany({
       where: {
         id: latestAttempt.id,
         examModerationId: null


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68593 

Fixes API-FASTIFY-2B