### PR TITLE
fix(api): check email rate limit before updating newEmail

### DIFF
--- a/api/src/routes/protected/settings.test.ts
+++ b/api/src/routes/protected/settings.test.ts
@@ -667,6 +667,16 @@ Please wait 5 minutes to resend an authentication link.`
           type: 'info',
           message: `Please wait 5 minutes to resend an authentication link.`
         });
+
+        // The rate-limited request must not overwrite the pending email,
+        // otherwise the confirmation link sent to the first address would be
+        // invalidated.
+        const user = await fastifyTestInstance.prisma.user.findFirstOrThrow({
+          where: { email: developerUserEmail },
+          select: { newEmail: true }
+        });
+
+        expect(user.newEmail).toEqual(unusedEmailOne);
       });
 
       test('PUT creates an auth token record for the requesting user', async () => {

--- a/api/src/routes/protected/settings.ts
+++ b/api/src/routes/protected/settings.ts
@@ -275,6 +275,25 @@ ${isLinkSentWithinLimitTTL}`
         });
       }
 
+      // TODO: combine emailVerifyTTL and emailAuthLinkTTL? I'm not sure why
+      // we need emailVeriftyTTL given that the main thing we want is to
+      // restrict the rate of attempts and the emailAuthLinkTTL already does
+      // that.
+      const tooManyRequestsMessage = getWaitMessage({
+        sentAt: user.emailAuthLinkTTL
+      });
+
+      if (tooManyRequestsMessage) {
+        req.log.warn(
+          'Email confirmation link has been sent within the last 5 minutes'
+        );
+        void reply.code(429);
+        return reply.send({
+          type: 'info',
+          message: tooManyRequestsMessage
+        });
+      }
+
       // ToDo(MVP): email the new email and wait user to confirm it, before we update the user schema.
       try {
         await fastify.prisma.user.update({
@@ -285,25 +304,6 @@ ${isLinkSentWithinLimitTTL}`
             emailVerifyTTL: new Date()
           }
         });
-
-        // TODO: combine emailVerifyTTL and emailAuthLinkTTL? I'm not sure why
-        // we need emailVeriftyTTL given that the main thing we want is to
-        // restrict the rate of attempts and the emailAuthLinkTTL already does
-        // that.
-        const tooManyRequestsMessage = getWaitMessage({
-          sentAt: user.emailAuthLinkTTL
-        });
-
-        if (tooManyRequestsMessage) {
-          req.log.warn(
-            'Email confirmation link has been sent within the last 5 minutes'
-          );
-          void reply.code(429);
-          return reply.send({
-            type: 'info',
-            message: tooManyRequestsMessage
-          });
-        }
 
         // Update the emailAuthLinkTTL to ensure we don't send too many emails.
         await fastify.prisma.user.update({


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68738

The rate limit check on `/update-my-email` ran after the `user.update`, so a second request within the 5 minute window returned 429 but had already overwritten `newEmail`. That left the confirmation link sent to the first address broken, since `/confirm-email` checks it against the stored `newEmail`.

I moved the check before the update, next to the other early returns (own email, email already taken, etc.). Same message and status code as before, and it reuses the `user` we already loaded so there's no extra query.

I also extended the existing "second request returns 429" test to assert that `newEmail` still holds the first email after the rejected request. Confirmed it fails on `main` without the change and passes with it.

Followed the approach @Sembauke suggested in the issue.