### PR TITLE
fix(curriculum): correct title case for structural hierarchy lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-importance-of-semantic-html/672985445d7da807c6b4f406.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-semantic-html/672985445d7da807c6b4f406.md
@@ -1,6 +1,6 @@
 ---
 id: 672985445d7da807c6b4f406
-title: Why is it Important to Have Good Structural Hierarchy?
+title: Why Is It Important to Have Good Structural Hierarchy?
 challengeType: 19
 dashedName: why-is-it-important-to-have-good-structural-hierarchy
 ---

--- a/curriculum/structure/blocks/lecture-importance-of-semantic-html.json
+++ b/curriculum/structure/blocks/lecture-importance-of-semantic-html.json
@@ -10,7 +10,7 @@
     },
     {
       "id": "672985445d7da807c6b4f406",
-      "title": "Why is it Important to Have Good Structural Hierarchy?"
+      "title": "Why Is It Important to Have Good Structural Hierarchy?"
     },
     {
       "id": "672990ecf71a852804ababe7",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68844

<!-- Feel free to add any additional description of changes below this line -->

- Corrected the lecture title to title case in the challenge frontmatter.
- Updated the corresponding `challengeOrder` title in the block structure JSON to match.
