### PR TITLE
fix(curriculum): add missing console.log removal instruction and hint…

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/699d20623e57e8ffee88545a.md
+++ b/curriculum/challenges/english/blocks/workshop-heritage-library-catalog/699d20623e57e8ffee88545a.md
@@ -9,11 +9,17 @@ dashedName: step-12
 
 With the catalog parsed, you can search it by field. `findByAuthor` will filter entries whose author contains a search term.
 
-Create a function named `findByAuthor` that takes `catalog` and `author` as parameters. Inside, declare a variable named `searchTerm` and set it to the lowercase version of `author` to enable case-insensitive matching later. 
+Remove `console.log(catalog.length);` and then create a function named `findByAuthor` that takes `catalog` and `author` as parameters. Inside, declare a variable named `searchTerm` and set it to the lowercase version of `author` to enable case-insensitive matching later. 
 
 Also declare a variable named `results` and assign it an empty array to hold the matches.
 
 # --hints--
+
+You should remove the `console.log(catalog.length);` statement.
+
+```js
+assert.notMatch(__helpers.removeJSComments(code), /console\.log\(catalog\.length\)/);
+```
 
 You should have a function named `findByAuthor` with `catalog` and `author` as parameters.
 
@@ -91,6 +97,6 @@ function parseCatalog(rawCards) {
 const catalog = parseCatalog(rawCatalogCards);
 
 --fcc-editable-region--
-
+console.log(catalog.length);
 --fcc-editable-region--
 ```


### PR DESCRIPTION
Updated the description in heritage library step 12 to instruct removing `console.log(catalog.length);`, added a corresponding hint, and updated the editable region markers to include that line.

Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #68945
<!-- Feel free to add any additional description of changes below this line -->