### PR TITLE
fix(curriculum): add missing tested requirements to travel agency lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -22,7 +22,7 @@ demoType: onClick
 1. You should have a `p` element introducing briefly the various packages.
 1. You should have an unordered list element with two list items. The two list items should have the text `Group Travels` and `Private Tours`, respectively. The text of each list item should be enclosed by an anchor element.
 1. You should have an `h2` element with the text `Top Itineraries`.
-1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element with a description of the image (see next user story).
+1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element that describes the figure's image.
 1. The three anchor elements should have an `img` element with an appropriate `alt` attribute and a `src` attribute set to a valid image as their content. You can use `https://cdn.freecodecamp.org/curriculum/labs/colosseo.jpg`, `https://cdn.freecodecamp.org/curriculum/labs/alps.jpg`, and `https://cdn.freecodecamp.org/curriculum/labs/sea.jpg` if you would like.
 1. All your five anchor elements should have an `href` attribute with the value of `https://www.freecodecamp.org/learn` and a `target` attribute with the value of `_blank`.
 

--- a/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -16,13 +16,13 @@ demoType: onClick
 1. You should have an `html` element with `lang` set to `en`.
 1. You should have a `head` element containing a `meta` void element with `charset` set to `utf-8` and a `title` with the text `Travel Agency Page`.
 1. You should have a `meta` tag in your `head` element that contains a short description of your website for SEO.
-1. You should have an `h1` element to present your travel destinations.
+1. You should have an `h1` element to present your travel destinations. It should be the only `h1` element on your page.
 1. You should have a paragraph below the `h1` element introducing the travel opportunities.
 1. You should have an `h2` element with the text `Packages`.
 1. You should have a `p` element introducing briefly the various packages.
 1. You should have an unordered list element with two list items. The two list items should have the text `Group Travels` and `Private Tours`, respectively. The text of each list item should be enclosed by an anchor element.
 1. You should have an `h2` element with the text `Top Itineraries`.
-1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element.
+1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element. Each `figcaption` should contain some text.
 1. The three anchor elements should have an `img` element with an appropriate `alt` attribute and a `src` attribute set to a valid image as their content. You can use `https://cdn.freecodecamp.org/curriculum/labs/colosseo.jpg`, `https://cdn.freecodecamp.org/curriculum/labs/alps.jpg`, and `https://cdn.freecodecamp.org/curriculum/labs/sea.jpg` if you would like.
 1. All your five anchor elements should have an `href` attribute with the value of `https://www.freecodecamp.org/learn` and a `target` attribute with the value of `_blank`.
 

--- a/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -22,7 +22,7 @@ demoType: onClick
 1. You should have a `p` element introducing briefly the various packages.
 1. You should have an unordered list element with two list items. The two list items should have the text `Group Travels` and `Private Tours`, respectively. The text of each list item should be enclosed by an anchor element.
 1. You should have an `h2` element with the text `Top Itineraries`.
-1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element. Each `figcaption` should contain some text.
+1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element with a description of the image (see next user story).
 1. The three anchor elements should have an `img` element with an appropriate `alt` attribute and a `src` attribute set to a valid image as their content. You can use `https://cdn.freecodecamp.org/curriculum/labs/colosseo.jpg`, `https://cdn.freecodecamp.org/curriculum/labs/alps.jpg`, and `https://cdn.freecodecamp.org/curriculum/labs/sea.jpg` if you would like.
 1. All your five anchor elements should have an `href` attribute with the value of `https://www.freecodecamp.org/learn` and a `target` attribute with the value of `_blank`.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68669

The Build a Travel Agency Page lab enforces two behaviors in its hints that the user stories never state:

- the hint `You should only have one h1 element` — but story 5 only asks for *an* `h1`
- the hint `Each figcaption should contain some text` — but story 11 only asks that each `figure` contain a `figcaption`

This updates the two user stories so every tested behavior is stated, reusing the hint wording:

- Story 5: "You should have an `h1` element to present your travel destinations. It should be the only `h1` element on your page."
- Story 11: "You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element. Each `figcaption` should contain some text."

English curriculum file only (`curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md`); no hint/test logic changed, so the lab's behavior is identical — the instructions just stop under-specifying it.