### PR TITLE
fix(curriculum): correct "a exoplanet" to "an exoplanet"

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68c1a929005bf54d342aa8d3.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68c1a929005bf54d342aa8d3.md
@@ -13,7 +13,7 @@ For the second day of Space Week, you are given a string where each character re
 - Characters `0-9` correspond to luminosity levels `0-9`.
 - Characters `A-Z` correspond to luminosity levels `10-35`.
 
-A star is considered to have an exoplanet if any single reading is less than or equal to 80% of the average of all readings. For example, if the average luminosity of a star is 10, it would be considered to have a exoplanet if any single reading is 8 or less.
+A star is considered to have an exoplanet if any single reading is less than or equal to 80% of the average of all readings. For example, if the average luminosity of a star is 10, it would be considered to have an exoplanet if any single reading is 8 or less.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68c1a929005bf54d342aa8d3.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68c1a929005bf54d342aa8d3.md
@@ -13,7 +13,7 @@ For the second day of Space Week, you are given a string where each character re
 - Characters `0-9` correspond to luminosity levels `0-9`.
 - Characters `A-Z` correspond to luminosity levels `10-35`.
 
-A star is considered to have an exoplanet if any single reading is less than or equal to 80% of the average of all readings. For example, if the average luminosity of a star is 10, it would be considered to have a exoplanet if any single reading is 8 or less.
+A star is considered to have an exoplanet if any single reading is less than or equal to 80% of the average of all readings. For example, if the average luminosity of a star is 10, it would be considered to have an exoplanet if any single reading is 8 or less.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68728

The description of the "Exoplanet Search" daily coding challenge uses the article "a" before "exoplanet". Since "exoplanet" begins with a vowel sound, it should be "an exoplanet" (the same sentence and the rest of the challenge already use "an exoplanet"). Fixed in both the JavaScript and Python versions of the challenge.
