### PR TITLE
fix(curriculum): correct iframe workshop instructions

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876097.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 Add `encrypted-media`, `gyroscope`, and `web-share` to the existing values in the `allow` attribute.
 
-These three will allow the use of encrypted media extensions to protect the video, grant access to the device’s motion and orientation sensors, and allow sharing the iframe content through the device's native share dialogs. 
+These three will allow the use of encrypted media extensions to protect the video, grant access to the device's motion and orientation sensors, and allow sharing the `iframe` content through the device's native share dialogs. 
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876099.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-video-display-using-iframe/68ba9c4f1688914d72876099.md
@@ -13,7 +13,7 @@ With that, the workshop is completed!
 
 # --hints--
 
-Your `iframe` element should have a `allowfullscreen` attribute.
+Your `iframe` element should have an `allowfullscreen` attribute.
 
 ```js
 const iframeEl = document.querySelector('iframe')
@@ -62,7 +62,6 @@ assert.exists(iframeEl?.getAttribute('allowfullscreen'))
   </head>
   <body>
     <h1>iframe Video Display</h1>
-    <br />
     <iframe
       width="560"
       height="315"


### PR DESCRIPTION
## Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #ISSUE_NUMBER

## Description

This PR fixes inconsistencies in the "Build a Video Display Using iframe" workshop.

Changes:
- Wrapped `iframe` in backticks in Step 6.
- Changed the curly apostrophe in `device’s` to `device's`.
- Changed "a `allowfullscreen` attribute" to "an `allowfullscreen` attribute" in Step 8.
- Removed the unnecessary `<br />` from the Step 8 solution.

Closes #68771