### PR TITLE
fix: Teach RegExp constructor before Regex Sandbox lab

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
@@ -19,7 +19,7 @@ const regex = /freeCodeCamp/;
 
 Notice how, in JavaScript, you define a regular expression by creating your pattern between two forward slashes (`/`). Try not to confuse this with a comment, where the text comes after both forward slashes.
 
-This particular regular expression will match the text `freeCodeCamp`, with capital `C`s, anywhere in a string. But how can you actually do that?
+This particular regular expression will match the text `freeCodeCamp`, with capital `C`s, anywhere in a string.
 
 If your pattern comes from a variable instead of being written directly into the regex literal, you can create the same kind of regular expression with the `RegExp` constructor:
 
@@ -27,6 +27,8 @@ If your pattern comes from a variable instead of being written directly into the
 const pattern = "freeCodeCamp";
 const regex = new RegExp(pattern);
 ```
+
+But how can you actually do that?
 
 That brings us to our first method, the `test()` method. The `test()` method is present on `RegExp` objects, which are objects representing a regular expression (such as the one we just defined).
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
@@ -70,22 +70,6 @@ Notice how the first three strings returned `true`. These strings all contain th
 
 Lines 5 and 6 return `false`. While they contain the text `freecodecamp`, the case does not match. Regular expressions are case-sensitive by default.
 
-However, you can change this behavior using a flag. A flag is a single character added after the closing slash that changes how the regular expression behaves.
-
-The `i` flag makes a regular expression case-insensitive:
-
-:::interactive_editor
-
-```js
-const regex = /freecodecamp/i;
-console.log(regex.test("freeCodeCamp"));
-console.log(regex.test("FREECODECAMP"));
-```
-
-:::
-
-Notice how `test()` now returns `true` for both, even though the casing doesn't match the pattern exactly.
-
 Finally, while the last three contain a portion of the pattern, the strings do not contain the entire pattern.
 
 The `test()` method returns a `boolean`, indicating whether the string matches the regular expression at all.
@@ -141,18 +125,7 @@ Is that what you expected? You can see how the `input` and `index` have changed 
 
 The other three lines, which do not match, return `null` instead of an array.
 
-By default, `match()` stops after finding the first match in a string. If you want to find every match instead, you can add the `g` flag, or global flag, to your regular expression:
-
-:::interactive_editor
-
-```js
-const regex = /Camp/g;
-console.log("freeCodeCamp Camp Camp".match(regex));
-```
-
-:::
-
-Notice how the returned array is different this time. With the `g` flag, `match()` returns a plain array of every matched string, instead of the single match with the extra `index`, `input`, and `groups` properties you saw earlier.
+By default, `match()` stops after finding the first match in a string.
 
 Now that we can test and match strings with our regular expression, what if we want to replace the content of a string? Maybe someone has written `freecodecamp` in all lowercase, and we want to automatically fix the casing for them.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
@@ -17,6 +17,14 @@ Let's take a look at a basic regular expression:
 const regex = /freeCodeCamp/;
 ```
 
+If your pattern or flags come from variables instead of being written directly into the regex literal, you can create the same kind of regular expression with the `RegExp` constructor:
+
+```js
+const pattern = "freeCodeCamp";
+const flags = "gi";
+const regex = new RegExp(pattern, flags);
+```
+
 Notice how, in JavaScript, you define a regular expression by creating your pattern between two forward slashes (`/`). Try not to confuse this with a comment, where the text comes after both forward slashes.
 
 This particular regular expression will match the text `freeCodeCamp`, with capital `C`s, anywhere in a string. But how can you actually do that?

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
@@ -28,7 +28,7 @@ const pattern = "freeCodeCamp";
 const regex = new RegExp(pattern);
 ```
 
-But how can you actually do that?
+But how can you actually use a regular expression?
 
 That brings us to our first method, the `test()` method. The `test()` method is present on `RegExp` objects, which are objects representing a regular expression (such as the one we just defined).
 
@@ -124,8 +124,6 @@ We know already that the first three strings should produce a match, so let's ta
 Is that what you expected? You can see how the `input` and `index` have changed depending on the string provided, and the location of the match in the string. 
 
 The other three lines, which do not match, return `null` instead of an array.
-
-By default, `match()` stops after finding the first match in a string.
 
 Now that we can test and match strings with our regular expression, what if we want to replace the content of a string? Maybe someone has written `freecodecamp` in all lowercase, and we want to automatically fix the casing for them.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
@@ -70,6 +70,22 @@ Notice how the first three strings returned `true`. These strings all contain th
 
 Lines 5 and 6 return `false`. While they contain the text `freecodecamp`, the case does not match. Regular expressions are case-sensitive by default.
 
+However, you can change this behavior using a flag. A flag is a single character added after the closing slash that changes how the regular expression behaves.
+
+The `i` flag makes a regular expression case-insensitive:
+
+:::interactive_editor
+
+```js
+const regex = /freecodecamp/i;
+console.log(regex.test("freeCodeCamp"));
+console.log(regex.test("FREECODECAMP"));
+```
+
+:::
+
+Notice how `test()` now returns `true` for both, even though the casing doesn't match the pattern exactly.
+
 Finally, while the last three contain a portion of the pattern, the strings do not contain the entire pattern.
 
 The `test()` method returns a `boolean`, indicating whether the string matches the regular expression at all.
@@ -124,6 +140,19 @@ We know already that the first three strings should produce a match, so let's ta
 Is that what you expected? You can see how the `input` and `index` have changed depending on the string provided, and the location of the match in the string. 
 
 The other three lines, which do not match, return `null` instead of an array.
+
+By default, `match()` stops after finding the first match in a string. If you want to find every match instead, you can add the `g` flag, or global flag, to your regular expression:
+
+:::interactive_editor
+
+```js
+const regex = /Camp/g;
+console.log("freeCodeCamp Camp Camp".match(regex));
+```
+
+:::
+
+Notice how the returned array is different this time. With the `g` flag, `match()` returns a plain array of every matched string, instead of the single match with the extra `index`, `input`, and `groups` properties you saw earlier.
 
 Now that we can test and match strings with our regular expression, what if we want to replace the content of a string? Maybe someone has written `freecodecamp` in all lowercase, and we want to automatically fix the casing for them.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733aad43b3ebff588a26fb5.md
@@ -17,17 +17,16 @@ Let's take a look at a basic regular expression:
 const regex = /freeCodeCamp/;
 ```
 
