### PR TITLE
fix(curriculum): replace regex-based test in profile lookup lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-profile-lookup/5688e62ea601b2482ff8422b.md
+++ b/curriculum/challenges/english/blocks/lab-profile-lookup/5688e62ea601b2482ff8422b.md
@@ -64,11 +64,12 @@ assert.exists(explorer.variables.contacts);
 assert.isArray(contacts);
 ```
 
-You should have a function named `lookUpProfile`.
+You should have a function named `lookUpProfile` with two parameters.
 
 ```js
 const explorer = await __helpers.Explorer(code);
 assert.exists(explorer.allFunctions.lookUpProfile);
+assert.lengthOf(explorer.allFunctions.lookUpProfile.parameters, 2);
 ```
 
 `lookUpProfile("Kristian", "lastName")` should return a string.

--- a/curriculum/challenges/english/blocks/lab-profile-lookup/5688e62ea601b2482ff8422b.md
+++ b/curriculum/challenges/english/blocks/lab-profile-lookup/5688e62ea601b2482ff8422b.md
@@ -59,13 +59,16 @@ globalThis.contacts = structuredClone(_contacts);
 The `contacts` array should still be present in the global scope. Reset the lesson to recover it if you deleted it.
 
 ```js
-assert.match(code, /(?:let|const|var)\s+contacts\s*=\s*\[/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.variables.contacts);
+assert.isArray(contacts);
 ```
 
 You should have a function named `lookUpProfile`.
 
 ```js
-assert.isFunction(lookUpProfile);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.allFunctions.lookUpProfile);
 ```
 
 `lookUpProfile("Kristian", "lastName")` should return a string.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68691 

<!-- Feel free to add any additional description of changes below this line -->
This is part of the Naomi's Sprints --> replacing regex-based tests with the Explorer AST helper:

- Replaces regex test with Explorer helper in profile lookup lab (with the help of Somil on discord, thanks again)
- This also replaces `isFunction` as discussed in the `naomis-sprints` discord channel: https://discord.com/channels/692816967895220344/1424801426160488520/1526950627924770866

## Testing
- Used GitHub CodeSpaces; Ran `FCC_BLOCK='lab-profile-lookup' pnpm run test-curriculum-content` before and after the change; all checks passed both times
- Temporarily changed solution by deleting `lookUpProfile` which failed with the hint's assertion message instead of a raw `ReferenceError`
- Temporarily deleted the `contacts` declaration which was caught by `assert.exists` check
- Temporarily changed `contacts` array to `let contacts = {}`, which was caught by `assert.isArray`