### PR TITLE
fix(curriculum): correct Step 9 hint ordinals

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-html-music-player/698c58745b73289bb6c89ece.md
+++ b/curriculum/challenges/english/blocks/workshop-html-music-player/698c58745b73289bb6c89ece.md
@@ -26,13 +26,13 @@ const h2 = document.querySelector('h2:nth-of-type(3)');
 assert.strictEqual(h2?.textContent.trim(), 'Scratching the Surface');
 ```
 
-You should have a `p` element.
+You should have a third `p` element.
 
 ```js
 assert.exists(document.querySelector('p:nth-of-type(3)'));
 ```
 
-Your `p` element should contain the text `Artist: Quincy Larson`.
+Your third `p` element should contain the text `Artist: Quincy Larson`.
 
 ```js
 const p = document.querySelector('p:nth-of-type(3)');


### PR DESCRIPTION
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #68671

Updated the Step 9 hints for the HTML Music Player workshop to refer to the third `p` element, matching the associated tests and the surrounding hint wording.