### PR TITLE
fix(curriculum): audit workshop-todo-app editable regions

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
@@ -303,7 +303,6 @@ h1 {
 const taskForm = document.getElementById("task-form");
 const confirmCloseDialog = document.getElementById("confirm-close-dialog");
 const openTaskFormBtn = document.getElementById("open-task-form-btn");
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
@@ -306,7 +306,6 @@ const openTaskFormBtn = document.getElementById("open-task-form-btn");
 const closeTaskFormBtn = document.getElementById("close-task-form-btn");
 const addOrUpdateTaskBtn = document.getElementById("add-or-update-task-btn");
 const cancelBtn = document.getElementById("cancel-btn");
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
@@ -297,7 +297,6 @@ const cancelBtn = document.getElementById("cancel-btn");
 const discardBtn = document.getElementById("discard-btn");
 const tasksContainer = document.getElementById("tasks-container");
 const titleInput = document.getElementById("title-input");
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4eaaa9070a66aecbfe603.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4eaaa9070a66aecbfe603.md
@@ -316,5 +316,4 @@ closeTaskFormBtn.addEventListener("click", () => {
 --fcc-editable-region--
 
 --fcc-editable-region--
-
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4eec13546c06d61a63d59.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4eec13546c06d61a63d59.md
@@ -331,7 +331,7 @@ taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9282cd547785258cecf2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9282cd547785258cecf2.md
@@ -329,6 +329,7 @@ taskForm.addEventListener("submit", (e) => {
   }
 
   --fcc-editable-region--
+
   taskData.forEach(({id, title, date, description}));
 
   --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9282cd547785258cecf2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9282cd547785258cecf2.md
@@ -329,7 +329,6 @@ taskForm.addEventListener("submit", (e) => {
   }
 
   --fcc-editable-region--
-
   taskData.forEach(({id, title, date, description}));
 
   --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9343769e8f85c1e17e05.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9343769e8f85c1e17e05.md
@@ -329,7 +329,7 @@ taskForm.addEventListener("submit", (e) => {
   taskData.forEach(({id, title, date, description}) => {
       tasksContainer.innerHTML += `
       --fcc-editable-region--
-          
+        
       --fcc-editable-region--
       `
     }

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec94f0de20c086e09b0fc3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec94f0de20c086e09b0fc3.md
@@ -339,7 +339,7 @@ taskForm.addEventListener("submit", (e) => {
       tasksContainer.innerHTML += `
         <div class="task" id="${id}">
     --fcc-editable-region--
-        
+          
     --fcc-editable-region--
         </div>
       `

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9b10356c2d8aa05d9ce1.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9b10356c2d8aa05d9ce1.md
@@ -329,8 +329,9 @@ taskForm.addEventListener("submit", (e) => {
       `
     }
   );
-  --fcc-editable-region--
 
+  --fcc-editable-region--
+  
   --fcc-editable-region--
 });
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fac365aeb8ad70b69b366f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fac365aeb8ad70b69b366f.md
@@ -311,11 +311,11 @@ const descriptionInput = document.getElementById("description-input");
 const taskData = [];
 let currentTask = {};
 
---fcc-editable-region--
 const reset = () => {
-  
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+}
 
 openTaskFormBtn.addEventListener("click", () =>
   taskForm.classList.toggle("hidden")

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fac6a497811572b338e5e5.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fac6a497811572b338e5e5.md
@@ -310,12 +310,12 @@ closeTaskFormBtn.addEventListener("click", () => {
 
 cancelBtn.addEventListener("click", () => confirmCloseDialog.close());
 
---fcc-editable-region--
 discardBtn.addEventListener("click", () => {
   confirmCloseDialog.close();
-  taskForm.classList.toggle("hidden");
-});
 --fcc-editable-region--
+  taskForm.classList.toggle("hidden");
+--fcc-editable-region--
+});
 
 
 taskForm.addEventListener("submit", (e) => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faca774fd9fd74bc084cc9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faca774fd9fd74bc084cc9.md
@@ -340,12 +340,12 @@ openTaskFormBtn.addEventListener("click", () =>
   taskForm.classList.toggle("hidden")
 );
 
---fcc-editable-region--
 closeTaskFormBtn.addEventListener("click", () => {
+--fcc-editable-region--
   confirmCloseDialog.showModal();
   
-});
 --fcc-editable-region--
+});
 
 cancelBtn.addEventListener("click", () => confirmCloseDialog.close());
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faca774fd9fd74bc084cc9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faca774fd9fd74bc084cc9.md
@@ -343,7 +343,6 @@ openTaskFormBtn.addEventListener("click", () =>
 closeTaskFormBtn.addEventListener("click", () => {
 --fcc-editable-region--
   confirmCloseDialog.showModal();
-  
 --fcc-editable-region--
 });
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fad07f43a101779cb8692a.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fad07f43a101779cb8692a.md
@@ -308,7 +308,6 @@ let currentTask = {};
 
 --fcc-editable-region--
 
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";
@@ -353,6 +352,7 @@ taskForm.addEventListener("submit", (e) => {
    if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
+  --fcc-editable-region--
 
  taskData.forEach(
     ({ id, title, date, description }) => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fad9cd2eeb1e7ca2ca8c8b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fad9cd2eeb1e7ca2ca8c8b.md
@@ -307,7 +307,6 @@ const addOrUpdateTask = () => {
 
 --fcc-editable-region--
 
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";
@@ -353,6 +352,7 @@ taskForm.addEventListener("submit", (e) => {
       `
     }
   );
+  --fcc-editable-region--
 
   reset()
 });

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fadae4f2d51b7d5d8b98d8.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fadae4f2d51b7d5d8b98d8.md
@@ -305,7 +305,7 @@ const addOrUpdateTask = () => {
   }
 
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
 };
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fadff23375f27ff06c6d40.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fadff23375f27ff06c6d40.md
@@ -297,7 +297,7 @@ const addOrUpdateTask = () => {
   if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
-  
+
   updateTaskContainer()
   reset()
 };

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf0418e828c0114a558a7.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf0418e828c0114a558a7.md
@@ -300,7 +300,7 @@ const addOrUpdateTask = () => {
   if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
-  
+
   updateTaskContainer()
   reset()
 };

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
@@ -341,11 +341,11 @@ const updateTaskContainer = () => {
   );
 };
 
---fcc-editable-region--
 const deleteTask = (buttonEl) => {
-
-}
 --fcc-editable-region--
+
+--fcc-editable-region--
+};
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
@@ -343,7 +343,7 @@ const updateTaskContainer = () => {
 
 const deleteTask = (buttonEl) => {
 --fcc-editable-region--
-
+  
 --fcc-editable-region--
 };
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf874364ec308f875f636.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf874364ec308f875f636.md
@@ -358,6 +358,7 @@ const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
+
 --fcc-editable-region--
   
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf874364ec308f875f636.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf874364ec308f875f636.md
@@ -354,14 +354,14 @@ const updateTaskContainer = () => {
   );
 };
 
---fcc-editable-region--
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
-  
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+};
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
@@ -352,7 +352,7 @@ const deleteTask = (buttonEl) => {
 
 const editTask = (buttonEl) => {
 --fcc-editable-region--
-
+  
 --fcc-editable-region--
 };
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
@@ -350,11 +350,11 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 }
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
-
-}
 --fcc-editable-region--
+
+--fcc-editable-region--
+};
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1061ca838611ed6a7d6b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1061ca838611ed6a7d6b.md
@@ -332,6 +332,7 @@ const deleteTask = (buttonEl) => {
 
 const editTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex((item) => item.id === buttonEl.parentElement.id);
+
 --fcc-editable-region--
   
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1061ca838611ed6a7d6b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1061ca838611ed6a7d6b.md
@@ -330,13 +330,12 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 }
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex((item) => item.id === buttonEl.parentElement.id);
-  
-
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+};
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1321e189a6136d200f77.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1321e189a6136d200f77.md
@@ -342,17 +342,16 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 }
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
     const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
   currentTask = taskData[dataArrIndex];
