### PR TITLE
fix(tests): update modal tests to use waitFor for asynchronous behavior

### DIFF
--- a/client/src/components/staging-warning-modal/staging-warning-modal.test.tsx
+++ b/client/src/components/staging-warning-modal/staging-warning-modal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import store from 'store';
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import StagingWarningModal from '.';
@@ -37,11 +37,13 @@ describe('StagingWarningModal', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  it('closes the modal when clicking the close button', () => {
+  it('closes the modal when clicking the close button', async () => {
     render(<StagingWarningModal />);
     fireEvent.click(screen.getByText('Close'));
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('displays the correct modal content', () => {
@@ -53,12 +55,14 @@ describe('StagingWarningModal', () => {
     expect(modalContent).toHaveTextContent('staging-warning.p3');
   });
 
-  it('accepts Warning, stores acceptance key in local storage, and closes the modal', () => {
+  it('accepts Warning, stores acceptance key in local storage, and closes the modal', async () => {
     render(<StagingWarningModal />);
 
     fireEvent.click(screen.getByTestId('accepts-warning'));
     expect(store.get('acceptedStagingWarning')).toBe(true);
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 });

--- a/client/src/templates/Challenges/components/mobile-app-modal.test.tsx
+++ b/client/src/templates/Challenges/components/mobile-app-modal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import {
   describe,
   it,
@@ -123,24 +123,36 @@ describe('MobileAppModal', () => {
     expect(dialog).toHaveTextContent('mobile-app-modal.body');
   });
 
-  it('closes the modal without persisting when X is clicked', () => {
+  it('closes the modal without persisting when X is clicked', async () => {
     render(<MobileAppModal superBlock={MOBILE_SUPERBLOCK} />);
     fireEvent.click(screen.getByText('Close'));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
     expect(store.get(STORE_KEY)).toBeUndefined();
   });
 
-  it('closes the modal without persisting when the store link is clicked', () => {
+  it('closes the modal without persisting when the store link is clicked', async () => {
     render(<MobileAppModal superBlock={MOBILE_SUPERBLOCK} />);
     fireEvent.click(screen.getByRole('link'));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
     expect(store.get(STORE_KEY)).toBeUndefined();
   });
 
-  it('closes the modal and stores a timestamp when "do not show" is clicked', () => {
+  it('closes the modal and stores a timestamp when "do not show" is clicked', async () => {
     render(<MobileAppModal superBlock={MOBILE_SUPERBLOCK} />);
     fireEvent.click(screen.getByText('mobile-app-modal.do-not-show'));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
     const stored = store.get(STORE_KEY) as number;
     expect(stored).toBeGreaterThan(0);
     expect(Date.now() - stored).toBeLessThan(1000);

--- a/client/src/templates/Challenges/exam/components/exit-exam-modal.test.tsx
+++ b/client/src/templates/Challenges/exam/components/exit-exam-modal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -70,7 +70,10 @@ describe('<ExitExamModal />', () => {
     );
 
     expect(store.getState().challenge.modal.exitExam).toBe(false);
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('closes from the header close button', async () => {
@@ -81,7 +84,10 @@ describe('<ExitExamModal />', () => {
     await user.click(screen.getByRole('button', { name: 'Close' }));
 
     expect(store.getState().challenge.modal.exitExam).toBe(false);
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('calls exitExam when the user confirms', async () => {

--- a/client/src/templates/Challenges/exam/components/finish-exam-modal.test.tsx
+++ b/client/src/templates/Challenges/exam/components/finish-exam-modal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -69,9 +69,11 @@ describe('<FinishExamModal />', () => {
       screen.getByRole('button', { name: 'learn.exam.finish-no' })
     );
 
-    expect(
-      screen.queryByRole('dialog', { name: modalName })
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: modalName })
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('calls finishExam and closes when the user finishes the exam', async () => {
@@ -87,9 +89,12 @@ describe('<FinishExamModal />', () => {
     );
 
     expect(finishExam).toHaveBeenCalledTimes(1);
-    expect(
-      screen.queryByRole('dialog', { name: modalName })
-    ).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: modalName })
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('closes when the user clicks the header close button', async () => {
@@ -98,8 +103,10 @@ describe('<FinishExamModal />', () => {
 
     await user.click(screen.getByRole('button', { name: 'Close' }));
 
-    expect(
-      screen.queryByRole('dialog', { name: modalName })
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: modalName })
+      ).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Updates all assertions related to closing modals to use `waitFor`, since the action is asynchronous.
- Closes #68846

<!-- Feel free to add any additional description of changes below this line -->
