### PR TITLE
fix(curriculum): punctuation and title mismatch in quotes and abbreviations lectures

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995c9e6f69436dbcccc79.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995c9e6f69436dbcccc79.md
@@ -42,7 +42,7 @@ All the paragraphs are contained within the same block quotation element, so the
 
 So far I've been using the `cite` attribute to attribute the source of the quotation, but the attribute doesn't really show the source to the user. It only works behind the scenes.
 
-If you want to attribute the source visually, you can add a citation element, `cite`, outside of the block quotation element. This is different from the `cite` attribute. The citation element is an HTML element that you can use to mark up the title of a referenced creative work like a book article, song, film, website, or research paper. Here's an example:
+If you want to attribute the source visually, you can add a citation element, `cite`, outside of the block quotation element. This is different from the `cite` attribute. The citation element is an HTML element that you can use to mark up the title of a referenced creative work like a book, article, song, film, website, or research paper. Here's an example:
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995d673bd3237200b9e7c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995d673bd3237200b9e7c.md
@@ -7,7 +7,7 @@ dashedName: how-do-you-display-abbreviations-and-acronyms-in-html
 
 # --interactive--
 
-An abbreviation is a shortened form of a word or phrase. For example, "Dr" followed by a period, is an abbreviation for the word "doctor".
+An abbreviation is a shortened form of a word or phrase. For example, "Dr" followed by a period is an abbreviation for the word "doctor".
 
 There are two common forms of abbreviations: acronyms and initialisms.
 

--- a/curriculum/structure/blocks/lecture-working-with-text-and-time-semantic-elements.json
+++ b/curriculum/structure/blocks/lecture-working-with-text-and-time-semantic-elements.json
@@ -11,7 +11,7 @@
     },
     {
       "id": "672995d673bd3237200b9e7c",
-      "title": "How Do You Display Abbreviations and Acronyms in HTML?"
+      "title": "How Do You Display Abbreviations in HTML?"
     },
     {
       "id": "672995e43674fb3775b9ec5d",


### PR DESCRIPTION
Closes #68870

## Changes:
1. Added missing comma between 'book' and 'article' in citation element description
2. Removed stray comma separating subject from verb in abbreviations lecture
3. Fixed block JSON title to match challenge frontmatter title