### PR TITLE
fix(curriculum): improve HTML video player workshop consistency

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
@@ -7,7 +7,7 @@ dashedName: step-4
 
 # --description--
 
-The `loop` attribute will restart the video once playback is completed. Think of an internet meme that repeats playback. Omitting the `loop` attribute will make the video playback once.
+The `loop` attribute will restart the video once playback is completed. Think of an internet meme that repeats playback. Omitting the `loop` attribute will make the video play once.
 
 The `loop` attribute is a boolean attribute and does not need a value.
 

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-The `controls` attribute provides playback controls including playback, rewind, and volume control for the `video` element. 
+The `controls` attribute provides play/pause, rewind, and volume control for the `video` element.
 
 The `controls` attribute is a boolean attribute and does not need a value.
 

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
@@ -9,7 +9,7 @@ dashedName: step-13
 
 The last `source` element you will add will be for the `video/quicktime` MIME type.
 
-QuickTime is an extensible multimedia architecture created by Apple, which supports playing, streaming, encoding, and transcoding a variety of digital media formats. Not as popular as the MP4 format, you may need it for legacy application support.
+QuickTime is an extensible multimedia architecture created by Apple, which supports playing, streaming, encoding, and transcoding a variety of digital media formats. Though it is not as popular as the MP4 format, you may need it for legacy application support.
 
 Below your third `source` element, add a fourth `source` element and give it a `src` attribute with the value `https://cdn.freecodecamp.org/curriculum/labs/mapmethod.mov` and `type` attribute with the value `video/quicktime`.
 
@@ -73,7 +73,7 @@ assert.strictEqual(source?.getAttribute('type'), 'video/quicktime');
     poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
   >
     <source
-      src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
       type="video/mp4"
     >
     <source
@@ -98,16 +98,16 @@ assert.strictEqual(source?.getAttribute('type'), 'video/quicktime');
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
   <video
     width="640"
-    controls
     loop
+    controls
     muted
     poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
   >


### PR DESCRIPTION
Closes #68751

## Summary

- Changed "playback once" to "play once".
- Changed "playback" to "play/pause" in the controls description.
- Improved the wording about the MP4 format.
- Fixed indentation in the solution.
- Reordered the video attributes.
- Fixed indentation for the first source element.