### PR TITLE
fix(client): update graduate count in funding manifest

### DIFF
--- a/client/static/funding.json
+++ b/client/static/funding.json
@@ -6,7 +6,7 @@
     "name": "freeCodeCamp",
     "email": "team@freecodecamp.org",
     "phone": "+1-415-663-6049",
-    "description": "freeCodeCamp is a 501(c)(3) tax-exempt charity that helps people learn math, programming, and computer science for free. Since 2014, more than 40,000 graduates have gotten developer jobs at companies like Google, Microsoft, and Amazon. We provide thousands of hours of coding curriculum, all open source and accessible to everyone.",
+    "description": "freeCodeCamp is a 501(c)(3) tax-exempt charity that helps people learn math, programming, and computer science for free. Since 2014, more than 100,000 graduates have gotten developer jobs at companies like Google, Microsoft, and Amazon. We provide thousands of hours of coding curriculum, all open source and accessible to everyone.",
     "webpageUrl": {
       "url": "https://www.freecodecamp.org"
     }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68614

## Summary
- Updates the funding manifest graduate count from 40,000 to 100,000.
- Aligns this remaining main-repo reference with the current site advert copy agreed in #68614.
- The companion CDN metadata update is in freeCodeCamp/cdn#400.

## Testing
- Parsed client/static/funding.json with Node.
- Ran Prettier check on client/static/funding.json.
- Ran git diff --check.