### PR TITLE
fix: wait for finish exam modal to close in test

### DIFF
--- a/client/src/templates/Challenges/exam/components/finish-exam-modal.test.tsx
+++ b/client/src/templates/Challenges/exam/components/finish-exam-modal.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, screen } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -64,14 +68,13 @@ describe('<FinishExamModal />', () => {
   it('closes when the user keeps working on the exam', async () => {
     const user = userEvent.setup();
     renderFinishExamModal();
+    const dialog = screen.getByRole('dialog', { name: modalName });
 
     await user.click(
       screen.getByRole('button', { name: 'learn.exam.finish-no' })
     );
 
-    expect(
-      screen.queryByRole('dialog', { name: modalName })
-    ).not.toBeInTheDocument();
+    await waitForElementToBeRemoved(dialog);
   });
 
   it('calls finishExam and closes when the user finishes the exam', async () => {
@@ -81,25 +84,23 @@ describe('<FinishExamModal />', () => {
       store.dispatch(closeModal('finishExam'));
     });
     renderFinishExamModal({ finishExam, store });
+    const dialog = screen.getByRole('dialog', { name: modalName });
 
     await user.click(
       screen.getByRole('button', { name: 'learn.exam.finish-yes' })
     );
 
     expect(finishExam).toHaveBeenCalledTimes(1);
-    expect(
-      screen.queryByRole('dialog', { name: modalName })
-    ).not.toBeInTheDocument();
+    await waitForElementToBeRemoved(dialog);
   });
 
   it('closes when the user clicks the header close button', async () => {
     const user = userEvent.setup();
     renderFinishExamModal();
+    const dialog = screen.getByRole('dialog', { name: modalName });
 
     await user.click(screen.getByRole('button', { name: 'Close' }));
 
-    expect(
-      screen.queryByRole('dialog', { name: modalName })
-    ).not.toBeInTheDocument();
+    await waitForElementToBeRemoved(dialog);
   });
 });


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #68846

This updates the finish exam modal tests to wait for the dialog to be removed after close actions. The previous assertions used synchronous `queryByRole` checks immediately after user clicks, which could run before the modal had finished closing.