### PR TITLE
fix(client): split socrates and button analytics events

### DIFF
--- a/client/src/analytics/call-ga.ts
+++ b/client/src/analytics/call-ga.ts
@@ -88,13 +88,26 @@ interface SignOut {
   user_id: undefined;
 }
 
-type CallSocratesAction =
-  | 'Socrates LowerJaw Button Click'
-  | 'Socrates Request Sent';
+interface ChallengeTestCodeButtonClickEvent {
+  event: 'challenge_test_code_button_click';
+}
+
+interface ChallengeSubmitButtonClickEvent {
+  event: 'challenge_submit_button_click';
+}
 
 interface CallSocratesEvent {
   event: 'call_socrates';
-  action: CallSocratesAction;
+  action: 'Socrates LowerJaw Button Click';
+  is_donating: boolean;
+  attempts: number | null;
+  limit: number | null;
+  optimized_request: Record<string, unknown> | null;
+}
+
+interface SendSocratesEvent {
+  event: 'send_socrates';
+  action: 'Socrates Request Sent';
   is_donating: boolean;
   attempts: number | null;
   limit: number | null;
@@ -111,7 +124,10 @@ export type GAevent =
   | UserData
   | SignOut
   | SignIn
-  | CallSocratesEvent;
+  | ChallengeTestCodeButtonClickEvent
+  | ChallengeSubmitButtonClickEvent
+  | CallSocratesEvent
+  | SendSocratesEvent;
 
 export default function callGA(payload: GAevent) {
   TagManager.dataLayer({

--- a/client/src/templates/Challenges/components/independent-lower-jaw.test.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.test.tsx
@@ -36,8 +36,9 @@ vi.mock('../../../../config/env.json', () => ({
 vi.mock('@growthbook/growthbook-react', () => ({
   useFeature: () => ({ on: showSocratesFlag })
 }));
+const mockSubmitChallenge = vi.hoisted(() => vi.fn());
 vi.mock('../utils/fetch-all-curriculum-data', () => ({
-  useSubmit: () => vi.fn()
+  useSubmit: () => mockSubmitChallenge
 }));
 
 const baseChallengeMeta: ChallengeMeta = {
@@ -166,6 +167,38 @@ describe('<IndependentLowerJaw />', () => {
       limit: 3,
       optimized_request: null
     });
+    expect(baseProps.askSocrates).toHaveBeenCalled();
+  });
+
+  it('tracks check code analytics when the check button is clicked', async () => {
+    render(
+      <IndependentLowerJaw
+        {...baseProps}
+        tests={[{ pass: false, err: 'fail', text: 'test', testString: 'test' }]}
+      />,
+      createStore()
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /check-code/ }));
+
+    expect(callGA).toHaveBeenCalledWith({
+      event: 'challenge_test_code_button_click'
+    });
+  });
+
+  it('tracks submit code analytics when the submit button is clicked', async () => {
+    mockSubmitChallenge.mockClear();
+
+    render(<IndependentLowerJaw {...baseProps} />, createStore());
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /submit-continue/ })
+    );
+
+    expect(callGA).toHaveBeenCalledWith({
+      event: 'challenge_submit_button_click'
+    });
+    expect(mockSubmitChallenge).toHaveBeenCalled();
   });
 
   it('hides socrates button when show-socrates flag is off', () => {

--- a/client/src/templates/Challenges/components/independent-lower-jaw.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.tsx
@@ -271,12 +271,6 @@ export function IndependentLowerJaw({
     setWasCheckButtonClicked(false);
   }, [isChallengeComplete, isSignedIn, wasCheckButtonClicked]);
 
-  const handleCheckButtonClick = () => {
-    setWasCheckButtonClicked(true);
-    setShowSocratesResults(false);
-    executeChallenge();
-  };
-
   const isMacOS = navigator.userAgent.includes('Mac OS');
   const showRevertButton = isSignedIn && challengeMeta.saveSubmissionToDB;
   const shouldShowSocratesDonateCta =
@@ -308,6 +302,22 @@ export function IndependentLowerJaw({
     setShowSubmissionHint(false);
     if (socratesHintState.isLoading) return;
     askSocrates();
+  };
+
+  const handleCheckButtonClick = () => {
+    callGA({
+      event: 'challenge_test_code_button_click'
+    });
+    setWasCheckButtonClicked(true);
+    setShowSocratesResults(false);
+    executeChallenge();
+  };
+
+  const handleSubmitButtonClick = () => {
+    callGA({
+      event: 'challenge_submit_button_click'
+    });
+    submitChallenge();
   };
 
   return (
@@ -467,7 +477,7 @@ export function IndependentLowerJaw({
               id='independent-lower-jaw-submit-button'
               data-playwright-test-label='independentLowerJaw-submit-button'
               aria-label={t('buttons.submit-continue')}
-              onClick={() => submitChallenge()}
+              onClick={handleSubmitButtonClick}
               ref={submitButtonRef}
             >
               {t('buttons.submit-continue')}

--- a/client/src/templates/Challenges/redux/ask-socrates-saga.js
+++ b/client/src/templates/Challenges/redux/ask-socrates-saga.js
@@ -104,7 +104,7 @@ export function* askSocratesSaga() {
     }
 
     callGA({
-      event: 'call_socrates',
+      event: 'send_socrates',
       action: 'Socrates Request Sent',
       is_donating: isDonating,
       attempts,

--- a/client/src/templates/Challenges/redux/ask-socrates-saga.test.js
+++ b/client/src/templates/Challenges/redux/ask-socrates-saga.test.js
@@ -4,7 +4,8 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { throwError } from 'redux-saga-test-plan/providers';
 import { describe, it, vi, expect } from 'vitest';
 
-import { askSocratesSaga } from './ask-socrates-saga';
+import { askSocratesSaga, createAskSocratesSaga } from './ask-socrates-saga';
+import { actionTypes } from './action-types';
 import callGA from '../../../analytics/call-ga';
 
 vi.mock('i18next', async () => ({
@@ -55,6 +56,12 @@ function reducer(state = baseState) {
 }
 
 describe('askSocratesSaga', () => {
+  it('watches askSocrates actions', () => {
+    expect(createAskSocratesSaga(actionTypes)[0].payload.args[0]).toBe(
+      actionTypes.askSocrates
+    );
+  });
+
   it('dispatches error when socrates is not enabled', () => {
     const state = {
       ...baseState,
@@ -202,7 +209,7 @@ describe('askSocratesSaga', () => {
       .silentRun();
 
     expect(callGA).toHaveBeenCalledWith({
-      event: 'call_socrates',
+      event: 'send_socrates',
       action: 'Socrates Request Sent',
       is_donating: false,
       attempts: null,


### PR DESCRIPTION
This pr correct the Socrates events and adds submission and test code events as well.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
