### PR TITLE
feat(client): add solution download to workshop toolbar

### DIFF
--- a/client/src/templates/Challenges/components/independent-lower-jaw.css
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.css
@@ -75,7 +75,8 @@
   border: 1px solid var(--quaternary-color);
 }
 
-.independent-lower-jaw .action-row-right button {
+.independent-lower-jaw .action-row-right button,
+.independent-lower-jaw .action-row-right a {
   height: 40px;
   width: 40px;
   display: flex;

--- a/client/src/templates/Challenges/components/independent-lower-jaw.test.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.test.tsx
@@ -4,7 +4,11 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useStaticQuery } from 'gatsby';
 
-import type { ChallengeMeta, Test } from '../../../redux/prop-types';
+import type {
+  ChallengeFiles,
+  ChallengeMeta,
+  Test
+} from '../../../redux/prop-types';
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import callGA from '../../../analytics/call-ga';
 import { IndependentLowerJaw } from './independent-lower-jaw';
@@ -41,9 +45,10 @@ vi.mock('../utils/fetch-all-curriculum-data', () => ({
   useSubmit: () => mockSubmitChallenge
 }));
 
-const baseChallengeMeta: ChallengeMeta = {
+const baseChallengeMeta: ChallengeMeta & { dashedName: string } = {
   block: 'test-block',
   id: 'test-challenge-id',
+  dashedName: 'test-challenge',
   isFirstStep: false,
   superBlock: SuperBlocks.RespWebDesignV9,
   helpCategory: 'HTML-CSS',
@@ -60,6 +65,7 @@ const baseProps = {
   askSocrates: vi.fn(),
   saveChallenge: vi.fn(),
   attempts: 0,
+  challengeFiles: null as ChallengeFiles,
   tests: passingTests,
   isDonating: false,
   isSignedIn: true,
@@ -546,5 +552,42 @@ describe('<IndependentLowerJaw />', () => {
     expect(getLiveRegion()).toHaveTextContent(
       /learn\.congratulations-code-passes .* learn\.percent-complete/
     );
+  });
+
+  it('does not show a download button when there are no challenge files', () => {
+    render(<IndependentLowerJaw {...baseProps} />, createStore());
+
+    expect(
+      screen.queryByLabelText('learn.download-solution')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a download button linking to the solution when challenge files exist', () => {
+    const objectUrl = 'blob:mock-solution-url';
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn().mockReturnValue(objectUrl),
+      revokeObjectURL: vi.fn()
+    });
+
+    render(
+      <IndependentLowerJaw
+        {...baseProps}
+        challengeFiles={[
+          { name: 'index', ext: 'html', contents: '<h1>Hi</h1>' } as never
+        ]}
+      />,
+      createStore()
+    );
+
+    const downloadLink = screen.getByLabelText('learn.download-solution');
+    expect(downloadLink).toBeInTheDocument();
+    expect(downloadLink).toHaveAttribute('href', objectUrl);
+    expect(downloadLink).toHaveAttribute(
+      'download',
+      `${baseChallengeMeta.dashedName}.txt`
+    );
+
+    vi.unstubAllGlobals();
   });
 });

--- a/client/src/templates/Challenges/components/independent-lower-jaw.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.tsx
@@ -11,7 +11,8 @@ import {
   faZap,
   faSave,
   faClockRotateLeft,
-  faRotateLeft
+  faRotateLeft,
+  faDownload
 } from '@fortawesome/free-solid-svg-icons';
 import Progress from '../../../components/Progress';
 import {
@@ -20,9 +21,10 @@ import {
   isSignedInSelector,
   isSocratesOnSelector
 } from '../../../redux/selectors';
-import { ChallengeMeta, Test } from '../../../redux/prop-types';
+import { ChallengeFiles, ChallengeMeta, Test } from '../../../redux/prop-types';
 import {
   attemptsSelector,
+  challengeFilesSelector,
   challengeMetaSelector,
   challengeTestsSelector,
   completedPercentageSelector,
@@ -36,6 +38,7 @@ import Help from '../../../assets/icons/help';
 import callGA from '../../../analytics/call-ga';
 import { Share } from '../../../components/share';
 import { useSubmit } from '../utils/fetch-all-curriculum-data';
+import { combineFileData } from './completion-modal';
 
 import './independent-lower-jaw.css';
 import Socrates from '../../../assets/icons/socrates';
@@ -88,6 +91,7 @@ const StatusAnnouncement = ({
 
 const mapStateToProps = createSelector(
   attemptsSelector,
+  challengeFilesSelector,
   challengeTestsSelector,
   isDonatingSelector,
   isSignedInSelector,
@@ -99,10 +103,11 @@ const mapStateToProps = createSelector(
   isSocratesOnSelector,
   (
     attempts: number,
+    challengeFiles: ChallengeFiles,
     tests: Test[],
     isDonating: boolean,
     isSignedIn: boolean,
-    challengeMeta: ChallengeMeta,
+    challengeMeta: ChallengeMeta & { dashedName: string },
     completedPercent: number,
     completedChallengeIds: string[],
     currentBlockIds: string[],
@@ -110,6 +115,7 @@ const mapStateToProps = createSelector(
     hasSocratesAccess: boolean
   ) => ({
     attempts,
+    challengeFiles,
     tests,
     isDonating,
     isSignedIn,
@@ -137,10 +143,11 @@ interface IndependentLowerJawProps {
   askSocrates: () => void;
   saveChallenge: () => void;
   attempts: number;
+  challengeFiles: ChallengeFiles;
   tests: Test[];
   isDonating: boolean;
   isSignedIn: boolean;
-  challengeMeta: ChallengeMeta;
+  challengeMeta: ChallengeMeta & { dashedName: string };
   completedPercent: number;
   completedChallengeIds: string[];
   currentBlockIds: string[];
@@ -154,6 +161,7 @@ export function IndependentLowerJaw({
   executeChallenge,
   saveChallenge,
   attempts,
+  challengeFiles,
   tests,
   isDonating,
   isSignedIn,
@@ -168,6 +176,21 @@ export function IndependentLowerJaw({
   const showSocratesFlag =
     useFeature('show-socrates').on && clientLocale === 'english';
   const submitChallenge = useSubmit();
+  const [downloadURL, setDownloadURL] = useState<string>();
+  // We can't useMemo here, because it does not guarantee that the URL object
+  // will be revoked when the dependencies change.
+  useEffect(() => {
+    // downloadURL is not in the dependency array because it should only change
+    // if the challengeFiles change. It is in the useEffect so that we cannot
+    // leak URL objects.
+    if (downloadURL) URL.revokeObjectURL(downloadURL);
+    if (challengeFiles?.length) {
+      const allFileContents = combineFileData(challengeFiles);
+      const blob = new Blob([allFileContents], { type: 'text/json' });
+      setDownloadURL(URL.createObjectURL(blob));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [challengeFiles]);
   const firstFailedTest = tests.find(test => !!test.err);
   const hint = firstFailedTest?.message;
   const sanitizedHint = React.useMemo(
@@ -552,6 +575,21 @@ export function IndependentLowerJaw({
               <FontAwesomeIcon icon={faRotateLeft} />
               <span className='tooltiptext'> {t('buttons.reset')}</span>
             </button>
+          )}
+          {downloadURL && (
+            <a
+              className='icon-button tooltip'
+              data-playwright-test-label='independentLowerJaw-download-button'
+              aria-label={t('learn.download-solution')}
+              download={`${challengeMeta.dashedName}.txt`}
+              href={downloadURL}
+            >
+              <FontAwesomeIcon icon={faDownload} />
+              <span className='tooltiptext'>
+                {' '}
+                {t('learn.download-solution')}
+              </span>
+            </a>
           )}
           <button
             type='button'

--- a/e2e/independent-lower-jaw.spec.ts
+++ b/e2e/independent-lower-jaw.spec.ts
@@ -41,6 +41,19 @@ test('Clicking "Check Your Code" reveals failing feedback', async ({
   ).toBeVisible();
 });
 
+test('Download button links to a file of the current solution', async ({
+  page
+}) => {
+  await page.goto(workshopChallengeUrl);
+
+  const downloadButton = page.getByTestId(
+    'independentLowerJaw-download-button'
+  );
+  await expect(downloadButton).toBeVisible();
+  await expect(downloadButton).toHaveAttribute('download', /\.txt$/);
+  await expect(downloadButton).toHaveAttribute('href', /^blob:/);
+});
+
 test('Reset button opens and closes the reset modal', async ({ page }) => {
   await page.goto(workshopChallengeUrl);
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67593

<!-- Feel free to add any additional description of changes below this line -->

The completion modal has a "Download Solution" button, but workshop-style challenges (multi-step layouts using `IndependentLowerJaw`) never show that modal, so there was no way to grab your solution files from those pages.

This adds the same download button to the `IndependentLowerJaw` toolbar, right next to Reset/Help, reusing the existing `combineFileData` helper that's already exported from `completion-modal.tsx` so both surfaces build the download the same way.

**Testing:**
- Added unit tests covering both states (no files → no button, files present → button with the right `href`/`download` attrs)
- Added a Playwright case checking the button shows up on a workshop challenge with a `blob:` href and the right download name
- `pnpm test-client` passes, lint/prettier clean