### PR TITLE
fix(curriculum): eliminate potential ReferenceError in JS strings quiz

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995c9e6f69436dbcccc79.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995c9e6f69436dbcccc79.md
@@ -42,7 +42,7 @@ All the paragraphs are contained within the same block quotation element, so the
 
 So far I've been using the `cite` attribute to attribute the source of the quotation, but the attribute doesn't really show the source to the user. It only works behind the scenes.
 
-If you want to attribute the source visually, you can add a citation element, `cite`, outside of the block quotation element. This is different from the `cite` attribute. The citation element is an HTML element that you can use to mark up the title of a referenced creative work like a book article, song, film, website, or research paper. Here's an example:
+If you want to attribute the source visually, you can add a citation element, `cite`, outside of the block quotation element. This is different from the `cite` attribute. The citation element is an HTML element that you can use to mark up the title of a referenced creative work like a book, article, song, film, website, or research paper. Here's an example:
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995d673bd3237200b9e7c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995d673bd3237200b9e7c.md
@@ -7,7 +7,7 @@ dashedName: how-do-you-display-abbreviations-and-acronyms-in-html
 
 # --interactive--
 
-An abbreviation is a shortened form of a word or phrase. For example, "Dr" followed by a period, is an abbreviation for the word "doctor".
+An abbreviation is a shortened form of a word or phrase. For example, "Dr" followed by a period is an abbreviation for the word "doctor".
 
 There are two common forms of abbreviations: acronyms and initialisms.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995f16ed97837b365a9f6.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995f16ed97837b365a9f6.md
@@ -7,9 +7,7 @@ dashedName: how-do-you-display-times-and-dates-in-html
 
 # --interactive--
 
-The `time` element is used to represent a specific moment in time.
-
-Here is an example using the `time` element to represent twenty hundred hours, or eight PM in the evening.
+The `time` element semantically represents a specific moment in time. For example, to display 8 PM (20:00 hours):
 
 :::interactive_editor
 
@@ -19,11 +17,9 @@ Here is an example using the `time` element to represent twenty hundred hours, o
 
 :::
 
-The `datetime` attribute is used to translate dates and times into a machine-readable format.
+The `datetime` attribute provides a machine-readable version of the date or time. This improves accessibility and allows search engines to better understand and display temporal information.
 
-This is important, because it helps with search engine results and helps the browser process date and time information more effectively.
-
-The value for the `datetime` attribute must be either a valid year, valid month, valid time, local date, global date, or valid duration string.
+The `datetime` attribute's value must follow a recognized format, often the ISO 8601 standard, to represent a specific date, time, or duration.
 
 Here is another example of using the time element to represent a particular date:
 
@@ -37,13 +33,11 @@ Here is another example of using the time element to represent a particular date
 
 :::
 
-The value for the `datetime` attribute is in the ISO 8601 format. ISO 8601 is an international standard to represent dates and times.
+The `datetime` attribute value adheres to the ISO 8601 format, an international standard for representing dates and times.
 
-The first part of that value is the year, month and day. The capital T in the value is a separator between the date and time.
+In the example, `2024-06-15T15:00` breaks down into `YYYY-MM-DD` for the date, with `T` as a separator, followed by `HH:MM` for the time (15:00 is 3 PM).
 
-The fifteen hundred hours would be three PM in the afternoon.
-
-Whenever you need to represent events, publication dates, or appointments, it is best to use the `time` element.
+Utilize the `time` element for events, publication dates, and appointments to provide semantic meaning.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/quiz-javascript-strings/66edc31c44f1b9c1d5c5ebca.md
+++ b/curriculum/challenges/english/blocks/quiz-javascript-strings/66edc31c44f1b9c1d5c5ebca.md
@@ -177,28 +177,28 @@ Which of the following is the correct way to access the third character of a str
 
 ```js
 const developer = "Jessica";
-developer[3];
+const thirdCharacter = developer[3];
 ```
 
 ---
 
 ```js
 const developer = "Jessica";
-developer[-1];
+const thirdCharacter = developer[-1];
 ```
 
 ---
 
 ```js
 const developer = "Jessica";
-developer[0];
+const thirdCharacter = developer[0];
 ```
 
 #### --answer--
 
 ```js
 const developer = "Jessica";
-developer[2];
+const thirdCharacter = developer[2];
 ```
 
 ### --question--

--- a/curriculum/structure/blocks/lecture-working-with-text-and-time-semantic-elements.json
+++ b/curriculum/structure/blocks/lecture-working-with-text-and-time-semantic-elements.json
@@ -11,7 +11,7 @@
     },
     {
       "id": "672995d673bd3237200b9e7c",
-      "title": "How Do You Display Abbreviations and Acronyms in HTML?"
+      "title": "How Do You Display Abbreviations in HTML?"
     },
     {
       "id": "672995e43674fb3775b9ec5d",


### PR DESCRIPTION
Closes #68867

## Changes:
- Changed bare expression `developer[N]` to `const thirdCharacter = developer[N]`
- Applied to all 4 code blocks in Question 8 (3 distractors + answer)
- Prevents confusion where `developer` could be misread as self-referencing in its own initializer