### PR TITLE
fix(client): use findByRole for profile dialog test

### DIFF
--- a/client/src/components/profile/profile.test.tsx
+++ b/client/src/components/profile/profile.test.tsx
@@ -177,7 +177,7 @@ describe('<Profile/>', () => {
       screen.getByRole('button', { name: 'aria.edit-my-profile' })
     );
 
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'profile.edit-my-profile' })
     ).toBeInTheDocument();


### PR DESCRIPTION
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [] I have tested these changes locally (or in GitHub Codespaces, if applicable).

Closes #68677

## Description

This PR updates the profile test to use `await screen.findByRole('dialog')` instead of `screen.getByRole('dialog')`. Since the dialog appears after a transition, waiting for it to appear makes the test more reliable and helps prevent flaky failures.
