### PR TITLE
fix(curriculum): correct writing in link element lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-the-html-boilerplate/670838977810401844af6fe0.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-html-boilerplate/670838977810401844af6fe0.md
@@ -21,7 +21,7 @@ It is considered best practice to separate your HTML and CSS in different files.
 
 The `href` attribute is used to specify the location of the URL for the external resource. 
 
-The `dot` followed by a forward slash in the example tells the computer to look in the current folder, or directory, for the `styles.css` file.
+The `.` followed by a forward slash in the example tells the computer to look in the current folder, or directory, for the `styles.css` file.
 
 The `link` element should be placed inside the `head` element as seen in the following example:
 
@@ -34,7 +34,7 @@ The `link` element should be placed inside the `head` element as seen in the fol
 </head>
 ```
 
-Often times you will see multiple `link` elements inside a professional codebase that link to different stylesheets, fonts, and icons. Here is an example of using the `link` element to link to an external Google Font called *Playwright Cuba*:
+Oftentimes you will see multiple `link` elements inside a professional codebase that link to different stylesheets, fonts, and icons. Here is an example of using the `link` element to link to an external Google Font called *Playwrite Cuba*:
 
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -67,7 +67,7 @@ It specifies the content type of the linked resource.
 
 ### --feedback--
 
-Pay close attention to the name of this element because it will give you clue as to what it does.
+Pay close attention to the name of this element because it will give you a clue as to what it does.
 
 ---
 
@@ -75,7 +75,7 @@ It determines the visibility of the linked resource on the webpage.
 
 ### --feedback--
 
-Pay close attention to the name of this element because it will give you clue as to what it does.
+Pay close attention to the name of this element because it will give you a clue as to what it does.
 
 ---
 
@@ -83,7 +83,7 @@ It defines the font size of the linked resource when displayed.
 
 ### --feedback--
 
-Pay close attention to the name of this element because it will give you clue as to what it does.
+Pay close attention to the name of this element because it will give you a clue as to what it does.
 
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68598

## Description

This PR fixes writing and formatting issues in the "What Is the Role of the Link Element in HTML" lecture by:

- Correcting the font name from **Playwright Cuba** to **Playwrite Cuba**.
- Changing **Often times** to **Oftentimes**.
- Replacing `` `dot` `` with `` `.` `` in the explanation.
- Adding the missing article ("a") in all three feedback messages.