### PR TITLE
feat(client): warn campers before leaving certification projects with unsaved code

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -771,6 +771,12 @@
       "exit-modal-yes": "Yes, I want to leave the quiz",
       "exit-modal-no": "No, I would like to continue the quiz"
     },
+    "exit-project-modal": {
+      "header": "You have unsaved changes",
+      "body": "Your code is not saved automatically. If you leave this page now, your unsaved changes will be lost.",
+      "yes": "Yes, leave the page",
+      "no": "No, stay on this page"
+    },
     "exam": {
       "qualified": "Congratulations, you have completed all the requirements to qualify for the exam.",
       "not-qualified": "You have not met the requirements to be eligible for the exam. To qualify, please complete the following challenges:",

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -304,6 +304,7 @@ export type DailyCodingChallengeNode = {
     videoUrl?: string;
     translationPending: false;
     saveSubmissionToDB?: boolean;
+    fields?: Fields;
   };
 };
 

--- a/client/src/templates/Challenges/classic/exit-project-modal.tsx
+++ b/client/src/templates/Challenges/classic/exit-project-modal.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Button, Modal, Spacer } from '@freecodecamp/ui';
+
+import { closeModal } from '../redux/actions';
+import { isExitProjectModalOpenSelector } from '../redux/selectors';
+
+interface ExitProjectModalProps {
+  closeExitProjectModal: () => void;
+  isExitProjectModalOpen: boolean;
+  onExit: () => void;
+}
+
+const mapStateToProps = (state: unknown) => ({
+  isExitProjectModalOpen: isExitProjectModalOpenSelector(state) as boolean
+});
+
+const mapDispatchToProps = {
+  closeExitProjectModal: () => closeModal('exitProject')
+};
+
+const ExitProjectModal = ({
+  closeExitProjectModal,
+  isExitProjectModalOpen,
+  onExit
+}: ExitProjectModalProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      onClose={closeExitProjectModal}
+      open={isExitProjectModalOpen}
+      variant='danger'
+    >
+      <Modal.Header closeButtonClassNames='close'>
+        {t('learn.exit-project-modal.header')}
+      </Modal.Header>
+      <Modal.Body alignment='center'>
+        {t('learn.exit-project-modal.body')}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button block variant='primary' onClick={closeExitProjectModal}>
+          {t('learn.exit-project-modal.no')}
+        </Button>
+        <Spacer size='xxs' />
+        <Button block variant='danger' onClick={onExit}>
+          {t('learn.exit-project-modal.yes')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+ExitProjectModal.displayName = 'ExitProjectModal';
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExitProjectModal);

--- a/client/src/templates/Challenges/classic/saved-challenges.test.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.test.ts
@@ -3,7 +3,7 @@ import type {
   ChallengeFile,
   SavedChallengeFile
 } from '../../../redux/prop-types';
-import { mergeChallengeFiles } from './saved-challenges';
+import { mergeChallengeFiles, hasUnsavedChanges } from './saved-challenges';
 
 const jsChallenge = {
   contents: 'js contents',
@@ -139,5 +139,39 @@ describe('mergeChallengeFiles', () => {
 
     expect(files).toEqual(filesCopy);
     expect(savedChallengeFiles).toEqual(savedFilesCopy);
+  });
+});
+
+describe('hasUnsavedChanges', () => {
+  it('should return false if challengeFiles is null or undefined', () => {
+    expect(hasUnsavedChanges(null, [jsChallenge])).toBe(false);
+    expect(hasUnsavedChanges(undefined, [jsChallenge])).toBe(false);
+  });
+
+  it('should return false if all file contents match the last saved files', () => {
+    const files: ChallengeFile[] = [jsChallenge, cssChallenge];
+    const lastSavedFiles: ChallengeFile[] = [
+      { ...cssChallenge },
+      { ...jsChallenge }
+    ];
+
+    expect(hasUnsavedChanges(files, lastSavedFiles)).toBe(false);
+  });
+
+  it('should return true if any file contents differ from the last saved files', () => {
+    const files: ChallengeFile[] = [
+      { ...jsChallenge, contents: 'edited js contents' },
+      cssChallenge
+    ];
+    const lastSavedFiles: ChallengeFile[] = [jsChallenge, cssChallenge];
+
+    expect(hasUnsavedChanges(files, lastSavedFiles)).toBe(true);
+  });
+
+  it('should return true if a file is missing from the last saved files', () => {
+    const files: ChallengeFile[] = [jsChallenge, cssChallenge];
+    const lastSavedFiles: ChallengeFile[] = [jsChallenge];
+
+    expect(hasUnsavedChanges(files, lastSavedFiles)).toBe(true);
   });
 });

