### PR TITLE
fix(curriculum): use Explorer helper in countup workshop step 3

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-countup/6948705160b66cf93a916e29.md
+++ b/curriculum/challenges/english/blocks/workshop-countup/6948705160b66cf93a916e29.md
@@ -18,6 +18,7 @@ You should declare an empty array named `countArray`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { countup } = explorer.functions;
+assert.exists(countup);
 const { countArray } = countup.variables;
 assert.exists(countArray);
 assert.isTrue(countArray.value.matches('[]'));

--- a/curriculum/challenges/english/blocks/workshop-countup/6948705160b66cf93a916e29.md
+++ b/curriculum/challenges/english/blocks/workshop-countup/6948705160b66cf93a916e29.md
@@ -16,7 +16,11 @@ This array will store the value of `number` at each function call.
 You should declare an empty array named `countArray`.
 
 ```js
-assert.match(countup.toString(), /(let|const|var)\s+countArray\s*=\s*\[\s*\]/);
+const explorer = await __helpers.Explorer(code);
+const { countup } = explorer.functions;
+const { countArray } = countup.variables;
+assert.exists(countArray);
+assert.isTrue(countArray.value.matches('[]'));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68700

<!-- Feel free to add any additional description of changes below this line -->
This is part of the Naomi's Sprints initiative → replacing regex-based tests with the Explorer AST helper.

- Replaces regex test with Explorer helper in countup workshop, Step 3

**Changes made**

Before:
\`\`\`js
assert.match(countup.toString(), /(let|const|var)\s+countArray\s*=\s*\[\s*\]/);
\`\`\`

After:
\`\`\`js
const explorer = await __helpers.Explorer(code);
const { countup } = explorer.functions;
const { countArray } = countup.variables;
assert.exists(countArray);
assert.isTrue(countArray.value.matches('[]'));
\`\`\`

Added `assert.exists()` before accessing `.value`, following the review feedback pattern from #68729 (inventory lab PR), to avoid a raw JS error if a camper doesn't declare `countArray`.

Of the 3 regex-based test hints in this workshop, only Step 3 could be cleanly replaced with the Explorer helper — Steps 4 and 5 check specific call expressions with arithmetic/literal arguments, which the current Explorer API doesn't support, so they were left as regex.

**Testing**

Ran `CURRICULUM_LOCALE=english FCC_BLOCK='workshop-countup' pnpm run test-curriculum-content` — all 26 tests passed, including Step 3's updated assertions.