### PR TITLE
fix(curriculam): correct div elements lesson text

### DIFF
--- a/curriculum/structure/blocks/lecture-html-fundamentals.json
+++ b/curriculum/structure/blocks/lecture-html-fundamentals.json
@@ -7,7 +7,7 @@
   "challengeOrder": [
     {
       "id": "670803abcb3e980233da4768",
-      "title": "What are Div Elements and When Should You Use Them?"
+      "title": "What Are Div Elements and When Should You Use Them?"
     },
     {
       "id": "6708382cf088b216580a9ff1",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Changes made:

- Corrected the lecture title to title case in the frontmatter.
- Updated the corresponding `challengeOrder` title in the block JSON.
- Improved the wording of the `section` element explanation for grammatical correctness.
- Standardized the incorrect-answer feedback for the third quiz question so all incorrect options use the same feedback.

Closes #68636