### PR TITLE
fix(client): include workshop/block title in Get a Hint search query

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -245,7 +245,7 @@ function ShowClassic({
     query: `(max-width: ${MAX_MOBILE_WIDTH}px)`
   });
 
-  const guideUrl = getGuideUrl({ forumTopicId, title });
+  const guideUrl = getGuideUrl({ forumTopicId, title, block, superBlock });
 
   const blockNameTitle = `${t(
     `intro:${superBlock}.blocks.${block}.title`

--- a/client/src/templates/Challenges/projects/backend/show.tsx
+++ b/client/src/templates/Challenges/projects/backend/show.tsx
@@ -194,7 +194,12 @@ const ShowBackEnd = (props: BackEndProps) => {
                 updateSolutionForm={updateSolutionFormValues}
               />
               <ProjectToolPanel
-                guideUrl={getGuideUrl({ forumTopicId, title })}
+                guideUrl={getGuideUrl({
+                  forumTopicId,
+                  title,
+                  block,
+                  superBlock
+                })}
               />
               <br />
               <Output

--- a/client/src/templates/Challenges/projects/frontend/show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/show.tsx
@@ -169,7 +169,12 @@ const ShowFrontEndProject = (props: ProjectProps) => {
                 updateSolutionForm={updateSolutionFormValues}
               />
               <ProjectToolPanel
-                guideUrl={getGuideUrl({ forumTopicId, title })}
+                guideUrl={getGuideUrl({
+                  forumTopicId,
+                  title,
+                  block,
+                  superBlock
+                })}
               />
               <br />
               <Spacer size='m' />

--- a/client/src/templates/Challenges/utils/index.test.ts
+++ b/client/src/templates/Challenges/utils/index.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import i18n from '../../../../i18n/config-for-tests';
 import envData from '../../../../config/env.json';
 import { getGuideUrl } from './index';
+
+vi.unmock('react-i18next');
 
 const { forumLocation } = envData;
 
@@ -20,6 +23,18 @@ describe('index', () => {
       });
       expect(value).toEqual(
         `${forumLocation}/search?q=%26%20a%20sample%20title%3F%20in%3Atitle%20order%3Aviews`
+      );
+    });
+
+    it('should include the block title in the search query when block and superBlock are supplied', async () => {
+      await i18n.reloadResources('en', 'intro');
+      const value = getGuideUrl({
+        title: 'Step 19',
+        block: 'learn-basic-javascript-by-building-a-role-playing-game',
+        superBlock: 'javascript-algorithms-and-data-structures-v8'
+      });
+      expect(value).toEqual(
+        `${forumLocation}/search?q=javascript-algorithms-and-data-structures-v8.blocks.learn-basic-javascript-by-building-a-role-playing-game.title%20-%20Step%2019%20in%3Atitle%20order%3Aviews`
       );
     });
   });

--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -6,13 +6,29 @@ const { forumLocation } = envData;
 interface GuideData {
   forumTopicId?: number;
   title?: string;
+  block?: string;
+  superBlock?: string;
 }
 
-export function getGuideUrl({ forumTopicId, title = '' }: GuideData): string {
-  title = encodeURIComponent(title);
-  return forumTopicId
-    ? `https://forum.freecodecamp.org/t/${forumTopicId}`
-    : `${forumLocation}/search?q=${title}%20in%3Atitle%20order%3Aviews`;
+export function getGuideUrl({
+  forumTopicId,
+  title = '',
+  block,
+  superBlock
+}: GuideData): string {
+  if (forumTopicId) {
+    return `https://forum.freecodecamp.org/t/${forumTopicId}`;
+  }
+
+  const blockTitle =
+    block && superBlock
+      ? i18next.t(`intro:${superBlock}.blocks.${block}.title`)
+      : '';
+  const query = blockTitle ? `${blockTitle} - ${title}` : title;
+
+  return `${forumLocation}/search?q=${encodeURIComponent(
+    query
+  )}%20in%3Atitle%20order%3Aviews`;
 }
 
 export function isGoodXHRStatus(status?: string): boolean {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #66832

## Summary
- `getGuideUrl()` built the "Get a Hint" forum search link from the raw challenge title alone (e.g. "Step 19") whenever a challenge has no `forumTopicId`, unlike `generateSearchLink()` (used by "Create a Help Post on the Forum"), which prepends the block title. On workshop steps this meant the search query was missing the workshop title entirely.
- `getGuideUrl()` now accepts optional `block`/`superBlock`, resolves the block title via `i18next.t`, and includes it in the query - "<Block Title> - <Challenge Title> in:title order:views" - matching the format the issue's expected output describes.
- Updated the three call sites that use this fallback: `classic/show.tsx` (covers workshop steps), `projects/frontend/show.tsx`, `projects/backend/show.tsx`.

## Test plan
- Added a unit test in `client/src/templates/Challenges/utils/index.test.ts` reproducing the exact "Step 19" workshop scenario from the issue
- Existing `getGuideUrl` tests (no block/superBlock passed) still pass unchanged
- `npx vitest run` on `utils/index.test.ts` and `components/help-modal.test.tsx` - all 6 tests pass
- `npx tsc --noEmit` - no new type errors introduced
- `npx prettier --check` - clean