-  
-
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+};
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1321e189a6136d200f77.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1321e189a6136d200f77.md
@@ -348,6 +348,7 @@ const editTask = (buttonEl) => {
   );
 
   currentTask = taskData[dataArrIndex];
+
 --fcc-editable-region--
   
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1436adef3e145b4c3501.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1436adef3e145b4c3501.md
@@ -330,7 +330,6 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 }
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
     const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -341,9 +340,10 @@ const editTask = (buttonEl) => {
   titleInput.value = currentTask.title;
   dateInput.value = currentTask.date;
   descriptionInput.value = currentTask.description;
-  
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+};
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1436adef3e145b4c3501.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1436adef3e145b4c3501.md
@@ -340,6 +340,7 @@ const editTask = (buttonEl) => {
   titleInput.value = currentTask.title;
   dateInput.value = currentTask.date;
   descriptionInput.value = currentTask.description;
+
 --fcc-editable-region--
   
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb14d890415c14f93069ce.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb14d890415c14f93069ce.md
@@ -342,6 +342,7 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
+
 --fcc-editable-region--
   
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb14d890415c14f93069ce.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb14d890415c14f93069ce.md
@@ -330,7 +330,6 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 }
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
     const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -343,10 +342,10 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  
-  
-}
 --fcc-editable-region--
