### PR TITLE
fix(curriculum): add missing periods to audio and video player hints

### DIFF
--- a/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
+++ b/curriculum/challenges/english/blocks/lab-html-audio-and-video-player/68de40f53fcaf106f51cc20f.md
@@ -39,7 +39,7 @@ const h1 = document.querySelector('h1');
 assert.isNotEmpty(h1.textContent.trim());
 ```
 
-You should have only one `h1` element
+You should have only one `h1` element.
 
 ```js
 assert.lengthOf(document.querySelectorAll('h1'), 1);
@@ -103,7 +103,7 @@ const srcAttr = source.getAttribute('src');
 assert.match(srcAttr, /\.(mp4|webm|ogg|avi|mov)$/i);
 ```
 
-The `source` element should have a `type` attribute
+The `source` element should have a `type` attribute.
 
 ```js
 const section = document.querySelector('section');


### PR DESCRIPTION
## Description

Adds the missing periods to two hint messages in the "Build an HTML Audio and Video Player" lab, matching the punctuation style used by the other hints.

Closes #68752