### PR TITLE
fix(curriculum): allow optional whitespace in else statement tests

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a3ce03013be44d116136e.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a3ce03013be44d116136e.md
@@ -24,13 +24,13 @@ Add an `else` clause to the existing `if` statement. Inside the body of your `el
 Your third `if` statement should have an `else` clause.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /const\s+timmyAge\s*\=\s*.+\bif\s*\(\s*timmyAge\s*>=\s*16\s*\)\s*\{\s*console\s*\.\s*log\s*\(\s*('|"|`)Timmy is old enough to drive.\1\s*\)\s*;?\s*\}\s+else\s+{/s);
+assert.match(__helpers.removeJSComments(code), /const\s+timmyAge\s*\=\s*.+\bif\s*\(\s*timmyAge\s*>=\s*16\s*\)\s*\{\s*console\s*\.\s*log\s*\(\s*('|"|`)Timmy is old enough to drive.\1\s*\)\s*;?\s*\}\s*else\s*\{/s);
 ```
 
 You should log `"Timmy is not old enough to drive."` to the console within the body of your `else` clause.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /const\s+timmyAge\s*\=\s*.+\bif\s*\(\s*timmyAge\s*>=\s*16\s*\)\s*\{\s*console\s*\.\s*log\s*\(\s*('|"|`)Timmy is old enough to drive.\1\s*\)\s*;?\s*\}\s+else\s+{\s*console\s*\.\s*log\s*\(\s*('|"|`)Timmy is not old enough to drive.\2\s*\)\s*;?\s*\}/s);
+assert.match(__helpers.removeJSComments(code), /const\s+timmyAge\s*\=\s*.+\bif\s*\(\s*timmyAge\s*>=\s*16\s*\)\s*\{\s*console\s*\.\s*log\s*\(\s*('|"|`)Timmy is old enough to drive.\1\s*\)\s*;?\s*\}\s*else\s*\{\s*console\s*\.\s*log\s*\(\s*('|"|`)Timmy is not old enough to drive.\2\s*\)\s*;?\s*\}/s);
 ```
 
 # --seed--


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Ref #68805
