### PR TITLE
fix(curriculum): clarified the h3 hint so a user better understands what went wrong 

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-curriculum-outline/683921c4769fd23dbadec2fe.md
+++ b/curriculum/challenges/english/blocks/workshop-curriculum-outline/683921c4769fd23dbadec2fe.md
@@ -23,7 +23,7 @@ You should have exactly two `h3` elements, make sure to not remove the existing 
 assert.lengthOf(document.querySelectorAll("h3"), 2);
 ```
 
-Your `h3` element's text should be `Introduction to CSS`. 
+The text of the `h3` elements should not be altered during this excersie, since they are not the focus of the assignment.
 
 ```js
 // purposefully removing friction for early users to help improve retention in early lessons


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes #68895 

<!-- Feel free to add any additional description of changes below this line -->

This pull request updates the instructions related to the `h3` elements in the workshop curriculum outline. The change clarifies that the text of the `h3` elements should remain unchanged during this exercise, as modifying them is not the focus of the assignment.