-If your pattern or flags come from variables instead of being written directly into the regex literal, you can create the same kind of regular expression with the `RegExp` constructor:
-
-```js
-const pattern = "freeCodeCamp";
-const flags = "gi";
-const regex = new RegExp(pattern, flags);
-```
-
 Notice how, in JavaScript, you define a regular expression by creating your pattern between two forward slashes (`/`). Try not to confuse this with a comment, where the text comes after both forward slashes.
 
 This particular regular expression will match the text `freeCodeCamp`, with capital `C`s, anywhere in a string. But how can you actually do that?
+
+If your pattern comes from a variable instead of being written directly into the regex literal, you can create the same kind of regular expression with the `RegExp` constructor:
+
+```js
+const pattern = "freeCodeCamp";
+const regex = new RegExp(pattern);
+```
 
 That brings us to our first method, the `test()` method. The `test()` method is present on `RegExp` objects, which are objects representing a regular expression (such as the one we just defined).
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -157,7 +157,7 @@ This is equivalent to writing `/freeCodeCamp/gi` directly. Let's confirm they be
 ```js
 const regex = new RegExp("freeCodeCamp", "gi");
 
-console.log(regex.test("freeCodeCamp")); // false
+console.log(regex.test("freeCodeCamp")); // true
 console.log(regex.test("FREECODECAMP")); // false
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -157,8 +157,8 @@ This is equivalent to writing `/freeCodeCamp/gi` directly. Let's confirm they be
 ```js
 const regex = new RegExp("freeCodeCamp", "gi");
 
-console.log(regex.test("freeCodeCamp")); // true
-console.log(regex.test("FREECODECAMP")); // true
+console.log(regex.test("freeCodeCamp")); // false
+console.log(regex.test("FREECODECAMP")); // false
 ```
 
 :::

--- a/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-regular-expressions/6733c5ba834ded4bb067e67c.md
@@ -143,6 +143,26 @@ Looking at this example, you can see how the state of the regular expression cha
 
 The global flag is great when you need to get multiple matches from a single string. But if you're testing multiple strings with the same regular expression it's best to leave the `g` flag off.
 
+Just like with a plain pattern, you can also create a regular expression with flags using the `RegExp` constructor. The constructor accepts the flags as an optional second argument:
+
+```js
+const pattern = "freeCodeCamp";
+const regex = new RegExp(pattern, "gi");
+```
+
+This is equivalent to writing `/freeCodeCamp/gi` directly. Let's confirm they behave the same way:
+
+:::interactive_editor
+
+```js
+const regex = new RegExp("freeCodeCamp", "gi");
+
+console.log(regex.test("freeCodeCamp")); // true
+console.log(regex.test("FREECODECAMP")); // true
+```
+
+:::
+
 Before learning about the next flag, you need to learn about anchors. The caret (`^`) anchor, at the beginning of the regular expression, says "match the start of the string":
 
 ```js

--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -15,13 +15,12 @@ dashedName: review-javascript-regular-expressions
 const regex = /freeCodeCamp/;
 ```
 
-- **`RegExp` Constructor**: When your pattern or flags come from variables, you can build the same kind of regex with the `RegExp` constructor. It accepts a pattern string and an optional flags string.
+- **`RegExp` Constructor**: When your pattern comes from variable, you can build the same kind of regex with the `RegExp` constructor. It also accepts an optional flags string as a second argument.
 
 ```js
 const pattern = "freeCodeCamp";
