### PR TITLE
fix(curriculum): replace regex with explorer helper in lab traffic light sequencer

### DIFF
--- a/curriculum/challenges/english/blocks/lab-traffic-light-sequencer/69b83e35f19ba26ba1fa517a.md
+++ b/curriculum/challenges/english/blocks/lab-traffic-light-sequencer/69b83e35f19ba26ba1fa517a.md
@@ -110,8 +110,11 @@ assert.isFunction(runSequence);
 Your `runSequence` function should accept two parameters, `config` and `cycles`.
 
 ```js
-const regex = __helpers.functionRegex('runSequence', ['config', 'cycles']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.runSequence.parameters;
+assert.equal(parameters.length, 2);
+assert.equal(parameters[0].toString(), "config");
+assert.equal(parameters[1].toString(), "cycles");
 ```
 
 `runSequence(config1, 1)` should log `Switching to green for 5 s`, `Switching to yellow for 2 s`, `Switching to red for 4 s` in order.
@@ -178,8 +181,11 @@ assert.isFunction(generateTimeline);
 Your `generateTimeline` function should accept two parameters, `config` and `cycles`.
 
 ```js
-const regEx = __helpers.functionRegex('generateTimeline', ['config', 'cycles']);
-assert.match(__helpers.removeJSComments(code), regEx);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.generateTimeline.parameters;
+assert.equal(parameters.length, 2);
+assert.equal(parameters[0].toString(), "config");
+assert.equal(parameters[1].toString(), "cycles");
 ```
 
 `generateTimeline(config1, 1)` should return `[5, 7, 11]`.

--- a/curriculum/challenges/english/blocks/lab-traffic-light-sequencer/69b83e35f19ba26ba1fa517a.md
+++ b/curriculum/challenges/english/blocks/lab-traffic-light-sequencer/69b83e35f19ba26ba1fa517a.md
@@ -111,10 +111,10 @@ Your `runSequence` function should accept two parameters, `config` and `cycles`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const parameters = explorer.allFunctions.runSequence.parameters;
-assert.equal(parameters.length, 2);
-assert.equal(parameters[0].toString(), "config");
-assert.equal(parameters[1].toString(), "cycles");
+const parameters = explorer.allFunctions.runSequence?.parameters;
+assert.equal(parameters?.length, 2);
+assert.equal(parameters?.[0]?.toString(), "config");
+assert.equal(parameters?.[1]?.toString(), "cycles");
 ```
 
 `runSequence(config1, 1)` should log `Switching to green for 5 s`, `Switching to yellow for 2 s`, `Switching to red for 4 s` in order.
@@ -182,10 +182,10 @@ Your `generateTimeline` function should accept two parameters, `config` and `cyc
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const parameters = explorer.allFunctions.generateTimeline.parameters;
-assert.equal(parameters.length, 2);
-assert.equal(parameters[0].toString(), "config");
-assert.equal(parameters[1].toString(), "cycles");
+const parameters = explorer.allFunctions.generateTimeline?.parameters;
+assert.equal(parameters?.length, 2);
+assert.equal(parameters?.[0]?.toString(), "config");
+assert.equal(parameters?.[1]?.toString(), "cycles");
 ```
 
 `generateTimeline(config1, 1)` should return `[5, 7, 11]`.

--- a/curriculum/challenges/english/blocks/lab-traffic-light-sequencer/69b83e35f19ba26ba1fa517a.md
+++ b/curriculum/challenges/english/blocks/lab-traffic-light-sequencer/69b83e35f19ba26ba1fa517a.md
@@ -104,7 +104,8 @@ assert.deepEqual(_config4, config4);
 You should have a function named `runSequence`.
 
 ```js
-assert.isFunction(runSequence);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.allFunctions.runSequence);
 ```
 
 Your `runSequence` function should accept two parameters, `config` and `cycles`.
@@ -175,7 +176,8 @@ assert.deepEqual(spy.calls, [["No phases found"]]);
 You should have a function named `generateTimeline`.
 
 ```js
-assert.isFunction(generateTimeline);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.allFunctions.generateTimeline);
 ```
 
 Your `generateTimeline` function should accept two parameters, `config` and `cycles`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68693 

<!-- Feel free to add any additional description of changes below this line -->

This PR is part of Naomi's Sprints for replacing regex-based tests with the Explorer AST helper.

This PR replaces the 2 test which uses regex with the explorer helper.