### PR TITLE
fix(curriculum): clarify h1 requirement in recipe lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-recipe-page/668f08ea07b99b1f4a91acab.md
+++ b/curriculum/challenges/english/blocks/lab-recipe-page/668f08ea07b99b1f4a91acab.md
@@ -16,7 +16,7 @@ demoType: onClick
 1. You should have an `html` element with `lang` set to `en`.
 1. You should have a `head` element containing a `title` element with the name of your recipe, and a `meta` element with a `charset` attribute set to `UTF-8`.
 1. You should have a `body` element.
-1. You should have an `h1` element with the name of your recipe.
+1. You should have exactly one `h1` element with the name of your recipe.
 1. You should have a `p` element that introduces the recipe below the `h1`.
 1. You should have one `h2` element with the text `Ingredients` for the ingredients section.
 1. You should have an unordered list (`ul` element) with at least four list items (`li` elements) that lists your ingredients below the first `h2` element.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68639

This updates the Build a Recipe Page lab user stories so they state the same single-`h1` requirement already enforced by the tests.

Validation:

- `CURRICULUM_LOCALE=english npx -y -p node@24 -p pnpm@10.33.3 pnpm test-curriculum-content`
- Result: 961 test files passed; 55,727 tests passed.

AI-assisted: yes. I reviewed and verified the final changes.