### PR TITLE
fix(curriculum): verify head is nested inside html in bookstore-page step 1

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
@@ -45,7 +45,7 @@ assert.match(code,/<head>[\s\S]*<\/head>/i);
 Your `head` element should be nested inside `html` element.
 
 ```js
-assert.match(code, /<\/html>\s*$/);
+assert.match(code, /<html\b[^>]*>[\s\S]*<head>[\s\S]*<\/head>[\s\S]*<\/html>/i);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68642

## Summary
- Step 1 of the Bookstore Page workshop has a hint that says "Your `head` element should be nested inside `html` element," but the assertion only checked `assert.match(code, /<\/html>\s*$/)` - i.e. that the code ends with `</html>`. That never verifies `head` is actually nested inside `html`, so a solution with `head` placed before `html` entirely (e.g. `<head></head><html lang="en"></html>`) still passes.
- Replaced the assertion with `assert.match(code, /<html\b[^>]*>[\s\S]*<head>[\s\S]*<\/head>[\s\S]*<\/html>/i)`, which follows the same nesting-check pattern already used elsewhere in this workshop (e.g. `title` nested inside `head` in a later step, and `h1` nested inside `body`).

## Test plan
- Verified in Node that the new regex rejects the exact buggy example from the issue (`<head></head><html lang="en"></html>`) and accepts a valid solution with `head` properly nested inside `html`
- Ran `challenge-linter` on the modified file - no lint errors