### PR TITLE
fix(api): dcc empty collections return 200 not 404

### DIFF
--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
@@ -339,7 +339,7 @@ describe('/daily-coding-challenge', () => {
       expect(res.status).toBe(200);
     });
 
-    it('should return 404 when no challenges exist for the given month', async () => {
+    it('should return 200 with an empty array when no challenges exist for the given month', async () => {
       const count = vi.fn();
       const originalSentry = fastifyTestInstance.Sentry;
       fastifyTestInstance.Sentry = {
@@ -351,11 +351,8 @@ describe('/daily-coding-challenge', () => {
         method: 'GET'
       }).send({});
 
-      expect(res.status).toBe(404);
-      expect(res.body).toEqual({
-        type: 'error',
-        message: 'No challenges found.'
-      });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
       expect(count).toHaveBeenCalledWith('dcc.challenge_not_found', 1, {
         attributes: { route: '/daily-coding-challenge/month/:month' }
       });
@@ -415,7 +412,7 @@ describe('/daily-coding-challenge', () => {
       fastifyTestInstance.Sentry = originalSentry;
     });
 
-    it('should return 404 when no challenges exist', async () => {
+    it('should return 200 with an empty array when no challenges exist', async () => {
       await fastifyTestInstance.prisma.dailyCodingChallenges.deleteMany();
 
       const count = vi.fn();
@@ -429,11 +426,8 @@ describe('/daily-coding-challenge', () => {
         method: 'GET'
       }).send({});
 
-      expect(res.status).toBe(404);
-      expect(res.body).toEqual({
-        type: 'error',
-        message: 'No challenges found.'
-      });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
       expect(count).toHaveBeenCalledWith('dcc.challenge_not_found', 1, {
         attributes: { route: '/daily-coding-challenge/all' }
       });

--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
@@ -353,7 +353,7 @@ describe('/daily-coding-challenge', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual([]);
-      expect(count).toHaveBeenCalledWith('dcc.challenge_not_found', 1, {
+      expect(count).toHaveBeenCalledWith('dcc.empty_result', 1, {
         attributes: { route: '/daily-coding-challenge/month/:month' }
       });
 
@@ -428,7 +428,7 @@ describe('/daily-coding-challenge', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual([]);
-      expect(count).toHaveBeenCalledWith('dcc.challenge_not_found', 1, {
+      expect(count).toHaveBeenCalledWith('dcc.empty_result', 1, {
         attributes: { route: '/daily-coding-challenge/all' }
       });
 

--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
@@ -182,7 +182,7 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
         });
 
         if (!challenges || challenges.length === 0) {
-          fastify.Sentry?.metrics?.count('dcc.challenge_not_found', 1, {
+          fastify.Sentry?.metrics?.count('dcc.empty_result', 1, {
             attributes: { route: '/daily-coding-challenge/month/:month' }
           });
           return reply.send([]);
@@ -241,7 +241,7 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
           });
 
         if (!allChallenges || allChallenges.length === 0) {
-          fastify.Sentry?.metrics?.count('dcc.challenge_not_found', 1, {
+          fastify.Sentry?.metrics?.count('dcc.empty_result', 1, {
             attributes: { route: '/daily-coding-challenge/all' }
           });
           return reply.send([]);

--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
@@ -182,13 +182,10 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
         });
 
         if (!challenges || challenges.length === 0) {
-          req.log.warn({ month }, 'No challenges found for month');
           fastify.Sentry?.metrics?.count('dcc.challenge_not_found', 1, {
             attributes: { route: '/daily-coding-challenge/month/:month' }
           });
-          return reply
-            .status(404)
-            .send({ type: 'error', message: 'No challenges found.' });
+          return reply.send([]);
         }
 
         const response = challenges.map(challenge => ({
@@ -244,13 +241,10 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
           });
 
         if (!allChallenges || allChallenges.length === 0) {
-          req.log.warn({ date: today }, 'No challenges found.');
           fastify.Sentry?.metrics?.count('dcc.challenge_not_found', 1, {
             attributes: { route: '/daily-coding-challenge/all' }
           });
-          return reply
-            .status(404)
-            .send({ type: 'error', message: 'No challenges found.' });
+          return reply.send([]);
         }
 
         const response = allChallenges.map(challenge => ({

--- a/api/src/daily-coding-challenge/schemas/daily-coding-challenge.ts
+++ b/api/src/daily-coding-challenge/schemas/daily-coding-challenge.ts
@@ -79,10 +79,6 @@ const month = {
       type: Type.Literal('error'),
       message: Type.Literal('Invalid date format. Please use YYYY-MM.')
     }),
-    404: Type.Object({
-      type: Type.Literal('error'),
-      message: Type.Literal('No challenges found.')
-    }),
     500: Type.Object({
       type: Type.Literal('error'),
       message: Type.Literal('Internal server error.')
@@ -93,10 +89,6 @@ const month = {
 const all = {
   response: {
     200: manyChallengesResponse,
-    404: Type.Object({
-      type: Type.Literal('error'),
-      message: Type.Literal('No challenges found.')
-    }),
     500: Type.Object({
       type: Type.Literal('error'),
       message: Type.Literal('Internal server error.')

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -137,7 +137,7 @@ function DailyCodingChallengeCalendar({
       const response = await fetch(`${apiLocation}/daily-coding-challenge/all`);
       const challenges = (await response.json()) as AllDailyChallengeFromDb[];
 
-      if (Array.isArray(challenges)) {
+      if (Array.isArray(challenges) && challenges.length > 0) {
         // Todo: validate shape of challenges
 
         const newDailyChallengesMap = new Map() as DailyChallengesMap;

--- a/client/src/pages/learn/daily-coding-challenge/archive.test.tsx
+++ b/client/src/pages/learn/daily-coding-challenge/archive.test.tsx
@@ -123,4 +123,18 @@ describe('<DailyCodingChallengeArchive />', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders the not found page when there are no challenges', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: vi.fn().mockResolvedValue([])
+    } as unknown as Response);
+
+    renderArchive();
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'daily-coding-challenges.not-found'
+      })
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
I would like to standardize HTTP error codes. Opening this up as draft since it may affect what the client apps are doing with the response. 

cc: @moT01 and @freeCodeCamp/mobile 