### PR TITLE
fix(curriculum): add string repetition operator

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python-strings/69414623940154f209922619.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python-strings/69414623940154f209922619.md
@@ -9,6 +9,8 @@ dashedName: what-are-string-concatenation-and-string-interpolation
 
 When working with strings, combining different pieces of text together is a common operation you'll often find yourself dealing with.
 
+## Concatenating strings: the `+` operator
+
 In Python, you can combine multiple strings together with the plus (`+`) operator. This process is called **string concatenation**. Here's how to concatenate two strings with the plus operator:
 
 ```python
@@ -19,7 +21,36 @@ str_plus_str = my_str_1 + ' ' + my_str_2
 print(str_plus_str) # Hello World
 ```
 
-But note that this only works with strings. If you try to concatenate a string with a number, you'll get a `TypeError`:
+You can also use the augmented assignment operator for concatenation. This is represented by a plus and equals sign (`+=`), and performs both concatenation and assignment in one step. Here's it in action:
+
+```py
+greet = 'Hello'
+greet += ' World'
+
+print(greet)  # Hello World
+```
+
+## Repeating strings: the `*` operator
+
+You can also repeat a string a number of times with the multiplication (`*`) operator. This process is called **string repetition**, and it works by multiplying a string by an integer:
+
+```python
+laugh = 'ha' * 3
+print(laugh) # hahaha
+```
+
+The integer can come before or after the string, since multiplication works the same either way:
+
+```python
+laugh = 3 * 'ha'
+print(laugh) # hahaha
+```
+
+Just like concatenation, this only works between a string and an integer. Multiplying a string by another string raises a `TypeError`.
+
+## Concatenating strings with numbers: the `TypeError` and the `str()` fix
+
+But note that concatenation only works with strings. If you try to concatenate a string with a number, you'll get a `TypeError`:
 
 ```python
 name = 'John Doe'
@@ -39,17 +70,7 @@ name_and_age = name + str(age)
 print(name_and_age) # John Doe26
 ```
 
-You can also use the augmented assignment operator for concatenation. This is represented by a plus and equals sign (`+=`), and performs both concatenation and assignment in one step. Here's it in action:
-
-```py
-name = 'John Doe'
-age = 26
-
-name_and_age = name  # Start with the name
-name_and_age += str(age)  # Append the age as string
-
-print(name_and_age)  # John Doe26
-```
+## String interpolation: f-strings
 
 The process of inserting variables and expressions into a string is called **string interpolation**. Python has a category of string called **f-strings** (short for formatted string literals), which allows you to handle interpolation with a compact and readable syntax.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68843

<!-- Feel free to add any additional description of changes below this line -->

Adds a "Repeating strings: the `*` operator" section to the string concatenation/interpolation lecture, since the string repetition operator (e.g. `'ha' * 3`) was never introduced before the augmented `*=` form is used in a later lecture. Restructured the lecture into subsections (concatenation, repetition, concatenating with numbers, interpolation) per maintainer feedback on the issue.

Tested locally with 3/3 pass