### PR TITLE
chore: secure GitHub Actions with explicit token permissions

### DIFF
--- a/.github/workflows/github-autoclose.yml
+++ b/.github/workflows/github-autoclose.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - '.gitignore'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   autoclose:
     runs-on: ubuntu-24.04

--- a/.github/workflows/github-autoclose.yml
+++ b/.github/workflows/github-autoclose.yml
@@ -7,10 +7,8 @@ on:
       - '.gitignore'
 
 permissions:
-  contents: read
   issues: write
   pull-requests: write
-
 jobs:
   autoclose:
     runs-on: ubuntu-24.04

--- a/.github/workflows/github-lock-closed-prs.yml
+++ b/.github/workflows/github-lock-closed-prs.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   lock:
     name: Lock Closed PR

--- a/.github/workflows/github-lock-closed-prs.yml
+++ b/.github/workflows/github-lock-closed-prs.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
-
 jobs:
   lock:
     name: Lock Closed PR

--- a/.github/workflows/github-spam.yml
+++ b/.github/workflows/github-spam.yml
@@ -4,9 +4,7 @@ on:
     types:
       - labeled
 
-permissions:
-  contents: read
-
+permissions: {}
 jobs:
   is-spam:
     runs-on: ubuntu-24.04

--- a/.github/workflows/github-spam.yml
+++ b/.github/workflows/github-spam.yml
@@ -4,6 +4,9 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   is-spam:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68941

Ran an OpenSSF Scorecard assessment on the repository and noticed that our Token-Permissions check currently has a gap due to a few utility workflows relying on default broad token privileges. 

To implement the principle of least privilege across our CI/CD, this PR explicitly scopes the top-level permissions for three specific automation workflows:

1. `github-lock-closed-prs.yml:` Granted `issues: write` and `pull-requests: write` so the script can lock resolved threads, while stripping all other access.
2. `github-spam.yml:` Set to `contents: read` to restrict the ambient token, since the script relies on a dedicated bot secret.
3. `github-autoclose.yml:` Scoped tightly to `contents: read`, `issues: write`, and `pull-requests: write` to allow the validation script to verify files, post comments, and update pull states without needing administrative repo write access.

These changes strictly secure our ambient token environment without impacting any core platform logic or testing setups.
