### PR TITLE
fix(curriculum): update h3 hints from curriculum outline step 10

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-curriculum-outline/683921c4769fd23dbadec2fe.md
+++ b/curriculum/challenges/english/blocks/workshop-curriculum-outline/683921c4769fd23dbadec2fe.md
@@ -17,8 +17,7 @@ CSS is used to style a webpage
 
 # --hints--
 
---- You should add a second `h3` element to the page.
-+++ You should have exactly two `h3` elements, make sure to not remove the existing ones, and to not add new ones.
+You should have exactly two `h3` elements, make sure to not remove the existing ones, and to not add new ones.
 
 ```js
 assert.lengthOf(document.querySelectorAll("h3"), 2);

--- a/curriculum/challenges/english/blocks/workshop-curriculum-outline/683921c4769fd23dbadec2fe.md
+++ b/curriculum/challenges/english/blocks/workshop-curriculum-outline/683921c4769fd23dbadec2fe.md
@@ -17,7 +17,8 @@ CSS is used to style a webpage
 
 # --hints--
 
-You should add a second `h3` element to the page.
+--- You should add a second `h3` element to the page.
++++ You should have exactly two `h3` elements, make sure to not remove the existing ones, and to not add new ones.
 
 ```js
 assert.lengthOf(document.querySelectorAll("h3"), 2);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ X] My pull request targets the `main` branch of freeCodeCamp.
- [X ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68633

<!-- Feel free to add any additional description of changes below this line -->
This pull request removes the unnecessary hint that asks campers to add a second h3 element in Step 10 of the Curriculum Outline workshop.
The step only requires adding a paragraph element, so removing the outdated h3 hints prevents incorrect guidance when a camper makes a mistake.

Closes #68633
