### PR TITLE
fix(curriculum): correct spelling of below in colorful boxes step 3

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-colorful-boxes/68f91df5776e693049fb8942.md
+++ b/curriculum/challenges/english/blocks/workshop-colorful-boxes/68f91df5776e693049fb8942.md
@@ -9,7 +9,7 @@ dashedName: step-3
 
 Now it is time to add some CSS rules to the `styles.css` file. Start by creating a selector for the `h1` element. 
 
-Center the content of the `h1` element by setting its `text-align` property to `center`. Also create a `margin-bottom` property with the value `10px` to add margin between the bottom of the `h1` element and any HTML element that goes bellow.
+Center the content of the `h1` element by setting its `text-align` property to `center`. Also create a `margin-bottom` property with the value `10px` to add margin between the bottom of the `h1` element and any HTML element that goes below.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68657

Fixes a spelling error in the Colorful Boxes workshop, step 3 description: "bellow" -> "below".