### PR TITLE
fix(curriculum): correct HTML lecture punctuation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-html-fundamentals/6708382cf088b216580a9ff1.md
+++ b/curriculum/challenges/english/blocks/lecture-html-fundamentals/6708382cf088b216580a9ff1.md
@@ -53,7 +53,7 @@ You can reference the `id` name of `title` within your JavaScript or CSS. Here's
 
 :::
 
-The hash symbol (`#`) in front of `title`, tells the computer you want to target an `id` with that value. `id` names should not be used more than once, and they should always be unique. Another thing to note about `id` values, is that they cannot have spaces in them. Here is an example of applying the words `main` and `heading` to an `id` attribute value:
+The hash symbol (`#`) in front of `title` tells the computer you want to target an `id` with that value. `id` names should not be used more than once, and they should always be unique. Another thing to note about `id` values is that they cannot have spaces in them. Here is an example of applying the words `main` and `heading` to an `id` attribute value:
 
 ```html
 <h1 id="main heading">Main heading</h1>

--- a/curriculum/challenges/english/blocks/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
+++ b/curriculum/challenges/english/blocks/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
@@ -39,7 +39,7 @@ These types of character references are known as named character references. Nam
 
 Another type of character reference would be the decimal numeric reference. This character reference starts with an ampersand sign and hash symbol (`#`), followed by one or more decimal digits, followed by a semicolon.
 
-Here is an example of using the decimal numeric reference for the less-than symbol. 
+Here is an example of using the decimal numeric reference for the less-than symbol.
 
 Enable the interactive editor and change the code to see different symbols. You can use `&#169;` for the copyright symbol and `&#174;` for the registered trademark symbol.
 

--- a/curriculum/challenges/english/blocks/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
+++ b/curriculum/challenges/english/blocks/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
@@ -20,7 +20,7 @@ Let's say you wanted to display the text `This is an <img/> element` on the scre
 
 :::
 
-When the HTML parser sees the less than (`<`) symbol followed by an HTML tag name, it interprets that as an HTML element. That is why you are not getting the desired result of `This is an <img/> element` on the screen.
+When the HTML parser sees the less-than (`<`) symbol followed by an HTML tag name, it interprets that as an HTML element. That is why you are not getting the desired result of `This is an <img/> element` on the screen.
 
 To fix this issue, you can use HTML entities. Here is an updated example using the correct HTML entities for the less-than (`<`) and greater-than (`>`) symbols. Now you should see `This is an <img/> element` on the screen.
 
@@ -39,7 +39,7 @@ These types of character references are known as named character references. Nam
 
 Another type of character reference would be the decimal numeric reference. This character reference starts with an ampersand sign and hash symbol (`#`), followed by one or more decimal digits, followed by a semicolon.
 
-Here is an example of using the decimal numeric reference for the less than symbol. 
+Here is an example of using the decimal numeric reference for the less-than symbol. 
 
 Enable the interactive editor and change the code to see different symbols. You can use `&#169;` for the copyright symbol and `&#174;` for the registered trademark symbol.
 
@@ -53,7 +53,7 @@ Enable the interactive editor and change the code to see different symbols. You 
 
 The last type of character reference would be the hexadecimal numeric reference. This character reference starts with an ampersand sign, hash symbol, and the letter `x`. Then it is followed by one or more ASCII hex digits and ends with a semicolon.
 
-Here is an example of using the hexadecimal numeric reference for the less than symbol.
+Here is an example of using the hexadecimal numeric reference for the less-than symbol.
 
 Enable the interactive editor and change the code to see different symbols. You can use `&#x20AC;` for the euro symbol and `&#x03A9;` for the Greek capital letter Omega symbol.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally by reviewing the affected curriculum files.

Closes #68637

## Description

This PR fixes punctuation inconsistencies in two HTML Fundamentals lectures.

### Changes made

- Removed the unnecessary comma after `title` in the "What Are IDs and Classes, and When Should You Use Them?" lecture.
- Removed the unnecessary comma after `id` values in the same lecture.
- Hyphenated "less-than" in three occurrences in the "What Are HTML Entities, and What Are Some Common Examples?" lecture to maintain consistency with the existing terminology used elsewhere in the lesson.

These changes improve grammatical correctness and consistency without affecting the lesson content or functionality.