### PR TITLE
fix(curriculum): replace regex based tests with Explorer api in logic-checker-app workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a51806fb743bc896c3af7.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a51806fb743bc896c3af7.md
@@ -25,8 +25,12 @@ Now, call `Boolean(truthyOrFalsy)` and log the result to the console.
 
 You should log `Boolean(truthyOrFalsy)` to the console.
 
-```js
-assert.match(__helpers.removeJSComments(code), /console\s*\.\s*log\s*\(\s*Boolean\s*\(\s*truthyOrFalsy\s*\)\s*\)\s*;?/);
+
+```js 
+const consoleSpy = __helpers.spyOn(console, 'log');
+const calledWithBoolean = consoleSpy.calls.some(args => args.includes(false) || args.includes(true));
+consoleSpy.restore();
+assert.isFalse(calledWithBoolean);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a51806fb743bc896c3af7.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a51806fb743bc896c3af7.md
@@ -25,12 +25,8 @@ Now, call `Boolean(truthyOrFalsy)` and log the result to the console.
 
 You should log `Boolean(truthyOrFalsy)` to the console.
 
-
-```js 
-const consoleSpy = __helpers.spyOn(console, 'log');
-const calledWithBoolean = consoleSpy.calls.some(args => args.includes(false) || args.includes(true));
-consoleSpy.restore();
-assert.isTrue(calledWithBoolean);
+```js
+assert.match(__helpers.removeJSComments(code), /console\s*\.\s*log\s*\(\s*Boolean\s*\(\s*truthyOrFalsy\s*\)\s*\)\s*;?/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a51806fb743bc896c3af7.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a51806fb743bc896c3af7.md
@@ -30,7 +30,7 @@ You should log `Boolean(truthyOrFalsy)` to the console.
 const consoleSpy = __helpers.spyOn(console, 'log');
 const calledWithBoolean = consoleSpy.calls.some(args => args.includes(false) || args.includes(true));
 consoleSpy.restore();
-assert.isFalse(calledWithBoolean);
+assert.isTrue(calledWithBoolean);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
@@ -15,8 +15,7 @@ You should not have a `truthyOrFalsy` variable.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.notProperty(explorer.variables, 'truthyOrFalsy');
-
+assert.isFalse(explorer.variables.truthyOrFalsy);
 ```
 
 You should not have `console.log(Boolean(truthyOrFalsy))` in your code.

--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
@@ -14,7 +14,9 @@ Now that you know what truthy and falsy values are, remove both your variable de
 You should not have a `truthyOrFalsy` variable.
 
 ```js
-assert.notMatch(__helpers.removeJSComments(code), /const\s+truthyOrFalsy\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.isFalse(explorer.variables.hasOwnProperty('truthyOrFalsy'));
+
 ```
 
 You should not have `console.log(Boolean(truthyOrFalsy))` in your code.

--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
@@ -15,20 +15,15 @@ You should not have a `truthyOrFalsy` variable.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isFalse(explorer.variables.truthyOrFalsy);
+assert.notExists(explorer.variables.truthyOrFalsy);
+
 ```
 
 You should not have `console.log(Boolean(truthyOrFalsy))` in your code.
 
-
 ```js
-const consoleSpy = __helpers.spyOn(console,'log');
-const calledWithFalse = consoleSpy.calls.some(args => args.includes(false) || args.includes(true));
-consoleSpy.restore();
-assert.isFalse(calledWithFalse);
-
+assert.notMatch(__helpers.removeJSComments(code), /console\s*\.\s*log\s*\(\s*Boolean\s*\(\s*truthyOrFalsy\s*\)\s*\)\s*;?/);
 ```
-
 
 # --seed--
 

--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
@@ -16,7 +16,6 @@ You should not have a `truthyOrFalsy` variable.
 ```js
 const explorer = await __helpers.Explorer(code);
 assert.notExists(explorer.variables.truthyOrFalsy);
-
 ```
 
 You should not have `console.log(Boolean(truthyOrFalsy))` in your code.

--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
@@ -15,7 +15,7 @@ You should not have a `truthyOrFalsy` variable.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isFalse(explorer.variables.hasOwnProperty('truthyOrFalsy'));
+assert.notProperty(explorer.variables, 'truthyOrFalsy');
 
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
+++ b/curriculum/challenges/english/blocks/workshop-logic-checker-app/690a57fef66aac39dffc61a2.md
@@ -21,9 +21,15 @@ assert.notProperty(explorer.variables, 'truthyOrFalsy');
 
 You should not have `console.log(Boolean(truthyOrFalsy))` in your code.
 
+
 ```js
-assert.notMatch(__helpers.removeJSComments(code), /console\s*\.\s*log\s*\(\s*Boolean\s*\(\s*truthyOrFalsy\s*\)\s*\)\s*;?/);
+const consoleSpy = __helpers.spyOn(console,'log');
+const calledWithFalse = consoleSpy.calls.some(args => args.includes(false) || args.includes(true));
+consoleSpy.restore();
+assert.isFalse(calledWithFalse);
+
 ```
+
 
 # --seed--
 


### PR DESCRIPTION
…orkshop (#68816)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68816 

<!-- Feel free to add any additional description of changes below this line -->

I looked at the workshop-logic-checker-app directory to find old regex based test, There were 13 .md files and out of them only one had a variable deletion check , where i made a single change. The rest of the files only had runtime checks or if..else and console log checks , which are irreplaceable for now.  