### PR TITLE
fix(curriculum): correct nuanced semantic elements lecture text

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-nuanced-semantic-elements/6729959bf9c8e835f46b3f78.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-nuanced-semantic-elements/6729959bf9c8e835f46b3f78.md
@@ -19,7 +19,7 @@ Here is an example from the official HTML spec, using the `i` element to show an
 
 :::
 
-The `lang` attribute inside the open `<i>` tag is used to specify the language of the content. In this case, the language would be French. The `i` element does not indicate if the text is important or not, it only shows that it's somehow different from the surrounding text.
+The `lang` attribute inside the opening `<i>` tag is used to specify the language of the content. In this case, the language would be French. The `i` element does not indicate if the text is important or not, it only shows that it's somehow different from the surrounding text.
 
 If you do need to emphasize the importance of the text, you can use a similar semantic element called the emphasis element, `em`. This is usually recommended if you need to provide more context. You should use this element for parts of the text that require a special emphasis compared to surrounding text. It's usually limited to only a few words, because it can alter the meaning of the sentence.
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-nuanced-semantic-elements/672995ac85fd943657c2ede5.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-nuanced-semantic-elements/672995ac85fd943657c2ede5.md
@@ -22,7 +22,7 @@ The "bring attention to" element, `b`, is commonly used to highlight keywords in
 
 :::
 
-The browser renders these parts of the text as bold text. This visual emphasis will draw readers attention to the product names.
+The browser renders these parts of the text as bold text. This visual emphasis will draw readers' attention to the product names.
 
 If you need to emphasize the importance of the text, you should use the `strong` element instead of the `b` element.
 
@@ -124,7 +124,7 @@ What is the primary difference between `b` and `strong`?
 
 ## --answers--
 
-There is no difference – they both make the text bold.
+There is no difference; they both make the text bold.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68858

<!-- Feel free to add any additional description of changes below this line -->

### Summary

This PR fixes text errors in the "Understanding Nuanced Semantic Elements" lessons.

Changes made:
- Changed "open <i> tag" to "opening <i> tag".
- Corrected "readers attention" to "readers' attention".
- Replaced the incorrect en dash with a semicolon in the answer text.
