### PR TITLE
fix(curriculum): improve basic HTML review

### DIFF
--- a/curriculum/challenges/english/blocks/review-basic-html/67072fc183c7ca6c588feb4d.md
+++ b/curriculum/challenges/english/blocks/review-basic-html/67072fc183c7ca6c588feb4d.md
@@ -46,7 +46,7 @@ A boolean attribute is an attribute that can either be present or absent in an H
 <!--This is an HTML comment.-->
 ```
 
-## Common HTML elements
+## Common HTML Elements
 
 - **Heading Elements**: There are six heading elements in HTML. The `h1` through `h6` heading elements are used to signify the importance of content below them. The lower the number, the higher the importance, so `h2` elements have less importance than `h1` elements.
 
@@ -128,6 +128,16 @@ A boolean attribute is an attribute that can either be present or absent in an H
 
 ```html
 <a href="https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg">cute cats</a>
+```
+
+:::
+
+- **`button` Element**: The `button` element is used to create a clickable button that users can interact with.
+
+:::interactive_editor
+
+```html
+<button>Click Me</button>
 ```
 
 :::
@@ -218,10 +228,10 @@ To create an ordered list of items you should use the `ol` element:
 <h1 id="title">Movie Review Page</h1>
 ```
 
-ID names cannot have spaces. If your ID name contains multiple words then you can use dashes between the words like this:
+ID names can contain letters, digits, underscores, and dashes, but they cannot have spaces. If your ID name contains multiple words, you can use underscores between the words like this:
 
 ```html
-<div id="red-box"></div>
+<div id="red_box"></div>
 ```
 
 - **Classes**: Classes are used to group elements for styling and behavior.
@@ -379,7 +389,7 @@ To embed a video within an `iframe` you can copy it directly from popular video 
 
 :::
 
-There are some other replaced elements, such as `video`, and `embed`. And some elements behave as replaced elements under specific circumstances. Here's an example of an `input` element with the `type` attribute set to `image`:
+There are some other replaced elements, such as `video` and `embed`. And some elements behave as replaced elements under specific circumstances. Here's an example of an `input` element with the `type` attribute set to `image`:
 
 ```html
 <input type="image" alt="Descriptive text goes here" src="example-img-url">
@@ -423,6 +433,8 @@ The `controls` attribute enables users to manage audio playback, including adjus
 ```
 
 :::
+
+- **`autoplay` Attribute**: The `autoplay` attribute is a boolean attribute that starts playing audio or video automatically when the page loads.
 
 - **`muted` Attribute**: When present in the `audio` element, the `muted` boolean attribute will start the audio in a muted state.
 
@@ -481,9 +493,9 @@ All the attributes we have learned so far are also supported in the `video` elem
 
 :::
 
-## Target attribute types
+## Target Attribute Types
 
-- **`target` Attribute**: This attribute tells the browser where to open the URL for the anchor element. There are four important possible values for this attribute: `_self`, `_blank`, `_parent` and `_top`. There is a fifth value, called `_unfencedTop`, which is currently used for the experimental `FencedFrame` API. You probably won't have a reason to use this one yet.
+- **`target` Attribute**: This attribute tells the browser where to open the URL for the anchor element. There are four important possible values for this attribute: `_self`, `_blank`, `_parent`, and `_top`. There is a fifth value, called `_unfencedTop`, which is currently used for the experimental `FencedFrame` API. You probably won't have a reason to use this one yet.
 - **`_self` Value**: This is the default value for the `target` attribute. This opens the link in the current browsing context. In most cases, this will be the current tab or window.
 
 ```html
@@ -519,7 +531,7 @@ public/index.html
 ../src/index.css
 ```
 
-- **Absolute Path**: An absolute path is a complete link to a resource. It starts from the root directory, includes every other directory, and finally the filename and extension. The "root directory" refers to the top-level directory or folder in a hierarchy. An absolute path also includes the protocol, which could be `http`, `https`, and `file` and the domain name if the resource is on the web. Here's an example of an absolute path that links to the freeCodeCamp logo:
+- **Absolute Path**: An absolute path starts from the root directory, includes every other directory, and finally the filename and extension. The "root directory" refers to the top-level directory or folder in a hierarchy. An absolute URL is a complete link to a resource and includes the protocol, such as `http`, `https`, or `file`, and the domain name if the resource is on the web. Here's an example of an absolute URL that links to the freeCodeCamp logo:
 
 :::interactive_editor
 
@@ -540,7 +552,7 @@ public/index.html
 </p>
 ```
 
-## Link states
+## Link States
 
 - **`:link`**: This is the default state. This state represents a link which the user has not visited, clicked, or interacted with yet. You can think of this state as providing the base styles for all links on your page. The other states build on top of it.
 - **`:visited`**: This applies when a user has already visited the page being linked to. By default, this turns the link purple, but you can leverage CSS to provide a different visual indication to the user.


### PR DESCRIPTION
This updates the Basic HTML review so it matches the concepts and wording taught in the related workshops and lectures.

- adds summaries for the `button` element and `autoplay` attribute
- aligns heading capitalization and list punctuation
- distinguishes absolute paths from absolute URLs
- documents the full set of allowed ID characters

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Checks:

- `git diff --check`
- YAML frontmatter parse
- assertions for all seven requested review corrections

Closes #68774
