### PR TITLE
fix(curriculum): correct Quincy's Job Tips errors

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68eab6a2b37d2f13602d0c3f.md
@@ -55,11 +55,11 @@ const thirdPEl = document.querySelector('main > section:nth-of-type(2) > blockqu
 assert.equal(thirdPEl?.innerText.trim(), 'Create GitHub, Twitter, LinkedIn, and Discord accounts.');
 ```
 
-Your forth `p` element should have the text `Go to tech meetups and conferences. Travel if you have to.`
+Your fourth `p` element should have the text `Go to tech meetups and conferences. Travel if you have to.`
 
 ```js
-const forthPEl = document.querySelector('main > section:nth-of-type(2) > blockquote > p:nth-of-type(4)');
-assert.equal(forthPEl?.innerText.trim(), 'Go to tech meetups and conferences. Travel if you have to.');
+const fourthPEl = document.querySelector('main > section:nth-of-type(2) > blockquote > p:nth-of-type(4)');
+assert.equal(fourthPEl?.innerText.trim(), 'Go to tech meetups and conferences. Travel if you have to.');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
+++ b/curriculum/challenges/english/blocks/workshop-quincys-job-tips/68ebe9cd7523d340c0b343d3.md
@@ -165,7 +165,6 @@ assert.equal(thirdPEl?.innerText.trim(), 'Hang out at hackerspaces and help peop
           &mdash;Quincy Larson, <cite>How to Learn to Code and Get a Developer Job [Full Book]</cite>
         </p>
       </section>
-
       <section>
         <h2>Importance of Networking</h2>
         <blockquote cite="https://www.freecodecamp.org/news/learn-to-code-book/">
@@ -175,7 +174,6 @@ assert.equal(thirdPEl?.innerText.trim(), 'Hang out at hackerspaces and help peop
           <p>Go to tech meetups and conferences. Travel if you have to.</p>
         </blockquote>
       </section>
-
       <section>
         <h2>Importance of Building a Reputation</h2>
         <blockquote cite="https://www.freecodecamp.org/news/learn-to-code-book/">


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68893

### Summary

- Corrected `forth` to `fourth` in the Step 12 hint.
- Renamed `forthPEl` to `fourthPEl` in its declaration and assertion.
- Removed the two unintended blank lines between `section` elements in the Step 13 solution.