### PR TITLE
fix(curriculum): correct its typo in Page of Playing Cards lab instructions

### DIFF
--- a/curriculum/challenges/english/blocks/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
+++ b/curriculum/challenges/english/blocks/lab-page-of-playing-cards/66be24cb4144f955b6bcc550.md
@@ -19,8 +19,8 @@ saveSubmissionToDB: true
 1. Within each `.card` element, you should have three `div` elements, the first with a class of `left`, the second with a class of `middle`, and the third with a class of `right`.
 1. Your `#playing-cards` element should use flexbox to horizontally center its children, allow them to wrap, and put a `20px` space between them.
 1. Each of your `.card` elements should use flexbox to justify its children using `space-between`.
-1. Each of your `.left` elements should use flexbox item properties to align itself at the start of its' parent container.
-1. Each of your `.middle` elements should use flexbox item properties to align itself in the center of its' parent container.
+1. Each of your `.left` elements should use flexbox item properties to align itself at the start of its parent container.
+1. Each of your `.middle` elements should use flexbox item properties to align itself in the center of its parent container.
 1. Each of your `.right` elements should use flexbox item properties to align itself at the end of its parent container.
 1. Each of your `.middle` elements should use flexbox to display its children in a column.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68909

### Additional description: 
This PR fixes a typo in the Page of Playing Cards lab instructions. Changed the incorrect possessive form `its'` to the correct `its` in two instructions:

- **Line 4:** "start of its' parent container" → "start of its parent container"
- **Line 5:** "center of its' parent container" → "center of its parent container"

This is a simple grammatical fix that improves the clarity of the lab instructions.