### PR TITLE
fix(curriculum): replace regex test with Explorer AST helper in space mission roaster workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c84330cbe604821b9deef.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c84330cbe604821b9deef.md
@@ -20,8 +20,11 @@ assert.isFunction(addCrewMember);
 Your `addCrewMember` function should have parameters `crew` and `astronaut`.
 
 ```js
-const regex = __helpers.functionRegex('addCrewMember', ['crew', 'astronaut']);
-assert.match(__helpers.removeJSComments(addCrewMember.toString()), regex);
+const explorer = await __helpers.Explorer(code);
+const { addCrewMember } = explorer.allFunctions;
+assert.lengthOf(addCrewMember.parameters, 2);
+assert.equal(addCrewMember.parameters[0].toString(), "crew");
+assert.equal(addCrewMember.parameters[1].toString(), "astronaut");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c84330cbe604821b9deef.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c84330cbe604821b9deef.md
@@ -15,7 +15,7 @@ You should create a function named `addCrewMember`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.property(explorer.allFunctions, "addCrewMember");
+assert.exists(explorer.allFunctions.addCrewMember);
 ```
 
 Your `addCrewMember` function should have parameters `crew` and `astronaut`.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c84330cbe604821b9deef.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c84330cbe604821b9deef.md
@@ -23,9 +23,9 @@ Your `addCrewMember` function should have parameters `crew` and `astronaut`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { addCrewMember } = explorer.allFunctions;
-assert.lengthOf(addCrewMember.parameters, 2);
-assert.equal(addCrewMember.parameters[0].toString(), "crew");
-assert.equal(addCrewMember.parameters[1].toString(), "astronaut");
+assert.lengthOf(addCrewMember?.parameters, 2);
+assert.equal(addCrewMember?.parameters?.[0]?.toString(), "crew");
+assert.equal(addCrewMember?.parameters?.[1]?.toString(), "astronaut");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c84330cbe604821b9deef.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694c84330cbe604821b9deef.md
@@ -14,7 +14,8 @@ Mission control requires a method for adding new members to the roster. Create a
 You should create a function named `addCrewMember`.
 
 ```js
-assert.isFunction(addCrewMember);
+const explorer = await __helpers.Explorer(code);
+assert.property(explorer.allFunctions, "addCrewMember");
 ```
 
 Your `addCrewMember` function should have parameters `crew` and `astronaut`.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ce8609fb805ba21cebc02.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ce8609fb805ba21cebc02.md
@@ -20,7 +20,8 @@ Mission control needs a method to swap the positions of two crew members in a ro
 You should create a function named `swapCrewMembers`.
 
 ```js
-assert.isFunction(swapCrewMembers);
+const explorer = await __helpers.Explorer(code);
+assert.property(explorer.allFunctions, "swapCrewMembers");
 ```
 
 Your `swapCrewMembers` function should have parameters `crew`, `fromIndex`, and `toIndex`.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ce8609fb805ba21cebc02.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ce8609fb805ba21cebc02.md
@@ -29,10 +29,10 @@ Your `swapCrewMembers` function should have parameters `crew`, `fromIndex`, and 
 ```js
 const explorer = await __helpers.Explorer(code);
 const { swapCrewMembers } = explorer.allFunctions;
-assert.lengthOf(swapCrewMembers.parameters, 3);
-assert.equal(swapCrewMembers.parameters[0].toString(), "crew");
-assert.equal(swapCrewMembers.parameters[1].toString(), "fromIndex");
-assert.equal(swapCrewMembers.parameters[2].toString(), "toIndex");
+assert.lengthOf(swapCrewMembers?.parameters, 3);
+assert.equal(swapCrewMembers?.parameters?.[0]?.toString(), "crew");
+assert.equal(swapCrewMembers?.parameters?.[1]?.toString(), "fromIndex");
+assert.equal(swapCrewMembers?.parameters?.[2]?.toString(), "toIndex");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ce8609fb805ba21cebc02.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ce8609fb805ba21cebc02.md
@@ -21,7 +21,7 @@ You should create a function named `swapCrewMembers`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.property(explorer.allFunctions, "swapCrewMembers");
+assert.exists(explorer.allFunctions.swapCrewMembers);
 ```
 
 Your `swapCrewMembers` function should have parameters `crew`, `fromIndex`, and `toIndex`.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ce8609fb805ba21cebc02.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694ce8609fb805ba21cebc02.md
