### PR TITLE
refactor(curriculum): replace regex-based test cases in Breadth First Search Workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989eb65324d97775c4965fe.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989eb65324d97775c4965fe.md
@@ -16,14 +16,21 @@ Start by creating a function named `genParentheses` with a single parameter `pai
 You should define a function named `genParentheses`.
 
 ```js
-assert.isFunction(genParentheses);
+const explorer = await __helpers.Explorer(code);
+const { genParentheses } = explorer.allFunctions;
+
+assert.exists(genParentheses);
 ```
 
 Your `genParentheses` function should have a single parameter named `pairs`.
 
 ```js
-const genParenthesesParams = __helpers.getFunctionParams(genParentheses.toString());
-assert.equal(genParenthesesParams[0].name, 'pairs')
+const explorer = await __helpers.Explorer(code);
+const { genParentheses } = explorer.allFunctions;
+const genParenthesesParams = genParentheses.parameters;
+
+assert.equal(genParenthesesParams.length, 1);
+assert.equal(genParenthesesParams[0].toString(), 'pairs');
 ```
 
 Your function should return an empty array.

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989eb65324d97775c4965fe.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989eb65324d97775c4965fe.md
@@ -27,15 +27,19 @@ Your `genParentheses` function should have a single parameter named `pairs`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const genParenthesesParams = genParentheses.parameters;
+const genParenthesesParams = genParentheses?.parameters;
 
-assert.equal(genParenthesesParams.length, 1);
-assert.equal(genParenthesesParams[0].toString(), 'pairs');
+assert.equal(genParenthesesParams?.length, 1);
+assert.equal(genParenthesesParams?.[0]?.toString(), 'pairs');
 ```
 
 Your function should return an empty array.
 
 ```js
+const explorer = await __helpers.Explorer(code);
+const { genParentheses } = explorer.allFunctions;
+
+assert.exists(genParentheses);
 assert.isArray(genParentheses(1));
 assert.lengthOf(genParentheses(1), 0);
 ```

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989eb65324d97775c4965fe.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989eb65324d97775c4965fe.md
@@ -27,19 +27,20 @@ Your `genParentheses` function should have a single parameter named `pairs`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const genParenthesesParams = genParentheses?.parameters;
-
-assert.equal(genParenthesesParams?.length, 1);
-assert.equal(genParenthesesParams?.[0]?.toString(), 'pairs');
+assert.exists(genParentheses);
+const genParenthesesParams = genParentheses.parameters;
+assert.exists(genParenthesesParams);
+assert.equal(genParenthesesParams.length, 1);
+assert.equal(genParenthesesParams[0].toString(), 'pairs');
 ```
 
 Your function should return an empty array.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const { genParentheses } = explorer.allFunctions;
+const { genParentheses: genParenthesesFunc } = explorer.allFunctions;
 
-assert.exists(genParentheses);
+assert.exists(genParenthesesFunc);
 assert.isArray(genParentheses(1));
 assert.lengthOf(genParentheses(1), 0);
 ```

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989eb65324d97775c4965fe.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989eb65324d97775c4965fe.md
@@ -17,9 +17,7 @@ You should define a function named `genParentheses`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const { genParentheses } = explorer.allFunctions;
-
-assert.exists(genParentheses);
+assert.exists(explorer.allFunctions.genParentheses);
 ```
 
 Your `genParentheses` function should have a single parameter named `pairs`.
@@ -27,20 +25,15 @@ Your `genParentheses` function should have a single parameter named `pairs`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-assert.exists(genParentheses);
-const genParenthesesParams = genParentheses.parameters;
-assert.exists(genParenthesesParams);
-assert.equal(genParenthesesParams.length, 1);
-assert.equal(genParenthesesParams[0].toString(), 'pairs');
+assert.equal(genParentheses?.parameters.length, 1);
+assert.equal(genParentheses?.parameters[0].toString(), 'pairs');
 ```
 
 Your function should return an empty array.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const { genParentheses: genParenthesesFunc } = explorer.allFunctions;
-
-assert.exists(genParenthesesFunc);
+assert.exists(explorer.allFunctions.genParentheses);
 assert.isArray(genParentheses(1));
 assert.lengthOf(genParentheses(1), 0);
 ```

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f1ba358acba651d5ee6b.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f1ba358acba651d5ee6b.md
@@ -16,19 +16,32 @@ Update your return statement to return `result` instead of an empty array.
 You should declare a variable named `result` in your `genParentheses` function.
 
 ```js
