### PR TITLE
refactor(curriculum): replace legacy helpers with Explorer AST helpers in Cargo Manifest Validator lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
+++ b/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
@@ -121,11 +121,11 @@ console.log = () => {};
 You should have a function named `normalizeUnits` with a `manifest` parameter.
 
 ```js
-assert.isFunction(normalizeUnits);
-const funcString = normalizeUnits.toString();
-const params = __helpers.getFunctionParams(funcString);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.allFunctions.normalizeUnits);
+const params = explorer.allFunctions.normalizeUnits.parameters;
 assert.equal(params.length, 1);
-assert.equal(params[0].name, 'manifest');
+assert.equal(params[0].toString(), 'manifest');
 ```
 
 Calling `normalizeUnits()` with `{ containerId: 68, destination: "Salinas", weight: 101, unit: "lb", hazmat: true }` should return the new object `{ containerId: 68, destination: "Salinas", weight: 45.45, unit: "kg", hazmat: true }` without mutating the source input.
@@ -148,7 +148,6 @@ const expected = {
 };
 
 const copy = normalizeUnits(testObj);
-
 assert.isObject(copy);
 assert.deepEqual(copy, expected, "normalizeUnits() did not return the expected normalized object");
 assert.notStrictEqual(copy, testObj, "normalizeUnits() should return a new object.");
@@ -213,11 +212,11 @@ assert.equal(Object.keys(original).length, 5, "Original object should not be mut
 You should have a function named `validateManifest` with a `manifest` parameter.
 
 ```js
-assert.isFunction(validateManifest);
-const funcString = validateManifest.toString();
-const params = __helpers.getFunctionParams(funcString);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.allFunctions.validateManifest);
+const params = explorer.allFunctions.validateManifest.parameters;
 assert.equal(params.length, 1);
-assert.equal(params[0].name, 'manifest');
+assert.equal(params[0].toString(), 'manifest');
 ```
 
 Calling `validateManifest()` with `{ containerId: 1, destination: "Santa Cruz", weight: 304, unit: "kg", hazmat: false }` should return the new object `{}`.
@@ -234,7 +233,6 @@ const testObj = {
 const expected = {};
 
 const copy = validateManifest(testObj);
-
 assert.isObject(copy);
 assert.deepEqual(copy, expected, "validateManifest() did not return the expected object for a valid manifest");
 assert.notStrictEqual(copy, testObj, "validateManifest() should return a new object, not mutate the original");
@@ -248,7 +246,7 @@ assert.strictEqual(testObj.hazmat, false, "Original object should not be mutated
 If the input manifest object is valid, your `validateManifest` function should return an empty object `{}`.
 
 ```js
-const solution = {}
+const solution = {};
 for (const obj of _validManifests) {
   assert.deepEqual(
     validateManifest(obj),
@@ -261,9 +259,7 @@ for (const obj of _validManifests) {
 Calling `validateManifest()` with `{}` should return the new object `{ containerId: "Missing", destination: "Missing", weight: "Missing", unit: "Missing", hazmat: "Missing" }` without mutating the source input.
 
 ```js
-const testObj = {
-
-};
+const testObj = {};
 
 const expected = {
   containerId: "Missing",
@@ -277,7 +273,7 @@ const copy = validateManifest(testObj);
 assert.isObject(copy);
 assert.deepEqual(copy, expected, "validateManifest() did not return the expected object for missing properties");
 assert.notStrictEqual(copy, testObj, "validateManifest() should return a new object, not mutate the original");
-assert.equal(Object.keys(testObj).length, 0, "validateManifest() should return a new object, not mutate the original")
+assert.equal(Object.keys(testObj).length, 0, "validateManifest() should return a new object, not mutate the original");
 ```
 
 Calling `validateManifest()` with `{ containerId: null, destination: "Santa Cruz", weight: 304, unit: "kg", hazmat: false }` should return the new object `{ containerId: "Invalid" }` without mutating the source input.
@@ -489,11 +485,11 @@ assert.equal(Object.keys(validOriginal).length, 5, "Original object should not b
 You should have a function named `processManifest` with a `manifest` parameter.
 
 ```js
-assert.isFunction(processManifest);
-const funcString = processManifest.toString();
-const params = __helpers.getFunctionParams(funcString);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.allFunctions.processManifest);
+const params = explorer.allFunctions.processManifest.parameters;
 assert.equal(params.length, 1);
-assert.equal(params[0].name, 'manifest');
+assert.equal(params[0].toString(), 'manifest');
 ```
 
 Calling `processManifest()` with `{ containerId: 55, destination: "Carmel", weight: 400, unit: "lb", hazmat: false }` should first log `"Validation success: 55"` and then log `"Total weight: 180 kg"`.
@@ -535,7 +531,7 @@ const testObj = {
   weight: 200,
   unit: "lb",
   hazmat: false
-}
+};
 
 const spy = __helpers.spyOn(console, "log");
 
@@ -544,7 +540,7 @@ try {
   const expectedCalls = [
     ["Validation success: 97"],
     ["Total weight: 90 kg"],
-  ]
+  ];
   assert.deepEqual(spy.calls[0], expectedCalls[0]);
 
 } catch (err) {
@@ -563,7 +559,7 @@ const testObj = {
   weight: 200,
   unit: "lb",
   hazmat: false
-}
+};
 
 const spy = __helpers.spyOn(console, "log");
 
@@ -572,7 +568,7 @@ try {
   const expectedCalls = [
     ["Validation success: 97"],
     ["Total weight: 90 kg"],
-  ]
+  ];
   assert.deepEqual(spy.calls[1], expectedCalls[1]);
 
 } catch (err) {
@@ -617,7 +613,7 @@ try {
     ["Total weight: 373.95 kg"],
     ["Validation success: 5"],
     ["Total weight: 151 kg"],
-  ]
+  ];
   assert.deepEqual(spy.calls, expectedCalls);
 
 } catch (err) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68684

<!-- Feel free to add any additional description of changes below this line -->

---

This PR replaces legacy helpers with TypeScript Explorer AST helpers in the Cargo Manifest Validator lab as part of Naomi’s sprint initiative.

Changes include:

- Replaced `assert.isFunction()` and Curriculum Helpers with TypeScript Explorer AST helpers
- Removed unused variables
- Added missing semicolons for consistency
- Removed whitespace for consistency and readability
