### PR TITLE
fix(client): mirror challenge layout in RTL languages

### DIFF
--- a/client/src/components/layouts/rtl-layout.css
+++ b/client/src/components/layouts/rtl-layout.css
@@ -10,11 +10,6 @@ Increase the spacing in paragraphs
 Intro project buttons and headings 
 */
 
-[dir='rtl'] .monaco-editor-tabs {
-  /* need to remove the margin because the editor is reversed */
-  margin-inline-end: 0;
-}
-
 [dir='rtl'] .map-ui .superblock-link > svg {
   transform: rotate(180deg);
 }
@@ -132,9 +127,9 @@ sections that need to stay left to right
   direction: rtl;
 }
 
-/* Revert the editor layout to account for reverted splitter */
+/* react-reflex splitters need panes laid out LTR in DOM order, so the panes
+are kept physically LTR and mirrored by reversing their order in the JSX */
 
-[dir='rtl'] .desktop-layout .tabs-row,
 [dir='rtl'] .desktop-layout .reflex-container:not(.horizontal) {
   flex-direction: row-reverse;
 }

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -224,7 +224,7 @@
 #mobile-layout .portal-button-wrap {
   position: absolute;
   top: auto;
-  right: 0;
+  inset-inline-end: 0;
   height: 2rem;
   border-bottom: 1px solid var(--quaternary-color);
 }

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import store from 'store';
 import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
