### PR TITLE
fix(curriculum): fix grammar and formatting in CSS Colors Review

### DIFF
--- a/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
+++ b/curriculum/challenges/english/blocks/review-css-colors/671a90c1cf517678b130419e.md
@@ -10,13 +10,13 @@ dashedName: review-css-colors
 ## Color Theory
 
 - **Color Theory Definition**: This is the study of how colors interact with each other and how they affect our perception. It covers color relationships, color harmony, and the psychological impact of color.
-- **Primary Colors**: These colors which are yellow, blue, and red, are the fundamental hues from which all other colors are derived.
+- **Primary Colors**: These colors, which are yellow, blue, and red, are the fundamental hues from which all other colors are derived.
 - **Secondary Colors**: These colors result from mixing equal amounts of two primary colors. Green, orange, and purple are examples of secondary colors.
 - **Tertiary Colors**: These colors result from combining a primary color with a neighboring secondary color. Yellow-Green, Blue-Green, and Blue-Violet are examples of tertiary colors.
-- **Warm Colors**: These colors which include reds, oranges, and yellows, evoke feelings of comfort, warmth, and coziness.
-- **Cool Colors**: These colors which include blues, green, and purples, evoke feelings of calmness, serenity, and professionalism.
+- **Warm Colors**: These colors, which include reds, oranges, and yellows, evoke feelings of comfort, warmth, and coziness.
+- **Cool Colors**: These colors, which include blues, greens, and purples, evoke feelings of calmness, serenity, and professionalism.
 - **Color Wheel**: The color wheel is a circular diagram that shows how colors relate to each other. It's an essential tool for designers because it helps them to select color combinations.
-- **Analogous Color Schemes**: These color schemes create cohesive and soothing experiences. They have analogous colors, which are adjacent to each other in the color wheel.
+- **Analogous Color Schemes**: These color schemes create cohesive and soothing experiences. They have analogous colors, which are adjacent to each other on the color wheel.
 - **Complementary Color Schemes**: These color schemes create high contrast and visual impact. Their colors are located on the opposite ends of the color wheel, relative to each other.
 - **Triadic Color Scheme**: This color scheme has vibrant colors. They are made from colors that are approximately equidistant from each other. If they are connected, they form an equilateral triangle on the color wheel.
 - **Monochromatic Color Scheme**: For this color scheme, all the colors are derived from the same base color by adjusting its lightness, darkness, and saturation. This evokes a feeling of unity and harmony while still creating contrast.
@@ -24,7 +24,7 @@ dashedName: review-css-colors
 ## Different Ways to Work with Colors in CSS
 
 - **Named Colors**: These colors are predefined color names recognized by browsers. Examples include `blue`, `darkred`, `lightgreen`.
-- **`rgb()` Function**: RGB stands for Red, Green, and Blue — the primary colors of light. These three colors are combined in different intensities to create a wide range of colors. the `rgb()` function allows you to define colors using the RGB color model.
+- **`rgb()` Function**: RGB stands for Red, Green, and Blue — the primary colors of light. These three colors are combined in different intensities to create a wide range of colors. The `rgb()` function allows you to define colors using the RGB color model.
 
 :::interactive_editor
 
@@ -98,7 +98,7 @@ div {
 
 :::
 
-- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits 0 to 9 and letters A to F. Hex codes can be 6 characters long, like `#F498A2`, or a 3-character shorthand, which works when each pair in the full form uses the same character twice. For example, `#2FB` is equivalent to `#22FFBB`.
+- **Hexadecimal**: A hex code (short for hexadecimal code) is used to represent colors in the RGB color model. The "hex" refers to the base-16 numbering system, which uses digits `0` to `9` and letters `A` to `F`. Hex codes can be 6 characters long, like `#F498A2`, or a 3-character shorthand, which works when each pair in the full form uses the same character twice. For example, `#2FB` is equivalent to `#22FFBB`.
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68595

## Summary

This PR fixes several grammar and formatting issues in the CSS Colors Review page by:

- adding the missing commas in the Primary Colors, Warm Colors, and Cool Colors descriptions
- changing **green** to **greens** for consistency
- changing "in the color wheel" to "on the color wheel"
- capitalizing **The** in the `rgb()` Function description
- wrapping `0` to `9` and `A` to `F` in backticks