### PR TITLE
fix(curriculum): remove the redundant words

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995f16ed97837b365a9f6.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995f16ed97837b365a9f6.md
@@ -9,7 +9,7 @@ dashedName: how-do-you-display-times-and-dates-in-html
 
 The `time` element is used to represent a specific moment in time.
 
-Here is an example using the `time` element to represent twenty hundred hours, or eight PM in the evening.
+Here is an example using the `time` element to represent twenty hundred hours, or eight in the evening.
 
 :::interactive_editor
 
@@ -23,7 +23,7 @@ The `datetime` attribute is used to translate dates and times into a machine-rea
 
 This is important, because it helps with search engine results and helps the browser process date and time information more effectively.
 
-The value for the `datetime` attribute must be either a valid year, valid month, valid time, local date, global date, or valid duration string.
+The value for the `datetime` attribute must be a valid year, valid month, valid time, local date, global date, or valid duration string.
 
 Here is another example of using the time element to represent a particular date:
 
@@ -41,7 +41,7 @@ The value for the `datetime` attribute is in the ISO 8601 format. ISO 8601 is an
 
 The first part of that value is the year, month and day. The capital T in the value is a separator between the date and time.
 
-The fifteen hundred hours would be three PM in the afternoon.
+Fifteen hundred hours would be three in the afternoon.
 
 Whenever you need to represent events, publication dates, or appointments, it is best to use the `time` element.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68869

<!-- Feel free to add any additional description of changes below this line -->

**Remove redundant words from 672995f16ed97837b365a9f6.md**

**Before:**   Here is an example using the `time` element to represent twenty hundred hours, or eight PM in the evening.
**After:**     Here is an example using the `time` element to represent twenty hundred hours, or **eight in the evening**.

**Before:**  The value for the `datetime` attribute must be either a valid year, valid month, valid time, local date, global date, or valid duration string.
**After:**    The value for the `datetime` attribute must **be a valid year**, valid month, valid time, local date, global date, or valid duration string.

**Before:**  The fifteen hundred hours would be three PM in the afternoon.
**After:**     Fifteen hundred hours would be **three in the afternoon**.