### PR TITLE
fix(client): use curriculum-help category for forum posts

### DIFF
--- a/client/i18n/locales/chinese-traditional/links.json
+++ b/client/i18n/locales/chinese-traditional/links.json
@@ -20,22 +20,22 @@
   },
   "nav": {
     "contribute": "https://contribute.freecodecamp.org/#/i18n/chinese/index",
-    "forum": "https://forum.freecodecamp.org/c/chinese/533",
+    "forum": "https://forum.freecodecamp.org/",
     "news": "https://chinese.freecodecamp.org/news/",
     "podcast": "open.spotify.com/show/3dIVV6XRRPMs75z2xDtsOg?si=Ugm6rwlcTgiEJ1Udw9WzVQ"
   },
   "help": {
-    "HTML-CSS": "world-languages/chinese",
-    "JavaScript": "world-languages/chinese",
-    "Python": "world-languages/chinese",
-    "Backend Development": "world-languages/chinese",
-    "C-Sharp": "world-languages/chinese",
-    "English": "world-languages/chinese",
-    "Spanish Curriculum": "world-languages/chinese",
-    "Chinese Curriculum": "world-languages/chinese",
-    "Odin": "world-languages/chinese",
-    "Euler": "world-languages/chinese",
-    "Rosetta": "world-languages/chinese",
-    "General": "world-languages/chinese"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/chinese/links.json
+++ b/client/i18n/locales/chinese/links.json
@@ -20,22 +20,22 @@
   },
   "nav": {
     "contribute": "https://contribute.freecodecamp.org/#/i18n/chinese/index",
-    "forum": "https://forum.freecodecamp.org/c/chinese/533",
+    "forum": "https://forum.freecodecamp.org/",
     "news": "https://chinese.freecodecamp.org/news/",
     "podcast": "open.spotify.com/show/3dIVV6XRRPMs75z2xDtsOg?si=Ugm6rwlcTgiEJ1Udw9WzVQ"
   },
   "help": {
-    "HTML-CSS": "world-languages/chinese",
-    "JavaScript": "world-languages/chinese",
-    "Python": "world-languages/chinese",
-    "Backend Development": "world-languages/chinese",
-    "C-Sharp": "world-languages/chinese",
-    "English": "world-languages/chinese",
-    "Spanish Curriculum": "world-languages/chinese",
-    "Chinese Curriculum": "world-languages/chinese",
-    "Odin": "world-languages/chinese",
-    "Euler": "world-languages/chinese",
-    "Rosetta": "world-languages/chinese",
-    "General": "world-languages/chinese"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/english/links.json
+++ b/client/i18n/locales/english/links.json
@@ -27,17 +27,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "programming/html-css",
-    "JavaScript": "programming/javascript",
-    "Python": "programming/python",
-    "Backend Development": "programming/backend-development",
-    "C-Sharp": "programming/c-sharp",
-    "English": "world-languages/english",
-    "Spanish Curriculum": "world-languages/spanish-curriculum",
-    "Chinese Curriculum": "world-languages/chinese-curriculum",
-    "Odin": "programming/the-odin-project",
-    "Euler": "programming/project-euler",
-    "Rosetta": "programming/rosetta-code",
-    "General": "General"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/espanol/links.json
+++ b/client/i18n/locales/espanol/links.json
@@ -20,22 +20,22 @@
   },
   "nav": {
     "contribute": "https://contribute.freecodecamp.org/#/i18n/espanol/index",
-    "forum": "https://forum.freecodecamp.org/c/espanol/",
+    "forum": "https://forum.freecodecamp.org/",
     "news": "https://freecodecamp.org/espanol/news/",
     "podcast": "https://www.freecodecamp.org/espanol/news/el-podcast-de-freecodecamp-en-espanol/"
   },
   "help": {
-    "HTML-CSS": "world-languages/espanol",
-    "JavaScript": "world-languages/espanol",
-    "Python": "world-languages/espanol",
-    "Backend Development": "world-languages/espanol",
-    "C-Sharp": "world-languages/espanol",
-    "English": "world-languages/espanol",
-    "Spanish Curriculum": "world-languages/espanol",
-    "Chinese Curriculum": "world-languages/espanol",
-    "Odin": "world-languages/espanol",
-    "Euler": "world-languages/espanol",
-    "Rosetta": "world-languages/espanol",
-    "General": "world-languages/espanol"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/german/links.json
+++ b/client/i18n/locales/german/links.json
@@ -20,22 +20,22 @@
   },
   "nav": {
     "contribute": "https://contribute.freecodecamp.org/#/i18n/german/index",
-    "forum": "https://forum.freecodecamp.org/c/german/577",
+    "forum": "https://forum.freecodecamp.org/",
     "news": "https://freecodecamp.org/german/news/",
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "world-languages/german",
-    "JavaScript": "world-languages/german",
-    "Python": "world-languages/german",
-    "Backend Development": "world-languages/german",
-    "C-Sharp": "world-languages/german",
-    "English": "world-languages/german",
-    "Spanish Curriculum": "world-languages/german",
-    "Chinese Curriculum": "world-languages/german",
-    "Odin": "world-languages/german",
-    "Euler": "world-languages/german",
-    "Rosetta": "world-languages/german",
-    "General": "world-languages/german"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/italian/links.json
+++ b/client/i18n/locales/italian/links.json
@@ -20,22 +20,22 @@
   },
   "nav": {
     "contribute": "https://contribute.freecodecamp.org/#/i18n/italian/index",
-    "forum": "https://forum.freecodecamp.org/c/italiano/",
+    "forum": "https://forum.freecodecamp.org/",
     "news": "https://freecodecamp.org/italian/news/",
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "world-languages/italiano",
-    "JavaScript": "world-languages/italiano",
-    "Python": "world-languages/italiano",
-    "Backend Development": "world-languages/italiano",
-    "C-Sharp": "world-languages/italiano",
-    "English": "world-languages/italiano",
-    "Spanish Curriculum": "world-languages/italiano",
-    "Chinese Curriculum": "world-languages/italiano",
-    "Odin": "world-languages/italiano",
-    "Euler": "world-languages/italiano",
-    "Rosetta": "world-languages/italiano",
-    "General": "world-languages/italiano"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/japanese/links.json
+++ b/client/i18n/locales/japanese/links.json
@@ -20,22 +20,22 @@
   },
   "nav": {
     "contribute": "https://contribute.freecodecamp.org/#/i18n/japanese/index",
-    "forum": "https://forum.freecodecamp.org/c/japanese/552",
+    "forum": "https://forum.freecodecamp.org/",
     "news": "https://www.freecodecamp.org/japanese/news/",
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "world-languages/japanese",
-    "JavaScript": "world-languages/japanese",
-    "Python": "world-languages/japanese",
-    "Backend Development": "world-languages/japanese",
-    "C-Sharp": "world-languages/japanese",
-    "English": "world-languages/japanese",
-    "Spanish Curriculum": "world-languages/japanese",
-    "Chinese Curriculum": "world-languages/japanese",
-    "Odin": "world-languages/japanese",
-    "Euler": "world-languages/japanese",
-    "Rosetta": "world-languages/japanese",
-    "General": "world-languages/japanese"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/korean/links.json
+++ b/client/i18n/locales/korean/links.json
@@ -27,17 +27,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "world-languages",
-    "JavaScript": "world-languages",
-    "Python": "world-languages",
-    "Backend Development": "world-languages",
-    "C-Sharp": "world-languages",
-    "English": "world-languages",
-    "Spanish Curriculum": "world-languages",
-    "Chinese Curriculum": "world-languages",
-    "Odin": "world-languages",
-    "Euler": "world-languages",
-    "Rosetta": "world-languages",
-    "General": "world-languages"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/portuguese/links.json
+++ b/client/i18n/locales/portuguese/links.json
@@ -20,22 +20,22 @@
   },
   "nav": {
     "contribute": "https://contribute.freecodecamp.org/#/i18n/portuguese/index",
-    "forum": "https://forum.freecodecamp.org/c/portugues/",
+    "forum": "https://forum.freecodecamp.org/",
     "news": "https://freecodecamp.org/portuguese/news/",
     "podcast": "https://open.spotify.com/show/70m92At5oht4zY4f87lLEE?si=6tozUAOBQFSVyaqixy6aCg"
   },
   "help": {
-    "HTML-CSS": "world-languages/portugues",
-    "JavaScript": "world-languages/portugues",
-    "Python": "world-languages/portugues",
-    "Backend Development": "world-languages/portugues",
-    "C-Sharp": "world-languages/portugues",
-    "English": "world-languages/portugues",
-    "Spanish Curriculum": "world-languages/portugues",
-    "Chinese Curriculum": "world-languages/portugues",
-    "Odin": "world-languages/portugues",
-    "Euler": "world-languages/portugues",
-    "Rosetta": "world-languages/portugues",
-    "General": "world-languages/portugues"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/swahili/links.json
+++ b/client/i18n/locales/swahili/links.json
@@ -25,17 +25,17 @@
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "world-languages",
-    "JavaScript": "world-languages",
-    "Python": "world-languages",
-    "Backend Development": "world-languages",
-    "C-Sharp": "world-languages",
-    "English": "world-languages",
-    "Spanish Curriculum": "world-languages",
-    "Chinese Curriculum": "world-languages",
-    "Odin": "world-languages",
-    "Euler": "world-languages",
-    "Rosetta": "world-languages",
-    "General": "world-languages"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/i18n/locales/ukrainian/links.json
+++ b/client/i18n/locales/ukrainian/links.json
@@ -20,22 +20,22 @@
   },
   "nav": {
     "contribute": "https://contribute.freecodecamp.org/#/i18n/ukrainian/index",
-    "forum": "https://forum.freecodecamp.org/c/ukrainian/",
+    "forum": "https://forum.freecodecamp.org/",
     "news": "https://www.freecodecamp.org/ukrainian/news/",
     "podcast": "https://freecodecamp.libsyn.com/"
   },
   "help": {
-    "HTML-CSS": "world-languages/ukrainian",
-    "JavaScript": "world-languages/ukrainian",
-    "Python": "world-languages/ukrainian",
-    "Backend Development": "world-languages/ukrainian",
-    "C-Sharp": "world-languages/ukrainian",
-    "English": "world-languages/ukrainian",
-    "Spanish Curriculum": "world-languages/ukrainian",
-    "Chinese Curriculum": "world-languages/ukrainian",
-    "Odin": "world-languages/ukrainian",
-    "Euler": "world-languages/ukrainian",
-    "Rosetta": "world-languages/ukrainian",
-    "General": "world-languages/ukrainian"
+    "HTML-CSS": "curriculum-help",
+    "JavaScript": "curriculum-help",
+    "Python": "curriculum-help",
+    "Backend Development": "curriculum-help",
+    "C-Sharp": "curriculum-help",
+    "English": "curriculum-help",
+    "Spanish Curriculum": "curriculum-help",
+    "Chinese Curriculum": "curriculum-help",
+    "Odin": "curriculum-help",
+    "Euler": "curriculum-help",
+    "Rosetta": "curriculum-help",
+    "General": "curriculum-help"
   }
 }

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -227,7 +227,9 @@ function createQuestionEpic(action$, state$, { window }) {
       );
 
       const category = window.encodeURIComponent(
-        i18next.t('links:help.' + helpCategory || 'Help')
+        i18next.t('links:help.' + helpCategory, {
+          defaultValue: 'curriculum-help'
+        })
       );
 
       const studentCode = window.encodeURIComponent(textMessage);


### PR DESCRIPTION
This makes all forum posts created in the curriculum use the curriculum-help category - and updates the forum URL for all languages to use the main forum URL.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68404

<!-- Feel free to add any additional description of changes below this line -->
