### PR TITLE
fix(curriculum): replace regex tests with Explorer API in note-taking workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688141a8be6e6be03af945ea.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688141a8be6e6be03af945ea.md
@@ -19,6 +19,7 @@ You should use `let` to create the `currentContent` variable.
 
 ```js
 const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.variables.currentContent);
 assert.isTrue(
   explorer.variables.currentContent.matches('let currentContent = ""')
 );

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688141a8be6e6be03af945ea.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688141a8be6e6be03af945ea.md
@@ -19,7 +19,9 @@ You should use `let` to create the `currentContent` variable.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.variables.currentContent);
+assert.isTrue(
+  explorer.variables.currentContent.matches('let currentContent = ""')
+);
 ```
 
 Your `currentContent` variable should be a string.

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688141a8be6e6be03af945ea.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688141a8be6e6be03af945ea.md
@@ -15,7 +15,7 @@ Use `let` to create a variable called `currentContent` and assign it an empty st
 
 # --hints--
 
-You should use `let` to create the `currentContent` variable.
+You should use `let` to create the `currentContent` variable and initialize it with an empty string.
 
 ```js
 const explorer = await __helpers.Explorer(code);
@@ -23,18 +23,6 @@ assert.exists(explorer.variables.currentContent);
 assert.isTrue(
   explorer.variables.currentContent.matches('let currentContent = ""')
 );
-```
-
-Your `currentContent` variable should be a string.
-
-```js
-assert.isString(currentContent);
-```
-
-Your `currentContent` variable should be initialized with an empty string.
-
-```js
-assert.equal(currentContent, "");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688141a8be6e6be03af945ea.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688141a8be6e6be03af945ea.md
@@ -18,7 +18,8 @@ Use `let` to create a variable called `currentContent` and assign it an empty st
 You should use `let` to create the `currentContent` variable.
 
 ```js
-assert.match(code, /let\s+currentContent/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.variables.currentContent);
 ```
 
 Your `currentContent` variable should be a string.

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688141e05e367de0e3ef7635.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688141e05e367de0e3ef7635.md
@@ -26,13 +26,7 @@ Start by attaching an `addEventListener` method to the `window` object. The firs
 You should attach an `addEventListener` method to the `window` object.
 
 ```js
