### PR TITLE
fix(curriculum): correct backticks and grammar in iframe lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-media/671682b3983489a819507553.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-media/671682b3983489a819507553.md
@@ -29,7 +29,7 @@ Here's an example of embedding a popular freeCodeCamp course from YouTube. To se
 
 The `src` attribute specifies the URL of the page you want to embed. The `width` attribute specifies the width of the `iframe`. The `height` attribute specifies the height of the `iframe`. The `allowfullscreen` attribute allows the user to display the `iframe` in full screen mode. It's also a good practice to specify a `title` attribute for the `iframe`, as it's important for accessibility.
 
-The `allow` attribute, on the other hand, lets you define what an iframe can or can't do. This is called an allowlist. In the above example, adding `clipboard-write` to it allows the embedded page to write items to your clipboard. Items in an allowlist can be separated by semicolons or spaces, and both can be used together.
+The `allow` attribute, on the other hand, lets you define what an `iframe` can or can't do. This is called an allowlist. In the above example, adding `clipboard-write` to it allows the embedded page to write items to your clipboard. Items in an allowlist can be separated by semicolons or spaces, and both can be used together.
 
 Note that the video can come from anywhere. It doesn't have to come from video services like YouTube and Vimeo.
 
@@ -60,13 +60,13 @@ Try interacting with the map by zooming in and out.
 
 :::
 
-If you want to embed direct HTML within the `iframe` element you have to use the `srcdoc` attribute instead of `src`.
+If you want to embed direct HTML within the `iframe` element, you have to use the `srcdoc` attribute instead of `src`.
 
 # --questions--
 
 ## --text--
 
-What does iframe mean?
+What does `iframe` mean?
 
 ## --answers--
 
@@ -146,7 +146,7 @@ Which attribute of the `iframe` element do you use instead of `src` if you want 
 
 ### --feedback--
 
-Look out for the attribute that is related to src.
+Look out for the attribute that is related to `src`.
 
 ---
 
@@ -154,7 +154,7 @@ Look out for the attribute that is related to src.
 
 ### --feedback--
 
-Look out for the attribute that is related to src.
+Look out for the attribute that is related to `src`.
 
 ---
 
@@ -162,7 +162,7 @@ Look out for the attribute that is related to src.
 
 ### --feedback--
 
-Look out for the attribute that is related to src.
+Look out for the attribute that is related to `src`.
 
 ---
 


### PR DESCRIPTION
### Description
This PR fixes the formatting and grammar issues in the "How Do You Embed Videos onto Your Page Using the iframe Element?" lecture.
- Wrapped `iframe` in backticks in the sentence explaining the `allow` attribute.
- Wrapped `iframe` in backticks in the question text "What does `iframe` mean?".
- Wrapped `src` in backticks in all three of the wrong-answer feedback blocks.
- Added a missing comma after `element` in the conditional clause explaining the `srcdoc` attribute.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68767

<!-- Feel free to add any additional description of changes below this line -->
