### PR TITLE
fix(curriculum): use getStyleAny to accept reordered compound class selectors

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d022dc8400c0763829a17.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d022dc8400c0763829a17.md
@@ -11,7 +11,13 @@ Target the `.face` element with the `left` class, and position it `5%` left of i
 
 # --hints--
 
-You should give `.face.left` (or `.left.face`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.face.left` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.face.left', '.left.face']));
+```
+
+You should give `.face.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.face.left', '.left.face'])?.left, '5%');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d022dc8400c0763829a17.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d022dc8400c0763829a17.md
@@ -11,22 +11,10 @@ Target the `.face` element with the `left` class, and position it `5%` left of i
 
 # --hints--
 
-You should use the `.face.left` selector.
+You should give `.face.left` (or `.left.face`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.face\.left\s*\{/);
-```
-
-You should give `.face.left` a `left` property.
-
-```js
-assert.notEmpty(new __helpers.CSSHelp(document).getStyle('.face.left')?.left);
-```
-
-You should give `.face.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
-
-```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.face.left')?.left, '5%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.face.left', '.left.face'])?.left, '5%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d02c7bc95bf0827a5d296.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d02c7bc95bf0827a5d296.md
@@ -11,7 +11,13 @@ Target the `.face` element with the `right` class, and position it `5%` right of
 
 # --hints--
 
-You should give `.face.right` (or `.right.face`) a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.face.right` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.face.right', '.right.face']));
+```
+
+You should give `.face.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.face.right', '.right.face'])?.right, '5%');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d02c7bc95bf0827a5d296.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d02c7bc95bf0827a5d296.md
@@ -11,22 +11,10 @@ Target the `.face` element with the `right` class, and position it `5%` right of
 
 # --hints--
 
-You should use the `.face.right` selector.
+You should give `.face.right` (or `.right.face`) a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.face\.right\s*\{/);
-```
-
-You should give `.face.right` a `right` property.
-
-```js
-assert.notEmpty(new __helpers.CSSHelp(document).getStyle('.face.right')?.right);
-```
-
-You should give `.face.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
-
-```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.face.right')?.right, '5%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.face.right', '.right.face'])?.right, '5%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d0c1594c38c0ebae75878.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d0c1594c38c0ebae75878.md
@@ -11,13 +11,26 @@ Target the `.eye` element with the `left` class, and position it `25%` from the 
 
 # --hints--
 
-You should give `.eye.left` (or `.left.eye`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.eye.left` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.eye.left', '.left.eye']));
+```
+
+You should give `.eye.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.eye.left', '.left.eye'])?.left, '25%');
 ```
 
-You should give `.eye.right` (or `.right.eye`) a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.eye.right` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.eye.right', '.right.eye']));
+```
+
+
+You should give `.eye.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.eye.right', '.right.eye'])?.right, '25%');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d0c1594c38c0ebae75878.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d0c1594c38c0ebae75878.md
@@ -11,28 +11,16 @@ Target the `.eye` element with the `left` class, and position it `25%` from the 
 
 # --hints--
 
-You should use the `.eye.left` selector.
+You should give `.eye.left` (or `.left.eye`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.eye\.left\s*\{/);
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.eye.left', '.left.eye'])?.left, '25%');
 ```
 
-You should give `.eye.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.eye.right` (or `.right.eye`) a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.eye.left')?.left, '25%');
-```
-
-You should use the `.eye.right` selector.
-
-```js
-assert.match(code, /\.eye\.right\s*\{/);
-```
-
-You should give `.eye.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
-
-```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.eye.right')?.right, '25%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.eye.right', '.right.eye'])?.right, '25%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d0c1594c38c0ebae75878.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d0c1594c38c0ebae75878.md
@@ -29,7 +29,6 @@ You should have a `.eye.right` selector.
 assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.eye.right', '.right.eye']));
 ```
 
-
 You should give `.eye.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d107edf7ddf13cc77106a.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d107edf7ddf13cc77106a.md
@@ -11,13 +11,25 @@ Target the `.blush` element with a `class` of `left`, and position it `15%` left
 
 # --hints--
 
-You should give `.blush.left` (or `.left.blush`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.blush.left` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.blush.left', '.left.blush']));
+```
+
+You should give `.blush.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.blush.left', '.left.blush'])?.left, '15%');
 ```
 
-You should give `.blush.right` (or `.right.blush`)  a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.blush.right` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.blush.right', '.right.blush']));
+```
+
+You should give `.blush.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.blush.right', '.right.blush'])?.right, '15%');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d107edf7ddf13cc77106a.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d107edf7ddf13cc77106a.md
@@ -11,28 +11,16 @@ Target the `.blush` element with a `class` of `left`, and position it `15%` left
 
 # --hints--
 
-You should use the `.blush.left` selector.
+You should give `.blush.left` (or `.left.blush`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.blush\.left\s*\{/);
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.blush.left', '.left.blush'])?.left, '15%');
 ```
 
-You should give `.blush.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.blush.right` (or `.right.blush`)  a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.blush.left')?.left, '15%');
-```
-
-You should use the `.blush.right` selector.
-
-```js
-assert.match(code, /\.blush\.right\s*\{/);
-```
-
-You should give `.blush.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
-
-```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.blush.right')?.right, '15%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.blush.right', '.right.blush'])?.right, '15%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d11e6d5ef9515d2a16033.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d11e6d5ef9515d2a16033.md
@@ -11,28 +11,22 @@ Target the `.beak` element with a `class` of `top`, give it a `width` of `20%`, 
 
 # --hints--
 
-You should use the `.beak.top` selector.
+You should give `.beak.top` (or `.top.beak`) a `width` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.beak\.top\s*\{/);
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.top', '.top.beak'])?.width, '20%');
 ```
 
-You should give `.beak.top` a `width` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.beak.top` (or `.top.beak`) a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.beak.top')?.width, '20%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.top', '.top.beak'])?.top, '60%');
 ```
 
-You should give `.beak.top` a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.beak.top` (or `.top.beak`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.beak.top')?.top, '60%');
-```
-
-You should give `.beak.top` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
-
-```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.beak.top')?.left, '40%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.top', '.top.beak'])?.left, '40%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d11e6d5ef9515d2a16033.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d11e6d5ef9515d2a16033.md
@@ -11,19 +11,25 @@ Target the `.beak` element with a `class` of `top`, give it a `width` of `20%`, 
 
 # --hints--
 
-You should give `.beak.top` (or `.top.beak`) a `width` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.beak.top` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.beak.top', '.top.beak']));
+```
+
+You should give `.beak.top` a `width` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.top', '.top.beak'])?.width, '20%');
 ```
 
-You should give `.beak.top` (or `.top.beak`) a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.beak.top` a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.top', '.top.beak'])?.top, '60%');
 ```
 
-You should give `.beak.top` (or `.top.beak`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.beak.top` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.top', '.top.beak'])?.left, '40%');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d129a417d0716a94de913.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d129a417d0716a94de913.md
@@ -11,28 +11,22 @@ Target the `.beak` element with a `class` of `bottom`, and give it a `width` tha
 
 # --hints--
 
-You should use the `.beak.bottom` selector.
+You should give `.beak.bottom` (or `.bottom.beak`) a `width` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.beak\.bottom\s*\{/);
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.bottom', '.bottom.beak'])?.width, '16%');
 ```
 
-You should give `.beak.bottom` a `width` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.beak.bottom` (or `.bottom.beak`) a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.beak.bottom')?.width, '16%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.bottom', '.bottom.beak'])?.top, '65%');
 ```
 
-You should give `.beak.bottom` a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.beak.bottom` (or `.bottom.beak`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.beak.bottom')?.top, '65%');
-```
-
-You should give `.beak.bottom` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
-
-```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.beak.bottom')?.left, '42%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.bottom', '.bottom.beak'])?.left, '42%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d129a417d0716a94de913.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d129a417d0716a94de913.md
@@ -11,19 +11,25 @@ Target the `.beak` element with a `class` of `bottom`, and give it a `width` tha
 
 # --hints--
 
-You should give `.beak.bottom` (or `.bottom.beak`) a `width` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.beak.bottom` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.beak.bottom', '.bottom.beak']));
+```
+
+You should give `.beak.bottom` a `width` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.bottom', '.bottom.beak'])?.width, '16%');
 ```
 
-You should give `.beak.bottom` (or `.bottom.beak`) a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.beak.bottom` a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.bottom', '.bottom.beak'])?.top, '65%');
 ```
 
-You should give `.beak.bottom` (or `.bottom.beak`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.beak.bottom` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.beak.bottom', '.bottom.beak'])?.left, '42%');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d21fe6a3f9b2016be9d9d.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d21fe6a3f9b2016be9d9d.md
@@ -11,28 +11,16 @@ Target the `.foot` element with a `class` of `left`, and position it `25%` left 
 
 # --hints--
 
-You should use the `.foot.left` selector.
+You should give `.foot.left` (or `.left.foot`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.foot\.left\s*\{/);
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.foot.left', '.left.foot'])?.left, '25%');
 ```
 
-You should give `.foot.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.foot.right` (or `.right.foot`) a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.foot.left')?.left, '25%');
-```
-
-You should use the `.foot.right` selector.
-
-```js
-assert.match(code, /\.foot\.right\s*\{/);
-```
-
-You should give `.foot.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
-
-```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.foot.right')?.right, '25%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.foot.right', '.right.foot'])?.right, '25%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d21fe6a3f9b2016be9d9d.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d21fe6a3f9b2016be9d9d.md
@@ -11,13 +11,25 @@ Target the `.foot` element with a `class` of `left`, and position it `25%` left 
 
 # --hints--
 
-You should give `.foot.left` (or `.left.foot`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.foot.left` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.foot.left', '.left.foot']));
+```
+
+You should give `.foot.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.foot.left', '.left.foot'])?.left, '25%');
 ```
 
-You should give `.foot.right` (or `.right.foot`) a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.foot.right` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.foot.right', '.right.foot']));
+```
+
+You should give `.foot.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.foot.right', '.right.foot'])?.right, '25%');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d229b0e542520cd91c685.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d229b0e542520cd91c685.md
@@ -11,7 +11,7 @@ To make the penguin's feet look more _penguiny_, rotate the left foot by `80deg`
 
 # --hints--
 
-You should give `.foot.left` (or `.left.foot`) a `transform` of `rotate(80deg)`.
+You should give `.foot.left` a `transform` of `rotate(80deg)`.
 
 ```js
 const leftFoot = new __helpers.CSSHelp(document).getStyleAny(['.foot.left', '.left.foot']);
@@ -23,7 +23,7 @@ if (leftFoot?.transform) {
 }
 ```
 
-You should give `.foot.right` (or `.right.foot`) a `transform` of `rotate(-80deg)`.
+You should give `.foot.right` a `transform` of `rotate(-80deg)`.
 
 ```js
 const rightFoot = new __helpers.CSSHelp(document).getStyleAny(['.foot.right', '.right.foot']);

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d229b0e542520cd91c685.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d229b0e542520cd91c685.md
@@ -11,10 +11,10 @@ To make the penguin's feet look more _penguiny_, rotate the left foot by `80deg`
 
 # --hints--
 
-You should give `.foot.left` a `transform` of `rotate(80deg)`.
+You should give `.foot.left` (or `.left.foot`) a `transform` of `rotate(80deg)`.
 
 ```js
-const leftFoot = new __helpers.CSSHelp(document).getStyle('.foot.left');
+const leftFoot = new __helpers.CSSHelp(document).getStyleAny(['.foot.left', '.left.foot']);
 
 if (leftFoot?.transform) {
   assert.equal(leftFoot.getPropVal('transform', true), 'rotate(80deg)');
@@ -23,10 +23,10 @@ if (leftFoot?.transform) {
 }
 ```
 
-You should give `.foot.right` a `transform` of `rotate(-80deg)`.
+You should give `.foot.right` (or `.right.foot`) a `transform` of `rotate(-80deg)`.
 
 ```js
-const rightFoot = new __helpers.CSSHelp(document).getStyle('.foot.right');
+const rightFoot = new __helpers.CSSHelp(document).getStyleAny(['.foot.right', '.right.foot']);
 
 if (rightFoot?.transform) {
   assert.equal(rightFoot.getPropVal('transform', true), 'rotate(-80deg)');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2b7a84e78b246f2d17a2.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2b7a84e78b246f2d17a2.md
@@ -11,25 +11,37 @@ Target the `.arm` element with a `class` of `left`, and position it `35%` from t
 
 # --hints--
 
-You should give `.arm.left` (or `.left.arm`) a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should have a `.arm.left` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm']));
+```
+
+You should give `.arm.left` a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.top, '35%');
 ```
 
-You should give `.arm.left` (or `.left.arm`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.left, '5%');
 ```
 
-You should give `.arm.right` (or `.right.arm`) a `top` of `0%`.
+You should have a `.arm.right` selector.
+
+```js
+assert.exists(new __helpers.CSSHelp(document).getStyleAny(['.arm.right', '.right.arm']));
+```
+
+You should give `.arm.right` a `top` of `0%`.
 
 ```js
 assert.include(['0%', '0', '0px'], new __helpers.CSSHelp(document).getStyleAny(['.arm.right', '.right.arm'])?.top);
 ```
 
-You should give `.arm.right` (or `.right.arm`) a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.right', '.right.arm'])?.right, '-5%');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2b7a84e78b246f2d17a2.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2b7a84e78b246f2d17a2.md
@@ -11,40 +11,28 @@ Target the `.arm` element with a `class` of `left`, and position it `35%` from t
 
 # --hints--
 
-You should use the `.arm.left` selector.
+You should give `.arm.left` (or `.left.arm`) a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.arm\.left\s*\{/);
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.top, '35%');
 ```
 
-You should give `.arm.left` a `top` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` (or `.left.arm`) a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.arm.left')?.top, '35%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.left, '5%');
 ```
 
-You should give `.arm.left` a `left` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.right` (or `.right.arm`) a `top` of `0%`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.arm.left')?.left, '5%');
+assert.include(['0%', '0', '0px'], new __helpers.CSSHelp(document).getStyleAny(['.arm.right', '.right.arm'])?.top);
 ```
 
-You should use the `.arm.right` selector.
+You should give `.arm.right` (or `.right.arm`) a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.match(code, /\.arm\.right\s*\{/);
-```
-
-You should give `.arm.right` a `top` of `0%`.
-
-```js
-assert.include(['0%', '0', '0px'], new __helpers.CSSHelp(document).getStyle('.arm.right')?.top);
-```
-
-You should give `.arm.right` a `right` of `--fcc-expected--`, but found `--fcc-actual--`.
-
-```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.arm.right')?.right, '-5%');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.right', '.right.arm'])?.right, '-5%');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2bd9c1d43c2526e96f1f.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2bd9c1d43c2526e96f1f.md
@@ -17,7 +17,7 @@ You should use the `transform-origin` property to do this.
 assert.notEmpty(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.transformOrigin);
 ```
 
-You should give `.arm.left` (or `.left.arm`) a `transform-origin` of `0% 0%` or `top left`.
+You should give `.arm.left` a `transform-origin` of `0% 0%` or `top left`.
 
 ```js
 assert.include(['0% 0%', 'left top', '0% 0% 0px', 'left top 0px'], new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.transformOrigin);

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2bd9c1d43c2526e96f1f.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2bd9c1d43c2526e96f1f.md
@@ -14,13 +14,13 @@ Within the `.arm.left` selector, alter the origin of the `transform` function to
 You should use the `transform-origin` property to do this.
 
 ```js
-assert.notEmpty(new __helpers.CSSHelp(document).getStyle('.arm.left')?.transformOrigin);
+assert.notEmpty(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.transformOrigin);
 ```
 
-You should give `.arm.left` a `transform-origin` of `0% 0%` or `top left`.
+You should give `.arm.left` (or `.left.arm`) a `transform-origin` of `0% 0%` or `top left`.
 
 ```js
-assert.include(['0% 0%', 'left top', '0% 0% 0px', 'left top 0px'], new __helpers.CSSHelp(document).getStyle('.arm.left')?.transformOrigin);
+assert.include(['0% 0%', 'left top', '0% 0% 0px', 'left top 0px'], new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.transformOrigin);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2d4e80400325ff89664a.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2d4e80400325ff89664a.md
@@ -11,10 +11,10 @@ To keep the linear gradient on the correct side of the penguin's left arm, first
 
 # --hints--
 
-You should give `.arm.left` a `transform` of `rotate(130deg) scaleX(-1)`.
+You should give `.arm.left` (or `.left.arm`) a `transform` of `rotate(130deg) scaleX(-1)`.
 
 ```js
-const leftArm = new __helpers.CSSHelp(document).getStyle('.arm.left');
+const leftArm = new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm']);
 
 if (leftArm?.rotate && leftArm?.transform) {
   assert.equal(leftArm.getPropVal('rotate', true), '130deg');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2d4e80400325ff89664a.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2d4e80400325ff89664a.md
@@ -11,7 +11,7 @@ To keep the linear gradient on the correct side of the penguin's left arm, first
 
 # --hints--
 
-You should give `.arm.left` (or `.left.arm`) a `transform` of `rotate(130deg) scaleX(-1)`.
+You should give `.arm.left` a `transform` of `rotate(130deg) scaleX(-1)`.
 
 ```js
 const leftArm = new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm']);

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2ebc81ba81271460850d.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2ebc81ba81271460850d.md
@@ -11,7 +11,7 @@ Rotate the right arm by `45deg` counterclockwise.
 
 # --hints--
 
-You should give `.arm.right` (or `.right.arm`) a `transform` of `rotate(-45deg)`.
+You should give `.arm.right` a `transform` of `rotate(-45deg)`.
 
 ```js
 const rightArm = new __helpers.CSSHelp(document).getStyleAny(['.arm.right', '.right.arm']);

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2ebc81ba81271460850d.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d2ebc81ba81271460850d.md
@@ -11,10 +11,10 @@ Rotate the right arm by `45deg` counterclockwise.
 
 # --hints--
 
-You should give `.arm.right` a `transform` of `rotate(-45deg)`.
+You should give `.arm.right` (or `.right.arm`) a `transform` of `rotate(-45deg)`.
 
 ```js
-const rightArm = new __helpers.CSSHelp(document).getStyle('.arm.right');
+const rightArm = new __helpers.CSSHelp(document).getStyleAny(['.arm.right', '.right.arm']);
 
 if (rightArm?.transform) {
   assert.equal(rightArm?.getPropVal('transform', true), 'rotate(-45deg)');

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d33c51140292cc5a21742.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d33c51140292cc5a21742.md
@@ -11,28 +11,28 @@ Use the `wave` animation on the left arm. Have the animation last `3s`, infinite
 
 # --hints--
 
-You should give `.arm.left` an `animation-name` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` (or `.left.arm`) an `animation-name` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.arm.left')?.animationName, 'wave');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.animationName, 'wave');
 ```
 
-You should give `.arm.left` an `animation-duration` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` (or `.left.arm`) an `animation-duration` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.arm.left')?.animationDuration, '3s');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.animationDuration, '3s');
 ```
 
-You should give `.arm.left` an `animation-iteration-count` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` (or `.left.arm`) an `animation-iteration-count` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.arm.left')?.animationIterationCount, 'infinite');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.animationIterationCount, 'infinite');
 ```
 
-You should give `.arm.left` an `animation-timing-function` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` (or `.left.arm`) an `animation-timing-function` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('.arm.left')?.animationTimingFunction, 'linear');
+assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.animationTimingFunction, 'linear');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d33c51140292cc5a21742.md
+++ b/curriculum/challenges/english/blocks/workshop-flappy-penguin/619d33c51140292cc5a21742.md
@@ -11,25 +11,25 @@ Use the `wave` animation on the left arm. Have the animation last `3s`, infinite
 
 # --hints--
 
-You should give `.arm.left` (or `.left.arm`) an `animation-name` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` an `animation-name` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.animationName, 'wave');
 ```
 
-You should give `.arm.left` (or `.left.arm`) an `animation-duration` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` an `animation-duration` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.animationDuration, '3s');
 ```
 
-You should give `.arm.left` (or `.left.arm`) an `animation-iteration-count` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` an `animation-iteration-count` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.animationIterationCount, 'infinite');
 ```
 
-You should give `.arm.left` (or `.left.arm`) an `animation-timing-function` of `--fcc-expected--`, but found `--fcc-actual--`.
+You should give `.arm.left` an `animation-timing-function` of `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyleAny(['.arm.left', '.left.arm'])?.animationTimingFunction, 'linear');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68621

<!-- Feel free to add any additional description of changes below this line -->

The earlier regex was checking for individual properties. I've removed that check since it's already covered by the value check.