### PR TITLE
fix(curriculum): remove transcript note from quiz with no audio (#68865)

### DIFF
--- a/curriculum/challenges/english/blocks/en-a2-quiz-giving-adivice-and-suggestions/696038967cf5869566708d3d.md
+++ b/curriculum/challenges/english/blocks/en-a2-quiz-giving-adivice-and-suggestions/696038967cf5869566708d3d.md
@@ -14,8 +14,6 @@ To pass the quiz, you must correctly answer at least 9 of the 10 questions below
 
 Read each question and choose the correct answer. There's only one correct answer for each question.
 
-For accessibility, transcripts are available for learners with hearing impairments; we recommend using them only if needed.
-
 # --quizzes--
 
 ## --quiz--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68865

<!-- Feel free to add any additional description of changes below this line -->
Removed the hardcoded transcript accessibility note from the --description-- section of the "Explaining Things to Others Quiz" quiz, as this quiz has no audio components.
