### PR TITLE
fix(curriculum): correct writing errors in fortune teller app workshop steps

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded461befea207a2f11a9a.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded461befea207a2f11a9a.md
@@ -13,7 +13,7 @@ Now you need a function that helps you get a random fortune.
 Declare a function named `getRandomItem` that takes an array of `items` as an argument. Use generics for this function.
 
 Inside the function, use `Math.random()` and `Math.floor()` to select a random fortune from the `items` array.
-Don’t forget to return the selected fortune.
+Don't forget to return the selected fortune.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ee6b09fce1154556413f7e.md
+++ b/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ee6b09fce1154556413f7e.md
@@ -7,7 +7,7 @@ dashedName: step-27
 
 # --description--
 
-Inside the `initializeEventListeners` method, attach a `click` event listener to `singleCardBtn`. Within the event handler, call the `singleCardSelected` method. remember to get the `singleCardBtn` from `elements`.
+Inside the `initializeEventListeners` method, attach a `click` event listener to `singleCardBtn`. Within the event handler, call the `singleCardSelected` method. Remember to get the `singleCardBtn` from `elements`.
 
 You will create this method in the coming steps.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68597

<!-- Feel free to add any additional description of changes below this line -->
Mentioned writing errors are corrected as followings:
[Step 9](https://github.com/freeCodeCamp/freeCodeCamp/blob/0c8049e15037fb21bdc731b5d7f81f16381fa19f/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ded461befea207a2f11a9a.md#16)
Before
```  md
 Don’t forget to return the selected fortune. 
```
After
```  md
Don't forget to return the selected fortune.
```
[Step 27](https://github.com/freeCodeCamp/freeCodeCamp/blob/0c8049e15037fb21bdc731b5d7f81f16381fa19f/curriculum/challenges/english/blocks/workshop-fortune-teller-app/68ee6b09fce1154556413f7e.md#L10)
Before
```  md
...method. remember to get the `singleCardBtn` from `elements`.
```
After
```  md
...method. Remember to get the `singleCardBtn` from `elements`.
```