### PR TITLE
fix: atomic concurrent modern-challenge updates

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -165,7 +165,7 @@ model user {
   portfolio                      Portfolio[]
   experience                     Experience[]
   profileUI                      ProfileUI? // Undefined
-  progressTimestamps             Json? // ProgressTimestamp[] | Null[] | Int64[] | Double[] - TODO: NORMALIZE
+  progressTimestamps             Json[] // ProgressTimestamp[] | Null[] | Int64[] | Double[] - TODO: NORMALIZE
   /// A random number between 0 and 1.
   ///
   /// Valuable for selectively performing random logic.

--- a/api/src/routes/protected/challenge.test.ts
+++ b/api/src/routes/protected/challenge.test.ts
@@ -1489,6 +1489,50 @@ describe('challengeRoutes', () => {
         });
         expect(resUpdate.statusCode).toBe(200);
       });
+
+      test('POST concurrent requests for different challenges should not lose completions', async () => {
+        // Send multiple simultaneous requests for different challenges.
+        // The read-then-write pattern in updateUserChallengeData means
+        // concurrent requests can read stale state and overwrite each
+        // other's completions.
+        const challengeIds = [
+          'aaa174fcf86c76b9248c6eb0',
+          'aaa174fcf86c76b9248c6eb1',
+          'aaa174fcf86c76b9248c6eb2',
+          'aaa174fcf86c76b9248c6eb3',
+          'aaa174fcf86c76b9248c6eb4',
+          'aaa174fcf86c76b9248c6eb4'
+        ];
+
+        const responses = await Promise.all(
+          challengeIds.map(id =>
+            superPost('/encoded/modern-challenge-completed').send({
+              challengeType: challengeTypes.html,
+              id
+            })
+          )
+        );
+
+        for (const res of responses) {
+          expect(res.statusCode).toBe(200);
+        }
+
+        const user = await fastifyTestInstance.prisma.user.findFirstOrThrow({
+          where: { email: 'foo@bar.com' }
+        });
+
+        // Every challenge should be recorded. If the race condition
+        // causes lost updates, this count will be less than 5.
+        expect(user.completedChallenges).toHaveLength(challengeIds.length);
+
+        const completedIds = user.completedChallenges.map(c => c.id);
+        for (const id of challengeIds) {
+          expect(completedIds).toContain(id);
+        }
+
+        // Each completion should add a progress timestamp
+        expect(user.progressTimestamps).toHaveLength(challengeIds.length);
+      });
     });
 
     describe('/daily-coding-challenge-completed', () => {

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -165,8 +165,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
         id: projectId,
         completedDate: Date.now()
       };
-      const progressTimestamps = user.progressTimestamps as ProgressTimestamp[];
-      const points = getPoints(progressTimestamps);
+      const points = getPoints(user.progressTimestamps);
 
       const { alreadyCompleted, completedDate } = await updateUserChallengeData(
         fastify,
@@ -225,10 +224,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
 
         select: userChallengeSelect
       });
-      const progressTimestamps = user.progressTimestamps as
-        | ProgressTimestamp[]
-        | null;
-      const points = getPoints(progressTimestamps);
+      const points = getPoints(user.progressTimestamps);
 
       const completedChallenge = {
         completedDate: Date.now(),
@@ -621,9 +617,6 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
           select: userChallengeSelect
         });
 
-        const progressTimestamps =
-          user.progressTimestamps as ProgressTimestamp[];
-
         const completedChallenge = {
           id: challengeId,
           solution: msTrophyStatus.msUserAchievementsApiUrl,
@@ -646,7 +639,8 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
 
         reply.send({
           alreadyCompleted,
-          points: getPoints(progressTimestamps) + (alreadyCompleted ? 0 : 1),
+          points:
+            getPoints(user.progressTimestamps) + (alreadyCompleted ? 0 : 1),
           completedDate: normalizeDate(completedDate)
         });
       } catch (error) {
@@ -795,7 +789,6 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
             };
           });
         const newCompletedExams: CompletedExam[] = completedExams;
-        const newProgressTimeStamps = progressTimestamps as ProgressTimestamp[];
         const completedDate = Date.now();
 
         const newCompletedChallenge = {
@@ -865,7 +858,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
                 completedExams: newCompletedExams,
                 completedChallenges: newCompletedChallenges,
                 progressTimestamps: [
-                  ...newProgressTimeStamps,
+                  ...(progressTimestamps as ProgressTimestamp[]),
                   newCompletedChallenge.completedDate
                 ]
               }
@@ -882,7 +875,7 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
           });
         }
 
