### PR TITLE
fix(lecture-html-fundamentals): fix title casing, grammar, and feedback consistency

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-html-fundamentals/670803abcb3e980233da4768.md
+++ b/curriculum/challenges/english/blocks/lecture-html-fundamentals/670803abcb3e980233da4768.md
@@ -1,6 +1,6 @@
 ---
 id: 670803abcb3e980233da4768
-title: What are Div Elements and When Should You Use Them?
+title: What Are Div Elements and When Should You Use Them?
 challengeType: 19
 dashedName: what-are-div-elements
 ---
@@ -48,7 +48,7 @@ Add another `section` element below the first one. Then inside of the `section` 
 
 :::
 
-The `section` element has semantic meaning over the `div` element which is not semantic. Semantics are the meaning of words or phrases in a language. In HTML, which is a language, elements have their own semantic meaning too. So, this means if you use a `section` element, the browser will pick up its semantic meaning and understand to treat this as a section - on desktops, mobiles, you name it.
+The `section` element has semantic meaning over the `div` element which is not semantic. Semantics are the meaning of words or phrases in a language. In HTML, which is a language, elements have their own semantic meaning too. So, this means if you use a `section` element, the browser will pick up its semantic meaning and know to treat it as a section, on desktops, mobiles, you name it.
 
 # --questions--
 
@@ -146,7 +146,7 @@ Refer back to the beginning of the lesson for the correct syntax.
 
 ### --feedback--
 
-Refer back to the notes for the correct answer.
+Refer back to the beginning of the lesson for the correct syntax.
 
 ---
 
@@ -154,7 +154,7 @@ Refer back to the notes for the correct answer.
 
 ### --feedback--
 
-Refer back to the notes for the correct answer.
+Refer back to the beginning of the lesson for the correct syntax.
 
 ## --video-solution--
 

--- a/curriculum/structure/blocks/lecture-html-fundamentals.json
+++ b/curriculum/structure/blocks/lecture-html-fundamentals.json
@@ -7,7 +7,7 @@
   "challengeOrder": [
     {
       "id": "670803abcb3e980233da4768",
-      "title": "What are Div Elements and When Should You Use Them?"
+      "title": "What Are Div Elements and When Should You Use Them?"
     },
     {
       "id": "6708382cf088b216580a9ff1",


### PR DESCRIPTION
Closes #68636

**Changes:**
1. Changed `What are Div Elements` to `What Are Div Elements` in frontmatter title
2. Fixed grammar: `understand to treat this as a section - on desktops` -> `know to treat it as a section, on desktops`
3. Made wrong-answer feedback consistent: `nav` and `h1` feedback now matches `aside` feedback format
4. Updated block JSON `challengeOrder` title to match

**Checklist:**
- [x] I have read and followed the contribution guidelines
- [x] I have read and followed the how to open a pull request guide
- [x] My pull request targets the `main` branch of freeCodeCamp
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces