### PR TITLE
fix(curriculum): improve wording in recipe page lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-recipe-page/668f08ea07b99b1f4a91acab.md
+++ b/curriculum/challenges/english/blocks/lab-recipe-page/668f08ea07b99b1f4a91acab.md
@@ -22,7 +22,7 @@ demoType: onClick
 1. You should have an unordered list (`ul` element) with at least four list items (`li` elements) that lists your ingredients below the first `h2` element.
 1. You should have a second `h2` element with the text `Instructions` for the instructions section.
 1. You should have an ordered list (`ol` element) with at least four list items that lists the recipe steps in order, below the second `h2`.
-1. You should have one `img` element with a `src` attribute set to a valid image, you can use `https://cdn.freecodecamp.org/curriculum/labs/recipe.jpg` if you would like, and an `alt` attribute describing the image.
+1. You should have one `img` element with a `src` attribute set to a valid image and an `alt` attribute describing the image. You can use `https://cdn.freecodecamp.org/curriculum/labs/recipe.jpg` if you would like.
 
 # --hints--
 
@@ -44,7 +44,7 @@ You should have a `head` element within the `html` element.
 assert.match(code, /<html[\s\S]*>[\s\S]*<\s*head\s*>[\s\S]*<\/\s*head\s*>[\s\S]*<\/\s*html\s*>/i);
 ```
 
-You should have `title` element within your `head` element.
+You should have a `title` element within your `head` element.
 
 ```js
 assert.match(code, /<\s*head\s*>[\s\S]*<\s*title\s*>[\s\S]*<\/\s*title\s*>[\s\S]*<\/\s*head\s*>/i);


### PR DESCRIPTION
## Description

This PR fixes two writing issues in the **Build a Recipe Page** lab.

- Moves the image URL suggestion into its own sentence so the `src` and `alt` attribute requirements remain together.
- Adds the missing article `a` before `title` for consistency with nearby hints.

### Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68627