### PR TITLE
fix(api): bypass cors warn logging for /exam-environment/

### DIFF
--- a/api/src/plugins/cors.test.ts
+++ b/api/src/plugins/cors.test.ts
@@ -71,7 +71,7 @@ describe('cors', () => {
     });
 
     expect(warnSpy).toHaveBeenCalledWith(
-      { origin: 'https://disallowed.example.com' },
+      { _origin: 'https://disallowed.example.com' },
       'Received request from disallowed origin'
     );
   });

--- a/api/src/plugins/cors.ts
+++ b/api/src/plugins/cors.ts
@@ -21,7 +21,11 @@ const cors: FastifyPluginCallback = (fastify, _options, done) => {
       // @fastify/cors instead.
       void reply.header('Access-Control-Allow-Origin', HOME_LOCATION);
 
-      if (origin && !req.url?.startsWith('/status/')) {
+      if (
+        origin &&
+        !req.url?.startsWith('/status/') &&
+        !req.url?.startsWith('/exam-environment/')
+      ) {
         req.log.warn({ origin }, 'Received request from disallowed origin');
       } else {
         req.log.debug({ origin }, 'Unknown or missing origin');

--- a/api/src/plugins/cors.ts
+++ b/api/src/plugins/cors.ts
@@ -10,10 +10,13 @@ const cors: FastifyPluginCallback = (fastify, _options, done) => {
   });
 
   fastify.addHook('onRequest', async (req, reply) => {
-    const origin = req.headers.origin;
-    if (origin && allowedOrigins.includes(origin)) {
-      req.log.debug({ origin }, 'Allowing access to origin');
-      void reply.header('Access-Control-Allow-Origin', origin);
+    // `origin` is an undocumented reserved keyword in Sentry
+    // if used as attribute name in logs, it is overwritten in queries
+    // https://github.com/getsentry/sentry/issues/120640
+    const _origin = req.headers.origin;
+    if (_origin && allowedOrigins.includes(_origin)) {
+      req.log.debug({ _origin }, 'Allowing access to origin');
+      void reply.header('Access-Control-Allow-Origin', _origin);
     } else {
       // TODO: Discuss if this is the correct approach. Standard practice is to
       // reflect one of a list of allowed origins and handle development
@@ -21,14 +24,10 @@ const cors: FastifyPluginCallback = (fastify, _options, done) => {
       // @fastify/cors instead.
       void reply.header('Access-Control-Allow-Origin', HOME_LOCATION);
 
-      if (
-        origin &&
-        !req.url?.startsWith('/status/') &&
-        !req.url?.startsWith('/exam-environment/')
-      ) {
-        req.log.warn({ origin }, 'Received request from disallowed origin');
+      if (_origin && !req.url?.startsWith('/status/')) {
+        req.log.warn({ _origin }, 'Received request from disallowed origin');
       } else {
-        req.log.debug({ origin }, 'Unknown or missing origin');
+        req.log.debug({ _origin }, 'Unknown or missing origin');
       }
     }
 

--- a/api/src/utils/allowed-origins.ts
+++ b/api/src/utils/allowed-origins.ts
@@ -3,6 +3,7 @@ import { HOME_LOCATION, FREECODECAMP_NODE_ENV } from './env.js';
 const ALLOWED_ORIGINS = [
   'https://www.freecodecamp.dev',
   'https://www.freecodecamp.org',
+  'https://exam-env.freecodecamp.org',
   // pretty sure the rest of these can go?
   'https://beta.freecodecamp.dev',
   'https://beta.freecodecamp.org',

--- a/api/src/utils/allowed-origins.ts
+++ b/api/src/utils/allowed-origins.ts
@@ -3,7 +3,7 @@ import { HOME_LOCATION, FREECODECAMP_NODE_ENV } from './env.js';
 const ALLOWED_ORIGINS = [
   'https://www.freecodecamp.dev',
   'https://www.freecodecamp.org',
-  'https://exam-env.freecodecamp.org',
+  'https://exam.freecodecamp.org',
   // pretty sure the rest of these can go?
   'https://beta.freecodecamp.dev',
   'https://beta.freecodecamp.org',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This use to introduce a lot of noise, because the app obviously does not log from our origins.