### PR TITLE
fix(curriculum): correct punctuation in the IDs and Classes and HTML Entities lectures

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-html-fundamentals/6708382cf088b216580a9ff1.md
+++ b/curriculum/challenges/english/blocks/lecture-html-fundamentals/6708382cf088b216580a9ff1.md
@@ -53,7 +53,7 @@ You can reference the `id` name of `title` within your JavaScript or CSS. Here's
 
 :::
 
-The hash symbol (`#`) in front of `title`, tells the computer you want to target an `id` with that value. `id` names should not be used more than once, and they should always be unique. Another thing to note about `id` values, is that they cannot have spaces in them. Here is an example of applying the words `main` and `heading` to an `id` attribute value:
+The hash symbol (`#`) in front of `title` tells the computer you want to target an `id` with that value. `id` names should not be used more than once, and they should always be unique. Another thing to note about `id` values is that they cannot have spaces in them. Here is an example of applying the words `main` and `heading` to an `id` attribute value:
 
 ```html
 <h1 id="main heading">Main heading</h1>

--- a/curriculum/challenges/english/blocks/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
+++ b/curriculum/challenges/english/blocks/lecture-html-fundamentals/67083868d5fdcb17bf8c14bd.md
@@ -20,7 +20,7 @@ Let's say you wanted to display the text `This is an <img/> element` on the scre
 
 :::
 
-When the HTML parser sees the less than (`<`) symbol followed by an HTML tag name, it interprets that as an HTML element. That is why you are not getting the desired result of `This is an <img/> element` on the screen.
+When the HTML parser sees the less-than (`<`) symbol followed by an HTML tag name, it interprets that as an HTML element. That is why you are not getting the desired result of `This is an <img/> element` on the screen.
 
 To fix this issue, you can use HTML entities. Here is an updated example using the correct HTML entities for the less-than (`<`) and greater-than (`>`) symbols. Now you should see `This is an <img/> element` on the screen.
 
@@ -39,7 +39,7 @@ These types of character references are known as named character references. Nam
 
 Another type of character reference would be the decimal numeric reference. This character reference starts with an ampersand sign and hash symbol (`#`), followed by one or more decimal digits, followed by a semicolon.
 
-Here is an example of using the decimal numeric reference for the less than symbol. 
+Here is an example of using the decimal numeric reference for the less-than symbol. 
 
 Enable the interactive editor and change the code to see different symbols. You can use `&#169;` for the copyright symbol and `&#174;` for the registered trademark symbol.
 
@@ -53,7 +53,7 @@ Enable the interactive editor and change the code to see different symbols. You 
 
 The last type of character reference would be the hexadecimal numeric reference. This character reference starts with an ampersand sign, hash symbol, and the letter `x`. Then it is followed by one or more ASCII hex digits and ends with a semicolon.
 
-Here is an example of using the hexadecimal numeric reference for the less than symbol.
+Here is an example of using the hexadecimal numeric reference for the less-than symbol.
 
 Enable the interactive editor and change the code to see different symbols. You can use `&#x20AC;` for the euro symbol and `&#x03A9;` for the Greek capital letter Omega symbol.
 
@@ -78,7 +78,7 @@ A set of Google fonts.
 
 ### --feedback--
 
-Remember that HTML has reserved characters, so you will need to use another way to write reserved characters like the less than and greater than symbols.
+Remember that HTML has reserved characters, so you will need to use another way to write reserved characters like the less-than and greater-than symbols.
 
 ---
 
@@ -86,7 +86,7 @@ A group of images and captions.
 
 ### --feedback--
 
-Remember that HTML has reserved characters, so you will need to use another way to write reserved characters like the less than and greater than symbols.
+Remember that HTML has reserved characters, so you will need to use another way to write reserved characters like the less-than and greater-than symbols.
 
 ---
 
@@ -94,7 +94,7 @@ A set of characters used to represent JavaScript code.
 
 ### --feedback--
 
-Remember that HTML has reserved characters, so you will need to use another way to write reserved characters like the less than and greater than symbols.
+Remember that HTML has reserved characters, so you will need to use another way to write reserved characters like the less-than and greater-than symbols.
 
 ---
 


### PR DESCRIPTION
Checklist:

-  [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/).
-  [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
-  [x] My pull request targets the main branch of freeCodeCamp.
-  [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes [#68637](https://github.com/freeCodeCamp/freeCodeCamp/issues/68637)

Fixes a few wording and punctuation issues in the HTML fundamentals lecture, including:
- removing an extra comma after "title"
- removing an extra comma after "id values"
- standardizing "less than" to "less-than" in the symbol explanations and examples.