### PR TITLE
refactor: make renderExperience a react component

### DIFF
--- a/client/src/components/profile/components/experience.test.tsx
+++ b/client/src/components/profile/components/experience.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 
@@ -101,7 +101,8 @@ describe('<Experience /> validation', () => {
     expect(screen.getByText('validation.company-short')).toBeInTheDocument();
 
     await user.clear(company);
-    await user.type(company, 'A'.repeat(145));
+    // paste is preferrable since typing hundreds of characters is slow (each keystroke triggers a re-render)
+    await user.paste('A'.repeat(145));
     expect(screen.getByText('validation.company-long')).toBeInTheDocument();
 
     await user.clear(company);
@@ -123,7 +124,7 @@ describe('<Experience /> validation', () => {
     expect(screen.getByText('validation.title-short')).toBeInTheDocument();
 
     await user.clear(jobTitle);
-    await user.type(jobTitle, 'A'.repeat(145));
+    await user.paste('A'.repeat(145));
     expect(screen.getByText('validation.title-long')).toBeInTheDocument();
 
     await user.clear(jobTitle);
@@ -177,7 +178,8 @@ describe('<Experience /> validation', () => {
 
     // Prefill to the limit so we only need to type the single character that
     // crosses it, instead of 501 keystrokes (which times the test out in CI).
-    fireEvent.change(description, { target: { value: 'A'.repeat(500) } });
+    await user.click(description);
+    await user.paste('A'.repeat(500));
     expect(
       screen.queryByText('validation.max-characters-500')
     ).not.toBeInTheDocument();

--- a/client/src/components/profile/components/experience.tsx
+++ b/client/src/components/profile/components/experience.tsx
@@ -40,6 +40,26 @@ interface ValidationResult {
   messageKey: string;
 }
 
+type ExperienceField =
+  | 'title'
+  | 'company'
+  | 'location'
+  | 'startDate'
+  | 'endDate'
+  | 'description';
+
+type ExperienceItemProps = {
+  data: ExperienceData;
+  createOnChangeHandler: (
+    id: string,
+    key: ExperienceField
+  ) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onSave: (id: string) => void;
+  onRemove: (id: string) => void;
+  pristine: boolean;
+  t: TFunction;
+};
+
 const mapDispatchToProps = {
   updateMyExperience
 };
@@ -98,6 +118,290 @@ function createEmptyExperienceItem(): ExperienceData {
 const byId = (id: string) => (exp: ExperienceData) => exp.id === id;
 const notById = (id: string) => (exp: ExperienceData) => exp.id !== id;
 
+const getDescriptionValidation = (
+  description: string,
+  t: TFunction
+): ExperienceValidation => {
+  const len = description.length;
+  const charsLeft = 500 - len;
+  if (charsLeft < 0) {
+    return {
+      state: 'error',
+      message: t('validation.max-characters-500', { charsLeft: 0 })
+    };
+  }
+  if (charsLeft < 41 && charsLeft > 0) {
+    return {
+      state: 'warning',
+      message: t('validation.max-characters-500', { charsLeft })
+    };
+  }
+  if (charsLeft === 500) {
+    return { state: null, message: '' };
+  }
+  return { state: 'success', message: '' };
+};
+
+const getTextValidation = (
+  value: string,
+  field: 'title' | 'company',
+  t: TFunction
+): ExperienceValidation => {
+  if (!value) {
+    return { state: 'error', message: t(`validation.${field}-required`) };
+  }
+  const len = value.length;
+  if (len < 2) {
+    return { state: 'error', message: t(`validation.${field}-short`) };
+  }
+  if (len > 144) {
+    return { state: 'error', message: t(`validation.${field}-long`) };
+  }
+  return { state: 'success', message: '' };
+};
+
+const getTitleValidation = (title: string, t: TFunction) =>
+  getTextValidation(title, 'title', t);
+const getCompanyValidation = (company: string, t: TFunction) =>
+  getTextValidation(company, 'company', t);
+
+const getStartDateValidation = (
+  startDate: string,
+  t: TFunction
+): ExperienceValidation => {
+  const result = validateDate({
+    date: startDate,
+    isRequired: true,
+    fieldName: 'start-date'
+  });
+  return {
+    state: result.state,
+    message: result.messageKey ? t(result.messageKey) : ''
+  };
+};
+
+const getEndDateValidation = (
+  endDate: string,
+  t: TFunction
+): ExperienceValidation => {
+  const result = validateDate({
+    date: endDate,
+    isRequired: false,
+    fieldName: 'end-date'
+  });
+  return {
+    state: result.state,
+    message: result.messageKey ? t(result.messageKey) : ''
+  };
+};
+
+const isItemValid = (experienceItem: ExperienceData, t: TFunction): boolean => {
+  const { title, company, startDate, endDate, description } = experienceItem;
+  return (
+    getTitleValidation(title, t).state !== 'error' &&
+    getCompanyValidation(company, t).state !== 'error' &&
+    getStartDateValidation(startDate, t).state !== 'error' &&
+    getEndDateValidation(endDate || '', t).state !== 'error' &&
+    getDescriptionValidation(description, t).state !== 'error'
+  );
+};
+
+const Experience = ({
+  data,
+  createOnChangeHandler,
+  onSave,
+  onRemove,
+  pristine,
+  t
+}: ExperienceItemProps) => {
+  const { id, title, company, location, startDate, endDate, description } =
+    data;
+
+  const { state: titleState, message: titleMessage } = getTitleValidation(
+    title,
+    t
+  );
+  const { state: companyState, message: companyMessage } = getCompanyValidation(
+    company,
+    t
+  );
+  const { state: startDateState, message: startDateMessage } =
+    getStartDateValidation(startDate, t);
+  const { state: endDateState, message: endDateMessage } = getEndDateValidation(
+    endDate || '',
+    t
+  );
+  const { state: descriptionState, message: descriptionMessage } =
+    getDescriptionValidation(description, t);
+  const isButtonDisabled = !isItemValid(data, t);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isButtonDisabled) return;
+    onSave(id);
+  };
+
+  return (
+    <FullWidthRow key={id}>
+      <form onSubmit={handleSubmit}>
+        <FormGroup
+          controlId={`${id}-title`}
+          validationState={
+            pristine || (!pristine && !title) ? null : titleState
+          }
+        >
+          <ControlLabel htmlFor={`${id}-title-input`}>
+            {t('profile.experience.job-title')}{' '}
+            <span aria-hidden='true'>*</span>
+          </ControlLabel>
+          <FormControl
+            onChange={createOnChangeHandler(id, 'title')}
+            required
+            type='text'
+            value={title}
+            name='experience-title'
+            id={`${id}-title-input`}
+            aria-describedby={titleMessage ? `${id}-title-error` : undefined}
+          />
+          {titleMessage ? (
+            <HelpBlock id={`${id}-title-error`}>{titleMessage}</HelpBlock>
+          ) : null}
+        </FormGroup>
+        <FormGroup
+          controlId={`${id}-company`}
+          validationState={
+            pristine || (!pristine && !company) ? null : companyState
+          }
+        >
+          <ControlLabel htmlFor={`${id}-company-input`}>
+            {t('profile.experience.company')} <span aria-hidden='true'>*</span>
+          </ControlLabel>
+          <FormControl
+            onChange={createOnChangeHandler(id, 'company')}
+            required
+            type='text'
+            value={company}
+            name='experience-company'
+            id={`${id}-company-input`}
+            aria-describedby={
+              companyMessage ? `${id}-company-error` : undefined
+            }
+          />
+          {companyMessage ? (
+            <HelpBlock id={`${id}-company-error`}>{companyMessage}</HelpBlock>
+          ) : null}
+        </FormGroup>
+        <FormGroup controlId={`${id}-location`}>
+          <ControlLabel htmlFor={`${id}-location-input`}>
+            {t('profile.experience.location')}
+          </ControlLabel>
+          <FormControl
+            onChange={createOnChangeHandler(id, 'location')}
+            type='text'
+            value={location || ''}
+            name='experience-location'
+            id={`${id}-location-input`}
+          />
+        </FormGroup>
+        <FormGroup
+          controlId={`${id}-startDate`}
+          validationState={
+            pristine || (!pristine && !startDate) ? null : startDateState
+          }
+        >
+          <ControlLabel htmlFor={`${id}-startDate-input`}>
+            {t('profile.experience.start-date')}{' '}
+            <span aria-hidden='true'>*</span>
+          </ControlLabel>
+          <FormControl
+            onChange={createOnChangeHandler(id, 'startDate')}
+            required
+            type='text'
+            value={startDate}
+            name='experience-startDate'
+            id={`${id}-startDate-input`}
+            placeholder='MM/YYYY'
+            aria-describedby={
+              startDateMessage ? `${id}-startDate-error` : undefined
+            }
+          />
+          {startDateMessage ? (
+            <HelpBlock id={`${id}-startDate-error`}>
+              {startDateMessage}
+            </HelpBlock>
+          ) : null}
+        </FormGroup>
+        <FormGroup
+          controlId={`${id}-endDate`}
+          validationState={
+            pristine || (!pristine && !endDate) ? null : endDateState
+          }
+        >
+          <ControlLabel htmlFor={`${id}-endDate-input`}>
+            {t('profile.experience.end-date')} (
+            {t('profile.experience.end-date-helper')})
+          </ControlLabel>
+          <FormControl
+            onChange={createOnChangeHandler(id, 'endDate')}
+            type='text'
+            value={endDate || ''}
+            name='experience-endDate'
+            id={`${id}-endDate-input`}
+            aria-describedby={
+              endDateMessage ? `${id}-endDate-error` : undefined
+            }
+          />
+          {endDateMessage ? (
+            <HelpBlock id={`${id}-endDate-error`}>{endDateMessage}</HelpBlock>
+          ) : null}
+        </FormGroup>
+        <FormGroup
+          controlId={`${id}-description`}
+          validationState={pristine ? null : descriptionState}
+        >
+          <ControlLabel htmlFor={`${id}-description-input`}>
+            {t('profile.experience.description')}{' '}
+            <span aria-hidden='true'>*</span>
+          </ControlLabel>
+          <FormControl
+            componentClass='textarea'
+            onChange={createOnChangeHandler(id, 'description')}
+            required
+            value={description}
+            name='experience-description'
+            id={`${id}-description-input`}
+            aria-describedby={
+              descriptionMessage ? `${id}-description-error` : undefined
+            }
+          />
+          {descriptionMessage ? (
+            <HelpBlock id={`${id}-description-error`}>
+              {descriptionMessage}
+            </HelpBlock>
+          ) : null}
+        </FormGroup>
+        <BlockSaveButton
+          disabled={isButtonDisabled || pristine}
+          bgSize='large'
+          {...((isButtonDisabled || pristine) && { tabIndex: -1 })}
+        >
+          {t('profile.experience.save')}
+        </BlockSaveButton>
+        <Spacer size='xs' />
+        <Button
+          block
+          size='large'
+          variant='danger'
+          onClick={() => onRemove(id)}
+          type='button'
+        >
+          {t('profile.experience.remove')}
+        </Button>
+      </form>
+    </FullWidthRow>
+  );
+};
+
 const ExperienceSettings = (props: ExperienceProps) => {
   const {
     t,
@@ -124,16 +428,7 @@ const ExperienceSettings = (props: ExperienceProps) => {
   const [newItemId, setNewItemId] = useState<string | null>(initial.newItemId);
 
   const createOnChangeHandler =
-    (
-      id: string,
-      key:
-        | 'title'
-        | 'company'
-        | 'location'
-        | 'startDate'
-        | 'endDate'
-        | 'description'
-    ) =>
+    (id: string, key: ExperienceField) =>
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       e.preventDefault();
       const userInput = e.target.value.slice();
@@ -150,7 +445,7 @@ const ExperienceSettings = (props: ExperienceProps) => {
     }
     const itemToSave = experience.find(byId(id));
 
-    if (itemToSave && isItemValid(itemToSave)) {
+    if (itemToSave && isItemValid(itemToSave, t)) {
       const itemIndex = props.experience.findIndex(byId(id));
       const updatedExperience =
         itemIndex >= 0
@@ -186,291 +481,6 @@ const ExperienceSettings = (props: ExperienceProps) => {
     return isEqual(original, edited);
   };
 
-  const getDescriptionValidation = (
-    description: string
-  ): ExperienceValidation => {
-    const len = description.length;
-    const charsLeft = 500 - len;
-    if (charsLeft < 0) {
-      return {
-        state: 'error',
-        message: t('validation.max-characters-500', { charsLeft: 0 })
-      };
-    }
-    if (charsLeft < 41 && charsLeft > 0) {
-      return {
-        state: 'warning',
-        message: t('validation.max-characters-500', { charsLeft })
-      };
-    }
-    if (charsLeft === 500) {
-      return { state: null, message: '' };
-    }
-    return { state: 'success', message: '' };
-  };
-
-  const getTextValidation = (
-    value: string,
-    field: 'title' | 'company'
-  ): ExperienceValidation => {
-    if (!value) {
-      return { state: 'error', message: t(`validation.${field}-required`) };
-    }
-    const len = value.length;
-    if (len < 2) {
-      return { state: 'error', message: t(`validation.${field}-short`) };
-    }
-    if (len > 144) {
-      return { state: 'error', message: t(`validation.${field}-long`) };
-    }
-    return { state: 'success', message: '' };
-  };
-
-  const getTitleValidation = (title: string) =>
-    getTextValidation(title, 'title');
-  const getCompanyValidation = (company: string) =>
-    getTextValidation(company, 'company');
-
-  const getStartDateValidation = (startDate: string): ExperienceValidation => {
-    const result = validateDate({
-      date: startDate,
-      isRequired: true,
-      fieldName: 'start-date'
-    });
-    return {
-      state: result.state,
-      message: result.messageKey ? t(result.messageKey) : ''
-    };
-  };
-
-  const getEndDateValidation = (endDate: string): ExperienceValidation => {
-    const result = validateDate({
-      date: endDate,
-      isRequired: false,
-      fieldName: 'end-date'
-    });
-    return {
-      state: result.state,
-      message: result.messageKey ? t(result.messageKey) : ''
-    };
-  };
-
-  const isItemValid = (experienceItem: ExperienceData): boolean => {
-    const { title, company, startDate, endDate, description } = experienceItem;
-    return (
-      getTitleValidation(title).state !== 'error' &&
-      getCompanyValidation(company).state !== 'error' &&
-      getStartDateValidation(startDate).state !== 'error' &&
-      getEndDateValidation(endDate || '').state !== 'error' &&
-      getDescriptionValidation(description).state !== 'error'
-    );
-  };
-
-  const getFormValidation = (experienceItem: ExperienceData) => {
-    const { id, title, company, startDate, endDate, description } =
-      experienceItem;
-    const { state: titleState, message: titleMessage } =
-      getTitleValidation(title);
-    const { state: companyState, message: companyMessage } =
-      getCompanyValidation(company);
-    const { state: startDateState, message: startDateMessage } =
-      getStartDateValidation(startDate);
-    const { state: endDateState, message: endDateMessage } =
-      getEndDateValidation(endDate || '');
-    const { state: descriptionState, message: descriptionMessage } =
-      getDescriptionValidation(description);
-    const pristine = isFormPristine(id);
-    const isButtonDisabled = !isItemValid(experienceItem);
-    return {
-      isButtonDisabled,
-      title: { titleState, titleMessage },
-      company: { companyState, companyMessage },
-      startDate: { startDateState, startDateMessage },
-      endDate: { endDateState, endDateMessage },
-      description: { descriptionState, descriptionMessage },
-      pristine
-    };
-  };
-
-  const renderExperience = (experienceItem: ExperienceData) => {
-    const { id, title, company, location, startDate, endDate, description } =
-      experienceItem;
-    const {
-      isButtonDisabled,
-      title: { titleState, titleMessage },
-      company: { companyState, companyMessage },
-      startDate: { startDateState, startDateMessage },
-      endDate: { endDateState, endDateMessage },
-      description: { descriptionState, descriptionMessage },
-      pristine
-    } = getFormValidation(experienceItem);
-    const handleSubmit = (e: React.FormEvent<HTMLFormElement>, id: string) => {
-      e.preventDefault();
-      if (isButtonDisabled) return null;
-      return saveItem(id);
-    };
-    return (
-      <FullWidthRow key={id}>
-        <form onSubmit={e => handleSubmit(e, id)}>
-          <FormGroup
-            controlId={`${id}-title`}
-            validationState={
-              pristine || (!pristine && !title) ? null : titleState
-            }
-          >
-            <ControlLabel htmlFor={`${id}-title-input`}>
-              {t('profile.experience.job-title')}{' '}
-              <span aria-hidden='true'>*</span>
-            </ControlLabel>
-            <FormControl
-              onChange={createOnChangeHandler(id, 'title')}
-              required
-              type='text'
-              value={title}
-              name='experience-title'
-              id={`${id}-title-input`}
-              aria-describedby={titleMessage ? `${id}-title-error` : undefined}
-            />
-            {titleMessage ? (
-              <HelpBlock id={`${id}-title-error`}>{titleMessage}</HelpBlock>
-            ) : null}
-          </FormGroup>
-          <FormGroup
-            controlId={`${id}-company`}
-            validationState={
-              pristine || (!pristine && !company) ? null : companyState
-            }
-          >
-            <ControlLabel htmlFor={`${id}-company-input`}>
-              {t('profile.experience.company')}{' '}
-              <span aria-hidden='true'>*</span>
-            </ControlLabel>
-            <FormControl
-              onChange={createOnChangeHandler(id, 'company')}
-              required
-              type='text'
-              value={company}
-              name='experience-company'
-              id={`${id}-company-input`}
-              aria-describedby={
-                companyMessage ? `${id}-company-error` : undefined
-              }
-            />
-            {companyMessage ? (
-              <HelpBlock id={`${id}-company-error`}>{companyMessage}</HelpBlock>
-            ) : null}
-          </FormGroup>
-          <FormGroup controlId={`${id}-location`}>
-            <ControlLabel htmlFor={`${id}-location-input`}>
-              {t('profile.experience.location')}
-            </ControlLabel>
-            <FormControl
-              onChange={createOnChangeHandler(id, 'location')}
-              type='text'
-              value={location || ''}
-              name='experience-location'
-              id={`${id}-location-input`}
-            />
-          </FormGroup>
-          <FormGroup
-            controlId={`${id}-startDate`}
-            validationState={
-              pristine || (!pristine && !startDate) ? null : startDateState
-            }
-          >
-            <ControlLabel htmlFor={`${id}-startDate-input`}>
-              {t('profile.experience.start-date')}{' '}
-              <span aria-hidden='true'>*</span>
-            </ControlLabel>
-            <FormControl
-              onChange={createOnChangeHandler(id, 'startDate')}
-              required
-              type='text'
-              value={startDate}
-              name='experience-startDate'
-              id={`${id}-startDate-input`}
-              placeholder='MM/YYYY'
-              aria-describedby={
-                startDateMessage ? `${id}-startDate-error` : undefined
-              }
-            />
-            {startDateMessage ? (
-              <HelpBlock id={`${id}-startDate-error`}>
-                {startDateMessage}
-              </HelpBlock>
-            ) : null}
-          </FormGroup>
-          <FormGroup
-            controlId={`${id}-endDate`}
-            validationState={
-              pristine || (!pristine && !endDate) ? null : endDateState
-            }
-          >
-            <ControlLabel htmlFor={`${id}-endDate-input`}>
-              {t('profile.experience.end-date')} (
-              {t('profile.experience.end-date-helper')})
-            </ControlLabel>
-            <FormControl
-              onChange={createOnChangeHandler(id, 'endDate')}
-              type='text'
-              value={endDate || ''}
-              name='experience-endDate'
-              id={`${id}-endDate-input`}
-              aria-describedby={
-                endDateMessage ? `${id}-endDate-error` : undefined
-              }
-            />
-            {endDateMessage ? (
-              <HelpBlock id={`${id}-endDate-error`}>{endDateMessage}</HelpBlock>
-            ) : null}
-          </FormGroup>
-          <FormGroup
-            controlId={`${id}-description`}
-            validationState={pristine ? null : descriptionState}
-          >
-            <ControlLabel htmlFor={`${id}-description-input`}>
-              {t('profile.experience.description')}{' '}
-              <span aria-hidden='true'>*</span>
-            </ControlLabel>
-            <FormControl
-              componentClass='textarea'
-              onChange={createOnChangeHandler(id, 'description')}
-              required
-              value={description}
-              name='experience-description'
-              id={`${id}-description-input`}
-              aria-describedby={
-                descriptionMessage ? `${id}-description-error` : undefined
-              }
-            />
-            {descriptionMessage ? (
-              <HelpBlock id={`${id}-description-error`}>
-                {descriptionMessage}
-              </HelpBlock>
-            ) : null}
-          </FormGroup>
-          <BlockSaveButton
-            disabled={isButtonDisabled || pristine}
-            bgSize='large'
-            {...((isButtonDisabled || pristine) && { tabIndex: -1 })}
-          >
-            {t('profile.experience.save')}
-          </BlockSaveButton>
-          <Spacer size='xs' />
-          <Button
-            block
-            size='large'
-            variant='danger'
-            onClick={() => handleRemoveItem(id)}
-            type='button'
-          >
-            {t('profile.experience.remove')}
-          </Button>
-        </form>
-      </FullWidthRow>
-    );
-  };
-
   const itemsToRender = autoAdd
     ? experience.filter(item => item.id === newItemId)
     : editItemId != null
@@ -499,13 +509,26 @@ const ExperienceSettings = (props: ExperienceProps) => {
           <Spacer size='l' />
         </>
       )}
-      {interleave(itemsToRender.map(renderExperience), () => (
-        <>
-          <Spacer size='m' />
-          <hr />
-          <Spacer size='m' />
-        </>
-      ))}
+      {interleave(
+        itemsToRender.map(data => (
+          <Experience
+            key={data.id}
+            data={data}
+            createOnChangeHandler={createOnChangeHandler}
+            onSave={saveItem}
+            onRemove={handleRemoveItem}
+            pristine={isFormPristine(data.id)}
+            t={t}
+          />
+        )),
+        () => (
+          <>
+            <Spacer size='m' />
+            <hr />
+            <Spacer size='m' />
+          </>
+        )
+      )}
     </section>
   );
 };


### PR DESCRIPTION
It's more idiomatic and makes the separation of responsibilities clearer.

There were still some slow tests, so I used .paste to avoid the
re-renders entailed by .type

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Followup to https://github.com/freeCodeCamp/freeCodeCamp/pull/68862. I was hoping the refactor would improve performance. It didn't - fundamentally typing in hundreds of characters is slow when each change causes a re-render. Without moving to an uncontrolled form (e.g. https://react-hook-form.com/), we're stuck with that.

<!-- Feel free to add any additional description of changes below this line -->