-assert.match(genParentheses.toString(), /result/);
+const explorer = await __helpers.Explorer(code);
+const { genParentheses } = explorer.allFunctions;
+const { result } = genParentheses.variables;
+
+assert.exists(result);
 ```
 
 You should initialize `result` to an empty array.
 
 ```js
-assert.match(genParentheses.toString(), /result\s*=\s*\[\]/);
+const explorer = await __helpers.Explorer(code);
+const { genParentheses } = explorer.allFunctions;
+const { result } = genParentheses.variables;
+const resultValue = eval(result.value.toString());
+
+assert.isArray(resultValue);
+assert.isEmpty(resultValue);
 ```
 
 You should return `result` at the end of your function.
 
 ```js
-assert.match(genParentheses.toString(), /return\s*result/);
+const explorer = await __helpers.Explorer(code);
+const { genParentheses } = explorer.allFunctions;
+
+assert.isTrue(genParentheses.hasReturn('result'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f1ba358acba651d5ee6b.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f1ba358acba651d5ee6b.md
@@ -18,8 +18,8 @@ You should declare a variable named `result` in your `genParentheses` function.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const { result } = genParentheses?.variables ?? {};
-
+assert.exists(genParentheses);
+const { result } = genParentheses.variables;
 assert.exists(result);
 ```
 
@@ -28,12 +28,11 @@ You should initialize `result` to an empty array.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const { result } = genParentheses?.variables ?? {};
-
-const resultValue = result?.value && !result.value.isEmpty()
-  ? eval(result.value.toString())
-  : undefined;
-
+assert.exists(genParentheses);
+const { result } = genParentheses.variables;
+assert.exists(result);
+assert.isFalse(result.value.isEmpty());
+const resultValue = eval(result.value.toString());
 assert.isArray(resultValue);
 assert.isEmpty(resultValue);
 ```
@@ -43,8 +42,8 @@ You should return `result` at the end of your function.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-
-assert.isTrue(genParentheses?.hasReturn('result'));
+assert.exists(genParentheses);
+assert.isTrue(genParentheses.hasReturn('result'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f1ba358acba651d5ee6b.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f1ba358acba651d5ee6b.md
@@ -18,9 +18,7 @@ You should declare a variable named `result` in your `genParentheses` function.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-assert.exists(genParentheses);
-const { result } = genParentheses.variables;
-assert.exists(result);
+assert.exists(genParentheses?.variables.result);
 ```
 
 You should initialize `result` to an empty array.
@@ -28,11 +26,9 @@ You should initialize `result` to an empty array.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-assert.exists(genParentheses);
-const { result } = genParentheses.variables;
-assert.exists(result);
-assert.isFalse(result.value.isEmpty());
-const resultValue = eval(result.value.toString());
+const { result } = genParentheses?.variables ?? {};
+assert.isFalse(result?.value.isEmpty());
+const resultValue = eval(result?.value.toString());
 assert.isArray(resultValue);
 assert.isEmpty(resultValue);
 ```
@@ -42,8 +38,7 @@ You should return `result` at the end of your function.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-assert.exists(genParentheses);
-assert.isTrue(genParentheses.hasReturn('result'));
+assert.isTrue(genParentheses?.hasReturn('result'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f1ba358acba651d5ee6b.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f1ba358acba651d5ee6b.md
@@ -18,7 +18,7 @@ You should declare a variable named `result` in your `genParentheses` function.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const { result } = genParentheses.variables;
+const { result } = genParentheses?.variables ?? {};
 
 assert.exists(result);
 ```
@@ -28,8 +28,11 @@ You should initialize `result` to an empty array.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const { result } = genParentheses.variables;
-const resultValue = eval(result.value.toString());
+const { result } = genParentheses?.variables ?? {};
+
+const resultValue = result?.value && !result.value.isEmpty()
+  ? eval(result.value.toString())
+  : undefined;
 
 assert.isArray(resultValue);
 assert.isEmpty(resultValue);
@@ -41,7 +44,7 @@ You should return `result` at the end of your function.
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
 
-assert.isTrue(genParentheses.hasReturn('result'));
+assert.isTrue(genParentheses?.hasReturn('result'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f207306332c06b0add39.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f207306332c06b0add39.md
@@ -20,13 +20,22 @@ Create a variable named `queue` and initialize it to an array containing one arr
 You should declare a variable named `queue` in your `genParentheses` function.
 
 ```js
-assert.match(genParentheses.toString(), /queue/);
+const explorer = await __helpers.Explorer(code);
+const { genParentheses } = explorer.allFunctions;
+const { queue } = genParentheses.variables;
+
+assert.exists(queue);
 ```
 
 You should initialize `queue` with an array containing the array `['', 0, 0]`.
 
 ```js
-assert.match(genParentheses.toString(), /queue\s*=\s*\[\s*\['',\s*0,\s*0\]\s*\]/);
+const explorer = await __helpers.Explorer(code);
+const { genParentheses } = explorer.allFunctions;
+const { queue } = genParentheses.variables;
+const queueValue = eval(queue.value.toString());
+
+assert.deepEqual(queueValue, [['', 0, 0]]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f207306332c06b0add39.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f207306332c06b0add39.md
@@ -22,9 +22,7 @@ You should declare a variable named `queue` in your `genParentheses` function.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const { queue } = genParentheses?.variables ?? {};
-
-assert.exists(queue);
+assert.exists(genParentheses?.variables.queue);
 ```
 
 You should initialize `queue` with an array containing the array `['', 0, 0]`.
@@ -32,11 +30,9 @@ You should initialize `queue` with an array containing the array `['', 0, 0]`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-assert.exists(genParentheses);
-const { queue } = genParentheses.variables;
-assert.exists(queue);
-assert.isFalse(queue.value.isEmpty());
-const queueValue = eval(queue.value.toString());
+const { queue } = genParentheses?.variables ?? {};
+assert.isFalse(queue?.value.isEmpty());
+const queueValue = eval(queue?.value.toString());
 assert.deepEqual(queueValue, [['', 0, 0]]);
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f207306332c06b0add39.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f207306332c06b0add39.md
@@ -32,12 +32,11 @@ You should initialize `queue` with an array containing the array `['', 0, 0]`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const { queue } = genParentheses?.variables ?? {};
-
-const queueValue = queue?.value && !queue.value.isEmpty()
-  ? eval(queue.value.toString())
-  : undefined;
-
+assert.exists(genParentheses);
+const { queue } = genParentheses.variables;
+assert.exists(queue);
+assert.isFalse(queue.value.isEmpty());
+const queueValue = eval(queue.value.toString());
 assert.deepEqual(queueValue, [['', 0, 0]]);
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f207306332c06b0add39.md
+++ b/curriculum/challenges/english/blocks/workshop-breadth-first-search-js/6989f207306332c06b0add39.md
@@ -22,7 +22,7 @@ You should declare a variable named `queue` in your `genParentheses` function.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const { queue } = genParentheses.variables;
+const { queue } = genParentheses?.variables ?? {};
 
 assert.exists(queue);
 ```
@@ -32,8 +32,11 @@ You should initialize `queue` with an array containing the array `['', 0, 0]`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { genParentheses } = explorer.allFunctions;
-const { queue } = genParentheses.variables;
-const queueValue = eval(queue.value.toString());
+const { queue } = genParentheses?.variables ?? {};
+
+const queueValue = queue?.value && !queue.value.isEmpty()
+  ? eval(queue.value.toString())
+  : undefined;
 
 assert.deepEqual(queueValue, [['', 0, 0]]);
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68695

---

<!-- Feel free to add any additional description of changes below this line -->

This PR replaces regex-based test cases with TypeScript Explorer AST helpers in the Breadth First Search Workshop as part of Naomi’s sprint initiative.

Changes include:

- Replace `assert.isFunction()` and regex-based tests with TypeScript Explorer AST helpers.
- In step 1, add a check ensuring `genParentheses()` defines exactly one parameter, as the hint text requires.
- In step 4, call `eval()` on `result.value.toString()` so that `new Array()` passes the test.
- In step 5, call `eval()` on `queue.value.toString()` so that `new Array(['', 0, 0])` passes the test.
- Add missing semicolons for consistency.