### PR TITLE
fix(curriculum): correct punctuation in HTML boilerplate lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-the-html-boilerplate/670838e914096b194b0c51aa.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-html-boilerplate/670838e914096b194b0c51aa.md
@@ -42,7 +42,7 @@ It tells browsers which version of HTML you're using. Next, comes the `html` tag
 </html>
 ```
 
-This wraps around all your content, and can specify the language of your page. Inside the `html` tag, you'll find two main sections: a `head` and a `body`:
+This wraps around all your content  and can specify the language of your page. Inside the `html` tag, you'll find two main sections, a `head` and a `body`:
 
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68638

## Description

This pull request fixes the punctuation issues in the "What Is an HTML Boilerplate, and Why Is It Important?" lecture by:

- Removing the unnecessary comma before "and" in the compound predicate.
- Replacing the first colon with a comma in the sentence introducing the `head` and `body` sections.