### PR TITLE
fix(curriculum): correct typo 'its\'' to 'its' in playing cards lab i…

### DIFF
--- a/curriculum/challenges/english/blocks/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
+++ b/curriculum/challenges/english/blocks/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
@@ -19,8 +19,8 @@ saveSubmissionToDB: true
 1. Within each `.card` element, you should have three `div` elements, the first with a class of `left`, the second with a class of `middle`, and the third with a class of `right`.
 1. Your `#playing-cards` element should use flexbox to horizontally center its children, allow them to wrap, and put a `20px` space between them.
 1. Each of your `.card` elements should use flexbox to justify its children using `space-between`.
-1. Each of your `.left` elements should use flexbox item properties to align itself at the start of its' parent container.
-1. Each of your `.middle` elements should use flexbox item properties to align itself in the center of its' parent container.
+1. Each of your `.left` elements should use flexbox item properties to align itself at the start of its parent container.
+1. Each of your `.middle` elements should use flexbox item properties to align itself in the center of its parent container.
 1. Each of your `.right` elements should use flexbox item properties to align itself at the end of its parent container.
 1. Each of your `.middle` elements should use flexbox to display its children in a column.
 


### PR DESCRIPTION
…nstructions

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

### Description of Changes
Fixed a minor grammatical typo in the "Page of Playing Cards" lab instructions, correcting `its'` to `its`.

### Issue
Fixed #68909

<!-- Feel free to add any additional description of changes below this line -->
