### PR TITLE
refactor(curriculum): replace regex with AST helpers in superhero app workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-superhero-application-form/680900675ae3d54ee19590d0.md
+++ b/curriculum/challenges/english/blocks/workshop-superhero-application-form/680900675ae3d54ee19590d0.md
@@ -16,11 +16,10 @@ Inside the function, destructure `value` and `checked` from `e.target` to get th
 You should create an `handlePowersChange` function with an `e` parameter.
 
 ```js
-assert.match(code, /(const|let|var)\s+handlePowersChange\s*=\s*(e|\(\s*e\s*\))\s*=>\s*{/)
 const explorer = await __helpers.Explorer(code);
 const { handlePowersChange } = explorer.allFunctions.SuperheroForm?.allFunctions ?? {};
 assert.lengthOf(handlePowersChange?.parameters, 1);
-assert.equal(handlePowersChange?.parameters?.[0]?.toString(), 'e');
+assert.equal(handlePowersChange?.parameters[0].toString(), 'e');
 ```
 
 You should destructure `value` and `checked` from `e.target`.

--- a/curriculum/challenges/english/blocks/workshop-superhero-application-form/680900675ae3d54ee19590d0.md
+++ b/curriculum/challenges/english/blocks/workshop-superhero-application-form/680900675ae3d54ee19590d0.md
@@ -17,6 +17,10 @@ You should create an `handlePowersChange` function with an `e` parameter.
 
 ```js
 assert.match(code, /(const|let|var)\s+handlePowersChange\s*=\s*(e|\(\s*e\s*\))\s*=>\s*{/)
+const explorer = await __helpers.Explorer(code);
+const { handlePowersChange } = explorer.allFunctions.SuperheroForm?.allFunctions ?? {};
+assert.lengthOf(handlePowersChange?.parameters, 1);
+assert.equal(handlePowersChange?.parameters?.[0]?.toString(), 'e');
 ```
 
 You should destructure `value` and `checked` from `e.target`.


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68722

<!-- Feel free to add any additional description of changes below this line -->
## Changes Made
* Replaced regex based test with AST helpers in superhero application form in three tests.
* Made changes in part where new functions are created or new states are made with useState. 