### PR TITLE
fix(curriculum): reword second h3 hint in workshop-curriculum-outline step 10

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-curriculum-outline/683921c4769fd23dbadec2fe.md
+++ b/curriculum/challenges/english/blocks/workshop-curriculum-outline/683921c4769fd23dbadec2fe.md
@@ -23,7 +23,7 @@ You should have exactly two `h3` elements, make sure to not remove the existing 
 assert.lengthOf(document.querySelectorAll("h3"), 2);
 ```
 
-Your `h3` element's text should be `Introduction to CSS`. 
+You should not change the text of the second `h3` element, it should still read `Introduction to CSS`. 
 
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons


### PR DESCRIPTION
fix(curriculum): improved the hint for the second <h3> to make it easier for the camper to understand (freeCodeCamp#68895)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68895

<!-- Feel free to add any additional description of changes below this line -->
**Before:** "Your `h3` element's text should be `Introduction to CSS`."
**After:**    "You should not change the text of the second `h3` element, it should still read `Introduction to CSS`."