### PR TITLE
fix(curriculum): move punctuation outside backticks

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-document-code-for-a-project/65e5cf002c98ea3289bf2bea.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-document-code-for-a-project/65e5cf002c98ea3289bf2bea.md
@@ -8,7 +8,7 @@ lang: en-US
 
 # --description--
 
-When a noun ending in `y` becomes plural, the `y` often changes to `ies.` This rule is particularly useful in technology contexts where certain terms frequently end in `y.`
+When a noun ending in `y` becomes plural, the `y` often changes to `ies`. This rule is particularly useful in technology contexts where certain terms frequently end in `y`.
 
 # --questions--
 
@@ -22,7 +22,7 @@ By changing `y` to `ys`
 
 ### --feedback--
 
-This is not the usual rule. Generally, `y` changes to `ies` for plurals, as in `query` to `queries.`
+This is not the usual rule. Generally, `y` changes to `ies` for plurals, as in `query` to `queries`.
 
 ---
 
@@ -30,7 +30,7 @@ By adding `s`
 
 ### --feedback--
 
-For most nouns ending in `y`, simply adding `s` is not correct. For example, `directory` becomes `directories`, not `directorys.`
+For most nouns ending in `y`, simply adding `s` is not correct. For example, `directory` becomes `directories`, not `directorys`.
 
 ---
 
@@ -42,7 +42,7 @@ By removing `y`
 
 ### --feedback--
 
-Removing the `y` is not the correct way to form plurals. The `y` usually changes to `ies` in plurals, like `binary` to `binaries.`
+Removing the `y` is not the correct way to form plurals. The `y` usually changes to `ies` in plurals, like `binary` to `binaries`.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68760 

<!-- Feel free to add any additional description of changes below this line -->

## Changes
Moved punctuation (periods) outside inline code backticks across the "Learn How to Document Code for a Project" lesson, per standard English typographic convention. Fixed on lines 11, 25, 33, and 45.

## Testing
Text-only change to a challenge markdown file. No local testing required — no JS/CSS/HTML behavior affected.