### PR TITLE
fix(curriculum): fix faulty tests in Build an Event Hub lab (#68967)

### DIFF
--- a/curriculum/challenges/english/blocks/lab-event-hub/66ebd4ae2812430bb883c787.md
+++ b/curriculum/challenges/english/blocks/lab-event-hub/66ebd4ae2812430bb883c787.md
@@ -15,6 +15,7 @@ In this lab you will utilize the semantic HTML elements to create the structure 
 **User Stories:**
 
 1. You should have a `header` element.
+1. Your `header` element should come after the opening `body` tag.
 1. Inside the `header` element, you should have an `h1` element that contains the text `Event Hub`, and a `nav` element.
 1. Inside the `nav` element, you should have an unordered list of two items containing links to different sections of the page. The first item should have the text `Upcoming Events`, and the second item should have the text `Past Events`.
 1. Each link should be represented by an `a` element with an `href` attribute that links to the corresponding section of the page, `#upcoming-events` and `#past-events` respectively.
@@ -74,7 +75,7 @@ Your `nav` element should contain an unordered list of two items.
 ```js
 const liElements = document.querySelectorAll('header nav>ul>li');
 
-assert.isNotNull('header nav>ul');
+assert.isNotNull(document.querySelector('header nav>ul'));
 assert.strictEqual(liElements.length, 2);
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68967

- Fixed `assert.isNotNull` that received a string literal instead of a DOM element 
- Updated user story 1 to match the test: `header` must be the first element inside `body`
