### PR TITLE
fix(curriculum): replace regex with explorer helper in lab javascript trivia bot

### DIFF
--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -77,21 +77,24 @@ assert.isString(favoriteLanguage);
 You should log to the console `"My name is (botName) and I live on (botLocation)."` and add the variables to the string.
 
 ```js
-const codeWithoutComments = __helpers.removeJSComments(code);
 assert.equal(getLogs()[1], `My name is ${botName} and I live on ${botLocation}.`)
 ```
 
 You should log to the console `"My favorite programming language is (favoriteLanguage)."` and add the variable to the string.
 
 ```js
-const codeWithoutComments = __helpers.removeJSComments(code);
 assert.equal(getLogs()[2], `My favorite programming language is ${favoriteLanguage}.`)
 ```
 
 You should use `let` to declare a new variable `codingFact`.
 
 ```js
+const codeWithoutComments = __helpers.removeJSComments(code);
+assert.match(codeWithoutComments, /let\s+codingFact/);
+
 const explorer = await __helpers.Explorer(code);
+const { codingFact } = explorer.variables;
+
 assert.isTrue(codingFact?.matches(`let codingFact = ${codingFact?.value?.toString()}`));
 ```
 
@@ -127,8 +130,8 @@ You should assign a value to `codingFact` for the third time that also contains 
 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
-assert.lengthOf(loggingCodingFacts, 3);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
+assert.lengthOf(loggingCodingFacts, 3);
 assert.notEqual(getLogs()[5], getLogs()[4]);
 assert.isNotEmpty(codingFact);
 ```

--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -92,7 +92,7 @@ You should use `let` to declare a new variable `codingFact`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.variables.codingFact);
+assert.isTrue(codingFact?.matches(`let codingFact = ${codingFact?.value?.toString()}`));
 ```
 
 You should give `codingFact` a value that includes `favoriteLanguage`.
@@ -100,11 +100,7 @@ You should give `codingFact` a value that includes `favoriteLanguage`.
 ```js
 const explorer = await __helpers.Explorer(code);
 assert.exists(explorer.variables.codingFact);
-assert.match(code, /codingFact\s*=\s*(("|'|`)?.+?\1?\s*\+?\s*|favoriteLanguage\s*\+\s*(("|'|`)?.+?\3?))/);
-assert.exists(codingFact);
-assert.isNotEmpty(codingFact);
 assert.include(String(codingFact), favoriteLanguage);
-assert.include(getLogs()[3], favoriteLanguage);
 ```
 
 You should log `codingFact` to the console.
@@ -121,24 +117,20 @@ You should assign a new value to `codingFact` that also contains `favoriteLangua
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-const [first, second, third] = codeWithoutComments.match(/(let )?\s*codingFact\s*=\s*(("|')?.+?\2?\s*\+?\s*|favoriteLanguage\s*\+\s*(("|')?.+?\2?))/g);
+assert.exists(loggingCodingFacts);
+assert.isAtLeast(loggingCodingFacts.length, 2);
 assert.include(getLogs()[4], favoriteLanguage);
 assert.notEqual(getLogs()[4], getLogs()[3]);
-assert.isAtLeast(loggingCodingFacts.length, 2);
-assert.exists(second);
-assert.isNotEmpty(codingFact); 
 ```
 
 You should assign a value to `codingFact` for the third time that also contains `favoriteLanguage`, and log it to the console.
 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
-const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-assert.include(getLogs()[5], favoriteLanguage);
-assert.notEqual(getLogs()[5], getLogs()[4]);
-assert.equal(getLogs()[5], codingFact);
 assert.lengthOf(loggingCodingFacts, 3);
-assert.isNotEmpty(codingFact); 
+const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
+assert.notEqual(getLogs()[5], getLogs()[4]);
+assert.isNotEmpty(codingFact);
 ```
 
 You should log to the console `"It was fun sharing these facts with you. Goodbye! - (botName) from (botLocation)."` and add the values of the variables.

--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -89,12 +89,8 @@ assert.equal(getLogs()[2], `My favorite programming language is ${favoriteLangua
 You should use `let` to declare a new variable `codingFact`.
 
 ```js
-const codeWithoutComments = __helpers.removeJSComments(code);
-assert.match(codeWithoutComments, /let\s+codingFact/);
-
 const explorer = await __helpers.Explorer(code);
 const { codingFact } = explorer.variables;
-
 assert.isTrue(codingFact?.matches(`let codingFact = ${codingFact?.value?.toString()}`));
 ```
 

--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -91,15 +91,15 @@ assert.equal(getLogs()[2], `My favorite programming language is ${favoriteLangua
 You should use `let` to declare a new variable `codingFact`.
 
 ```js
-const codeWithoutComments = __helpers.removeJSComments(code);
-assert.match(code, /let\s+codingFact/)
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.variables.codingFact);
 ```
 
 You should give `codingFact` a value that includes `favoriteLanguage`.
 
 ```js
-const codeWithoutComments = __helpers.removeJSComments(code);
-assert.match(code, /let\s+codingFact/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.variables.codingFact);
 assert.match(code, /codingFact\s*=\s*(("|'|`)?.+?\1?\s*\+?\s*|favoriteLanguage\s*\+\s*(("|'|`)?.+?\3?))/);
 assert.exists(codingFact);
 assert.isNotEmpty(codingFact);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68688

<!-- Feel free to add any additional description of changes below this line -->

This PR is part of Naomi's Sprints for replacing regex-based tests with the Explorer AST helper.

This PR replaces the test which uses regex with the explorer helper.