### PR TITLE
fix(lab-travel-agency-page): add missing requirements to user stories

### DIFF
--- a/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -16,13 +16,13 @@ demoType: onClick
 1. You should have an `html` element with `lang` set to `en`.
 1. You should have a `head` element containing a `meta` void element with `charset` set to `utf-8` and a `title` with the text `Travel Agency Page`.
 1. You should have a `meta` tag in your `head` element that contains a short description of your website for SEO.
-1. You should have an `h1` element to present your travel destinations.
+1. You should have exactly one `h1` element to present your travel destinations.
 1. You should have a paragraph below the `h1` element introducing the travel opportunities.
 1. You should have an `h2` element with the text `Packages`.
 1. You should have a `p` element introducing briefly the various packages.
 1. You should have an unordered list element with two list items. The two list items should have the text `Group Travels` and `Private Tours`, respectively. The text of each list item should be enclosed by an anchor element.
 1. You should have an `h2` element with the text `Top Itineraries`.
-1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element.
+1. You should have at least three `figure` elements, each containing an anchor element and a `figcaption` element with text.
 1. The three anchor elements should have an `img` element with an appropriate `alt` attribute and a `src` attribute set to a valid image as their content. You can use `https://cdn.freecodecamp.org/curriculum/labs/colosseo.jpg`, `https://cdn.freecodecamp.org/curriculum/labs/alps.jpg`, and `https://cdn.freecodecamp.org/curriculum/labs/sea.jpg` if you would like.
 1. All your five anchor elements should have an `href` attribute with the value of `https://www.freecodecamp.org/learn` and a `target` attribute with the value of `_blank`.
 


### PR DESCRIPTION
Closes #68669

**Changes:**
- Updated user story 5 to specify "exactly one h1" to match the test requirement
- Updated user story 11 to require figcaption elements to contain text to match the test requirement

**Checklist:**
- [x] I have read and followed the contribution guidelines
- [x] I have read and followed the how to open a pull request guide
- [x] My pull request targets the `main` branch of freeCodeCamp
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces