### PR TITLE
fix: modifying(curriculum): migrate binary search hints to AST explorer

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-binary-search-js/6995d0325fd7da40854fac40.md
+++ b/curriculum/challenges/english/blocks/workshop-binary-search-js/6995d0325fd7da40854fac40.md
@@ -20,14 +20,17 @@ To begin, create a `binarySearch` function with a `searchList` and `value` param
 You should create a `binarySearch` function.
 
 ```js
-assert.isFunction(binarySearch);
+const explorer = await __helpers.Explorer(code);
+const binarySearchFunc = explorer.allFunctions.binarySearch;
 ```
 
 Your `binarySearch` function should have a `searchList` and `value` parameters.
 
 ```js
-const regex = __helpers.functionRegex('binarySearch', ['searchList', 'value']);
-assert.match(__helpers.removeJSComments(code), regex);
+
+assert.isDefined(binarySearchFunc,"you have to define a function named binarySearch");
+const paramNames = binarySearchFunc.parameters.map(p => p.name);
+assert.deepEqual(paramNames, ["searchList", "value"]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-binary-search-js/6996c60281feca6718cc15c1.md
+++ b/curriculum/challenges/english/blocks/workshop-binary-search-js/6996c60281feca6718cc15c1.md
@@ -15,9 +15,8 @@ You should have a `pathToTarget` variable set to an empty array `[]` within your
 
 ```js
 assert.match(
-  __helpers.removeJSComments(String(binarySearch)),
-  /(const|let|var)\s+pathToTarget\s*=\s*\[\s*\]/
-);
+const explorer = await __helpers.Explorer(code);
+assert.isDefined(explorer.variables.pathToTarget, "You should declare an empty array named pathToTarget.");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-binary-search-js/6996c675b599baa7b103192d.md
+++ b/curriculum/challenges/english/blocks/workshop-binary-search-js/6996c675b599baa7b103192d.md
@@ -18,16 +18,15 @@ To account for those two, you have to consider the entire array being searched. 
 You should have a variable named `low` set to `0` in your `binarySearch` function.
 
 ```js
-assert.match(__helpers.removeJSComments(String(binarySearch)), /(const|let|var)\s+low\s*=\s*0/);
+const explorer = await __helpers.Explorer(code);
+assert.isDefined(explorer.variables.low, "You should declare a variable named low.");
 ```
 
 You should have a variable named `high` set to `searchList.length - 1` in your `binarySearch` function.
 
 ```js
-assert.match(
-  __helpers.removeJSComments(String(binarySearch)),
-  /(const|let|var)\s+high\s*=\s*searchList\.length\s*-\s*1/
-);
+const explorer = await __helpers.Explorer(code);
+assert.isDefined(explorer.variables.high, "You should declare a variable named high.");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-binary-search-js/6996c796385b6ea4e222d5e8.md
+++ b/curriculum/challenges/english/blocks/workshop-binary-search-js/6996c796385b6ea4e222d5e8.md
@@ -18,9 +18,11 @@ Within your `while` loop, create a `mid` variable set to the average of `low` an
 Within the while loop you should create a `mid` variable set to `Math.floor((low + high) / 2)`.
 
 ```js
+//modified the mid variable test only in order to match the new AST
+assert.isDefined(explorer.variables.mid, "Within the while loop you should create a mid variable.");
 assert.match(
   __helpers.removeJSComments(String(binarySearch)),
-  /(const|let|var)\s+mid\s*=\s*Math\.floor\(\s*\(\s*low\s*\+\s*high\s*\)\s*\/\s*2\s*\)/
+ Math\.floor\(\s*\(\s*low\s*\+\s*high\s*\)\s*\/\s*2\s*\)/
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-binary-search-js/6996c8375f4301004459ee85.md
+++ b/curriculum/challenges/english/blocks/workshop-binary-search-js/6996c8375f4301004459ee85.md
@@ -17,9 +17,8 @@ You should create a `valueAtMiddle` variable set to `searchList[mid]`.
 
 ```js
 assert.match(
-  __helpers.removeJSComments(String(binarySearch)),
-  /(const|let|var)\s+valueAtMiddle\s*=\s*searchList\s*\[\s*mid\s*\]/
-);
+const explorer = await __helpers.Explorer(code);
+assert.isDefined(explorer.variables.valueAtMiddle, "You should declare a variable named valueAtMiddle.");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-binary-search-js/6996ca21a74104721f2c7e5d.md
+++ b/curriculum/challenges/english/blocks/workshop-binary-search-js/6996ca21a74104721f2c7e5d.md
@@ -27,7 +27,11 @@ assert.match(
 You should return an empty array after your `while` loop.
 
 ```js
-assert.match(__helpers.removeJSComments(String(binarySearch)), /return\s*\[\s*\]/);
+const explorer = await __helpers.Explorer(code);
+assert.true(
+  explorer.allFunctions.binarySearch.hasReturn("[]"),
+  "You should return an empty array at the end of the function."
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-binary-search-js/6996d1032feed88e2957dc8e.md
+++ b/curriculum/challenges/english/blocks/workshop-binary-search-js/6996d1032feed88e2957dc8e.md
@@ -14,9 +14,10 @@ You can see that the last call prints an empty array. To further specify that th
 You should update the `return` statement to return `[], 'Value not found'`.
 
 ```js
-assert.match(
-  __helpers.removeJSComments(String(binarySearch)),
-  /return\s*\[\s*\[\s*\]\s*,\s*('|"|`)Value not found\1\s*\]/
+const explorer = await __helpers.Explorer(code);
+assert.true(
+  explorer.allFunctions.binarySearch.hasReturn("[[], 'Value not found']"),
+  "You should return an array containing an empty array and the string 'Value not found'."
 );
 ```
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

replace for regex tests to new tests.
note: concerning the test with id:6996c796385b6ea4e222d5e8 the test which enters the while loop fails  when modifing the regex test .
Closes #68694

<