### PR TITLE
fix(curriculum): correct grammar and accuracy in HTML catalog intros

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -9281,7 +9281,7 @@
       "lecture-understanding-the-html-boilerplate": {
         "title": "Understanding the HTML Boilerplate",
         "intro": [
-          "In these lectures, you will learn about the HTML boilerplate which is a ready-made template for your webpages.",
+          "In these lectures, you will learn about the HTML boilerplate, which is a ready-made template for your webpages.",
           "You will learn how to work with the <code>link</code> element, <code>meta</code> element and more."
         ]
       },
@@ -9301,13 +9301,13 @@
       "lecture-html-fundamentals": {
         "title": "HTML Fundamentals",
         "intro": [
-          "In these lectures, you will learn about HTML fundamentals like the <code>div</code> element, the <code>id</code> and <code>class</code> attributes, the HTML boilerplate, HTML entities, and more."
+          "In these lectures, you will learn about HTML fundamentals like the <code>div</code> element, the <code>id</code> and <code>class</code> attributes, the <code>script</code> element, HTML entities, and more."
         ]
       },
       "workshop-bookstore-page": {
         "title": "Build a Bookstore Page",
         "intro": [
-          "In this workshop, you will practice working with classes, ids and the <code>div</code> element by building a bookstore page."
+          "In this workshop, you will practice working with classes, ids, and the <code>div</code> element by building a bookstore page."
         ]
       },
       "lecture-understanding-how-html-affects-seo": {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68656

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes grammar and accuracy issues in the Basic HTML catalog intros in `client/i18n/locales/english/intro.json`.

### Changes made

- Added the missing comma before the non-restrictive clause in the Understanding the HTML Boilerplate intro:
  `the HTML boilerplate which is a ready-made template`
  to
  `the HTML boilerplate, which is a ready-made template`
- Replaced the inaccurate topic in the HTML Fundamentals intro (the block covers the `script` element, not the boilerplate):
  `the <code>div</code> element, the <code>id</code> and <code>class</code> attributes, the HTML boilerplate, HTML entities, and more`
  to
  `the <code>div</code> element, the <code>id</code> and <code>class</code> attributes, the <code>script</code> element, HTML entities, and more`
- Added the missing Oxford comma in the Build a Bookstore Page intro:
  `classes, ids and the <code>div</code> element`
  to
  `classes, ids, and the <code>div</code> element`

### Testing

- Verified `intro.json` still parses as valid JSON after the changes.
- Confirmed all three fixes requested in the issue have been applied.