### PR TITLE
fix: correct value/attribute terminology and grammar in working-with-links lectures

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-links/6716744f7245947a3dd60009.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/6716744f7245947a3dd60009.md
@@ -45,7 +45,7 @@ How many current `target` values are there to choose from?
 
 ### --feedback--
 
-Don't include the experimental `_unfencedTop` attribute.
+Don't include the experimental `_unfencedTop` value.
 
 ---
 
@@ -57,7 +57,7 @@ Don't include the experimental `_unfencedTop` attribute.
 
 ### --feedback--
 
-Don't include the experimental `_unfencedTop` attribute.
+Don't include the experimental `_unfencedTop` value.
 
 ---
 
@@ -65,7 +65,7 @@ Don't include the experimental `_unfencedTop` attribute.
 
 ### --feedback--
 
-Don't include the experimental `_unfencedTop` attribute.
+Don't include the experimental `_unfencedTop` value.
 
 ## --video-solution--
 
@@ -117,7 +117,7 @@ Opens in a new window or tab.
 
 ### --feedback--
 
-The default attribute type is `_self`.
+The default value is `_self`.
 
 ---
 
@@ -125,7 +125,7 @@ Opens in the parent context.
 
 ### --feedback--
 
-The default attribute type is `_self`.
+The default value is `_self`.
 
 ---
 
@@ -137,7 +137,7 @@ Does not open.
 
 ### --feedback--
 
-The default attribute type is `_self`.
+The default value is `_self`.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/671682dd88e461a8e2620f38.md
@@ -25,7 +25,7 @@ If you are linking to a resource on your local machine, use an absolute path, wh
 
 It looks like this because we are starting from the root and going into a folder called `Users`, then into a folder called `user`, then into a folder called `Desktop`, then into a folder called `fCC`, then into a folder called `script-code`, then into a folder called `absolute-vs-relative-paths`, then into a folder called `pages` to finally get the `about.html` file.
 
-An absolute URL is a complete address used to access a resource. It includes the protocol - which could be `http`, `https`, and `file` and the domain name if the resource is on the web. Here's an example of an absolute URL that links to the freeCodeCamp logo:
+An absolute URL is a complete address used to access a resource. It includes the protocol (which could be `http`, `https`, or `file`), and the domain name if the resource is on the web. Here's an example of an absolute URL that links to the freeCodeCamp logo:
 
 ```html
 <a href="https://design-style-guide.freecodecamp.org/img/fcc_secondary_small.svg">
@@ -60,7 +60,7 @@ So, which should you use and when: an absolute path, an absolute URL, or a relat
 
 - Use absolute paths when you want to reference a resource from a fixed location, such as from the root of your site or a known directory on your local machine.
 
-- Use absolute URL when linking to a resource hosted on an external website.
+- Use an absolute URL when linking to a resource hosted on an external website.
 
 - Use relative paths when linking to resources within the same website.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68772

<!-- Feel free to add any additional description of changes below this line -->

### Summary of Changes

**File: `6716744f7245947a3dd60009.md`** (What Are the Different Target Attribute Types lecture)

- Fixed 3 feedback blocks: changed "experimental `_unfencedTop` attribute" to "experimental `_unfencedTop` value". `_unfencedTop` is a value of the `target` attribute, not an attribute itself — consistent with how the lecture body describes it.
- Fixed 3 feedback blocks: changed "The default attribute type is `_self`." to "The default value is `_self`." — consistent with how the lecture body describes `_self` as a value.

**File: `671682dd88e461a8e2620f38.md`** (What Is the Difference Between Absolute and Relative Paths lecture)

- Fixed an unclosed aside and incorrect conjunction: changed `protocol - which could be http, https, and file and the domain name` to `protocol (which could be \`http\`, \`https\`, or \`file\`), and the domain name`. A URL uses exactly one protocol so `or` is correct; the parentheses properly close the aside.
- Fixed missing article: changed `Use absolute URL when` to `Use an absolute URL when` to match the grammar of the surrounding bullets.