### PR TITLE
fix(curriculum): correct text formatting and wording errors in Cat Photo App workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc1798ff86c76b9248c6eb3.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc1798ff86c76b9248c6eb3.md
@@ -31,7 +31,7 @@ You should only have one `h1` element. Remove the extra.
 assert.lengthOf(document.querySelectorAll('h1'), 1);
 ```
 
-Your `h1` element's text should be 'CatPhotoApp'. You have either omitted the text or have a typo.
+Your `h1` element's text should be `CatPhotoApp`. You have either omitted the text or have a typo.
 
 ```js
 assert.equal(document.querySelector('h1')?.innerText?.trim().toLowerCase(), 'catphotoapp');

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc17dc8f86c76b9248c6eb5.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc17dc8f86c76b9248c6eb5.md
@@ -9,7 +9,7 @@ dashedName: step-4
 
 Commenting allows you to leave messages without affecting the browser display. It also allows you to make code inactive. A comment in HTML starts with `<!--`, contains any number of lines of text, and ends with `-->`. 
 
-Here is an example of a comment with the `TODO: Remove h1`:
+Here is an example of a comment with the text `TODO: Remove h1`:
 
 ```html
 <!-- TODO: Remove h1 -->

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc24073f86c76b9248c6ebb.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc24073f86c76b9248c6ebb.md
@@ -33,7 +33,7 @@ Your `img` element should have a `src` attribute. You have either omitted the at
 assert.exists(document.querySelector('img')?.src);
 ```
 
-Your `img` element's `src` attribute should be set to '`https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg`'. You have either omitted the URL or have a typo. The case of the URL is important.
+Your `img` element's `src` attribute should be set to `https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg`. You have either omitted the URL or have a typo. The case of the URL is important.
 
 ```js
 assert.equal(document.querySelector('img')?.src, 'https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg');

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dfa371beacea3f48c6300af.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dfa371beacea3f48c6300af.md
@@ -48,7 +48,7 @@ assert.equal(
 );
 ```
 
-There should be an `h2` element with the text `Cat Lists` above the last `h3` element that is nested in the last `section` element'. You may have accidentally deleted the `h2` element.
+There should be an `h2` element with the text `Cat Lists` above the last `h3` element that is nested in the last `section` element. You may have accidentally deleted the `h2` element.
 
 ```js
 const secondSectionLastElemNode = document.querySelectorAll('main > section')[1]

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/62bb4009e3458a128ff57d5d.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/62bb4009e3458a128ff57d5d.md
@@ -13,7 +13,7 @@ You can set browser behavior by adding `meta` elements in the `head`. Here's an 
 <meta attribute="value">
 ```
 
-Inside the `head` element, nest a `meta` element with a `charset` attribute set to the value of `utf-8`. This tells the browser how to encode characters for the page. 
+Inside the `head` element, nest a `meta` element with a `charset` attribute set to the value of `UTF-8`. This tells the browser how to encode characters for the page. 
 
 Note that the `meta` element is a void element.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68596

## Summary
Fixes the five text issues in the Cat Photo App workshop identified by the maintainer:

- **Step 2** (`5dc1798ff86c76b9248c6eb3.md`): `'CatPhotoApp'` -> `` `CatPhotoApp` `` so the value is formatted as inline code, matching the Step 1 hint's convention.
- **Step 4** (`5dc17dc8f86c76b9248c6eb5.md`): added the missing word "text" so the sentence reads "comment with the text `TODO: Remove h1`", paralleling the wording in Steps 11 and 26.
- **Step 8** (`5dc24073f86c76b9248c6ebb.md`): removed the redundant single quotes wrapping the already-backticked URL.
- **Step 21** (`5dfa371beacea3f48c6300af.md`): removed a stray apostrophe after `` `section` `` element.
- **Step 42** (`62bb4009e3458a128ff57d5d.md`): changed the description's `utf-8` to `UTF-8` so it matches the hint text and solution code on the same step.

## Test plan
- Ran `challenge-linter` on all five modified files - no lint errors
- Diffed each change against the exact expected behavior described in the issue