### PR TITLE
perf(client): fix O(n^2) block lookup in challenge page creation

### DIFF
--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -88,6 +88,12 @@ exports.createChallengePages = function (
   createPage,
   { idToNextPathCurrentCurriculum, idToPrevPathCurrentCurriculum }
 ) {
+  // allChallengeNodes is the same array reference across every call in a
+  // given forEach, so the grouping only needs to be built once and reused,
+  // rather than re-filtering the entire node list for every single page.
+  let challengesByBlockSource = null;
+  let challengesByBlock = null;
+
   return function (node, index, allChallengeNodes) {
     const {
       dashedName,
@@ -106,6 +112,11 @@ exports.createChallengePages = function (
       isLastChallengeInBlock,
       saveSubmissionToDB
     } = node.challenge;
+
+    if (challengesByBlockSource !== allChallengeNodes) {
+      challengesByBlockSource = allChallengeNodes;
+      challengesByBlock = groupChallengesByBlock(allChallengeNodes);
+    }
 
     createPage({
       path: slug,
@@ -132,7 +143,7 @@ exports.createChallengePages = function (
         },
         projectPreview: getProjectPreviewConfig(
           node.challenge,
-          allChallengeNodes
+          challengesByBlock
         ),
         id: node.id
       }
@@ -140,13 +151,24 @@ exports.createChallengePages = function (
   };
 };
 
+function groupChallengesByBlock(allChallengeNodes) {
+  const challengesByBlock = new Map();
+  for (const { challenge } of allChallengeNodes) {
+    const existing = challengesByBlock.get(challenge.block);
+    if (existing) {
+      existing.push(challenge);
+    } else {
+      challengesByBlock.set(challenge.block, [challenge]);
+    }
+  }
+  return challengesByBlock;
+}
+
 // TODO: figure out a cleaner way to get the last challenge in a block.
-function getProjectPreviewConfig(challenge, allChallengeNodes) {
+function getProjectPreviewConfig(challenge, challengesByBlock) {
   const { block } = challenge;
 
-  const challengesInBlock = allChallengeNodes
-    .filter(({ challenge }) => challenge.block === block)
-    .map(({ challenge }) => challenge);
+  const challengesInBlock = challengesByBlock.get(block) ?? [];
   const lastChallenge = challengesInBlock[challengesInBlock.length - 1];
   const solutionFiles = lastChallenge.solutions[0] ?? [];
   const lastChallengeFiles = lastChallenge.challengeFiles ?? [];

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -89,10 +89,10 @@ exports.createChallengePages = function (
   { idToNextPathCurrentCurriculum, idToPrevPathCurrentCurriculum }
 ) {
   // allChallengeNodes is the same array reference across every call in a
-  // given forEach, so the grouping only needs to be built once and reused,
-  // rather than re-filtering the entire node list for every single page.
-  let challengesByBlockSource = null;
-  let challengesByBlock = null;
+  // given forEach, so this only needs to be built once and reused, rather
+  // than re-filtering the entire node list for every single page.
+  let lastChallengeByBlockSource = null;
+  let lastChallengeByBlock = null;
 
   return function (node, index, allChallengeNodes) {
     const {
@@ -113,9 +113,9 @@ exports.createChallengePages = function (
       saveSubmissionToDB
     } = node.challenge;
 
-    if (challengesByBlockSource !== allChallengeNodes) {
-      challengesByBlockSource = allChallengeNodes;
-      challengesByBlock = groupChallengesByBlock(allChallengeNodes);
+    if (lastChallengeByBlockSource !== allChallengeNodes) {
+      lastChallengeByBlockSource = allChallengeNodes;
+      lastChallengeByBlock = getLastChallengeByBlock(allChallengeNodes);
     }
 
     createPage({
@@ -143,7 +143,7 @@ exports.createChallengePages = function (
         },
         projectPreview: getProjectPreviewConfig(
           node.challenge,
-          challengesByBlock
+          lastChallengeByBlock
         ),
         id: node.id
       }
@@ -151,25 +151,20 @@ exports.createChallengePages = function (
   };
 };
 
-function groupChallengesByBlock(allChallengeNodes) {
-  const challengesByBlock = new Map();
+// allChallengeNodes is in block order, so overwriting on every challenge
+// leaves each block's entry pointing at the last challenge seen for it.
+function getLastChallengeByBlock(allChallengeNodes) {
+  const lastChallengeByBlock = new Map();
   for (const { challenge } of allChallengeNodes) {
-    const existing = challengesByBlock.get(challenge.block);
-    if (existing) {
-      existing.push(challenge);
-    } else {
-      challengesByBlock.set(challenge.block, [challenge]);
-    }
+    lastChallengeByBlock.set(challenge.block, challenge);
   }
-  return challengesByBlock;
+  return lastChallengeByBlock;
 }
 
-// TODO: figure out a cleaner way to get the last challenge in a block.
-function getProjectPreviewConfig(challenge, challengesByBlock) {
+function getProjectPreviewConfig(challenge, lastChallengeByBlock) {
   const { block } = challenge;
 
-  const challengesInBlock = challengesByBlock.get(block) ?? [];
-  const lastChallenge = challengesInBlock[challengesInBlock.length - 1];
+  const lastChallenge = lastChallengeByBlock.get(block);
   const solutionFiles = lastChallenge.solutions[0] ?? [];
   const lastChallengeFiles = lastChallenge.challengeFiles ?? [];
 

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -91,7 +91,6 @@ exports.createChallengePages = function (
   // allChallengeNodes is the same array reference across every call in a
   // given forEach, so this only needs to be built once and reused, rather
   // than re-filtering the entire node list for every single page.
-  let lastChallengeByBlockSource = null;
   let lastChallengeByBlock = null;
 
   return function (node, index, allChallengeNodes) {
@@ -113,8 +112,7 @@ exports.createChallengePages = function (
       saveSubmissionToDB
     } = node.challenge;
 
-    if (lastChallengeByBlockSource !== allChallengeNodes) {
-      lastChallengeByBlockSource = allChallengeNodes;
+    if (lastChallengeByBlock === null) {
       lastChallengeByBlock = getLastChallengeByBlock(allChallengeNodes);
     }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## What's this for

`createChallengePages` calls `getProjectPreviewConfig` once per challenge, roughly 19,000 times during `createPagesStatefully`. Each call filtered the *entire* challenge node array to find the other challenges in the same block, so the whole pass was doing something like 277 million comparisons. Grouping challenges by block once into a `Map` and doing an O(1) lookup per page took `createPagesStatefully` from 12.5s down to 1.27s locally.

Verified the new grouped-map logic against the old filter-based one on real curriculum data: for the same challenge, both approaches resolve to the exact same "last challenge in block" object (same reference, not just equal content), so the output is unchanged.

(This PR previously also included a Monaco language restriction and a dead-field cleanup; I have dropped those from this PR after CI turned up an E2E failure I could not confidently attribute to either of them in the time available, and did not want to hold up this verified fix while investigating further.)