-const flags = "gi";
-const regex = new RegExp(pattern, flags);
-console.log(regex.test("FREECODECAMP")); // true
+const regex = new RegExp(pattern);
+console.log(regex.test("freeCodeCamp")); // true
 ```
 
 - **`test()` Method**: This method accepts a string, which is the string to test for matches against the regular expression. This method will return a boolean if the string matches the regex.
@@ -109,6 +108,19 @@ console.log(regex.test("FREECODECAMP")); // true
 const regex = /freeCodeCamp/gi;
 console.log(regex.test("freeCodeCamp")); // true
 console.log(regex.test("freeCodeCamp is great")); // false
+```
+
+:::
+
+- **`RegExp` Constructor with Flags**: Now that you know what the `i` and `g` flags do, you can pass them to the `RegExp` constructor as a second argument.
+
+:::interactive_editor
+
+```js
+const pattern = "freeCodeCamp";
+const flags = "gi";
+const regex = new RegExp(pattern, flags);
+console.log(regex.test("FREECODECAMP")); // true
 ```
 
 :::

--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -15,6 +15,15 @@ dashedName: review-javascript-regular-expressions
 const regex = /freeCodeCamp/;
 ```
 
+- **`RegExp` Constructor**: When your pattern or flags come from variables, you can build the same kind of regex with the `RegExp` constructor. It accepts a pattern string and an optional flags string.
+
+```js
+const pattern = "freeCodeCamp";
+const flags = "gi";
+const regex = new RegExp(pattern, flags);
+console.log(regex.test("FREECODECAMP")); // true
+```
+
 - **`test()` Method**: This method accepts a string, which is the string to test for matches against the regular expression. This method will return a boolean if the string matches the regex.
 
 :::interactive_editor

--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -21,7 +21,7 @@ const regex = /freeCodeCamp/;
 const pattern = "freeCodeCamp";
 const flags = "gi";
 const regex = new RegExp(pattern, flags);
-console.log(regex.test("FREECODECAMP")); // true
+console.log(regex); // /freeCodeCamp/gi
 ```
 
 - **`test()` Method**: This method accepts a string, which is the string to test for matches against the regular expression. This method will return a boolean if the string matches the regex.

--- a/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
+++ b/curriculum/challenges/english/blocks/review-javascript-regular-expressions/6723cdfa4ae237bf6b7e32eb.md
@@ -15,12 +15,13 @@ dashedName: review-javascript-regular-expressions
 const regex = /freeCodeCamp/;
 ```
 
-- **`RegExp` Constructor**: When your pattern comes from variable, you can build the same kind of regex with the `RegExp` constructor. It also accepts an optional flags string as a second argument.
+- **`RegExp` Constructor**: When your pattern or flags come from variables, you can build the same kind of regex with the `RegExp` constructor. It accepts a pattern string and an optional flags string.
 
 ```js
 const pattern = "freeCodeCamp";
-const regex = new RegExp(pattern);
-console.log(regex.test("freeCodeCamp")); // true
+const flags = "gi";
+const regex = new RegExp(pattern, flags);
+console.log(regex.test("FREECODECAMP")); // true
 ```
 
 - **`test()` Method**: This method accepts a string, which is the string to test for matches against the regular expression. This method will return a boolean if the string matches the regex.
@@ -108,19 +109,6 @@ console.log(regex.test("FREECODECAMP")); // true
 const regex = /freeCodeCamp/gi;
 console.log(regex.test("freeCodeCamp")); // true
 console.log(regex.test("freeCodeCamp is great")); // false
-```
-
-:::
-
-- **`RegExp` Constructor with Flags**: Now that you know what the `i` and `g` flags do, you can pass them to the `RegExp` constructor as a second argument.
-
-:::interactive_editor
-
-```js
-const pattern = "freeCodeCamp";
-const flags = "gi";
-const regex = new RegExp(pattern, flags);
-console.log(regex.test("FREECODECAMP")); // true
 ```
 
 :::

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2690,7 +2690,7 @@ const regex = /freeCodeCamp/;
 const pattern = "freeCodeCamp";
 const flags = "gi";
 const regex = new RegExp(pattern, flags);
-console.log(regex.test("FREECODECAMP")); // true
+console.log(regex); // /freeCodeCamp/gi
 ```
 
 - **`test()` Method**: This method accepts a string, which is the string to test for matches against the regular expression. This method will return a boolean if the string matches the regex.

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -2684,6 +2684,15 @@ console.dir(document);
 const regex = /freeCodeCamp/;
 ```
 
+- **`RegExp` Constructor**: When your pattern or flags come from variables, you can build the same kind of regex with the `RegExp` constructor. It accepts a pattern string and an optional flags string.
+
+```js
+const pattern = "freeCodeCamp";
+const flags = "gi";
+const regex = new RegExp(pattern, flags);
+console.log(regex.test("FREECODECAMP")); // true
+```
+
 - **`test()` Method**: This method accepts a string, which is the string to test for matches against the regular expression. This method will return a boolean if the string matches the regex.
 
 :::interactive_editor


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68733 