### PR TITLE
fix(curriculum): replace uncovered quiz questions

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-data-structures-js/699c6f4d4e468a10d3ae25ff.md
+++ b/curriculum/challenges/english/blocks/quiz-data-structures-js/699c6f4d4e468a10d3ae25ff.md
@@ -193,45 +193,45 @@ Which operation removes the element at the front of a queue?
 
 #### --text--
 
-What is the typical average-case time complexity to look up a value by key in a hash map?
+In a singly linked list, what does the tail node's next pointer reference?
 
 #### --distractors--
 
-`O(n)` because all keys must be scanned sequentially.
+The head node, creating a circular structure.
 
 ---
 
-`O(log n)` due to binary search within buckets.
+The previous node, enabling backward traversal.
 
 ---
 
-`O(n log n)` because keys are sorted during insertion.
+A copy of the first element in the list.
 
 #### --answer--
 
-`O(1)` on average with a good hash function and low load factor.
+`null`, indicating the end of the list.
 
 ### --question--
 
 #### --text--
 
-Which guarantee is provided by a set data structure?
+What is the time complexity of deleting a node from the beginning of a singly linked list?
 
 #### --distractors--
 
-Elements are stored in sorted order by default.
+`O(n)` because the list must be traversed to find the node.
 
 ---
 
-Duplicate values are allowed and kept together.
+`O(log n)` because the list is partitioned during deletion.
 
 ---
 
-Elements are indexed by their insertion position.
+`O(n²)` because nested traversals are required.
 
 #### --answer--
 
-It stores only unique elements (no duplicates).
+`O(1)` because only the head pointer needs to be updated.
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

  - [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
  - [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
  - [x] My pull request targets the `main` branch of freeCodeCamp.
  - [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

  Closes #68602

  The JS data structures quiz had two questions about hash maps and sets — neither topic is covered in the data
  structures review. Replaced them with two questions that are explicitly covered in the review:

  1. What the tail node's next pointer references in a singly linked list (`null`) — covered under "Tail Node: Last
  node in the list, points to null"
  2. Time complexity of deleting a node from the beginning of a singly linked list (`O(1)`) — covered under "Delete
  from beginning: O(1)"