+  
+--fcc-editable-region--
+};
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb154a7c48cd159924bb18.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb154a7c48cd159924bb18.md
@@ -300,12 +300,12 @@ const addOrUpdateTask = () => {
     description: descriptionInput.value,
   };
 
-  --fcc-editable-region--
   if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
-
-  --fcc-editable-region--
+--fcc-editable-region--
+  
+--fcc-editable-region--
 
   updateTaskContainer()
   reset()

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1c4dc0feb219149a7c7d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1c4dc0feb219149a7c7d.md
@@ -386,6 +386,7 @@ closeTaskFormBtn.addEventListener("click", () => {
   --fcc-editable-region--
 
   --fcc-editable-region--
+
   if (formInputsContainValues) {
     confirmCloseDialog.showModal();
   } else {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb285637fa1e1c222033e3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb285637fa1e1c222033e3.md
@@ -368,11 +368,11 @@ closeTaskFormBtn.addEventListener("click", () => {
 
 --fcc-editable-region--
   if (formInputsContainValues) {
+--fcc-editable-region--
     confirmCloseDialog.showModal();
   } else {
     reset();
   }
---fcc-editable-region--
 });
 
 cancelBtn.addEventListener("click", () => confirmCloseDialog.close());

--- a/curriculum/challenges/english/blocks/workshop-todo-app/65003986d17d1e1865b269c0.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/65003986d17d1e1865b269c0.md
@@ -315,8 +315,9 @@ const addOrUpdateTask = () => {
   } else {
     taskData[dataArrIndex] = taskObj;
   }
-  --fcc-editable-region--
 
+  --fcc-editable-region--
+  
   --fcc-editable-region--
   updateTaskContainer()
   reset()

--- a/curriculum/challenges/english/blocks/workshop-todo-app/650046832f92c01a35834bca.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/650046832f92c01a35834bca.md
@@ -349,7 +349,7 @@ const deleteTask = (buttonEl) => {
   buttonEl.parentElement.remove();
   taskData.splice(dataArrIndex, 1);
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
 }
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/650300a25b6f72964ab8aca6.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/650300a25b6f72964ab8aca6.md
@@ -315,7 +315,7 @@ taskForm.addEventListener("submit", (e) => {
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {
     --fcc-editable-region--
-    id: `${titleInput.value.toLowerCase().split(' ').join('-')}`,  
+    id: `${titleInput.value.toLowerCase().split(' ').join('-')}`,
     --fcc-editable-region--
   };
   console.log(taskObj);

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d86150a52ced178d567f3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d86150a52ced178d567f3.md
@@ -324,7 +324,7 @@ taskForm.addEventListener("submit", (e) => {
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
 
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d8ca387f989d6b25a3343.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d8ca387f989d6b25a3343.md
@@ -313,11 +313,11 @@ taskForm.addEventListener("submit", (e) => {
 
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
 
---fcc-editable-region--
   const taskObj = {
-
+--fcc-editable-region--
+    
+--fcc-editable-region--
   };
   console.log(taskObj);
---fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/6632420f81f3cc554a5e540b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/6632420f81f3cc554a5e540b.md
@@ -354,7 +354,7 @@ const editTask = (buttonEl) => {
 
 const reset = () => {
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
   titleInput.value = "";
   dateInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/66ad0f178ed5791ed898fe56.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/66ad0f178ed5791ed898fe56.md
@@ -301,7 +301,7 @@ let currentTask = {};
 
 const addOrUpdateTask = () => {
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/67168a7243b6396cb69c1bdf.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/67168a7243b6396cb69c1bdf.md
@@ -299,14 +299,14 @@ const addOrUpdateTask = () => {
     return;
   }
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
-  --fcc-editable-region--
   const taskObj = {
+--fcc-editable-region--
     id: `${titleInput.value.toLowerCase().split(" ").join("-")}-${Date.now()}`,
+--fcc-editable-region--
     title: titleInput.value,
     date: dateInput.value,
     description: descriptionInput.value,
   };
-  --fcc-editable-region--
 
   if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
@@ -743,7 +743,7 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  
+
 
   taskForm.classList.toggle("hidden");  
 }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref to #67721

This PR is part of Naomi's sprint for editable regions in workshops.
This PR fixes editable region in `curriculum/challenges/english/blocks/workshop-todo-app/`.
I also cleaned up unnecessary trailing whitespace on empty lines outside those regions.