@@ -26,8 +26,12 @@ assert.isFunction(swapCrewMembers);
 Your `swapCrewMembers` function should have parameters `crew`, `fromIndex`, and `toIndex`.
 
 ```js
-const regex = __helpers.functionRegex('swapCrewMembers', ['crew', 'fromIndex', 'toIndex']);
-assert.match(__helpers.removeJSComments(swapCrewMembers.toString()), regex);
+const explorer = await __helpers.Explorer(code);
+const { swapCrewMembers } = explorer.allFunctions;
+assert.lengthOf(swapCrewMembers.parameters, 3);
+assert.equal(swapCrewMembers.parameters[0].toString(), "crew");
+assert.equal(swapCrewMembers.parameters[1].toString(), "fromIndex");
+assert.equal(swapCrewMembers.parameters[2].toString(), "toIndex");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
@@ -20,15 +20,15 @@ const copyArray = originalArray.slice();
 You should use the `slice()` method to copy the input `crew` array and store the result in a new variable named `updatedCrew`.
 
 ```js
-const funcStr = __helpers.removeJSComments(swapCrewMembers.toString());
-assert.match(
-  funcStr,
-  /(var|let|const)\s+updatedCrew/,
-  "You must have at least one space between the declaration keyword (let/const) and 'updatedCrew'"
-);
+const explorer = await __helpers.Explorer(code);
+const { swapCrewMembers } = explorer.allFunctions;
+const { updatedCrew } = swapCrewMembers.variables;
 
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(swapCrewMembers.toString()));
-assert.match(cleaned, /(var|let|const)updatedCrew=crew\.slice\(\);?\}$/);
+assert.isTrue(
+  ["var", "let", "const"].some(keyword =>
+    updatedCrew.matches(`${keyword} updatedCrew = crew.slice()`)
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
@@ -24,11 +24,7 @@ const explorer = await __helpers.Explorer(code);
 const { swapCrewMembers } = explorer.allFunctions;
 const { updatedCrew } = swapCrewMembers?.variables ?? {};
 
-assert.isTrue(
-  ["var", "let", "const"].some(keyword =>
-    updatedCrew?.matches(`${keyword} updatedCrew = crew.slice()`)
-  )
-);
+assert.equal(updatedCrew?.value?.toString(), "crew.slice()");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
@@ -22,11 +22,11 @@ You should use the `slice()` method to copy the input `crew` array and store the
 ```js
 const explorer = await __helpers.Explorer(code);
 const { swapCrewMembers } = explorer.allFunctions;
-const { updatedCrew } = swapCrewMembers.variables;
+const { updatedCrew } = swapCrewMembers?.variables ?? {};
 
 assert.isTrue(
   ["var", "let", "const"].some(keyword =>
-    updatedCrew.matches(`${keyword} updatedCrew = crew.slice()`)
+    updatedCrew?.matches(`${keyword} updatedCrew = crew.slice()`)
   )
 );
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694d8ddbfc4bb6940b921bbc.md
@@ -24,7 +24,7 @@ const explorer = await __helpers.Explorer(code);
 const { swapCrewMembers } = explorer.allFunctions;
 const { updatedCrew } = swapCrewMembers?.variables ?? {};
 
-assert.equal(updatedCrew?.value?.toString(), "crew.slice()");
+assert.isTrue(updatedCrew?.value?.matches("crew.slice()"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
@@ -16,7 +16,8 @@ You should use `swapCrewMembers()` to swap `squad` members at indices `2` and `5
 ```js
 const explorer = await __helpers.Explorer(code);
 const { updatedSquad: updatedSquadVar } = explorer.variables;
-assert.oneOf(updatedSquadVar?.value?.toString(), ["swapCrewMembers(squad, 2, 5)", "swapCrewMembers(squad, 5, 2)"]);
+const validCalls = ["swapCrewMembers(squad, 2, 5)", "swapCrewMembers(squad, 5, 2)"];
+assert.isTrue(validCalls.some(call => updatedSquadVar?.value.matches(call)));
 const result = [...updatedSquad];
 assert.strictEqual(result[2].name, "Felix");
 assert.strictEqual(result[5].name, "Caroline");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
@@ -16,12 +16,7 @@ You should use `swapCrewMembers()` to swap `squad` members at indices `2` and `5
 ```js
 const explorer = await __helpers.Explorer(code);
 const { updatedSquad } = explorer.variables;
-assert.isTrue(
-  ["let", "const"].some(keyword =>
-    updatedSquad?.matches(`${keyword} updatedSquad = swapCrewMembers(squad, 2, 5)`) ||
-    updatedSquad?.matches(`${keyword} updatedSquad = swapCrewMembers(squad, 5, 2)`)
-  )
-);
+assert.oneOf(updatedSquad?.value?.toString(), ["swapCrewMembers(squad, 2, 5)", "swapCrewMembers(squad, 5, 2)"]);
 const result = [...updatedSquad];
 assert.strictEqual(result[2].name, "Felix");
 assert.strictEqual(result[5].name, "Caroline");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
@@ -15,8 +15,8 @@ You should use `swapCrewMembers()` to swap `squad` members at indices `2` and `5
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const { updatedSquad } = explorer.variables;
-assert.oneOf(updatedSquad?.value?.toString(), ["swapCrewMembers(squad, 2, 5)", "swapCrewMembers(squad, 5, 2)"]);
+const { updatedSquad: updatedSquadVar } = explorer.variables;
+assert.oneOf(updatedSquadVar?.value?.toString(), ["swapCrewMembers(squad, 2, 5)", "swapCrewMembers(squad, 5, 2)"]);
 const result = [...updatedSquad];
 assert.strictEqual(result[2].name, "Felix");
 assert.strictEqual(result[5].name, "Caroline");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
@@ -18,8 +18,8 @@ const explorer = await __helpers.Explorer(code);
 const { updatedSquad } = explorer.variables;
 assert.isTrue(
   ["let", "const"].some(keyword =>
-    updatedSquad.matches(`${keyword} updatedSquad = swapCrewMembers(squad, 2, 5)`) ||
-    updatedSquad.matches(`${keyword} updatedSquad = swapCrewMembers(squad, 5, 2)`)
+    updatedSquad?.matches(`${keyword} updatedSquad = swapCrewMembers(squad, 2, 5)`) ||
+    updatedSquad?.matches(`${keyword} updatedSquad = swapCrewMembers(squad, 5, 2)`)
   )
 );
 const result = [...updatedSquad];

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694dfd604c32cfe8e298784c.md
@@ -14,13 +14,14 @@ Mission control has requested you to swap the positions of two astronauts in you
 You should use `swapCrewMembers()` to swap `squad` members at indices `2` and `5` and store the resulting array in a new variable named `updatedSquad`.
 
 ```js
-assert.match(
-  __helpers.removeJSComments(code),
-  /(let|const)\s+updatedSquad/,
-  "You must have at least one space between the declaration keyword (let/const) and 'updatedSquad'"
+const explorer = await __helpers.Explorer(code);
+const { updatedSquad } = explorer.variables;
+assert.isTrue(
+  ["let", "const"].some(keyword =>
+    updatedSquad.matches(`${keyword} updatedSquad = swapCrewMembers(squad, 2, 5)`) ||
+    updatedSquad.matches(`${keyword} updatedSquad = swapCrewMembers(squad, 5, 2)`)
+  )
 );
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(code));
-assert.match(cleaned, /(let|const)updatedSquad=swapCrewMembers\(squad,?(2,?5|5,?2)\)/);
 const result = [...updatedSquad];
 assert.strictEqual(result[2].name, "Felix");
 assert.strictEqual(result[5].name, "Caroline");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0952a3742f2898aef517.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0952a3742f2898aef517.md
@@ -14,7 +14,8 @@ Mission control requires a method for copying EVA-eligible astronauts from a cre
 You should create a function named `getEVAReadyCrew`.
 
 ```js
-assert.isFunction(getEVAReadyCrew);
+const explorer = await __helpers.Explorer(code);
+assert.property(explorer.allFunctions, "getEVAReadyCrew");
 ```
 
 Your `getEVAReadyCrew` function should have a `crew` parameter.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0952a3742f2898aef517.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0952a3742f2898aef517.md
@@ -20,8 +20,10 @@ assert.isFunction(getEVAReadyCrew);
 Your `getEVAReadyCrew` function should have a `crew` parameter.
 
 ```js
-const regex = __helpers.functionRegex('getEVAReadyCrew', ['crew']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const { getEVAReadyCrew } = explorer.allFunctions;
+assert.lengthOf(getEVAReadyCrew.parameters, 1);
+assert.equal(getEVAReadyCrew.parameters[0].toString(), "crew");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0952a3742f2898aef517.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0952a3742f2898aef517.md
@@ -23,8 +23,8 @@ Your `getEVAReadyCrew` function should have a `crew` parameter.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { getEVAReadyCrew } = explorer.allFunctions;
-assert.lengthOf(getEVAReadyCrew.parameters, 1);
-assert.equal(getEVAReadyCrew.parameters[0].toString(), "crew");
+assert.lengthOf(getEVAReadyCrew?.parameters, 1);
+assert.equal(getEVAReadyCrew?.parameters?.[0]?.toString(), "crew");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0952a3742f2898aef517.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0952a3742f2898aef517.md
@@ -15,7 +15,7 @@ You should create a function named `getEVAReadyCrew`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.property(explorer.allFunctions, "getEVAReadyCrew");
+assert.exists(explorer.allFunctions.getEVAReadyCrew);
 ```
 
 Your `getEVAReadyCrew` function should have a `crew` parameter.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
@@ -31,8 +31,8 @@ You should return the `eligible` array.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const { getEVAReadyCrew } = explorer.allFunctions;
-assert.isTrue(getEVAReadyCrew?.hasReturn("eligible"));
+const { getEVAReadyCrew: getEVAReadyCrewFn } = explorer.allFunctions;
+assert.isTrue(getEVAReadyCrewFn?.hasReturn("eligible"));
 
 const sample2 = [{ isEVAEligible: true }];
 assert.isArray(getEVAReadyCrew(sample2));

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
@@ -17,7 +17,9 @@ You should create an empty array named `eligible`.
 const explorer = await __helpers.Explorer(code);
 const { getEVAReadyCrew } = explorer.allFunctions;
 const { eligible } = getEVAReadyCrew?.variables ?? {};
-assert.equal(eligible?.value?.toString(), "[]");
+const eligibleVal = eval(eligible?.value?.toString());
+assert.isArray(eligibleVal);
+assert.isEmpty(eligibleVal);
 ```
 
 You should use a `for` loop to iterate through the input `crew` array.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
@@ -14,14 +14,14 @@ First, create an empty array named `eligible`. Then loop through every astronaut
 You should create an array named `eligible`.
 
 ```js
-const funcStr = __helpers.removeJSComments(getEVAReadyCrew.toString());
-assert.match(
-  funcStr,
-  /(var|let|const)\s+eligible/,
-  "You must have at least one space between the declaration keyword (let/const) and 'eligible'"
+const explorer = await __helpers.Explorer(code);
+const { getEVAReadyCrew } = explorer.allFunctions;
+const { eligible } = getEVAReadyCrew.variables;
+assert.isTrue(
+  ["var", "let", "const"].some(keyword =>
+    eligible.matches(`${keyword} eligible = []`)
+  )
 );
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(getEVAReadyCrew.toString()));
-assert.match(cleaned, /(?:^|[^a-zA-Z])(var|let|const)eligible=\[\]/);
 ```
 
 You should use a `for` loop to iterate through the input `crew` array.
@@ -34,8 +34,9 @@ assert.match(cleaned, /for\s*\(/);
 You should return the `eligible` array.
 
 ```js
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(getEVAReadyCrew.toString()));
-assert.match(cleaned, /returneligible;?}$/);
+const explorer = await __helpers.Explorer(code);
+const { getEVAReadyCrew } = explorer.allFunctions;
+assert.isTrue(getEVAReadyCrew.hasReturn("eligible"));
 
 const sample2 = [{ isEVAEligible: true }];
 assert.isArray(getEVAReadyCrew(sample2));

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
@@ -17,11 +17,7 @@ You should create an array named `eligible`.
 const explorer = await __helpers.Explorer(code);
 const { getEVAReadyCrew } = explorer.allFunctions;
 const { eligible } = getEVAReadyCrew?.variables ?? {};
-assert.isTrue(
-  ["var", "let", "const"].some(keyword =>
-    eligible?.matches(`${keyword} eligible = []`)
-  )
-);
+assert.equal(eligible?.value?.toString(), "[]");
 ```
 
 You should use a `for` loop to iterate through the input `crew` array.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
@@ -16,10 +16,10 @@ You should create an array named `eligible`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { getEVAReadyCrew } = explorer.allFunctions;
-const { eligible } = getEVAReadyCrew.variables;
+const { eligible } = getEVAReadyCrew?.variables ?? {};
 assert.isTrue(
   ["var", "let", "const"].some(keyword =>
-    eligible.matches(`${keyword} eligible = []`)
+    eligible?.matches(`${keyword} eligible = []`)
   )
 );
 ```
@@ -36,7 +36,7 @@ You should return the `eligible` array.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { getEVAReadyCrew } = explorer.allFunctions;
-assert.isTrue(getEVAReadyCrew.hasReturn("eligible"));
+assert.isTrue(getEVAReadyCrew?.hasReturn("eligible"));
 
 const sample2 = [{ isEVAEligible: true }];
 assert.isArray(getEVAReadyCrew(sample2));

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e0c6e2cf8b9b45755f0f5.md
@@ -11,7 +11,7 @@ First, create an empty array named `eligible`. Then loop through every astronaut
 
 # --hints--
 
-You should create an array named `eligible`.
+You should create an empty array named `eligible`.
 
 ```js
 const explorer = await __helpers.Explorer(code);

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
@@ -38,7 +38,7 @@ const explorer = await __helpers.Explorer(code);
 const { sortByPriorityDescending } = explorer.allFunctions;
 assert.exists(sortByPriorityDescending);
 assert.lengthOf(sortByPriorityDescending.parameters, 1);
-assert.equal(sortByPriorityDescending?.parameters?.[0]?.toString(), "crew");
+assert.equal(sortByPriorityDescending.parameters?.[0]?.toString(), "crew");
 ```
 
 Your `sortByPriorityDescending` function should use two nested `for` loops to perform the sort.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
@@ -35,9 +35,9 @@ You should have a function named `sortByPriorityDescending` with a `crew` parame
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.allFunctions.sortByPriorityDescending);
 const { sortByPriorityDescending } = explorer.allFunctions;
-assert.lengthOf(sortByPriorityDescending?.parameters, 1);
+assert.exists(sortByPriorityDescending);
+assert.lengthOf(sortByPriorityDescending.parameters, 1);
 assert.equal(sortByPriorityDescending?.parameters?.[0]?.toString(), "crew");
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
@@ -35,9 +35,10 @@ You should have a function named `sortByPriorityDescending` with a `crew` parame
 
 ```js
 assert.isFunction(sortByPriorityDescending);
-const regex = __helpers.functionRegex('sortByPriorityDescending', ['crew']);
-const cleaned = __helpers.removeJSComments(sortByPriorityDescending.toString());
-assert.match(cleaned, regex);
+const explorer = await __helpers.Explorer(code);
+const { sortByPriorityDescending } = explorer.allFunctions;
+assert.lengthOf(sortByPriorityDescending.parameters, 1);
+assert.equal(sortByPriorityDescending.parameters[0].toString(), "crew");
 ```
 
 Your `sortByPriorityDescending` function should use two nested `for` loops to perform the sort.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
@@ -34,8 +34,8 @@ Create a new helper function named `sortByPriorityDescending` that accepts a `cr
 You should have a function named `sortByPriorityDescending` with a `crew` parameter.
 
 ```js
-assert.isFunction(sortByPriorityDescending);
 const explorer = await __helpers.Explorer(code);
+assert.property(explorer.allFunctions, "sortByPriorityDescending");
 const { sortByPriorityDescending } = explorer.allFunctions;
 assert.lengthOf(sortByPriorityDescending.parameters, 1);
 assert.equal(sortByPriorityDescending.parameters[0].toString(), "crew");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
@@ -37,8 +37,8 @@ You should have a function named `sortByPriorityDescending` with a `crew` parame
 const explorer = await __helpers.Explorer(code);
 assert.property(explorer.allFunctions, "sortByPriorityDescending");
 const { sortByPriorityDescending } = explorer.allFunctions;
-assert.lengthOf(sortByPriorityDescending.parameters, 1);
-assert.equal(sortByPriorityDescending.parameters[0].toString(), "crew");
+assert.lengthOf(sortByPriorityDescending?.parameters, 1);
+assert.equal(sortByPriorityDescending?.parameters?.[0]?.toString(), "crew");
 ```
 
 Your `sortByPriorityDescending` function should use two nested `for` loops to perform the sort.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694e1931f6509ae16aa1c36f.md
@@ -35,7 +35,7 @@ You should have a function named `sortByPriorityDescending` with a `crew` parame
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.property(explorer.allFunctions, "sortByPriorityDescending");
+assert.exists(explorer.allFunctions.sortByPriorityDescending);
 const { sortByPriorityDescending } = explorer.allFunctions;
 assert.lengthOf(sortByPriorityDescending?.parameters, 1);
 assert.equal(sortByPriorityDescending?.parameters?.[0]?.toString(), "crew");

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
@@ -18,7 +18,7 @@ const explorer = await __helpers.Explorer(code);
 const { EVAReadySquad } = explorer.variables;
 assert.isTrue(
   ["let", "const"].some(keyword =>
-    EVAReadySquad.matches(`${keyword} EVAReadySquad = getEVAReadyCrew(updatedSquad)`)
+    EVAReadySquad?.matches(`${keyword} EVAReadySquad = getEVAReadyCrew(updatedSquad)`)
   )
 );
 assert.isArray(EVAReadySquad);

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
@@ -16,11 +16,7 @@ You should call `getEVAReadyCrew()` with `updatedSquad` and store the result in 
 ```js
 const explorer = await __helpers.Explorer(code);
 const { EVAReadySquad } = explorer.variables;
-assert.isTrue(
-  ["let", "const"].some(keyword =>
-    EVAReadySquad?.matches(`${keyword} EVAReadySquad = getEVAReadyCrew(updatedSquad)`)
-  )
-);
+assert.equal(EVAReadySquad?.value?.toString(), "getEVAReadyCrew(updatedSquad)");
 assert.isArray(EVAReadySquad);
 assert.strictEqual(EVAReadySquad.length, 6)
 const EVANames = EVAReadySquad.map(a => a.name);

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
@@ -15,8 +15,8 @@ You should call `getEVAReadyCrew()` with `updatedSquad` and store the result in 
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const { EVAReadySquad } = explorer.variables;
-assert.equal(EVAReadySquad?.value?.toString(), "getEVAReadyCrew(updatedSquad)");
+const { EVAReadySquad: EVAReadySquadVar } = explorer.variables;
+assert.equal(EVAReadySquadVar?.value?.toString(), "getEVAReadyCrew(updatedSquad)");
 assert.isArray(EVAReadySquad);
 assert.strictEqual(EVAReadySquad.length, 6)
 const EVANames = EVAReadySquad.map(a => a.name);

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
@@ -14,13 +14,13 @@ Invoke `getEVAReadyCrew()` with your `updatedSquad` roster and store the result 
 You should call `getEVAReadyCrew()` with `updatedSquad` and store the result in a new variable named `EVAReadySquad`.
 
 ```js
-assert.match(
-  __helpers.removeJSComments(code),
-  /(let|const)\s+EVAReadySquad/,
-  "You must have at least one space between the declaration keyword (let/const) and 'EVAReadySquad'"
+const explorer = await __helpers.Explorer(code);
+const { EVAReadySquad } = explorer.variables;
+assert.isTrue(
+  ["let", "const"].some(keyword =>
+    EVAReadySquad.matches(`${keyword} EVAReadySquad = getEVAReadyCrew(updatedSquad)`)
+  )
 );
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(code));
-assert.match(cleaned, /(let|const)EVAReadySquad=getEVAReadyCrew\(updatedSquad\)/);
 assert.isArray(EVAReadySquad);
 assert.strictEqual(EVAReadySquad.length, 6)
 const EVANames = EVAReadySquad.map(a => a.name);

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694eef2a7aa196d5f4fa96b9.md
@@ -16,7 +16,7 @@ You should call `getEVAReadyCrew()` with `updatedSquad` and store the result in 
 ```js
 const explorer = await __helpers.Explorer(code);
 const { EVAReadySquad: EVAReadySquadVar } = explorer.variables;
-assert.equal(EVAReadySquadVar?.value?.toString(), "getEVAReadyCrew(updatedSquad)");
+assert.isTrue(EVAReadySquadVar?.value?.matches("getEVAReadyCrew(updatedSquad)"));
 assert.isArray(EVAReadySquad);
 assert.strictEqual(EVAReadySquad.length, 6)
 const EVANames = EVAReadySquad.map(a => a.name);

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
@@ -15,7 +15,7 @@ You should create a function named `chunkCrew`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.property(explorer.allFunctions, "chunkCrew");
+assert.exists(explorer.allFunctions.chunkCrew);
 ```
 
 Your `chunkCrew` function should have `crew` and `size` parameters.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
@@ -14,7 +14,8 @@ Mission control has requested a new function for breaking down a crew into chunk
 You should create a function named `chunkCrew`.
 
 ```js
-assert.isFunction(chunkCrew);
+const explorer = await __helpers.Explorer(code);
+assert.property(explorer.allFunctions, "chunkCrew");
 ```
 
 Your `chunkCrew` function should have `crew` and `size` parameters.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
@@ -20,8 +20,11 @@ assert.isFunction(chunkCrew);
 Your `chunkCrew` function should have `crew` and `size` parameters.
 
 ```js
-const regex = __helpers.functionRegex('chunkCrew', ['crew', 'size']);
-assert.match(__helpers.removeJSComments(chunkCrew.toString()), regex);
+const explorer = await __helpers.Explorer(code);
+const { chunkCrew } = explorer.allFunctions;
+assert.lengthOf(chunkCrew.parameters, 2);
+assert.equal(chunkCrew.parameters[0].toString(), "crew");
+assert.equal(chunkCrew.parameters[1].toString(), "size");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f55431c34fe3ab17c482f.md
@@ -23,9 +23,9 @@ Your `chunkCrew` function should have `crew` and `size` parameters.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { chunkCrew } = explorer.allFunctions;
-assert.lengthOf(chunkCrew.parameters, 2);
-assert.equal(chunkCrew.parameters[0].toString(), "crew");
-assert.equal(chunkCrew.parameters[1].toString(), "size");
+assert.lengthOf(chunkCrew?.parameters, 2);
+assert.equal(chunkCrew?.parameters?.[0]?.toString(), "crew");
+assert.equal(chunkCrew?.parameters?.[1]?.toString(), "size");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
@@ -39,10 +39,10 @@ You should create an empty array named `chunks`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { chunkCrew } = explorer.allFunctions;
-const { chunks } = chunkCrew.variables;
+const { chunks } = chunkCrew?.variables ?? {};
 assert.isTrue(
   ["var", "let", "const"].some(keyword =>
-    chunks.matches(`${keyword} chunks = []`)
+    chunks?.matches(`${keyword} chunks = []`)
   )
 );
 ```
@@ -66,7 +66,7 @@ After the loop, you should return the `chunks` array.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { chunkCrew } = explorer.allFunctions;
-assert.isTrue(chunkCrew.hasReturn("chunks"));
+assert.isTrue(chunkCrew?.hasReturn("chunks"));
 ```
 
 Your `chunkCrew` function should return chunks of length `size` from the input array `crew` without mutating it.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
@@ -40,11 +40,7 @@ You should create an empty array named `chunks`.
 const explorer = await __helpers.Explorer(code);
 const { chunkCrew } = explorer.allFunctions;
 const { chunks } = chunkCrew?.variables ?? {};
-assert.isTrue(
-  ["var", "let", "const"].some(keyword =>
-    chunks?.matches(`${keyword} chunks = []`)
-  )
-);
+assert.equal(chunks?.value?.toString(), "[]");
 ```
 
 You should use a `for` loop to build chunks.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
@@ -40,7 +40,9 @@ You should create an empty array named `chunks`.
 const explorer = await __helpers.Explorer(code);
 const { chunkCrew } = explorer.allFunctions;
 const { chunks } = chunkCrew?.variables ?? {};
-assert.equal(chunks?.value?.toString(), "[]");
+const chunksVal = eval(chunks?.value?.toString());
+assert.isArray(chunksVal);
+assert.isEmpty(chunksVal);
 ```
 
 You should use a `for` loop to build chunks.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/694f8510e8a0a3d89e146a01.md
@@ -37,14 +37,14 @@ To complete the `chunkCrew` function, you must:
 You should create an empty array named `chunks`.
 
 ```js
-const funcStr = __helpers.removeJSComments(chunkCrew.toString());
-assert.match(
-  funcStr,
-  /(var|let|const)\s+chunks/,
-  "You must have at least one space between the declaration keyword (let/const) and 'chunks'"
+const explorer = await __helpers.Explorer(code);
+const { chunkCrew } = explorer.allFunctions;
+const { chunks } = chunkCrew.variables;
+assert.isTrue(
+  ["var", "let", "const"].some(keyword =>
+    chunks.matches(`${keyword} chunks = []`)
+  )
 );
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(chunkCrew.toString()));
-assert.match(cleaned, /(?:^|[^a-zA-Z])(var|let|const)chunks=\[\]/);
 ```
 
 You should use a `for` loop to build chunks.
@@ -64,8 +64,9 @@ assert.match(cleaned, /chunks\.push\(crew\.slice\(/);
 After the loop, you should return the `chunks` array.
 
 ```js
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(chunkCrew.toString()));
-assert.match(cleaned, /returnchunks;?}$/);
+const explorer = await __helpers.Explorer(code);
+const { chunkCrew } = explorer.allFunctions;
+assert.isTrue(chunkCrew.hasReturn("chunks"));
 ```
 
 Your `chunkCrew` function should return chunks of length `size` from the input array `crew` without mutating it.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
@@ -16,7 +16,7 @@ You should call `chunkCrew()` with `EVAReadySquad` and `3` and store the result 
 ```js
 const explorer = await __helpers.Explorer(code);
 const { EVAChunks: EVAChunksVar } = explorer.variables;
-assert.equal(EVAChunksVar?.value?.toString(), "chunkCrew(EVAReadySquad, 3)");
+assert.isTrue(EVAChunksVar?.value?.matches("chunkCrew(EVAReadySquad, 3)"));
 assert.isArray(EVAChunks);
 assert.deepEqual(EVAChunks, [
   [

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
@@ -18,7 +18,7 @@ const explorer = await __helpers.Explorer(code);
 const { EVAChunks } = explorer.variables;
 assert.isTrue(
   ["let", "const"].some(keyword =>
-    EVAChunks.matches(`${keyword} EVAChunks = chunkCrew(EVAReadySquad, 3)`)
+    EVAChunks?.matches(`${keyword} EVAChunks = chunkCrew(EVAReadySquad, 3)`)
   )
 );
 assert.isArray(EVAChunks);

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
@@ -15,8 +15,8 @@ You should call `chunkCrew()` with `EVAReadySquad` and `3` and store the result 
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const { EVAChunks } = explorer.variables;
-assert.equal(EVAChunks?.value?.toString(), "chunkCrew(EVAReadySquad, 3)");
+const { EVAChunks: EVAChunksVar } = explorer.variables;
+assert.equal(EVAChunksVar?.value?.toString(), "chunkCrew(EVAReadySquad, 3)");
 assert.isArray(EVAChunks);
 assert.deepEqual(EVAChunks, [
   [

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
@@ -14,13 +14,13 @@ Use your `chunkCrew()` function to create chunks of size `3` from your `EVAReady
 You should call `chunkCrew()` with `EVAReadySquad` and `3` and store the result in a new variable named `EVAChunks`.
 
 ```js
-assert.match(
-  __helpers.removeJSComments(code),
-  /(let|const)\s+EVAChunks/,
-  "You must have at least one space between the declaration keyword (let/const) and 'EVAChunks'"
+const explorer = await __helpers.Explorer(code);
+const { EVAChunks } = explorer.variables;
+assert.isTrue(
+  ["let", "const"].some(keyword =>
+    EVAChunks.matches(`${keyword} EVAChunks = chunkCrew(EVAReadySquad, 3)`)
+  )
 );
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(code));
-assert.match(cleaned, /(let|const)EVAChunks=chunkCrew\(EVAReadySquad,?3\)/);
 assert.isArray(EVAChunks);
 assert.deepEqual(EVAChunks, [
   [

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/69504214cbcb33319a1fa506.md
@@ -16,11 +16,7 @@ You should call `chunkCrew()` with `EVAReadySquad` and `3` and store the result 
 ```js
 const explorer = await __helpers.Explorer(code);
 const { EVAChunks } = explorer.variables;
-assert.isTrue(
-  ["let", "const"].some(keyword =>
-    EVAChunks?.matches(`${keyword} EVAChunks = chunkCrew(EVAReadySquad, 3)`)
-  )
-);
+assert.equal(EVAChunks?.value?.toString(), "chunkCrew(EVAReadySquad, 3)");
 assert.isArray(EVAChunks);
 assert.deepEqual(EVAChunks, [
   [

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
@@ -23,8 +23,8 @@ Your `printCrewSummary` function should have a `crew` parameter.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { printCrewSummary } = explorer.allFunctions;
-assert.lengthOf(printCrewSummary.parameters, 1);
-assert.equal(printCrewSummary.parameters[0].toString(), "crew");
+assert.lengthOf(printCrewSummary?.parameters, 1);
+assert.equal(printCrewSummary?.parameters?.[0]?.toString(), "crew");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
@@ -14,7 +14,8 @@ Mission Control requires one more function for logging a summary of your crew. C
 You should create a function named `printCrewSummary`.
 
 ```js
-assert.isFunction(printCrewSummary);
+const explorer = await __helpers.Explorer(code);
+assert.property(explorer.allFunctions, "printCrewSummary");
 ```
 
 Your `printCrewSummary` function should have a `crew` parameter.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
@@ -15,7 +15,7 @@ You should create a function named `printCrewSummary`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.property(explorer.allFunctions, "printCrewSummary");
+assert.exists(explorer.allFunctions.printCrewSummary);
 ```
 
 Your `printCrewSummary` function should have a `crew` parameter.

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4676b22517fd225b2497.md
@@ -20,8 +20,10 @@ assert.isFunction(printCrewSummary);
 Your `printCrewSummary` function should have a `crew` parameter.
 
 ```js
-const regex = __helpers.functionRegex('printCrewSummary', ['crew']);
-assert.match(__helpers.removeJSComments(printCrewSummary.toString()), regex);
+const explorer = await __helpers.Explorer(code);
+const { printCrewSummary } = explorer.allFunctions;
+assert.lengthOf(printCrewSummary.parameters, 1);
+assert.equal(printCrewSummary.parameters[0].toString(), "crew");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
@@ -14,15 +14,14 @@ First, create a shallow copy of the input `crew` array using `slice()` and assig
 You should use the `slice()` method to copy the input `crew` array into a new variable named `sorted`.
 
 ```js
-const funcStr = __helpers.removeJSComments(printCrewSummary.toString());
-assert.match(
-  funcStr,
-  /(var|let|const)\s+sorted/,
-  "You must have at least one space between the declaration keyword (let/const) and 'sorted'"
+const explorer = await __helpers.Explorer(code);
+const { printCrewSummary } = explorer.allFunctions;
+const { sorted } = printCrewSummary.variables;
+assert.isTrue(
+  ["var", "let", "const"].some(keyword =>
+    sorted.matches(`${keyword} sorted = crew.slice()`)
+  )
 );
-
-const cleaned = __helpers.removeWhiteSpace(__helpers.removeJSComments(printCrewSummary.toString()));
-assert.match(cleaned, /(?:var|let|const)sorted=crew\.slice\(\);?/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
@@ -17,11 +17,7 @@ You should use the `slice()` method to copy the input `crew` array into a new va
 const explorer = await __helpers.Explorer(code);
 const { printCrewSummary } = explorer.allFunctions;
 const { sorted } = printCrewSummary?.variables ?? {};
-assert.isTrue(
-  ["var", "let", "const"].some(keyword =>
-    sorted?.matches(`${keyword} sorted = crew.slice()`)
-  )
-);
+assert.equal(sorted?.value?.toString(), "crew.slice()");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
@@ -16,10 +16,10 @@ You should use the `slice()` method to copy the input `crew` array into a new va
 ```js
 const explorer = await __helpers.Explorer(code);
 const { printCrewSummary } = explorer.allFunctions;
-const { sorted } = printCrewSummary.variables;
+const { sorted } = printCrewSummary?.variables ?? {};
 assert.isTrue(
   ["var", "let", "const"].some(keyword =>
-    sorted.matches(`${keyword} sorted = crew.slice()`)
+    sorted?.matches(`${keyword} sorted = crew.slice()`)
   )
 );
 ```

--- a/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
+++ b/curriculum/challenges/english/blocks/workshop-space-mission-roster/695a4886b85613bdcd8dfc3f.md
@@ -17,7 +17,7 @@ You should use the `slice()` method to copy the input `crew` array into a new va
 const explorer = await __helpers.Explorer(code);
 const { printCrewSummary } = explorer.allFunctions;
 const { sorted } = printCrewSummary?.variables ?? {};
-assert.equal(sorted?.value?.toString(), "crew.slice()");
+assert.isTrue(sorted?.value?.matches("crew.slice()"));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68721

<!-- Feel free to add any additional description of changes below this line -->

Replace regex-based assertion with TS explorer assertions in space mission roaster workshop