### PR TITLE
fix(curriculum): fix misleading correct answer in sum function quiz

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-functions/672d269da46786225e3fe3fd.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-functions/672d269da46786225e3fe3fd.md
@@ -194,7 +194,7 @@ Review the section where function calls were discussed.
 ---
 
 ```js
-sum()
+sum(1,2)
 ```
 
 ---


### PR DESCRIPTION
### Describe the Changes

Fixes a misleading quiz answer in the "What Is the Purpose of Functions, and How Do They Work?" lecture.

The quiz asks for the correct way to invoke `sum(num1, num2)`, and marks `sum()` as the correct answer. Since `num1` and `num2` have no default values, calling `sum()` returns `NaN`, not a valid sum. Changed the correct answer from `sum()` to `sum(1, 2)` — a call that is both syntactically valid and actually returns a correct result, consistent with the `calculateSum(1,2)` example used earlier in the same lecture.

Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68744