### PR TITLE
fix(curriculum): assert data state in medical data validator step 19

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-medical-data-validator/6846ba7ef391f007fcc37688.md
+++ b/curriculum/challenges/english/blocks/workshop-medical-data-validator/6846ba7ef391f007fcc37688.md
@@ -16,7 +16,42 @@ You should see a validation message appear in the terminal.
 You should comment out the line `'age': 34,` in your code.
 
 ```js
-({ test: () => assert.match(code, /#\s*'age'\s*:\s*34\s*,/)})
+({ test: () => runPython(`
+_medical_records = [
+    {
+        'patient_id': 'P1001',
+        'gender': 'Female',
+        'diagnosis': 'Hypertension',
+        'medications': ['Lisinopril'],
+        'last_visit_id': 'V2301',
+    },
+    {
+        'patient_id': 'p1002',
+        'age': 47,
+        'gender': 'male',
+        'diagnosis': 'Type 2 Diabetes',
+        'medications': ['Metformin', 'Insulin'],
+        'last_visit_id': 'v2302',
+    },
+    {
+        'patient_id': 'P1003',
+        'age': 29,
+        'gender': 'female',
+        'diagnosis': 'Asthma',
+        'medications': ['Albuterol'],
+        'last_visit_id': 'v2303',
+    },
+    {
+        'patient_id': 'p1004',
+        'age': 56,
+        'gender': 'Male',
+        'diagnosis': 'Chronic Back Pain',
+        'medications': ['Ibuprofen', 'Physical Therapy'],
+        'last_visit_id': 'V2304',
+    }
+]
+assert medical_records == _medical_records
+`) })
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68731

<!-- Feel free to add any additional description of changes below this line -->

Replace the source-text regex with a behavioral check that asserts
medical_records matches the expected state after the age key is removed
from the first record. This passes whether the camper comments out or
deletes the line, and no longer depends on formatting.