### PR TITLE
fix(curriculum): add missing space after comma in task-38

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c4e019a6cbfa3210603aef.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-describe-places-and-events/66c4e019a6cbfa3210603aef.md
@@ -16,7 +16,7 @@ This is a review of the entire dialogue you just studied.
 
 Write the following words or phrases in the correct spot:
 
-`Where can I`, `Is that right`, `How many` , `Do you know if`,`How does that`, and `Does your app`.
+`Where can I`, `Is that right`, `How many` , `Do you know if`, `How does that`, and `Does your app`.
 
 # --fillInTheBlank--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68823

### Summary of Changes

In `66c4e019a6cbfa3210603aef.md` (Task 38), line 19 was missing a space after the comma between `` `Do you know if` `` and `` `How does that` ``:

**Before:**

Do you know if,How does that



**After:**
Do you know if, How does that



This makes the formatting consistent with all other comma-separated items in the same list.