### PR TITLE
fix(curriculum): use Explorer helper in rps game workshop steps 4 and 8

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-rps-game/66cf13fe7619e9a1d57c7b5e.md
+++ b/curriculum/challenges/english/blocks/workshop-rps-game/66cf13fe7619e9a1d57c7b5e.md
@@ -15,6 +15,12 @@ Create a function called `getRandomComputerResult` that returns a random choice 
 
 # --hints--
 
+You should have a function called `getRandomComputerResult`.
+
+```js
+assert.isFunction(getRandomComputerResult);
+```
+
 Your `getRandomComputerResult` function should return a string.
 
 ```js

--- a/curriculum/challenges/english/blocks/workshop-rps-game/66cf315cff4d36b27da828ba.md
+++ b/curriculum/challenges/english/blocks/workshop-rps-game/66cf315cff4d36b27da828ba.md
@@ -30,7 +30,12 @@ assert.isFunction(hasPlayerWonTheRound);
 Your function should have two parameters called `playerChoice` and `computerChoice`.
 
 ```js
-assert.match(code, /hasPlayerWonTheRound\s*(?:=\s*)?\(\s*playerChoice\s*,\s*computerChoice\s*\)\s*/);
+const explorer = await __helpers.Explorer(code);
+const { hasPlayerWonTheRound } = explorer.allFunctions;
+assert.deepEqual(
+  hasPlayerWonTheRound.parameters.map(p => p.toString()),
+  ['playerChoice', 'computerChoice']
+);
 ```
 
 Your `hasPlayerWonTheRound` function should return a boolean.

--- a/curriculum/challenges/english/blocks/workshop-rps-game/66cf315cff4d36b27da828ba.md
+++ b/curriculum/challenges/english/blocks/workshop-rps-game/66cf315cff4d36b27da828ba.md
@@ -33,7 +33,7 @@ Your function should have two parameters called `playerChoice` and `computerChoi
 const explorer = await __helpers.Explorer(code);
 const { hasPlayerWonTheRound } = explorer.allFunctions;
 assert.deepEqual(
-  hasPlayerWonTheRound.parameters.map(p => p.toString()),
+  hasPlayerWonTheRound?.parameters?.map(p => p.toString()),
   ['playerChoice', 'computerChoice']
 );
 ```

--- a/curriculum/challenges/english/blocks/workshop-rps-game/66cf34fcb005e7b447141afd.md
+++ b/curriculum/challenges/english/blocks/workshop-rps-game/66cf34fcb005e7b447141afd.md
@@ -31,7 +31,7 @@ Your `showResults` function should have a parameter called `userOption`.
 const explorer = await __helpers.Explorer(code);
 const { showResults } = explorer.allFunctions;
 assert.deepEqual(
-  showResults.parameters.map(p => p.toString()),
+  showResults?.parameters?.map(p => p.toString()),
   ['userOption']
 );
 ```

--- a/curriculum/challenges/english/blocks/workshop-rps-game/66cf34fcb005e7b447141afd.md
+++ b/curriculum/challenges/english/blocks/workshop-rps-game/66cf34fcb005e7b447141afd.md
@@ -28,7 +28,12 @@ assert.isFunction(showResults);
 Your `showResults` function should have a parameter called `userOption`.
 
 ```js
-assert.match(code, /showResults\s*(?:=\s*)?(?:\(\s*)?userOption(?:\s*\))?\s*/);
+const explorer = await __helpers.Explorer(code);
+const { showResults } = explorer.allFunctions;
+assert.deepEqual(
+  showResults.parameters.map(p => p.toString()),
+  ['userOption']
+);
 ```
 
 Your `showResults` function should update the `roundResultsMsg` with the result of the round.

--- a/curriculum/challenges/english/blocks/workshop-rps-game/66d064c7d79408da050f8b2f.md
+++ b/curriculum/challenges/english/blocks/workshop-rps-game/66d064c7d79408da050f8b2f.md
@@ -28,7 +28,7 @@ You should use `let` to declare the `playerScore` variable.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { playerScore } = explorer.variables;
-assert.isTrue(playerScore.matches(`let playerScore = ${playerScore?.value?.toString()}`));
+assert.isTrue(playerScore?.matches(`let playerScore = ${playerScore?.value?.toString()}`));
 ```
 
 Your `playerScore` should be initialized with the value `0`.
@@ -48,7 +48,7 @@ You should use `let` to declare the `computerScore` variable.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { computerScore } = explorer.variables;
-assert.isTrue(computerScore.matches(`let computerScore = ${computerScore?.value?.toString()}`));
+assert.isTrue(computerScore?.matches(`let computerScore = ${computerScore?.value?.toString()}`));
 ```
 
 Your `computerScore` should be initialized with the value `0`.

--- a/curriculum/challenges/english/blocks/workshop-rps-game/66d064c7d79408da050f8b2f.md
+++ b/curriculum/challenges/english/blocks/workshop-rps-game/66d064c7d79408da050f8b2f.md
@@ -26,7 +26,9 @@ assert.isNotNull(playerScore);
 You should use `let` to declare the `playerScore` variable.
 
 ```js
-assert.match(code, /let\s+playerScore/);
+const explorer = await __helpers.Explorer(code);
+const { playerScore } = explorer.variables;
+assert.isTrue(playerScore.matches(`let playerScore = ${playerScore?.value?.toString()}`));
 ```
 
 Your `playerScore` should be initialized with the value `0`.
@@ -44,7 +46,9 @@ assert.isNotNull(computerScore);
 You should use `let` to declare the `computerScore` variable.
 
 ```js
-assert.match(code, /let\s+computerScore/);
+const explorer = await __helpers.Explorer(code);
+const { computerScore } = explorer.variables;
+assert.isTrue(computerScore.matches(`let computerScore = ${computerScore?.value?.toString()}`));
 ```
 
 Your `computerScore` should be initialized with the value `0`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68716

This is part of the Naomi's Sprints initiative → replacing regex-based tests with the Explorer AST helper.

- Replaces regex tests with Explorer helper in RPS Game workshop, Steps 4 and 8

**Changes made**

Before (Step 4):
\`\`\`js
assert.match(code, /hasPlayerWonTheRound\s*(?:=\s*)?\(\s*playerChoice\s*,\s*computerChoice\s*\)\s*/);
\`\`\`

After:
\`\`\`js
const explorer = await __helpers.Explorer(code);
const { hasPlayerWonTheRound } = explorer.allFunctions;
assert.deepEqual(
  hasPlayerWonTheRound.parameters.map(p => p.toString()),
  ['playerChoice', 'computerChoice']
);
\`\`\`

Before (Step 8):
\`\`\`js
assert.match(code, /showResults\s*(?:=\s*)?(?:\(\s*)?userOption(?:\s*\))?\s*/);
\`\`\`

After:
\`\`\`js
const explorer = await __helpers.Explorer(code);
const { showResults } = explorer.allFunctions;
assert.deepEqual(
  showResults.parameters.map(p => p.toString()),
  ['userOption']
);
\`\`\`

Used `allFunctions` instead of `functions` in both cases, since the original regex allowed for both `function foo(...)` declarations and `foo = (...) =>` arrow-assignment style with the optional `(?:=\s*)?` group - `allFunctions` covers both.

**Testing**

Ran `FCC_BLOCK='workshop-rps-game' pnpm run test-curriculum-content` - all 69 tests passed.