### PR TITLE
fix(curriculum): validate head is nested inside html in Bookstore workshop step 1

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
+++ b/curriculum/challenges/english/blocks/workshop-bookstore-page/69134b6cb43aa5f254950a10.md
@@ -45,7 +45,10 @@ assert.match(code,/<head>[\s\S]*<\/head>/i);
 Your `head` element should be nested inside `html` element.
 
 ```js
-assert.match(code, /<\/html>\s*$/);
+assert.match(
+  code,
+  /<html\b[^>]*>[\s\S]*<head\b[^>]*>[\s\S]*?<\/head>[\s\S]*?<\/html>\s*$/i
+);
 ```
 
 # --seed--


### PR DESCRIPTION
## Description

This PR updates the Step 1 test for the Bookstore Page workshop.

The last hint states that the `head` element should be nested inside the `html` element, but the previous assertion only checked that the document ended with `</html>`. This allowed solutions with the `head` element outside the `html` element to pass.

The assertion has been updated to verify that the `head` element is nested inside the `html` element, matching the hint's expected behavior.

## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #68645