+import { isRtlLanguage } from '../../../utils/is-rtl-language';
 import {
   ChallengeFiles,
   DailyCodingChallengeLanguages,
@@ -277,6 +278,121 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     challengeType === challengeTypes.pyLab ||
     challengeType === challengeTypes.dailyChallengePy;
 
+  const panes = [
+    ...(areInstructionsDisplayable && showInstructions
+      ? [
+          <ReflexElement
+            key='instructionPane'
+            flex={instructionPane.flex}
+            {...resizeProps}
+            name='instructionPane'
+            data-playwright-test-label='instruction-pane'
+          >
+            {instructions}
+          </ReflexElement>,
+          <ReflexSplitter
+            key='instructionPaneSplitter'
+            propagate={true}
+            {...resizeProps}
+          />
+        ]
+      : []),
+    <ReflexElement
+      key='editorPane'
+      flex={editorPaneFlex}
+      name='editorPane'
+      {...resizeProps}
+      data-playwright-test-label='editor-pane'
+      className='editor-pane'
+    >
+      {!isEmpty(challengeFiles) && (
+        <ReflexContainer
+          key='codePane'
+          orientation='horizontal'
+          className='editor-pane-code'
+        >
+          <ReflexElement
+            name='codePane'
+            {...(displayEditorConsole && { flex: codePane.flex })}
+            {...reflexProps}
+            {...resizeProps}
+          >
+            {editor}
+          </ReflexElement>
+          {displayEditorConsole && (
+            <ReflexSplitter propagate={true} {...resizeProps} />
+          )}
+          {displayEditorConsole && (
+            <ReflexElement
+              flex={testsPane.flex}
+              {...reflexProps}
+              {...resizeProps}
+            >
+              {testOutput}
+            </ReflexElement>
+          )}
+        </ReflexContainer>
+      )}
+      {showIndependentLowerJaw && <IndependentLowerJaw />}
+    </ReflexElement>,
+    ...(displayNotes
+      ? [
+          <ReflexSplitter
+            key='notesPaneSplitter'
+            propagate={true}
+            {...resizeProps}
+          />,
+          <ReflexElement
+            key='notesPane'
+            name='notesPane'
+            flex={notesPane.flex}
+            {...resizeProps}
+          >
+            <Notes notes={notes} />
+          </ReflexElement>
+        ]
+      : []),
+    ...(displayPreviewPane || displayPreviewConsole
+      ? [
+          <ReflexSplitter
+            key='previewPaneSplitter'
+            data-playwright-test-label='preview-left-splitter'
+            propagate={true}
+            {...resizeProps}
+          />,
+          <ReflexElement
+            key='previewPane'
+            flex={previewPane.flex}
+            name='previewPane'
+            {...resizeProps}
+            data-playwright-test-label='preview-pane'
+          >
+            <ReflexContainer orientation='horizontal'>
+              {displayPreviewPane && (
+                <ReflexElement {...reflexProps}>{preview}</ReflexElement>
+              )}
+              {displayPreviewPane && displayPreviewConsole && (
+                <ReflexSplitter propagate={true} {...resizeProps} />
+              )}
+              {displayPreviewConsole && (
+                <ReflexElement
+                  name='testsPane'
+                  {...(displayPreviewPane && { flex: testsPane.flex })}
+                  {...resizeProps}
+                >
+                  {testOutput}
+                </ReflexElement>
+              )}
+            </ReflexContainer>
+          </ReflexElement>
+        ]
+      : [])
+  ];
+
+  if (isRtlLanguage) {
+    panes.reverse();
+  }
+
   return (
     <div className='desktop-layout' data-playwright-test-label='desktop-layout'>
       {isProjectStyle && (
@@ -301,101 +417,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
         orientation='vertical'
         data-playwright-test-label='main-container'
       >
-        {areInstructionsDisplayable && showInstructions && (
-          <ReflexElement
-            flex={instructionPane.flex}
-            {...resizeProps}
-            name='instructionPane'
-            data-playwright-test-label='instruction-pane'
-          >
-            {instructions}
-          </ReflexElement>
-        )}
-        {areInstructionsDisplayable && showInstructions && (
-          <ReflexSplitter propagate={true} {...resizeProps} />
-        )}
-
-        <ReflexElement
-          flex={editorPaneFlex}
-          name='editorPane'
-          {...resizeProps}
-          data-playwright-test-label='editor-pane'
-          className='editor-pane'
-        >
-          {!isEmpty(challengeFiles) && (
-            <ReflexContainer
-              key='codePane'
-              orientation='horizontal'
-              className='editor-pane-code'
-            >
-              <ReflexElement
-                name='codePane'
-                {...(displayEditorConsole && { flex: codePane.flex })}
-                {...reflexProps}
-                {...resizeProps}
-              >
-                {editor}
-              </ReflexElement>
-              {displayEditorConsole && (
-                <ReflexSplitter propagate={true} {...resizeProps} />
-              )}
-              {displayEditorConsole && (
-                <ReflexElement
-                  flex={testsPane.flex}
-                  {...reflexProps}
-                  {...resizeProps}
-                >
-                  {testOutput}
-                </ReflexElement>
-              )}
-            </ReflexContainer>
-          )}
-          {showIndependentLowerJaw && <IndependentLowerJaw />}
-        </ReflexElement>
-        {displayNotes && <ReflexSplitter propagate={true} {...resizeProps} />}
-        {displayNotes && (
-          <ReflexElement
-            name='notesPane'
-            flex={notesPane.flex}
-            {...resizeProps}
-          >
-            <Notes notes={notes} />
-          </ReflexElement>
-        )}
-
-        {(displayPreviewPane || displayPreviewConsole) && (
-          <ReflexSplitter
-            data-playwright-test-label='preview-left-splitter'
-            propagate={true}
-            {...resizeProps}
-          />
-        )}
-        {(displayPreviewPane || displayPreviewConsole) && (
-          <ReflexElement
-            flex={previewPane.flex}
-            name='previewPane'
-            {...resizeProps}
-            data-playwright-test-label='preview-pane'
-          >
-            <ReflexContainer orientation='horizontal'>
-              {displayPreviewPane && (
-                <ReflexElement {...reflexProps}>{preview}</ReflexElement>
-              )}
-              {displayPreviewPane && displayPreviewConsole && (
-                <ReflexSplitter propagate={true} {...resizeProps} />
-              )}
-              {displayPreviewConsole && (
-                <ReflexElement
-                  name='testsPane'
-                  {...(displayPreviewPane && { flex: testsPane.flex })}
-                  {...resizeProps}
-                >
-                  {testOutput}
-                </ReflexElement>
-              )}
-            </ReflexContainer>
-          </ReflexElement>
-        )}
+        {panes}
       </ReflexContainer>
       {displayPreviewPortal && (
         <PreviewPortal onResize={onPreviewResize} windowTitle={windowTitle}>

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -26,6 +26,7 @@ import {
   showPreviewPaneSelector
 } from '../redux/selectors';
 import { TOOL_PANEL_HEIGHT } from '../../../../config/misc';
+import { isRtlLanguage } from '../../../utils/is-rtl-language';
 import PreviewPortal from '../components/preview-portal';
 import Notes from '../components/notes';
 import EditorTabs from './editor-tabs';
@@ -248,6 +249,7 @@ export class MobileLayout extends Component<
       <>
         <Tabs
           id='mobile-layout'
+          dir={isRtlLanguage ? 'rtl' : 'ltr'}
           className={hasEditableBoundaries ? 'has-editable-boundaries' : ''}
           onKeyDown={this.handleKeyDown}
           onMouseDown={this.handleClick}

--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -8,6 +8,7 @@ import {
   visibleEditorsSelector
 } from '../redux/selectors';
 import { getTargetEditor } from '../utils/get-target-editor';
+import { isRtlLanguage } from '../../../utils/is-rtl-language';
 import './editor.css';
 import Editor, { type EditorProps } from './editor';
 
@@ -113,6 +114,10 @@ const MultifileEditor = (props: MultifileEditorProps) => {
       return [...acc, `${key}-splitter`, key];
     }
   }, []);
+
+  if (isRtlLanguage) {
+    editorAndSplitterKeys.reverse();
+  }
 
   return (
     <ReflexContainer

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -79,7 +79,7 @@
   border-bottom: calc(1.2rem / 2) solid transparent;
   border-inline-start: calc(1.1rem / 2) solid var(--quaternary-background);
   height: 100%;
-  margin-left: 3px;
+  margin-inline-start: 3px;
 }
 
 .breadcrumb-right {

--- a/client/src/utils/is-rtl-language.ts
+++ b/client/src/utils/is-rtl-language.ts
@@ -1,0 +1,6 @@
+import { rtlLangs } from '@freecodecamp/shared/config/i18n';
+import envData from '../../config/env.json';
+
+const { clientLocale } = envData;
+
+export const isRtlLanguage = rtlLangs.includes(clientLocale);


### PR DESCRIPTION
This PR fixes the pane, button, tab orders for RTL languages.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->


rel : https://github.com/freeCodeCamp/freeCodeCamp/issues/67661

<!-- Feel free to add any additional description of changes below this line -->
