### PR TITLE
fix(curriculum): state h1 uniqueness and figcaption text in travel agency user stories

### DIFF
--- a/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -16,13 +16,13 @@ demoType: onClick
 1. You should have an `html` element with `lang` set to `en`.
 1. You should have a `head` element containing a `meta` void element with `charset` set to `utf-8` and a `title` with the text `Travel Agency Page`.
 1. You should have a `meta` tag in your `head` element that contains a short description of your website for SEO.
-1. You should have an `h1` element to present your travel destinations.
+1. You should have exactly one `h1` element to present your travel destinations.
 1. You should have a paragraph below the `h1` element introducing the travel opportunities.
 1. You should have an `h2` element with the text `Packages`.
 1. You should have a `p` element introducing briefly the various packages.
 1. You should have an unordered list element with two list items. The two list items should have the text `Group Travels` and `Private Tours`, respectively. The text of each list item should be enclosed by an anchor element.
 1. You should have an `h2` element with the text `Top Itineraries`.
-1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element.
+1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element that contains some text.
 1. The three anchor elements should have an `img` element with an appropriate `alt` attribute and a `src` attribute set to a valid image as their content. You can use `https://cdn.freecodecamp.org/curriculum/labs/colosseo.jpg`, `https://cdn.freecodecamp.org/curriculum/labs/alps.jpg`, and `https://cdn.freecodecamp.org/curriculum/labs/sea.jpg` if you would like.
 1. All your five anchor elements should have an `href` attribute with the value of `https://www.freecodecamp.org/learn` and a `target` attribute with the value of `_blank`.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68669

Two hints in the Build a Travel Agency Page lab test behavior the
user stories never promised:

- The tests require exactly one `h1`, but story 5 only asked for an
  `h1` with no uniqueness constraint.
- The tests require every `figcaption` to contain text, but story 11
  only asked that each `figure` contain a `figcaption`, without
  mentioning it needs text.

Updated both story lines to state the tested requirement, rather than
relaxing the tests, since the example solution already satisfies both
(single `h1`, three non-empty `figcaption`s).

**Testing**
Ran `pnpm run audit-challenges` (needed CURRICULUM_LOCALE=english set)
and the curriculum `type-check`. The full multi-locale audit script
fails in my environment on the espanol i18n submodule not being
checked out, unrelated to this change, so I called
`getChallengesForLang('english', ...)` directly to build and parse
just this block. Confirmed the challenge parses successfully (32
tests, unchanged), and confirmed both new story sentences render
correctly in the built HTML output.

I have used AI in the creation of this PR. I used Claude Code to
locate the tested requirements in the challenge file, draft the
wording change, and verify it against the real curriculum build
pipeline. I reviewed the change and the verification output myself.