-        const points = getPoints(newProgressTimeStamps);
+        const points = getPoints(progressTimestamps);
 
         fastify.Sentry?.metrics?.count('curriculum_exam.completed', 1, {
           attributes: {
@@ -1182,7 +1175,9 @@ async function postDailyCodingChallengeCompleted(
 
   const { completedDailyCodingChallenges, progressTimestamps = [] } = user;
 
-  const points = getPoints(progressTimestamps as ProgressTimestamp[]);
+  const points = getPoints(
+    progressTimestamps.filter((ts): ts is ProgressTimestamp => ts !== null)
+  );
   const oldCompletedChallenge = completedDailyCodingChallenges.find(
     c => c.id === id
   );
@@ -1243,7 +1238,12 @@ async function postDailyCodingChallengeCompleted(
     ];
 
     const newProgressTimestamps = Array.isArray(progressTimestamps)
-      ? [...progressTimestamps, newCompletedDate]
+      ? [
+          ...progressTimestamps.filter(
+            (ts): ts is ProgressTimestamp => ts !== null
+          ),
+          newCompletedDate
+        ]
       : [newCompletedDate];
 
     await this.prisma.user.update({
@@ -1338,9 +1338,7 @@ async function postModernChallengeCompleted(
     where: { id: userId },
     select: userChallengeSelect
   });
-  const RawProgressTimestamp = user.progressTimestamps as
-    | ProgressTimestamp[]
-    | null;
+  const RawProgressTimestamp = user.progressTimestamps;
   const points = getPoints(RawProgressTimestamp);
 
   const completedChallenge: CompletedChallenge = {

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -193,7 +193,7 @@ const computedProperties = {
   calendar: {},
   completedChallengeCount: 0,
   isEmailVerified: minimalUserData.emailVerified,
-  points: 1,
+  points: 0,
   // This is the default value if profileUI is missing. If individual properties
   // are missing from the db, they will be omitted from the response.
   profileUI: lockedProfileUI

--- a/api/src/routes/protected/user.ts
+++ b/api/src/routes/protected/user.ts
@@ -935,13 +935,11 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
             completedChallenges: normalizeChallenges(completedChallenges),
             completedChallengeCount: completedChallenges.length,
             completedDailyCodingChallenges,
-            // This assertion is necessary until the database is normalized.
             calendar: getCalendar(
-              progressTimestamps as ProgressTimestamp[] | null
+              progressTimestamps as (ProgressTimestamp | null)[]
             ),
             emailVerified: !!emailVerified,
-            // This assertion is necessary until the database is normalized.
-            points: getPoints(progressTimestamps as ProgressTimestamp[] | null),
+            points: getPoints(progressTimestamps),
             profileUI: normalizeProfileUI(profileUI),
             // TODO(Post-MVP) remove this and just use emailVerified
             isEmailVerified: !!emailVerified,

--- a/api/src/routes/public/user.ts
+++ b/api/src/routes/public/user.ts
@@ -181,17 +181,16 @@ export const userPublicGetRoutes: FastifyPluginCallbackTypebox = (
           result: user.username
         });
       } else {
-        const progressTimestamps = user.progressTimestamps as
-          | ProgressTimestamp[]
-          | null;
         const sharedUser = replacePrivateData({
           ...user,
-          calendar: getCalendar(progressTimestamps),
+          calendar: getCalendar(
+            user.progressTimestamps as (ProgressTimestamp | null)[]
+          ),
           completedChallenges: normalizeChallenges(user.completedChallenges),
           location: user.location ?? '',
           joinDate: new ObjectId(user.id).getTimestamp().toISOString(),
           name: user.name ?? '',
-          points: getPoints(progressTimestamps),
+          points: getPoints(user.progressTimestamps),
           profileUI: normalizedProfileUI,
           experience: user.experience.map(removeNulls) ?? []
         });

--- a/api/src/utils/common-challenge-functions.ts
+++ b/api/src/utils/common-challenge-functions.ts
@@ -119,12 +119,7 @@ export async function updateUserChallengeData(
   fastify: FastifyInstance,
   user: Pick<
     user,
-    | 'id'
-    | 'completedChallenges'
-    | 'needsModeration'
-    | 'savedChallenges'
-    | 'progressTimestamps'
-    | 'partiallyCompletedChallenges'
+    'id' | 'completedChallenges' | 'needsModeration' | 'savedChallenges'
   >,
   challengeId: string,
   _completedChallenge: CompletedChallenge
@@ -156,9 +151,7 @@ export async function updateUserChallengeData(
   const {
     completedChallenges = [],
     needsModeration = false,
-    savedChallenges = [],
-    progressTimestamps = [],
-    partiallyCompletedChallenges = []
+    savedChallenges = []
   } = user;
 
   let savedChallengesUpdate: Prisma.userUpdateInput['savedChallenges'];
@@ -178,21 +171,8 @@ export async function updateUserChallengeData(
   // check and update some property of the user record such that the same update
   // can't be applied twice.
   const userCompletedChallenges = alreadyCompleted
-    ? completedChallenges.map(x =>
-        x.id === challengeId
-          ? finalChallenge
-          : { ...x, completedDate: normalizeDate(x.completedDate) }
-      )
+    ? { updateMany: { where: { id: challengeId }, data: finalChallenge } }
     : { push: finalChallenge };
-
-  // We can't use push, because progressTimestamps is a JSON blob and, until
-  // we convert it to an array, push is not available. Since this could result
-  // in the completedChallenges and progressTimestamps arrays being out of sync,
-  // we should prioritize normalizing the data structure.
-  const userProgressTimestamps =
-    !alreadyCompleted && progressTimestamps && Array.isArray(progressTimestamps)
-      ? [...progressTimestamps, newProgressTimeStamp]
-      : progressTimestamps;
 
   if (savableChallenges.has(challengeId)) {
     const challengeToSave: SavedChallenge = {
@@ -206,14 +186,9 @@ export async function updateUserChallengeData(
     const isSaved = savedChallenges.some(({ id }) => challengeId === id);
 
     savedChallengesUpdate = isSaved
-      ? savedChallenges.map(x => (x.id === challengeId ? challengeToSave : x))
+      ? { updateMany: { where: { id: challengeId }, data: challengeToSave } }
       : { push: challengeToSave };
   }
-
-  // remove from partiallyCompleted on submit
-  const userPartiallyCompletedChallenges = partiallyCompletedChallenges.filter(
-    challenge => challenge.id !== challengeId
-  );
 
   const { savedChallenges: userSavedChallenges } =
     await fastify.prisma.user.update({
@@ -224,8 +199,14 @@ export async function updateUserChallengeData(
         //       `undefined` in Prisma is a no-op
         needsModeration: needsModeration || undefined,
         savedChallenges: savedChallengesUpdate,
-        progressTimestamps: userProgressTimestamps,
-        partiallyCompletedChallenges: userPartiallyCompletedChallenges
+        // Use atomic deleteMany instead of read-filter-write to avoid
+        // concurrent requests overwriting each other's removals.
+        partiallyCompletedChallenges: {
+          deleteMany: { where: { id: challengeId } }
+        },
+        progressTimestamps: alreadyCompleted
+          ? undefined
+          : { push: newProgressTimeStamp }
       },
       select: {
         savedChallenges: true

--- a/api/src/utils/progress.test.ts
+++ b/api/src/utils/progress.test.ts
@@ -5,7 +5,6 @@ describe('utils/progress', () => {
   describe('getCalendar', () => {
     test('should return an empty object if no timestamps are passed', () => {
       expect(getCalendar([])).toEqual({});
-      expect(getCalendar(null)).toEqual({});
     });
     test('should take timestamps and return a calendar object', () => {
       const timestamps = [-1111001, 0, 1111000, 1111500, 1113000, 9999999];
@@ -19,8 +18,8 @@ describe('utils/progress', () => {
       });
     });
 
-    test('should handle null, { timestamp: number } and float entries', () => {
-      const timestamps = [null, { timestamp: 1113000 }, 1111000.5];
+    test('should handle { timestamp: number } and float entries', () => {
+      const timestamps = [{ timestamp: 1113000 }, 1111000.5];
 
       expect(getCalendar(timestamps)).toEqual({
         1111: 1,
@@ -30,9 +29,6 @@ describe('utils/progress', () => {
   });
 
   describe('getPoints', () => {
-    test('should return 1 if there are no progressTimestamps', () => {
-      expect(getPoints(null)).toEqual(1);
-    });
     test('should return then number of progressTimestamps if there are any', () => {
       expect(getPoints([0, 1, 2])).toEqual(3);
     });

--- a/api/src/utils/progress.ts
+++ b/api/src/utils/progress.ts
@@ -1,4 +1,4 @@
-export type ProgressTimestamp = number | { timestamp: number } | null;
+export type ProgressTimestamp = number | { timestamp: number }; // they can be null in the db, but we handle that as ProgressTimestamp | null, not by folding null into the type.
 export type Calendar = Record<number, 1>;
 /**
  * Converts a ProgressTimestamp array to a object with keys based on the timestamps.
@@ -7,7 +7,7 @@ export type Calendar = Record<number, 1>;
  * @returns The object with keys based on the timestamps.
  */
 export const getCalendar = (
-  progressTimestamps: ProgressTimestamp[] | null
+  progressTimestamps: (ProgressTimestamp | null)[]
 ): Calendar => {
   const calendar: Calendar = {};
 
@@ -29,8 +29,6 @@ export const getCalendar = (
  * @param progressTimestamps The ProgressTimestamp array.
  * @returns The number of points.
  */
-export const getPoints = (
-  progressTimestamps: ProgressTimestamp[] | null
-): number => {
-  return progressTimestamps?.length ?? 1;
+export const getPoints = (progressTimestamps: unknown[]): number => {
+  return progressTimestamps.length;
 };


### PR DESCRIPTION
And all other routes that use updateUserChallengeData (project-completed, backend-challenge-completed, ms-trophy-challenge-conmpleted and coderoad-challenge-completed). Now they all use atomic updates (e.g. push) to reduce deadlocks.

This probably doesn't prevent write conflicts entirely, however. It's still possible for two concurrent requests to attempt to modify the same document. It just takes less time, now.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
