### PR TITLE
fix(api): correct exam-environment status codes

### DIFF
--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -173,7 +173,7 @@ describe('/exam-environment/', () => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           message: expect.any(String)
         });
-        expect(res.status).toBe(403);
+        expect(res.status).toBe(410);
 
         expect(count).toHaveBeenCalledWith(
           'exam.attempt_submission_expired',
@@ -466,7 +466,7 @@ describe('/exam-environment/', () => {
           );
 
         expect(res).toMatchObject({
-          status: 403,
+          status: 409,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_EXAM_ATTEMPT'
           }
@@ -511,7 +511,7 @@ describe('/exam-environment/', () => {
           );
 
         expect(res).toMatchObject({
-          status: 429,
+          status: 403,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_PREREQUISITES'
           }
@@ -544,7 +544,7 @@ describe('/exam-environment/', () => {
           );
 
         expect(res2).toMatchObject({
-          status: 429,
+          status: 403,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_PREREQUISITES'
           }
@@ -1623,7 +1623,7 @@ describe('/exam-environment/', () => {
         );
 
         expect(res).toMatchObject({
-          status: 418,
+          status: 401,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN'
           }
@@ -1641,7 +1641,7 @@ describe('/exam-environment/', () => {
         );
 
         expect(res).toMatchObject({
-          status: 418,
+          status: 401,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN'
           }

--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -1630,7 +1630,7 @@ describe('/exam-environment/', () => {
         });
       });
 
-      it('should tell the requester if the token does not exist', async () => {
+      it('should reject a token whose payload is not an object id', async () => {
         const validToken = jwt.sign(
           { examEnvironmentAuthorizationToken: 'does-not-exist' },
           JWT_SECRET
@@ -1642,6 +1642,24 @@ describe('/exam-environment/', () => {
 
         expect(res).toMatchObject({
           status: 401,
+          body: {
+            code: 'FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN'
+          }
+        });
+      });
+
+      it('should tell the requester if the token does not exist', async () => {
+        const validToken = jwt.sign(
+          { examEnvironmentAuthorizationToken: '5fa5c1c3b1c9d40000000000' },
+          JWT_SECRET
+        );
+        const res = await superGet('/exam-environment/token-meta').set(
+          'exam-environment-authorization-token',
+          validToken
+        );
+
+        expect(res).toMatchObject({
+          status: 404,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN'
           }

--- a/api/src/exam-environment/routes/exam-environment.test.ts
+++ b/api/src/exam-environment/routes/exam-environment.test.ts
@@ -511,7 +511,7 @@ describe('/exam-environment/', () => {
           );
 
         expect(res).toMatchObject({
-          status: 403,
+          status: 429,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_PREREQUISITES'
           }
@@ -544,7 +544,7 @@ describe('/exam-environment/', () => {
           );
 
         expect(res2).toMatchObject({
-          status: 403,
+          status: 429,
           body: {
             code: 'FCC_EINVAL_EXAM_ENVIRONMENT_PREREQUISITES'
           }

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -328,7 +328,7 @@ async function postExamGeneratedExamHandler(
           'User has completed exam too recently to retake.'
         );
         this.Sentry?.metrics?.count('exam.retake_cooldown_blocked', 1);
-        void reply.code(403);
+        void reply.code(429);
         // TODO: Consider sending last completed time
         return reply.send(
           ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_PREREQUISITES(

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -136,7 +136,7 @@ async function tokenMetaHandler(
   } catch (e) {
     // Server refuses to brew (verify) coffee (jwts) with a teapot (random strings)
     req.log.warn(e, 'Invalid token provided.');
-    void reply.code(418);
+    void reply.code(401);
     return reply.send(
       ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN(JSON.stringify(e))
     );
@@ -144,7 +144,7 @@ async function tokenMetaHandler(
 
   if (!isObjectID(payload.examEnvironmentAuthorizationToken)) {
     req.log.warn('Token is not an object id.');
-    void reply.code(418);
+    void reply.code(401);
     return reply.send(
       ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_AUTHORIZATION_TOKEN(
         'Token is not valid'
@@ -304,7 +304,7 @@ async function postExamGeneratedExamHandler(
         'User has an exam attempt awaiting grading.'
       );
       this.Sentry?.metrics?.count('exam.attempt_blocked_pending_moderation', 1);
-      void reply.code(403);
+      void reply.code(409);
       return reply.send(
         // TODO: Better error type
         ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_EXAM_ATTEMPT(
@@ -328,7 +328,7 @@ async function postExamGeneratedExamHandler(
           'User has completed exam too recently to retake.'
         );
         this.Sentry?.metrics?.count('exam.retake_cooldown_blocked', 1);
-        void reply.code(429);
+        void reply.code(403);
         // TODO: Consider sending last completed time
         return reply.send(
           ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_PREREQUISITES(
@@ -636,7 +636,7 @@ async function postExamAttemptHandler(
       'Attempt has exceeded submission time.'
     );
     this.Sentry?.metrics?.count('exam.attempt_submission_expired', 1);
-    void reply.code(403);
+    void reply.code(410);
     return reply.send(
       ERRORS.FCC_EINVAL_EXAM_ENVIRONMENT_EXAM_ATTEMPT(
         'Attempt has exceeded submission time.'

--- a/api/src/exam-environment/routes/exam-environment.ts
+++ b/api/src/exam-environment/routes/exam-environment.ts
@@ -134,7 +134,6 @@ async function tokenMetaHandler(
   try {
     payload = jwt.verify(encodedToken, JWT_SECRET) as JwtPayload;
   } catch (e) {
-    // Server refuses to brew (verify) coffee (jwts) with a teapot (random strings)
     req.log.warn(e, 'Invalid token provided.');
     void reply.code(401);
     return reply.send(

--- a/api/src/exam-environment/schemas/exam-environment-exam-generated-exam.ts
+++ b/api/src/exam-environment/schemas/exam-environment-exam-generated-exam.ts
@@ -16,6 +16,7 @@ export const examEnvironmentPostExamGeneratedExam = {
     403: STANDARD_ERROR,
     404: STANDARD_ERROR,
     409: STANDARD_ERROR,
-    500: STANDARD_ERROR
+    500: STANDARD_ERROR,
+    default: STANDARD_ERROR
   }
 };

--- a/api/src/exam-environment/schemas/exam-environment-exam-generated-exam.ts
+++ b/api/src/exam-environment/schemas/exam-environment-exam-generated-exam.ts
@@ -15,7 +15,7 @@ export const examEnvironmentPostExamGeneratedExam = {
     }),
     403: STANDARD_ERROR,
     404: STANDARD_ERROR,
-    429: STANDARD_ERROR,
+    409: STANDARD_ERROR,
     500: STANDARD_ERROR
   }
 };

--- a/api/src/exam-environment/schemas/exam-environment-exam-generated-exam.ts
+++ b/api/src/exam-environment/schemas/exam-environment-exam-generated-exam.ts
@@ -16,6 +16,7 @@ export const examEnvironmentPostExamGeneratedExam = {
     403: STANDARD_ERROR,
     404: STANDARD_ERROR,
     409: STANDARD_ERROR,
+    429: STANDARD_ERROR,
     500: STANDARD_ERROR,
     default: STANDARD_ERROR
   }

--- a/api/src/exam-environment/schemas/token-meta.ts
+++ b/api/src/exam-environment/schemas/token-meta.ts
@@ -9,7 +9,7 @@ export const examEnvironmentTokenMeta = {
     200: Type.Object({
       expireAt: Type.String({ format: 'date-time' })
     }),
-    404: STANDARD_ERROR,
-    418: STANDARD_ERROR
+    401: STANDARD_ERROR,
+    404: STANDARD_ERROR
   }
 };


### PR DESCRIPTION
I would like to standardize HTTP error codes. Opening this up as draft since it may affect what the client apps are doing with the response.