### PR TITLE
fix(curriculum): correct wording in specialized semantic elements lectures

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-specialized-semantic-elements/672995ffdfd2f337f5f215f8.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-specialized-semantic-elements/672995ffdfd2f337f5f215f8.md
@@ -37,7 +37,7 @@ Superior lettering refers to letters written in superscript, usually to indicate
 
 It is important to note that the superscript element should only be used for typographical reasons. If you want to style a piece of text with a raised baseline, then you should use CSS instead of the superscript element.
 
-To represent chemical equations inside HTML, you would use the subscript element. This element uses a subscript which displays a lowered baseline using smaller text.
+To represent chemical formulas inside HTML, you would use the subscript element. This element uses a subscript which displays a lowered baseline using smaller text.
 
 Here is an example of using the subscript element to show the chemical representation for carbon dioxide (to see the previews, enable the interactive editor):
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-specialized-semantic-elements/6729963b1ab11638753cf082.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-specialized-semantic-elements/6729963b1ab11638753cf082.md
@@ -108,7 +108,7 @@ It's used to represent when text is no longer accurate or relevant.
 
 ---
 
-It's used to create navigational aides on websites.
+It's used to create navigational aids on websites.
 
 ### --feedback--
 


### PR DESCRIPTION
﻿Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. -->
- [x] My pull request closes related issue #68872

## Description

Fixes two wording issues in the Working with Specialized Semantic Elements lectures:

1. Change `chemical equations` to `chemical formulas` (subscript is for formulas like CO2, not reaction equations)
2. Change `navigational aides` to `navigational aids` (aides = people, aids = tools)

Closes #68872
