### PR TITLE
fix(curriculum): align N-Queens lab title

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -1985,7 +1985,7 @@
         ]
       },
       "lab-n-queens-problem": {
-        "title": "Implement the N-Queens Problem",
+        "title": "Implement the N-Queens Algorithm",
         "intro": [
           "In this lab, you will implement a solution for the N-Queens problem."
         ]
@@ -5866,7 +5866,7 @@
         ]
       },
       "lab-n-queens-problem-js": {
-        "title": "Implement the N-Queens Problem",
+        "title": "Implement the N-Queens Algorithm",
         "intro": [
           "In this lab, you will implement a solution for the N-Queens problem."
         ]
@@ -6873,7 +6873,7 @@
         ]
       },
       "lab-n-queens-problem": {
-        "title": "Implement the N-Queens Problem",
+        "title": "Implement the N-Queens Algorithm",
         "intro": [
           "In this lab, you will implement a solution for the N-Queens problem."
         ]


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
Closes #68943
Aligns the N-Queens block titles in `intro.json` with the challenge titles so the breadcrumb and instructions match.