### PR TITLE
fix(curriculum): fix redundant wording and missing focus state in working with links lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-links/6716830dbaf95da9564f2e3b.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/6716830dbaf95da9564f2e3b.md
@@ -11,9 +11,9 @@ You may have seen links like `/public/logo.png`, `./script.js`, or `../styles.cs
 
 The slash is known as the "path separator". It is used to indicate a break in the text between folder or file names. This is how your computer knows that `naomis-files/` points to a directory of that same name, while `naomis/files/` points to a `files` directory in the `naomis` directory.
 
-A single dot points to the current directory, and two dots point to the parent directory. You will typically see a single dot used to ensure that the path is recognized as a relative path. Remember that you learned in a previous lesson about relative versus absolute paths before.
+A single dot points to the current directory, and two dots point to the parent directory. You will typically see a single dot used to ensure that the path is recognized as a relative path. Remember that you learned about relative versus absolute paths in a previous lesson.
 
-Double dots, however, are much more common to access files outside of the current working directory.
+Double dots, however, are more commonly used to access files outside of the current working directory.
 
 For example, given this file tree:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
@@ -203,7 +203,7 @@ In what order should you style your links?
 
 ## --answers--
 
-`visited`, `link`, `active`, `hover`.
+`visited`, `link`, `active`, `focus`, `hover`.
 
 ### --feedback--
 
@@ -211,7 +211,7 @@ Review the last part of the lesson for the answer.
 
 ---
 
-`link`, `active`, `hover`, `visited`.
+`link`, `active`, `focus`, `hover`, `visited`.
 
 ### --feedback--
 
@@ -219,7 +219,7 @@ Review the last part of the lesson for the answer.
 
 ---
 
-`hover`, `active`, `link`, `visited`.
+`hover`, `focus`, `active`, `link`, `visited`.
 
 ### --feedback--
 
@@ -227,7 +227,7 @@ Review the last part of the lesson for the answer.
 
 ---
 
-`link`, `visited`, `hover`, `active`.
+`link`, `visited`, `hover`, `focus`, `active`.
 
 ## --video-solution--
 


### PR DESCRIPTION
### Description
This PR fixes redundant wording and updates the quiz answers for link states to include the `focus` state, as outlined in issue #68773.

Specifically, the following changes were made:
- Reworded a redundant sentence regarding relative vs absolute paths.
- Fixed awkward phrasing regarding the use of double dots (`..`).
- Added the missing `focus` state to every multiple-choice option in the link states quiz, and updated the correct answer to reflect the proper 5-state order (`link`, `visited`, `hover`, `focus`, `active`).

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68773

<!-- Feel free to add any additional description of changes below this line -->