-assert.match(code, /window\.addEventListener/);
-```
-
-Your event listener should listen for the `"DOMContentLoaded"` event.
-
-```js
-assert.match(code, /window\.addEventListener\(['"]DOMContentLoaded['"]\,/);
+assert.match(code, /window\s*\.\s*addEventListener/);
 ```
 
 Inside the body of the arrow function, assign the value of `noteEl.textContent` to `currentContent`.

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/68814221fc4752e17b9696bd.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/68814221fc4752e17b9696bd.md
@@ -21,13 +21,22 @@ Attach an `addEventListener` method to the `noteEl` variable. The first argument
 
 # --hints--
 
-You should attach an `addEventListener` method to the `noteEl` variable, listen for the `"blur"` event, and assign `noteEl.innerHTML` to a new variable called `newContent` inside the callback.
+You should attach an `addEventListener` method to the `noteEl` variable.
 
 ```js
-const event = new Event('blur');
-noteEl.dispatchEvent(event);
+assert.match(code, /noteEl\.addEventListener/);
+```
 
-assert.equal(currentContent, noteEl.innerHTML);
+Your `addEventListener` method should have a first argument of the `"blur"` event.
+
+```js
+assert.match(code, /noteEl\.addEventListener\(['"]blur['"],/);
+```
+
+Inside of the body of the arrow function, you should use `const` to create a new variable called `newContent` and assign it the value of `noteEl.innerHTML`.
+
+```js
+assert.match(code, /noteEl\.addEventListener\(['"]blur['"],\s*\(\)\s*=>\s*{[^}]*const\s+newContent\s*=\s*noteEl\.innerHTML[^}]*}\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/68814221fc4752e17b9696bd.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/68814221fc4752e17b9696bd.md
@@ -21,22 +21,13 @@ Attach an `addEventListener` method to the `noteEl` variable. The first argument
 
 # --hints--
 
-You should attach an `addEventListener` method to the `noteEl` variable.
+You should attach an `addEventListener` method to the `noteEl` variable, listen for the `"blur"` event, and assign `noteEl.innerHTML` to a new variable called `newContent` inside the callback.
 
 ```js
-assert.match(code, /noteEl\.addEventListener/);
-```
+const event = new Event('blur');
+noteEl.dispatchEvent(event);
 
-Your `addEventListener` method should have a first argument of the `"blur"` event.
-
-```js
-assert.match(code, /noteEl\.addEventListener\(['"]blur['"],/);
-```
-
-Inside of the body of the arrow function, you should use `const` to create a new variable called `newContent` and assign it the value of `noteEl.innerHTML`.
-
-```js
-assert.match(code, /noteEl\.addEventListener\(['"]blur['"],\s*\(\)\s*=>\s*{[^}]*const\s+newContent\s*=\s*noteEl\.innerHTML[^}]*}\)/);
+assert.equal(currentContent, noteEl.innerHTML);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/6881424b87c826e21247645b.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/6881424b87c826e21247645b.md
@@ -16,7 +16,9 @@ Inside of the event listener, assign `newContent` to `currentContent`.
 You should assign `newContent` to `currentContent` inside of the event listener.
 
 ```js
-assert.match(code, /noteEl\.addEventListener\(['"]blur['"],\s*\(\)\s*=>\s*{[^}]*const\s+newContent\s*=\s*noteEl\.innerHTML[^}]*currentContent\s*=\s*newContent[^}]*}\)/);
+noteEl.innerHTML = "Updated note";
+noteEl.dispatchEvent(new Event("blur"));
+assert.equal(currentContent, "Updated note");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/6881424b87c826e21247645b.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/6881424b87c826e21247645b.md
@@ -16,10 +16,7 @@ Inside of the event listener, assign `newContent` to `currentContent`.
 You should assign `newContent` to `currentContent` inside of the event listener.
 
 ```js
-const event = new Event('blur');
-noteEl.dispatchEvent(event);
-
-assert.equal(currentContent, noteEl.innerHTML);
+assert.match(code, /noteEl\.addEventListener\(['"]blur['"],\s*\(\)\s*=>\s*{[^}]*const\s+newContent\s*=\s*noteEl\.innerHTML[^}]*currentContent\s*=\s*newContent[^}]*}\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/6881424b87c826e21247645b.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/6881424b87c826e21247645b.md
@@ -16,7 +16,10 @@ Inside of the event listener, assign `newContent` to `currentContent`.
 You should assign `newContent` to `currentContent` inside of the event listener.
 
 ```js
-assert.match(code, /noteEl\.addEventListener\(['"]blur['"],\s*\(\)\s*=>\s*{[^}]*const\s+newContent\s*=\s*noteEl\.innerHTML[^}]*currentContent\s*=\s*newContent[^}]*}\)/);
+const event = new Event('blur');
+noteEl.dispatchEvent(event);
+
+assert.equal(currentContent, noteEl.innerHTML);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688142a607d1dce2aa82da77.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688142a607d1dce2aa82da77.md
@@ -18,7 +18,11 @@ To test out your changes, trying editing the note and then clicking out of the n
 You should add a `console.log(currentContent);` inside of the event listener, after assigning `newContent` to `currentContent`.
 
 ```js
-assert.match(code, /noteEl\.addEventListener\(['"]blur['"],\s*\(\)\s*=>\s*{[^}]*const\s+newContent\s*=\s*noteEl\.innerHTML[^}]*currentContent\s*=\s*newContent[^}]*console\.log\(currentContent\)[^}]*}\)/);
+const consoleLogSpy = __helpers.spyOn(console, "log");
+noteEl.innerHTML = "Updated note";
+noteEl.dispatchEvent(new Event("blur"));
+assert.deepEqual(consoleLogSpy.calls, [["Updated note"]]);
+consoleLogSpy.restore();
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688142a607d1dce2aa82da77.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688142a607d1dce2aa82da77.md
@@ -18,7 +18,10 @@ To test out your changes, trying editing the note and then clicking out of the n
 You should add a `console.log(currentContent);` inside of the event listener, after assigning `newContent` to `currentContent`.
 
 ```js
-assert.match(code, /noteEl\.addEventListener\(['"]blur['"],\s*\(\)\s*=>\s*{[^}]*const\s+newContent\s*=\s*noteEl\.innerHTML[^}]*currentContent\s*=\s*newContent[^}]*console\.log\(currentContent\)[^}]*}\)/);
+const event = new Event('blur');
+noteEl.dispatchEvent(event);
+
+assert.equal(currentContent, noteEl.innerHTML);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/688142a607d1dce2aa82da77.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/688142a607d1dce2aa82da77.md
@@ -18,10 +18,7 @@ To test out your changes, trying editing the note and then clicking out of the n
 You should add a `console.log(currentContent);` inside of the event listener, after assigning `newContent` to `currentContent`.
 
 ```js
-const event = new Event('blur');
-noteEl.dispatchEvent(event);
-
-assert.equal(currentContent, noteEl.innerHTML);
+assert.match(code, /noteEl\.addEventListener\(['"]blur['"],\s*\(\)\s*=>\s*{[^}]*const\s+newContent\s*=\s*noteEl\.innerHTML[^}]*currentContent\s*=\s*newContent[^}]*console\.log\(currentContent\)[^}]*}\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-note-taking-app/6881436e1e2afae400e8b4fe.md
+++ b/curriculum/challenges/english/blocks/workshop-note-taking-app/6881436e1e2afae400e8b4fe.md
@@ -18,7 +18,13 @@ Above your `currentContent = newContent;` line, add an `if` statement to check i
 You should add an `if` statement to check if `currentContent` is equal to `newContent`. If so, return.
 
 ```js
-assert.match(code, /if\s*\(\s*currentContent\s*={2,3}\s*newContent\s*\)\s*(?:{\s*return;?\s*}|return\s*;?)/);
+noteEl.innerHTML = "Updated note";
+noteEl.dispatchEvent(new Event("blur"));
+assert.equal(statusEl.textContent, "Note saved successfully!");
+
+statusEl.textContent = "";
+noteEl.dispatchEvent(new Event("blur"));
+assert.equal(statusEl.textContent, "");
 ```
 
 # --seed--


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68711 

This is part of the Naomi's Sprints --> replacing regex-based tests with the Explorer AST helper:

- Replaces regex test with Explorer helper in note-taking workshop

<!-- Feel free to add any additional description of changes below this line -->
