### PR TITLE
fix(curriculum): correct apostrophe and add serial comma in Basic HTML Quiz

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-basic-html/66df3b712c41c499e9d31e5b.md
+++ b/curriculum/challenges/english/blocks/quiz-basic-html/66df3b712c41c499e9d31e5b.md
@@ -1245,7 +1245,7 @@ Which of the following elements is used to link to external resources like style
 
 #### --text--
 
-Which of the following elements is used to convey a sense of urgency, seriousness or strong importance?
+Which of the following elements is used to convey a sense of urgency, seriousness, or strong importance?
 
 #### --distractors--
 
@@ -1435,7 +1435,7 @@ It automatically starts the audio when the page loads.
 
 ---
 
-It specifies the audio file’s source URL.
+It specifies the audio file's source URL.
 
 #### --answer--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68775

<!-- Feel free to add any additional description of changes below this line -->

Changed curly apostrophe to a straight apostrophe in "file's" (distractor answer), and added the missing serial comma in "urgency, seriousness, or strong importance" (question text) in the Basic HTML Quiz.