### PR TITLE
fix: Fix duplicate-email sign-ins by failing closed

### DIFF
--- a/api/src/plugins/auth-dev.ts
+++ b/api/src/plugins/auth-dev.ts
@@ -5,7 +5,10 @@ import {
   getPrefixedLandingPath,
   haveSamePath
 } from '../utils/redirection.js';
-import { findOrCreateUser } from '../routes/helpers/auth-helpers.js';
+import {
+  DuplicateUserEmailError,
+  findOrCreateUser
+} from '../routes/helpers/auth-helpers.js';
 import { createAccessToken } from '../utils/tokens.js';
 
 const trimTrailingSlash = (str: string) =>
@@ -37,7 +40,20 @@ export const devAuth: FastifyPluginCallbackTypebox = (
   fastify.get('/signin', async (req, reply) => {
     const email = 'foo@bar.com';
 
-    const { id } = await findOrCreateUser(fastify, email);
+    let id: string;
+    try {
+      ({ id } = await findOrCreateUser(fastify, email));
+    } catch (error) {
+      fastify.log.error(error, 'Failed to find or create user during dev sign-in');
+      if (!(error instanceof DuplicateUserEmailError)) {
+        fastify.Sentry.captureException(error);
+      }
+
+      return reply.status(500).send({
+        message: 'We could not log you in, please try again in a moment.',
+        type: 'danger'
+      });
+    }
 
     reply.setAccessTokenCookie(createAccessToken(id));
 

--- a/api/src/plugins/auth0.test.ts
+++ b/api/src/plugins/auth0.test.ts
@@ -325,6 +325,27 @@ describe('auth0 plugin', () => {
       );
     });
 
+    test('should redirect with a generic error if duplicate users exist for the email', async () => {
+      await fastify.prisma.user.create({
+        data: createUserInput(email)
+      });
+      await fastify.prisma.user.create({
+        data: createUserInput(email)
+      });
+      mockAuthSuccess();
+
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/auth/auth0/callback?state=valid'
+      });
+
+      expect(res.headers.location).toMatch(
+        `${HOME_LOCATION}/?${formatMessage({ type: 'danger', content: 'flash.generic-error' })}`
+      );
+      expect(res.statusCode).toBe(302);
+      expect(res.headers['set-cookie']).toBeUndefined();
+    });
+
     test('should use the login-returnto cookie if present and valid', async () => {
       mockAuthSuccess();
       await fastify.prisma.user.create({

--- a/api/src/plugins/auth0.ts
+++ b/api/src/plugins/auth0.ts
@@ -13,7 +13,10 @@ import {
   COOKIE_DOMAIN,
   HOME_LOCATION
 } from '../utils/env.js';
-import { findOrCreateUser } from '../routes/helpers/auth-helpers.js';
+import {
+  DuplicateUserEmailError,
+  findOrCreateUser
+} from '../routes/helpers/auth-helpers.js';
 import { createAccessToken } from '../utils/tokens.js';
 import { getLoginRedirectParams } from '../utils/redirection.js';
 
@@ -181,7 +184,19 @@ export const auth0Client: FastifyPluginCallbackTypebox = fp(
         });
       }
 
-      const { id } = await findOrCreateUser(fastify, email);
+      let id: string;
+      try {
+        ({ id } = await findOrCreateUser(fastify, email));
+      } catch (error) {
+        logger.error(error, 'Failed to find or create user during sign-in');
+        if (!(error instanceof DuplicateUserEmailError)) {
+          fastify.Sentry.captureException(error);
+        }
+        return reply.redirectWithMessage(returnTo, {
+          type: 'danger',
+          content: 'flash.generic-error'
+        });
+      }
 
       reply.setAccessTokenCookie(createAccessToken(id));
 

--- a/api/src/routes/helpers/auth-helpers.test.ts
+++ b/api/src/routes/helpers/auth-helpers.test.ts
@@ -12,7 +12,7 @@ import Fastify, { FastifyInstance } from 'fastify';
 import db from '../../db/prisma.js';
 import { createUserInput } from '../../utils/create-user.js';
 import { checkCanConnectToDb } from '../../../vitest.utils.js';
-import { findOrCreateUser } from './auth-helpers.js';
+import { DuplicateUserEmailError, findOrCreateUser } from './auth-helpers.js';
 import { assignVariantBucket } from '../../utils/drip-campaign.js';
 import growthBook from '../../plugins/growth-book.js';
 import {
@@ -64,11 +64,16 @@ describe('findOrCreateUser', () => {
 
     const ids = [user1.id, user2.id];
 
-    await findOrCreateUser(fastify, email);
+    await expect(findOrCreateUser(fastify, email)).rejects.toBeInstanceOf(
+      DuplicateUserEmailError
+    );
 
     expect(captureException).toHaveBeenCalledTimes(1);
     expect(captureException).toHaveBeenCalledWith(
-      new Error(`Multiple user records found for: ${ids.join(', ')}`)
+      expect.objectContaining({
+        name: 'DuplicateUserEmailError',
+        message: `Multiple user records found for ${email}: ${ids.join(', ')}`
+      })
     );
   });
 

--- a/api/src/routes/helpers/auth-helpers.ts
+++ b/api/src/routes/helpers/auth-helpers.ts
@@ -2,6 +2,13 @@ import { FastifyInstance } from 'fastify';
 import { createUserInput } from '../../utils/create-user.js';
 import { assignVariantBucket } from '../../utils/drip-campaign.js';
 
+export class DuplicateUserEmailError extends Error {
+  constructor(email: string, userIds: string[]) {
+    super(`Multiple user records found for ${email}: ${userIds.join(', ')}`);
+    this.name = 'DuplicateUserEmailError';
+  }
+}
+
 /**
  * Finds an existing user with the given email or creates a new user if none exists.
  * @param fastify - The Fastify instance.
@@ -12,18 +19,17 @@ export const findOrCreateUser = async (
   fastify: FastifyInstance,
   email: string
 ): Promise<{ id: string; acceptedPrivacyTerms: boolean }> => {
-  // TODO: handle the case where there are multiple users with the same email.
-  // e.g. use findMany and throw an error if more than one is found.
   const existingUser = await fastify.prisma.user.findMany({
     where: { email },
     select: { id: true, acceptedPrivacyTerms: true }
   });
   if (existingUser.length > 1) {
-    fastify.Sentry.captureException(
-      new Error(
-        `Multiple user records found for: ${existingUser.map(user => user.id).join(', ')}`
-      )
+    const error = new DuplicateUserEmailError(
+      email,
+      existingUser.map(user => user.id)
     );
+    fastify.Sentry.captureException(error);
+    throw error;
   }
 
   if (existingUser[0]) {

--- a/api/src/routes/public/auth.ts
+++ b/api/src/routes/public/auth.ts
@@ -4,7 +4,7 @@ import validator from 'validator';
 import { AUTH0_DOMAIN } from '../../utils/env.js';
 import { auth0Client } from '../../plugins/auth0.js';
 import { createAccessToken } from '../../utils/tokens.js';
-import { findOrCreateUser } from '../helpers/auth-helpers.js';
+import { DuplicateUserEmailError, findOrCreateUser } from '../helpers/auth-helpers.js';
 
 const getEmailFromAuth0 = async (
   req: FastifyRequest
@@ -64,7 +64,20 @@ export const mobileAuth0Routes: FastifyPluginCallback = (
       });
     }
 
-    const { id } = await findOrCreateUser(fastify, email);
+    let id: string;
+    try {
+      ({ id } = await findOrCreateUser(fastify, email));
+    } catch (error) {
+      logger.error(error, 'Failed to find or create user during mobile sign-in');
+      if (!(error instanceof DuplicateUserEmailError)) {
+        fastify.Sentry.captureException(error);
+      }
+
+      return reply.status(500).send({
+        message: 'We could not log you in, please try again in a moment.',
+        type: 'danger'
+      });
+    }
 
     reply.setAccessTokenCookie(createAccessToken(id));
   });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #68653

<!-- Feel free to add any additional description of changes below this line -->
## Description

This change makes sign-in reject duplicate user records instead of selecting the first match. The shared auth helper now throws a dedicated error when multiple users share the same email, and the Auth0, mobile, and dev sign-in paths catch that case and return the existing generic login failure. Updated tests cover the new duplicate-account behavior.