--- a/client/src/templates/Challenges/classic/saved-challenges.test.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.test.ts
@@ -144,34 +144,71 @@ describe('mergeChallengeFiles', () => {
 
 describe('hasUnsavedChanges', () => {
   it('should return false if challengeFiles is null or undefined', () => {
-    expect(hasUnsavedChanges(null, [jsChallenge])).toBe(false);
-    expect(hasUnsavedChanges(undefined, [jsChallenge])).toBe(false);
+    expect(hasUnsavedChanges(null, [[jsChallenge]])).toBe(false);
+    expect(hasUnsavedChanges(undefined, [[jsChallenge]])).toBe(false);
   });
 
-  it('should return false if all file contents match the last saved files', () => {
+  it('should return false if all file contents match a baseline', () => {
     const files: ChallengeFile[] = [jsChallenge, cssChallenge];
-    const lastSavedFiles: ChallengeFile[] = [
-      { ...cssChallenge },
-      { ...jsChallenge }
-    ];
+    const baseline = [{ ...cssChallenge }, { ...jsChallenge }];
 
-    expect(hasUnsavedChanges(files, lastSavedFiles)).toBe(false);
+    expect(hasUnsavedChanges(files, [baseline])).toBe(false);
   });
 
-  it('should return true if any file contents differ from the last saved files', () => {
+  it('should return true if any file contents differ from the baseline', () => {
     const files: ChallengeFile[] = [
       { ...jsChallenge, contents: 'edited js contents' },
       cssChallenge
     ];
-    const lastSavedFiles: ChallengeFile[] = [jsChallenge, cssChallenge];
 
-    expect(hasUnsavedChanges(files, lastSavedFiles)).toBe(true);
+    expect(hasUnsavedChanges(files, [[jsChallenge, cssChallenge]])).toBe(true);
   });
 
-  it('should return true if a file is missing from the last saved files', () => {
+  it('should return true if a file is missing from the baseline', () => {
     const files: ChallengeFile[] = [jsChallenge, cssChallenge];
-    const lastSavedFiles: ChallengeFile[] = [jsChallenge];
 
-    expect(hasUnsavedChanges(files, lastSavedFiles)).toBe(true);
+    expect(hasUnsavedChanges(files, [[jsChallenge]])).toBe(true);
+  });
+
+  it('should return false if the contents match any one of the baselines', () => {
+    const editedJs = { ...jsChallenge, contents: 'edited js contents' };
+    const files: ChallengeFile[] = [editedJs, cssChallenge];
+    const dbBaseline = [jsChallenge, cssChallenge];
+    const localStorageBaseline = [
+      { fileKey: editedJs.fileKey, contents: editedJs.contents },
+      { fileKey: cssChallenge.fileKey, contents: cssChallenge.contents }
+    ];
+
+    expect(hasUnsavedChanges(files, [dbBaseline, localStorageBaseline])).toBe(
+      false
+    );
+  });
+
+  it('should return true only when the contents differ from every baseline', () => {
+    const files: ChallengeFile[] = [
+      { ...jsChallenge, contents: 'brand new contents' },
+      cssChallenge
+    ];
+    const dbBaseline = [jsChallenge, cssChallenge];
+    const localStorageBaseline = [
+      { fileKey: jsChallenge.fileKey, contents: 'older stored contents' },
+      { fileKey: cssChallenge.fileKey, contents: cssChallenge.contents }
+    ];
+
+    expect(hasUnsavedChanges(files, [dbBaseline, localStorageBaseline])).toBe(
+      true
+    );
+  });
+
+  it('should treat an empty baseline as unable to recover the work', () => {
+    const files: ChallengeFile[] = [jsChallenge];
+
+    expect(hasUnsavedChanges(files, [[jsChallenge], []])).toBe(false);
+    expect(
+      hasUnsavedChanges(files, [
+        [{ ...jsChallenge, contents: 'other contents' }],
+        []
+      ])
+    ).toBe(true);
   });
 });

--- a/client/src/templates/Challenges/classic/saved-challenges.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.ts
@@ -28,3 +28,16 @@ export function mergeChallengeFiles(
       sortedSavedChallengeFiles[index].editableRegionBoundaries
   }));
 }
+
+export function hasUnsavedChanges(
+  challengeFiles: ChallengeFile[] | null | undefined,
+  lastSavedFiles: ChallengeFile[]
+): boolean {
+  if (!challengeFiles) return false;
+  return challengeFiles.some(file => {
+    const savedFile = lastSavedFiles.find(
+      saved => saved.fileKey === file.fileKey
+    );
+    return savedFile?.contents !== file.contents;
+  });
+}

--- a/client/src/templates/Challenges/classic/saved-challenges.ts
+++ b/client/src/templates/Challenges/classic/saved-challenges.ts
@@ -29,15 +29,23 @@ export function mergeChallengeFiles(
   }));
 }
 
+type FileContents = Pick<ChallengeFile, 'fileKey' | 'contents'>;
+
+// A camper's work is only at risk if it differs from every copy it could be
+// restored from, so the caller passes one baseline per recoverable copy (the
+// challenge saved to the account, and the localStorage copy written by the
+// code-storage epic).
 export function hasUnsavedChanges(
   challengeFiles: ChallengeFile[] | null | undefined,
-  lastSavedFiles: ChallengeFile[]
+  baselines: FileContents[][]
 ): boolean {
   if (!challengeFiles) return false;
-  return challengeFiles.some(file => {
-    const savedFile = lastSavedFiles.find(
-      saved => saved.fileKey === file.fileKey
-    );
-    return savedFile?.contents !== file.contents;
-  });
+  return baselines.every(baseline =>
+    challengeFiles.some(file => {
+      const baselineFile = baseline.find(
+        saved => saved.fileKey === file.fileKey
+      );
+      return baselineFile?.contents !== file.contents;
+    })
+  );
 }

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -1,5 +1,5 @@
-import { graphql } from 'gatsby';
-import React, { useState, useEffect, useRef } from 'react';
+import { graphql, navigate } from 'gatsby';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -55,6 +55,7 @@ import {
   previewMounted,
   updateChallengeMeta,
   openModal,
+  closeModal,
   setEditorFocusability,
   setIsAdvancing
 } from '../redux/actions';
@@ -70,11 +71,13 @@ import envData from '../../../../config/env.json';
 import ToolPanel from '../components/tool-panel';
 import { getChallengePaths } from '../utils/challenge-paths';
 import { challengeHasPreview, isJavaScriptChallenge } from '../utils/build';
+import { usePageLeave } from '../hooks';
+import ExitProjectModal from './exit-project-modal';
 import { XtermTerminal } from './xterm';
 import MultifileEditor from './multifile-editor';
 import DesktopLayout from './desktop-layout';
 import MobileLayout from './mobile-layout';
-import { mergeChallengeFiles } from './saved-challenges';
+import { mergeChallengeFiles, hasUnsavedChanges } from './saved-challenges';
 
 import './classic.css';
 import '../components/test-frame.css';
@@ -100,6 +103,7 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
       cancelTests,
       previewMounted,
       openModal,
+      closeModal,
       setEditorFocusability,
       setIsAdvancing
     },
@@ -124,6 +128,7 @@ interface ShowClassicProps extends Pick<PreviewProps, 'previewMounted'> {
   pageContext: PageContext | DailyCodingChallengePageContext;
   updateChallengeMeta: (arg0: ChallengeMeta) => void;
   openModal: (modal: string) => void;
+  closeModal: (modal: string) => void;
   setDailyCodingChallengeLanguage: (
     language: DailyCodingChallengeLanguages
   ) => void;
@@ -206,7 +211,8 @@ function ShowClassic({
         notes,
         videoUrl,
         translationPending,
-        saveSubmissionToDB
+        saveSubmissionToDB,
+        fields
       }
     }
   },
@@ -227,6 +233,7 @@ function ShowClassic({
   setDailyCodingChallengeLanguage,
   updateChallengeMeta,
   openModal,
+  closeModal,
   setIsAdvancing,
   savedChallenges,
   isChallengeCompleted,
@@ -243,6 +250,55 @@ function ShowClassic({
   const xtermFitRef = useRef<FitAddon | null>(null);
   const isMobile = useMediaQuery({
     query: `(max-width: ${MAX_MOBILE_WIDTH}px)`
+  });
+
+  // Warn campers before they leave a certification project page with changes
+  // they have not saved to their account, since those changes would be lost.
+  const exitConfirmed = useRef(false);
+  const [exitPathname, setExitPathname] = useState('');
+
+  const savedChallenge = savedChallenges?.find(
+    challenge => challenge.id === challengeMeta.id
+  );
+  const showLeaveWarning =
+    !!saveSubmissionToDB &&
+    hasUnsavedChanges(
+      challengeFiles,
+      mergeChallengeFiles(seedChallengeFiles, savedChallenge?.challengeFiles)
+    );
+
+  const handleExitProject = () => {
+    exitConfirmed.current = true;
+    closeModal('exitProject');
+    void navigate(exitPathname || fields?.blockHashSlug || '/learn');
+  };
+
+  const onWindowClose = useCallback((event: BeforeUnloadEvent) => {
+    event.preventDefault();
+  }, []);
+
+  const onHistoryChange = useCallback(
+    (targetPathname: string): boolean => {
+      if (exitConfirmed.current) {
+        return false;
+      }
+
+      // For link clicks, save the target pathname. For back button
+      // (empty targetPathname), keep the default (i.e. blockHashSlug).
+      if (targetPathname) {
+        setExitPathname(targetPathname);
+      }
+
+      openModal('exitProject');
+      return true;
+    },
+    [openModal]
+  );
+
+  usePageLeave({
+    onWindowClose,
+    onHistoryChange,
+    enabled: showLeaveWarning
   });
 
   const guideUrl = getGuideUrl({ forumTopicId, title, block, superBlock });
@@ -550,6 +606,7 @@ function ShowClassic({
         />
         <ShortcutsModal />
         <MobileAppModal superBlock={superBlock} />
+        {saveSubmissionToDB && <ExitProjectModal onExit={handleExitProject} />}
       </LearnLayout>
     </Hotkeys>
   );
@@ -585,6 +642,7 @@ export const query = graphql`
         }
         fields {
           slug
+          blockHashSlug
         }
         required {
           link

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -64,7 +64,10 @@ import {
   consoleOutputSelector,
   isChallengeCompletedSelector
 } from '../redux/selectors';
-import { savedChallengesSelector } from '../../../redux/selectors';
+import {
+  isSignedInSelector,
+  savedChallengesSelector
+} from '../../../redux/selectors';
 import { getGuideUrl } from '../utils';
 import { preloadPage } from '../../../../utils/gatsby/page-loading';
 import envData from '../../../../config/env.json';
@@ -84,6 +87,7 @@ import '../components/test-frame.css';
 
 const mapStateToProps = (state: unknown) => ({
   challengeFiles: challengeFilesSelector(state) as ChallengeFiles,
+  isSignedIn: isSignedInSelector(state),
   output: consoleOutputSelector(state) as string,
   isChallengeCompleted: isChallengeCompletedSelector(state),
   savedChallenges: savedChallengesSelector(state) as SavedChallenge[]
@@ -123,6 +127,7 @@ interface ShowClassicProps extends Pick<PreviewProps, 'previewMounted'> {
   initHooks: (hooks?: Hooks) => void;
   initVisibleEditors: () => void;
   isChallengeCompleted: boolean;
+  isSignedIn: boolean;
   isDailyCodingChallenge?: boolean;
   output: string;
   pageContext: PageContext | DailyCodingChallengePageContext;
@@ -237,6 +242,7 @@ function ShowClassic({
   setIsAdvancing,
   savedChallenges,
   isChallengeCompleted,
+  isSignedIn,
   output,
   executeChallenge,
   previewMounted
@@ -253,19 +259,34 @@ function ShowClassic({
   });
 
   // Warn campers before they leave a certification project page with changes
-  // they have not saved to their account, since those changes would be lost.
+  // that would actually be lost. Only signed-in campers can save to their
+  // account, and the code-storage epic mirrors the editor contents to
+  // localStorage when they run the tests, so the warning arms only when the
+  // contents differ from both of those recoverable copies.
   const exitConfirmed = useRef(false);
   const [exitPathname, setExitPathname] = useState('');
 
-  const savedChallenge = savedChallenges?.find(
-    challenge => challenge.id === challengeMeta.id
-  );
-  const showLeaveWarning =
-    !!saveSubmissionToDB &&
-    hasUnsavedChanges(
-      challengeFiles,
-      mergeChallengeFiles(seedChallengeFiles, savedChallenge?.challengeFiles)
+  const hasChangesToLose = (): boolean => {
+    const savedChallenge = savedChallenges?.find(
+      challenge => challenge.id === challengeMeta.id
     );
+    const storedFiles: unknown = store.get(challengeMeta.id);
+    const localStorageFiles = Array.isArray(storedFiles)
+      ? (storedFiles as { fileKey?: unknown; contents?: unknown }[]).filter(
+          (file): file is { fileKey: string; contents: string } =>
+            typeof file?.fileKey === 'string' &&
+            typeof file?.contents === 'string'
+        )
+      : [];
+
+    return hasUnsavedChanges(challengeFiles, [
+      mergeChallengeFiles(seedChallengeFiles, savedChallenge?.challengeFiles),
+      localStorageFiles
+    ]);
+  };
+
+  const showLeaveWarning =
+    !!saveSubmissionToDB && isSignedIn && hasChangesToLose();
 
   const handleExitProject = () => {
     exitConfirmed.current = true;

--- a/client/src/templates/Challenges/hooks/use-page-leave.test.tsx
+++ b/client/src/templates/Challenges/hooks/use-page-leave.test.tsx
@@ -1,0 +1,123 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePageLeave } from './use-page-leave';
+
+vi.mock('@gatsbyjs/reach-router', () => ({
+  useLocation: () => ({ pathname: '/current-page' })
+}));
+
+const clickAnchor = (
+  href: string,
+  init: MouseEventInit = {},
+  attributes: Record<string, string> = {}
+) => {
+  const anchor = document.createElement('a');
+  anchor.setAttribute('href', href);
+  Object.entries(attributes).forEach(([name, value]) =>
+    anchor.setAttribute(name, value)
+  );
+  document.body.appendChild(anchor);
+  const event = new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...init
+  });
+  anchor.dispatchEvent(event);
+  anchor.remove();
+  return event;
+};
+
+describe('usePageLeave', () => {
+  const onWindowClose = vi.fn();
+  const onHistoryChange = vi.fn((_targetPathname: string) => true);
+  let pushStateSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    onHistoryChange.mockClear();
+    pushStateSpy = vi.spyOn(window.history, 'pushState');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should block a plain left-click on an internal link', () => {
+    renderHook(() => usePageLeave({ onWindowClose, onHistoryChange }));
+
+    const event = clickAnchor('/learn');
+
+    expect(onHistoryChange).toHaveBeenCalledWith('/learn');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it.each([
+    ['ctrlKey', { ctrlKey: true }],
+    ['metaKey', { metaKey: true }],
+    ['shiftKey', { shiftKey: true }],
+    ['altKey', { altKey: true }],
+    ['non-primary button', { button: 1 }]
+  ])('should not intercept a click with %s', (_name, init) => {
+    renderHook(() => usePageLeave({ onWindowClose, onHistoryChange }));
+
+    const event = clickAnchor('/learn', init);
+
+    expect(onHistoryChange).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('should not intercept a click on a link targeting another tab', () => {
+    renderHook(() => usePageLeave({ onWindowClose, onHistoryChange }));
+
+    const event = clickAnchor('/learn', {}, { target: '_blank' });
+
+    expect(onHistoryChange).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('should not listen or push history state while disabled', () => {
+    renderHook(() =>
+      usePageLeave({ onWindowClose, onHistoryChange, enabled: false })
+    );
+
+    clickAnchor('/learn');
+
+    expect(onHistoryChange).not.toHaveBeenCalled();
+    expect(pushStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should push the dummy history state at most once per mount', () => {
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        usePageLeave({ onWindowClose, onHistoryChange, enabled }),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(pushStateSpy).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+
+    // Disarm and re-arm, as happens on every save-then-edit cycle.
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stop intercepting clicks after being disabled', () => {
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        usePageLeave({ onWindowClose, onHistoryChange, enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    rerender({ enabled: false });
+    const event = clickAnchor('/learn');
+
+    expect(onHistoryChange).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/client/src/templates/Challenges/hooks/use-page-leave.ts
+++ b/client/src/templates/Challenges/hooks/use-page-leave.ts
@@ -4,12 +4,19 @@ import { useLocation } from '@gatsbyjs/reach-router';
 interface Props {
   onWindowClose: (event: BeforeUnloadEvent) => void;
   onHistoryChange: (targetPathname: string) => boolean;
+  enabled?: boolean;
 }
 
-export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
+export const usePageLeave = ({
+  onWindowClose,
+  onHistoryChange,
+  enabled = true
+}: Props) => {
   const curLocation = useLocation();
 
   useEffect(() => {
+    if (!enabled) return;
+
     window.addEventListener('beforeunload', onWindowClose);
     // Push a dummy state so that navigating back will restore the current page,
     // allowing us to manually handle navigation.
@@ -45,5 +52,5 @@ export const usePageLeave = ({ onWindowClose, onHistoryChange }: Props) => {
       window.removeEventListener('popstate', handlePopState);
       document.removeEventListener('click', handleLinkClick, true);
     };
-  }, [onWindowClose, onHistoryChange, curLocation]);
+  }, [onWindowClose, onHistoryChange, curLocation, enabled]);
 };

--- a/client/src/templates/Challenges/hooks/use-page-leave.ts
+++ b/client/src/templates/Challenges/hooks/use-page-leave.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from '@gatsbyjs/reach-router';
 
 interface Props {
@@ -13,14 +13,21 @@ export const usePageLeave = ({
   enabled = true
 }: Props) => {
   const curLocation = useLocation();
+  // The dummy history entry must be pushed at most once per mount, or every
+  // re-arming of the hook would add another entry and the back button would
+  // need one dead press per entry to leave the page.
+  const hasPushedState = useRef(false);
 
   useEffect(() => {
     if (!enabled) return;
 
     window.addEventListener('beforeunload', onWindowClose);
-    // Push a dummy state so that navigating back will restore the current page,
-    // allowing us to manually handle navigation.
-    window.history.pushState({}, curLocation.pathname);
+    if (!hasPushedState.current) {
+      // Push a dummy state so that navigating back will restore the current
+      // page, allowing us to manually handle navigation.
+      window.history.pushState({}, curLocation.pathname);
+      hasPushedState.current = true;
+    }
 
     const handlePopState = () => {
       // The argument should be an empty string, so that onHistoryChange knows
@@ -31,8 +38,23 @@ export const usePageLeave = ({
     window.addEventListener('popstate', handlePopState);
 
     const handleLinkClick = (event: MouseEvent) => {
+      // Only intercept plain left-clicks that navigate the current tab.
+      // Modified clicks (new tab, new window, download) and clicks on anchors
+      // targeting another browsing context leave this page's state untouched,
+      // so they must not be blocked.
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      )
+        return;
+
       const anchor = (event.target as HTMLElement).closest('a');
       if (!anchor) return;
+      if (anchor.target && anchor.target !== '_self') return;
 
       const href = anchor.getAttribute('href');
       if (!href || !href.startsWith('/')) return;

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -46,6 +46,7 @@ const initialState = {
     exitExam: false,
     finishExam: false,
     exitQuiz: false,
+    exitProject: false,
     finishQuiz: false,
     examResults: false,
     survey: false,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -48,6 +48,8 @@ export const isSurveyModalOpenSelector = state => state[ns].modal.survey;
 export const isExamResultsModalOpenSelector = state =>
   state[ns].modal.examResults;
 export const isExitQuizModalOpenSelector = state => state[ns].modal.exitQuiz;
+export const isExitProjectModalOpenSelector = state =>
+  state[ns].modal.exitProject;
 export const isFinishQuizModalOpenSelector = state =>
   state[ns].modal.finishQuiz;
 export const isProjectPreviewModalOpenSelector = state =>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #54796

## What this does

Certification project pages do not save code automatically, and campers have reported losing work after navigating away or closing the tab without clicking the **Save your Code** button. This PR adds a leave-page warning to certification project pages (challenges with `saveSubmissionToDB`), implementing the solution agreed in the issue thread (dialog on navigation/reload, following the existing quiz/exam navigation-blocking pattern).

- **In-app navigation** (link clicks, browser back button) opens a confirmation modal ("You have unsaved changes"), mirroring the existing `ExitQuizModal` pattern and reusing the `usePageLeave` hook.
- **Tab close / reload** triggers the native `beforeunload` prompt.
- The warning **only arms when there are actual unsaved changes**: a new `hasUnsavedChanges` helper compares the current editor contents against the last challenge state saved to the camper's account (`savedChallenges`), falling back to the seed when the project has never been saved.
- The warning **disarms automatically** after clicking Save your Code or submitting the project, since both update `savedChallenges` in the store. Programmatic navigation (e.g. the completion modal's "go to next challenge") is unaffected, as `usePageLeave` intentionally only intercepts link clicks and popstate.

## Implementation notes

- `usePageLeave` gains an optional `enabled` flag (default `true`, so quiz/exam behavior is unchanged) so the hook can stay dormant on project pages until there is something to protect.
- New `exitProject` modal state + selector in the challenge redux slice, and a new `ExitProjectModal` component modeled on `exit-quiz-modal.tsx`.
- The classic template's GraphQL query now also fetches `fields.blockHashSlug`, used as the default exit target for back-button navigation (same as the quiz page). `fields` is optional on `DailyCodingChallengeNode` since daily challenges don't provide it.
- Four new English i18n keys under `learn.exit-project-modal`.

Known trade-off inherited from the existing `usePageLeave` design: arming the hook pushes a duplicate history entry (the quiz page does the same), so after saving, the back button can require one extra press.

## How this differs from the previously closed #66709

That PR warned on every navigation away from a cert project page, even when nothing had been typed or everything was already saved. This one only warns when leaving would actually lose unsaved work.

## Testing

- Added unit tests for `hasUnsavedChanges` in `saved-challenges.test.ts` (null files, clean state, edited contents, missing file key).
- Ran locally: `vitest` suites for `Challenges/classic`, `Challenges/quiz`, `completion-modal` (53 tests) and `i18n/locales.test.ts` (216 tests) — all passing.
- `tsc --noEmit` and `eslint --max-warnings 0` clean on all changed files.