### PR TITLE
fix(curriculum): use Explorer helper in inventory lab test

### DIFF
--- a/curriculum/challenges/english/blocks/lab-inventory-management-program/66d75dd0aa65a71600dc669b.md
+++ b/curriculum/challenges/english/blocks/lab-inventory-management-program/66d75dd0aa65a71600dc669b.md
@@ -30,7 +30,9 @@ In this lab, you will build an inventory management program that will allow you 
 You should declare an empty array named `inventory`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /(let|const|var)\s+inventory\s*=\s*\[\s*\]\s*;?/)
+const explorer = await __helpers.Explorer(code);
+const inventory = explorer.variables.inventory;
+assert.isTrue(inventory.value.matches('[]'));
 ```
 
 You should have a function named `findProductIndex`.

--- a/curriculum/challenges/english/blocks/lab-inventory-management-program/66d75dd0aa65a71600dc669b.md
+++ b/curriculum/challenges/english/blocks/lab-inventory-management-program/66d75dd0aa65a71600dc669b.md
@@ -32,6 +32,7 @@ You should declare an empty array named `inventory`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const inventory = explorer.variables.inventory;
+assert.exists(inventory);
 assert.isTrue(inventory.value.matches('[]'));
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68687

<!-- Feel free to add any additional description of changes below this line -->
This is part of the Naomi's Sprints --> replacing regex-based tests with the Explorer AST helper:

- Replaces regex test with Explorer helper in inventory management program lab

## Changes made

- Before:

```js
assert.match(__helpers.removeJSComments(code), /(let|const|var)\s+inventory\s*=\s*\[\s*\]\s*;?/)
```

- After:

```js
const explorer = await __helpers.Explorer(code);
const inventory = explorer.variables.inventory;
assert.isTrue(inventory.value.matches('[]'));
```

Of the 16 test hints I saw only the first one used regex, so the others are left untouched

## Testing

- Used GitHub CodeSpaces; Ran `FCC_BLOCK='lab-inventory-management-program' pnpm run test-curriculum-content` before and after the change; all checks passed both times
