### PR TITLE
fix(curriculum): teach the RegExp constructor

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
@@ -19,6 +19,16 @@ const regex = /freeCodeCamp/;
 
 Notice how, in JavaScript, you define a regular expression by creating your pattern between two forward slashes (`/`). Try not to confuse this with a comment, where the text comes after both forward slashes.
 
+You can also create a regular expression with the `RegExp` constructor. The constructor accepts a string for the pattern as its first argument and an optional string of flags as its second argument:
+
+```js
+const pattern = "freeCodeCamp";
+const flags = "i";
+const regex = new RegExp(pattern, flags);
+```
+
+The `RegExp` constructor is useful when the pattern or flags are only known at runtime, such as when they come from user input. If the pattern and flags are known when you write the code, a regular expression literal is typically shorter and easier to read.
+
 This particular regular expression will match the text `freeCodeCamp`, with capital `C`s, anywhere in a string. But how can you actually do that?
 
 That brings us to our first method, the `test()` method. The `test()` method is present on `RegExp` objects, which are objects representing a regular expression (such as the one we just defined).
@@ -148,35 +158,35 @@ Regular expressions, and all of the methods associated with them, can seem compl
 
 ## --text--
 
-In JavaScript, how is a basic regular expression defined? 
+Which code creates a regular expression from a pattern and flags stored in variables?
 
 ## --answers--
 
-Using single quotes: `'pattern'`
+`const regex = /pattern/flags;`
 
 ### --feedback--
 
-The lesson shows a specific syntax for defining a regular expression.
+This creates a literal using the words `pattern` and `flags`, not the values stored in the variables.
 
 ---
 
-Using double quotes: `"pattern"`
+`const regex = "pattern" + "flags";`
 
 ### --feedback--
 
-The lesson shows a specific syntax for defining a regular expression.
+Combining strings does not create a regular expression.
 
 ---
 
-Using forward slashes: `/pattern/`
+`const regex = new RegExp(pattern, flags);`
 
 ---
 
-Using parentheses: `(pattern)`
+`const regex = RegExp(/pattern/, /flags/);`
 
 ### --feedback--
 
-The lesson shows a specific syntax for defining a regular expression.
+The constructor expects the dynamic pattern and flags values, rather than two regular expression literals.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -15,6 +15,14 @@ dashedName: review-javascript-regular-expressions
 const regex = /freeCodeCamp/;
 ```
 
+- **`RegExp` Constructor**: You can use the `RegExp` constructor to create a regular expression from strings. This is useful when the pattern or flags are only known at runtime.
+
+```js
+const pattern = "freeCodeCamp";
+const flags = "i";
+const regex = new RegExp(pattern, flags);
+```
+
 - **`test()` Method**: This method accepts a string, which is the string to test for matches against the regular expression. This method will return a boolean if the string matches the regex.
 
 :::interactive_editor

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2684,6 +2684,14 @@ console.dir(document);
 const regex = /freeCodeCamp/;
 ```
 
+- **`RegExp` Constructor**: You can use the `RegExp` constructor to create a regular expression from strings. This is useful when the pattern or flags are only known at runtime.
+
+```js
+const pattern = "freeCodeCamp";
+const flags = "i";
+const regex = new RegExp(pattern, flags);
+```
+
 - **`test()` Method**: This method accepts a string, which is the string to test for matches against the regular expression. This method will return a boolean if the string matches the regex.
 
 :::interactive_editor


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines for this project.
- [x] I have read and followed the guidance for opening a pull request.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #68733

This teaches the RegExp constructor in the lecture, module review, and chapter review, including the runtime-input use case and an updated review question.

Validation:
- git diff --check
- Node validation confirmed all three lessons include the constructor, the dynamic example works, and the quiz solution remains correct.