### PR TITLE
fix(curriculum): correct text in travel agency page lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -58,7 +58,7 @@ assert.match(code, /<\s*head\s*>[\s\S]*(<\s*meta[\s\S]*>[\s\S]*){2,}<\/\s*head\s
 One `meta` element should have a `name` attribute with value of `description` and a non-empty `content` attribute.
 
 ```js
- assert.match(code,
+assert.match(code,
   /<\s*meta\s+[^>]*name\s*=\s*["']description["'][^>]*content\s*=\s*["'][^"']+?["'][^>]*>/i,
 );
 ```

--- a/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
+++ b/curriculum/challenges/english/blocks/lab-travel-agency-page/669e2f60e83c011754f711f9.md
@@ -57,19 +57,19 @@ assert.match(code, /<\s*head\s*>[\s\S]*(<\s*meta[\s\S]*>[\s\S]*){2,}<\/\s*head\s
 
 One `meta` element should have a `name` attribute with value of `description` and a non-empty `content` attribute.
 
- ```js
+```js
  assert.match(code,
   /<\s*meta\s+[^>]*name\s*=\s*["']description["'][^>]*content\s*=\s*["'][^"']+?["'][^>]*>/i,
 );
 ```
 
-One `meta` element should have its `charset` attribute set to `UTF-8`.
+One `meta` element should have its `charset` attribute set to `utf-8`.
 
 ```js
-assert.match(code, /<\s*meta[\s\S]+?charset\s*=\s*('|")UTF-8\1/i);
+assert.match(code, /<\s*meta[\s\S]+?charset\s*=\s*('|")utf-8\1/i);
 ```
 
-You should have `title` element within your `head` element.
+You should have a `title` element within your `head` element.
 
 ```js
 assert.match(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the text issues in the Build a Travel Agency Page lab by:

- adding the missing article before `title`
- changing `UTF-8` to `utf-8`
- fixing the indentation of the code block

Closes #68777
