### PR TITLE
fix: Fix remove hex code tags

### DIFF
--- a/client/i18n/locales/chinese-traditional/intro.json
+++ b/client/i18n/locales/chinese-traditional/intro.json
@@ -8434,7 +8434,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {
@@ -9748,7 +9748,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {

--- a/client/i18n/locales/chinese/intro.json
+++ b/client/i18n/locales/chinese/intro.json
@@ -8434,7 +8434,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {
@@ -9748,7 +9748,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {

--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -8528,7 +8528,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {
@@ -9836,7 +9836,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {

--- a/client/i18n/locales/espanol/intro.json
+++ b/client/i18n/locales/espanol/intro.json
@@ -9914,7 +9914,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {

--- a/client/i18n/locales/german/intro.json
+++ b/client/i18n/locales/german/intro.json
@@ -8542,7 +8542,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {
@@ -9856,7 +9856,7 @@
         "title": "CSS Colors Review",
         "intro": [
           "Before you're quizzed on CSS colors, you should review what you've learned about them.",
-          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, <code>hex codes</code>, and more."
+          "Open up this page to review concepts like the <code>rgb()</code> function, <code>hsl()</code> function, hex codes, and more."
         ]
       },
       "quiz-css-colors": {

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
@@ -11,7 +11,7 @@ CSS combinators are used to define the relationship between selectors in CSS. Th
 
 We will discuss some primary CSS combinators and their use cases, starting with the descendant combinator.
 
-A descendant combinator is used to target elements matched by the second selector if they are nested within an ancestor element that matches the first selector. An ancestor can be a parent element or a parent's parent.
+A descendant combinator is used to target elements matched by the second selector if they are nested within an ancestor element that matches the first selector. An ancestor can be a parent, grandparent, or any other element higher in the document hierarchy.
 
 To better understand how this works, let's take a look at an example.
 


### PR DESCRIPTION
## Description

Removed unnecessary `<code>` tags around hex color values as discussed in the issue.

## Changes

- Removed `<code>` tags from the specified hex color values.
- No functional changes.