### PR TITLE
perf(curriculum): parse challenges on a worker pool

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -84,6 +84,7 @@
     "vitest": "4.1.5"
   },
   "dependencies": {
-    "@types/node": "24.12.2"
+    "@types/node": "24.12.2",
+    "workerpool": "^10.0.3"
   }
 }

--- a/curriculum/src/build-curriculum.ts
+++ b/curriculum/src/build-curriculum.ts
@@ -27,6 +27,7 @@ import {
   type BlockStructure
 } from './file-handler.js';
 import { SHOW_UPCOMING_CHANGES } from './config.js';
+import type { Parser } from './generate/parser-pool.js';
 const log = debug('fcc:build-curriculum');
 
 /**
@@ -42,7 +43,8 @@ const log = debug('fcc:build-curriculum');
 export const getBlockCreator = (
   lang: string,
   skipValidation?: boolean,
-  opts?: { baseDir: string; i18nBaseDir: string; structureDir: string }
+  opts?: { baseDir: string; i18nBaseDir: string; structureDir: string },
+  parser?: Parser
 ) => {
   const {
     blockContentDir,
@@ -62,7 +64,8 @@ export const getBlockCreator = (
       dictionariesDir,
       targetDictionariesDir
     ),
-    skipValidation: skipValidation ?? false
+    skipValidation: skipValidation ?? false,
+    parser
   });
 };
 
@@ -414,14 +417,18 @@ export async function parseCurriculumStructure(filter?: Filter) {
   };
 }
 
-export async function buildCurriculum(lang: string, filters?: Filter) {
+export async function buildCurriculum(
+  lang: string,
+  filters?: Filter,
+  parser?: Parser
+) {
   // Block validation assumes the entire block is being built, if that's not the
   // case, skip validation
   const skipBlockValidation = filters?.challengeId !== undefined;
   const contentDir = getContentDir(lang);
 
   const builder = new SuperblockCreator(
-    getBlockCreator(lang, skipBlockValidation)
+    getBlockCreator(lang, skipBlockValidation, undefined, parser)
   );
 
   const { fullSuperblockList, certifications } =
@@ -444,10 +451,13 @@ export async function buildCurriculum(lang: string, filters?: Filter) {
     return !isUndefined(superOrder);
   });
 
-  for (const superblock of liveSuperblocks) {
-    const processedSuperblock = await builder.processSuperblock(superblock);
-    fullCurriculum[superblock.name] = processedSuperblock;
-  }
+  const processedSuperblocks = await Promise.all(
+    liveSuperblocks.map(superblock => builder.processSuperblock(superblock))
+  );
+
+  liveSuperblocks.forEach((superblock, i) => {
+    fullCurriculum[superblock.name] = processedSuperblocks[i];
+  });
 
   for (const cert of certifications) {
     const certPath = resolve(contentDir, 'certifications', `${cert}.yml`);

--- a/curriculum/src/build-superblock.ts
+++ b/curriculum/src/build-superblock.ts
@@ -280,25 +280,29 @@ export class BlockCreator {
   lang: string;
   commentTranslations: CommentDictionary;
   skipValidation: boolean | undefined;
+  parser: typeof parseMD;
 
   constructor({
     blockContentDir,
     i18nBlockContentDir,
     lang,
     commentTranslations,
-    skipValidation
+    skipValidation,
+    parser
   }: {
     blockContentDir: string;
     i18nBlockContentDir: string;
     lang: string;
     commentTranslations: CommentDictionary;
     skipValidation?: boolean;
+    parser?: typeof parseMD;
   }) {
     this.blockContentDir = blockContentDir;
     this.i18nBlockContentDir = i18nBlockContentDir;
     this.lang = lang;
     this.commentTranslations = commentTranslations;
     this.skipValidation = skipValidation;
+    this.parser = parser ?? parseMD;
   }
 
   /**
@@ -318,7 +322,7 @@ export class BlockCreator {
       meta,
       isAudited
     }: { filename: string; block: string; meta: Meta; isAudited: boolean },
-    parser = parseMD
+    parser = this.parser
   ) {
     log(
       `Creating challenge from file: ${filename} in block: ${block}, using lang: ${this.lang}`
@@ -443,16 +447,18 @@ export class SuperblockCreator {
   }) {
     const superBlock: { blocks: Record<string, unknown> } = { blocks: {} };
 
-    for (let i = 0; i < blocks.length; i++) {
-      const block: BlockStructure = blocks[i]!;
-      const blockResult = await this.blockCreator.processBlock(block, {
-        superBlock: name,
-        order: i
-      });
+    const blockResults = await Promise.all(
+      blocks.map((block, i) =>
+        this.blockCreator.processBlock(block, { superBlock: name, order: i })
+      )
+    );
+
+    blocks.forEach((block, i) => {
+      const blockResult = blockResults[i];
       if (blockResult) {
         superBlock.blocks[block.dashedName] = blockResult;
       }
-    }
+    });
 
     log(
       `Completed parsing superblock. Total blocks: ${Object.keys(superBlock.blocks).length}`

--- a/curriculum/src/generate/build-curriculum.ts
+++ b/curriculum/src/generate/build-curriculum.ts
@@ -3,12 +3,16 @@ import path from 'path';
 
 import { getChallengesForLang } from '../get-challenges';
 import { CURRICULUM_LOCALE } from '../config';
+import { createParserPool } from './parser-pool';
 
 const globalConfigPath = path.resolve(__dirname, '../../generated/');
 
-void getChallengesForLang(CURRICULUM_LOCALE)
+const pool = createParserPool();
+
+void getChallengesForLang(CURRICULUM_LOCALE, undefined, pool.parse)
   .then(JSON.stringify)
   .then(json => {
     fs.mkdirSync(globalConfigPath, { recursive: true });
     fs.writeFileSync(`${globalConfigPath}/curriculum.json`, json);
-  });
+  })
+  .finally(() => pool.terminate());

--- a/curriculum/src/generate/parse-worker.ts
+++ b/curriculum/src/generate/parse-worker.ts
@@ -1,21 +1,5 @@
-import { parentPort } from 'worker_threads';
+import workerpool from 'workerpool';
 
 import { parseMD } from '../../../tools/challenge-parser/parser';
 
-type ParsedChallenge = Awaited<ReturnType<typeof parseMD>>;
-type Task = { id: number; filename: string };
-type Result =
-  | { id: number; data: ParsedChallenge }
-  | { id: number; error: string };
-
-parentPort?.on('message', ({ id, filename }: Task) => {
-  parseMD(filename)
-    .then((data: ParsedChallenge) => {
-      const result: Result = { id, data };
-      parentPort?.postMessage(result);
-    })
-    .catch((error: Error) => {
-      const result: Result = { id, error: error.message };
-      parentPort?.postMessage(result);
-    });
-});
+workerpool.worker({ parseMD });

--- a/curriculum/src/generate/parse-worker.ts
+++ b/curriculum/src/generate/parse-worker.ts
@@ -1,0 +1,21 @@
+import { parentPort } from 'worker_threads';
+
+import { parseMD } from '../../../tools/challenge-parser/parser';
+
+type ParsedChallenge = Awaited<ReturnType<typeof parseMD>>;
+type Task = { id: number; filename: string };
+type Result =
+  | { id: number; data: ParsedChallenge }
+  | { id: number; error: string };
+
+parentPort?.on('message', ({ id, filename }: Task) => {
+  parseMD(filename)
+    .then((data: ParsedChallenge) => {
+      const result: Result = { id, data };
+      parentPort?.postMessage(result);
+    })
+    .catch((error: Error) => {
+      const result: Result = { id, error: error.message };
+      parentPort?.postMessage(result);
+    });
+});

--- a/curriculum/src/generate/parser-pool.ts
+++ b/curriculum/src/generate/parser-pool.ts
@@ -1,0 +1,69 @@
+import { Worker } from 'worker_threads';
+import { cpus } from 'os';
+import { resolve } from 'path';
+
+import type { parseMD } from '../../../tools/challenge-parser/parser';
+
+type ParsedChallenge = Awaited<ReturnType<typeof parseMD>>;
+
+type PendingTask = {
+  resolve: (data: ParsedChallenge) => void;
+  reject: (error: Error) => void;
+};
+
+export type Parser = (filename: string) => Promise<ParsedChallenge>;
+
+export type ParserPool = {
+  parse: Parser;
+  terminate: () => Promise<void>;
+};
+
+// Parsing a challenge's markdown is synchronous, CPU-bound work (remark/
+// unified), so running it on the main thread means challenges are parsed
+// one at a time no matter how many are kicked off with Promise.all. Spreading
+// that work across worker threads lets it actually run in parallel.
+export function createParserPool(
+  size = Math.max(1, cpus().length - 1)
+): ParserPool {
+  const workerPath = resolve(__dirname, 'parse-worker.js');
+  const workers = Array.from({ length: size }, () => new Worker(workerPath));
+  const pending = new Map<number, PendingTask>();
+  let nextId = 0;
+  let nextWorker = 0;
+
+  for (const worker of workers) {
+    worker.on(
+      'message',
+      (msg: { id: number; data?: ParsedChallenge; error?: string }) => {
+        const task = pending.get(msg.id);
+        if (!task) return;
+        pending.delete(msg.id);
+        if (msg.error) task.reject(new Error(msg.error));
+        else task.resolve(msg.data!);
+      }
+    );
+    worker.on('error', (error: Error) => {
+      for (const [id, task] of pending) {
+        task.reject(error);
+        pending.delete(id);
+      }
+    });
+  }
+
+  const parse: Parser = filename => {
+    const id = nextId++;
+    const worker = workers[nextWorker]!;
+    nextWorker = (nextWorker + 1) % workers.length;
+
+    return new Promise((resolvePromise, reject) => {
+      pending.set(id, { resolve: resolvePromise, reject });
+      worker.postMessage({ id, filename });
+    });
+  };
+
+  const terminate = async () => {
+    await Promise.all(workers.map(worker => worker.terminate()));
+  };
+
+  return { parse, terminate };
+}

--- a/curriculum/src/generate/parser-pool.ts
+++ b/curriculum/src/generate/parser-pool.ts
@@ -1,15 +1,10 @@
-import { Worker } from 'worker_threads';
 import { cpus } from 'os';
 import { resolve } from 'path';
+import workerpool from 'workerpool';
 
 import type { parseMD } from '../../../tools/challenge-parser/parser';
 
 type ParsedChallenge = Awaited<ReturnType<typeof parseMD>>;
-
-type PendingTask = {
-  resolve: (data: ParsedChallenge) => void;
-  reject: (error: Error) => void;
-};
 
 export type Parser = (filename: string) => Promise<ParsedChallenge>;
 
@@ -23,46 +18,18 @@ export type ParserPool = {
 // one at a time no matter how many are kicked off with Promise.all. Spreading
 // that work across worker threads lets it actually run in parallel.
 export function createParserPool(
-  size = Math.max(1, cpus().length - 1)
+  maxWorkers = Math.max(1, cpus().length - 1)
 ): ParserPool {
-  const workerPath = resolve(__dirname, 'parse-worker.js');
-  const workers = Array.from({ length: size }, () => new Worker(workerPath));
-  const pending = new Map<number, PendingTask>();
-  let nextId = 0;
-  let nextWorker = 0;
+  const pool = workerpool.pool(resolve(__dirname, 'parse-worker.js'), {
+    maxWorkers,
+    workerType: 'thread'
+  });
 
-  for (const worker of workers) {
-    worker.on(
-      'message',
-      (msg: { id: number; data?: ParsedChallenge; error?: string }) => {
-        const task = pending.get(msg.id);
-        if (!task) return;
-        pending.delete(msg.id);
-        if (msg.error) task.reject(new Error(msg.error));
-        else task.resolve(msg.data!);
-      }
-    );
-    worker.on('error', (error: Error) => {
-      for (const [id, task] of pending) {
-        task.reject(error);
-        pending.delete(id);
-      }
-    });
-  }
-
-  const parse: Parser = filename => {
-    const id = nextId++;
-    const worker = workers[nextWorker]!;
-    nextWorker = (nextWorker + 1) % workers.length;
-
-    return new Promise((resolvePromise, reject) => {
-      pending.set(id, { resolve: resolvePromise, reject });
-      worker.postMessage({ id, filename });
-    });
-  };
+  const parse: Parser = filename =>
+    pool.exec('parseMD', [filename]) as Promise<ParsedChallenge>;
 
   const terminate = async () => {
-    await Promise.all(workers.map(worker => worker.terminate()));
+    await pool.terminate();
   };
 
   return { parse, terminate };

--- a/curriculum/src/get-challenges.ts
+++ b/curriculum/src/get-challenges.ts
@@ -6,6 +6,7 @@ import { availableLangs } from '@freecodecamp/shared/config/i18n';
 import { buildCurriculum } from './build-curriculum.js';
 import { curriculumFilter } from './config.js';
 import type { Filter } from './filter.js';
+import type { Parser } from './generate/parser-pool.js';
 
 const { curriculum: curriculumLangs } = availableLangs;
 
@@ -13,14 +14,15 @@ const access = promisify(_access);
 
 export async function getChallengesForLang(
   lang: string,
-  filters: Filter = curriculumFilter // default to global curriculum filter, but allow override (e.g. when testing specific blocks)
+  filters: Filter = curriculumFilter, // default to global curriculum filter, but allow override (e.g. when testing specific blocks)
+  parser?: Parser
 ) {
   const invalidLang = !curriculumLangs.includes(lang);
   if (invalidLang)
     throw Error(`${lang} is not an accepted language.
 Accepted languages are ${curriculumLangs.join(', ')}`);
 
-  return buildCurriculum(lang, filters);
+  return buildCurriculum(lang, filters, parser);
 }
 
 export async function hasEnglishSource(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,9 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
+      workerpool:
+        specifier: ^10.0.3
+        version: 10.0.3
     devDependencies:
       '@babel/core':
         specifier: 7.23.7
@@ -12232,6 +12235,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerpool@10.0.3:
+    resolution: {integrity: sha512-6z2Iis68Wqth93/G/wJP9u+R3O+d2XTlgWChGCwuT1qLbBsOYueGRZuJ++v3mtDP5KjYdy+WzvWC+VWETSVXJA==}
+
   workerpool@6.5.1:
     resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
 
@@ -17738,7 +17744,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@26.1.0)(msw@2.14.2(@types/node@24.12.2)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@16.7.0)(msw@2.14.2(@types/node@24.12.2)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -26875,6 +26881,8 @@ snapshots:
   wildcard@2.0.1: {}
 
   word-wrap@1.2.5: {}
+
+  workerpool@10.0.3: {}
 
   workerpool@6.5.1: {}
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

The curriculum build (`pnpm build:curriculum`, which generates `curriculum.json`) was running fully single-threaded. Each challenge's markdown gets parsed synchronously by remark/unified, and the block/superblock loops around it awaited one at a time, so the whole thing only ever used a single core no matter how many were available.

This adds a worker thread pool for the markdown parsing and fans the block/superblock loops out with `Promise.all` so the pool actually has enough concurrent work to stay busy.

On my machine (16 cores) this takes the full build from ~26s down to ~5.6s. I diffed the generated `curriculum.json` against a serial build from the same source tree and it's byte-identical, so this is purely a speed change, not a behavior change.

The gatsby dev server's watch-mode path (reparsing a single challenge file on save) is untouched, it never opts into the pool, so single-file saves during local development still work exactly as before.

This is a draft while I get a bit more testing done around it, happy to get eyes on the approach in the meantime.