### PR TITLE
fix(client): prevent flaky profile dialog test

### DIFF
--- a/client/src/components/profile/profile.test.tsx
+++ b/client/src/components/profile/profile.test.tsx
@@ -177,7 +177,7 @@ describe('<Profile/>', () => {
       screen.getByRole('button', { name: 'aria.edit-my-profile' })
     );
 
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'profile.edit-my-profile' })
     ).toBeInTheDocument();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68677

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes a flaky test in `client/src/components/profile/profile.test.tsx` by replacing the synchronous `getByRole('dialog')` query with `await screen.findByRole('dialog')`.