### PR TITLE
fix(curriculum): rename `id` to `dev_id` in `zip()` examples to fix inconsistent syntax highlighting

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops-and-sequences/6839e4b003571c149bcda122.md
@@ -97,12 +97,12 @@ And here's an example of using the `zip()` function with a `for` loop to iterate
 developers = ['Naomi', 'Dario', 'Jessica', 'Tom']
 ids = [1, 2, 3, 4]
 
-for name, id in zip(developers, ids):
+for name, dev_id in zip(developers, ids):
     print(f'Name: {name}')
-    print(f'ID: {id}')
+    print(f'ID: {dev_id}')
 ```
 
-In this example, `zip()` combines the two lists into pairs of elements and returns an iterator of tuples. The `for` loop then unpacks each tuple into `name` and `id`. Finally, for each print statement, we are printing each `name` and `id` from the `ids` and `developers` lists respectively. Here is what the result looks like in the console:
+In this example, `zip()` combines the two lists into pairs of elements and returns an iterator of tuples. The `for` loop then unpacks each tuple into `name` and `dev_id`. Finally, for each print statement, we are printing each `name` and `dev_id` from the `ids` and `developers` lists respectively. Here is what the result looks like in the console:
 
 ```md
 Name: Naomi

--- a/curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md
+++ b/curriculum/challenges/english/blocks/review-loops-and-sequences/67f39b91583dec1e1eddbb9e.md
@@ -622,9 +622,9 @@ print(list(enumerate(languages)))
 developers = ['Naomi', 'Dario', 'Jessica', 'Tom']
 ids = [1, 2, 3, 4]
 
-for name, id in zip(developers, ids):
+for name, dev_id in zip(developers, ids):
     print(f'Name: {name}')
-    print(f'ID: {id}')
+    print(f'ID: {dev_id}')
 
 
 """

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -1486,9 +1486,9 @@ print(list(enumerate(languages)))
 developers = ['Naomi', 'Dario', 'Jessica', 'Tom']
 ids = [1, 2, 3, 4]
 
-for name, id in zip(developers, ids):
+for name, dev_id in zip(developers, ids):
     print(f'Name: {name}')
-    print(f'ID: {id}')
+    print(f'ID: {dev_id}')
 
 
 """


### PR DESCRIPTION
fix(curriculum): rename `id` to `dev_id` in zip() examples to fix syntax highlighting

The loop variable `id` shadows Python's built-in `id()` function, causing the syntax highlighter to color `{id}` differently from `{name}` inside f-strings. Renaming to `dev_id` resolves the inconsistency.

Updated in three files:
- lecture-working-with-loops-and-sequences (code + explanation text)
- review-loops-and-sequences (code)
- review-python (code)
- 
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68922

### Specific Changes

**`6839e4b003571c149bcda122.md`** (lecture):
- `for name, id in zip(developers, ids):` → `for name, dev_id in zip(developers, ids):`
- `print(f'ID: {id}')` → `print(f'ID: {dev_id}')`
- Updated explanation text: "`name` and `id`" → "`name` and `dev_id`"

**`67f39b91583dec1e1eddbb9e.md`** (review-loops-and-sequences):
- `for name, id in zip(developers, ids):` → `for name, dev_id in zip(developers, ids):`
- `print(f'ID: {id}')` → `print(f'ID: {dev_id}')`

**`67f39e391c9b373069def02c.md`** (review-python):
- `for name, id in zip(developers, ids):` → `for name, dev_id in zip(developers, ids):`
- `print(f'ID: {id}')` → `print(f'ID: {dev_id}')`
