### PR TITLE
fix(curriculum): remove dead conditional in regex sandbox lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-regex-sandbox/66e028680eca7d21db7e1aee.md
+++ b/curriculum/challenges/english/blocks/lab-regex-sandbox/66e028680eca7d21db7e1aee.md
@@ -689,16 +689,10 @@ const testButton = document.getElementById("test-btn")
 testButton.addEventListener(
     "click",
     () => {
-        let matched;
-        let flags = getFlags();
+        const flags = getFlags();
         const regex = new RegExp(regexPattern.value, flags)
-        if (flags.includes(globalFlag)) {
-            stringToTest.innerHTML = stringToTest.innerText.replaceAll(regex, '<span class="highlight">$&</span>')
-            matched = stringToTest.innerText.matchAll(regex)
-        } else {
-            stringToTest.innerHTML = stringToTest.innerText.replace(regex, '<span class="highlight">$&</span>')
-            matched = stringToTest.innerText.match(regex);             
-        }
+        stringToTest.innerHTML = stringToTest.innerText.replace(regex, '<span class="highlight">$&</span>')
+        const matched = stringToTest.innerText.match(regex);
         testResult.innerText = matched ? matched.join(", ") : 'no match';
     }
 )


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68732

Removed a dead conditional in the reference solution — `flags.includes(globalFlag)` compared a string against a DOM element and could never evaluate to true. The `else` branch already handled both global and non-global cases correctly, so the branching was not needed hence, it was removed.