### PR TITLE
fix(curriculum): add missing topics to Semantic HTML review

### DIFF
--- a/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
+++ b/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
@@ -75,12 +75,12 @@ dashedName: review-semantic-html
 
 :::interactive_editor
 
-```html
+  ```html
   <article>
     <h2>My First Blog Post</h2>
     <p>This is the content of my first blog post.</p>
   </article>
-```
+  ```
 
 :::
 
@@ -339,10 +339,10 @@ The `lang` attribute inside the open `i` tag is used to specify the language of 
 
 :::interactive_editor
 
-```html
+  ```html
   <a href="tel:+11234567890">Call us</a>
   <a href="mailto:example@email.com">Email us</a>
-```
+  ```
 
 :::
 

--- a/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
+++ b/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
@@ -124,7 +124,9 @@ dashedName: review-semantic-html
 
 :::
 
-The `lang` attribute inside the open `i` tag is used to specify the language of the content. In this case, the language would be French. The `i` element does not indicate if the text is important or not, it only shows that it's somehow different from the surrounding text. Since `i` and `em` carry meaning, text that only needs to look italic for presentation purposes should be styled with CSS instead.
+The `lang` attribute inside the open `i` tag is used to specify the language of the content. In this case, the language would be French. The `i` element does not indicate if the text is important or not, it only shows that it's somehow different from the surrounding text.
+
+- **Choosing CSS over `i`/`em`**: since `i` and `em` carry meaning, text that only needs to look italic for presentation purposes should be styled with CSS instead.
 
 - **Strong Importance (`strong`) element**: marks text that has strong importance.
 

--- a/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
+++ b/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
@@ -230,12 +230,12 @@ The `lang` attribute inside the open `i` tag is used to specify the language of 
 
 :::interactive_editor
 
-```html
+  ```html
   <address>
     123 Main Street<br>
     Springfield, IL 62701
   </address>
-```
+  ```
 
 :::
 

--- a/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
+++ b/curriculum/challenges/english/blocks/review-semantic-html/671a83934b61f64cefe87a61.md
@@ -9,7 +9,7 @@ dashedName: review-semantic-html
 
 ## Importance of Semantic HTML
 
-- **Structural hierarchy for heading elements**: It is important to use the correct heading element to maintain the structural hierarchy of the content. The `h1` element is the highest level of heading and the `h6` element is the lowest level of heading.
+- **Structural hierarchy for heading elements**: It is important to use the correct heading element to maintain the structural hierarchy of the content. The `h1` element is the highest level of heading and the `h6` element is the lowest level of heading. Skipping heading levels disrupts the logical hierarchy for screen readers and hinders accessibility.
 - **Presentational HTML elements**: Elements that define the appearance of content. Ex. the deprecated `center`, `big` and `font` elements.
 - **Semantic HTML elements**: Elements that hold meaning and structure. Ex. `header`, `nav`, `figure`.
 
@@ -71,6 +71,19 @@ dashedName: review-semantic-html
 
 :::
 
+- **Article (`article`) element**: used to represent self-contained, independent content that can stand alone, such as a blog post or news article.
+
+:::interactive_editor
+
+```html
+  <article>
+    <h2>My First Blog Post</h2>
+    <p>This is the content of my first blog post.</p>
+  </article>
+```
+
+:::
+
 - **Figure element**: used to contain illustrations and diagrams.
 
 :::interactive_editor
@@ -111,7 +124,7 @@ dashedName: review-semantic-html
 
 :::
 
-The `lang` attribute inside the open `i` tag is used to specify the language of the content. In this case, the language would be French. The `i` element does not indicate if the text is important or not, it only shows that it's somehow different from the surrounding text.
+The `lang` attribute inside the open `i` tag is used to specify the language of the content. In this case, the language would be French. The `i` element does not indicate if the text is important or not, it only shows that it's somehow different from the surrounding text. Since `i` and `em` carry meaning, text that only needs to look italic for presentation purposes should be styled with CSS instead.
 
 - **Strong Importance (`strong`) element**: marks text that has strong importance.
 
@@ -198,7 +211,7 @@ The `lang` attribute inside the open `i` tag is used to specify the language of 
 
 :::
 
-- **Abbreviation (`abbr`) element**: used to represent an abbreviation or acronym. To help users understand what the abbreviation or acronym is, you can show its full form, a human readable description, with the `title` attribute.
+- **Abbreviation (`abbr`) element**: used to represent an abbreviation. To help users understand what the abbreviation is, you can show its full form, a human readable description, with the `title` attribute.
 
 :::interactive_editor
 
@@ -210,7 +223,20 @@ The `lang` attribute inside the open `i` tag is used to specify the language of 
 
 :::
 
-- **Contact Address (`address`) element**: used to represent the contact information. 
+- **Contact Address (`address`) element**: used to represent the contact information.
+- **Line Break (`br`) element**: used to create a line break within text, such as splitting the lines of a physical address.
+
+:::interactive_editor
+
+```html
+  <address>
+    123 Main Street<br>
+    Springfield, IL 62701
+  </address>
+```
+
+:::
+
 - **(Date) Time (`time`) element**: used to represent a date and/or time. The `datetime` attribute is used to translate dates and times into a machine-readable format.
 
 :::interactive_editor
@@ -304,6 +330,17 @@ The `lang` attribute inside the open `i` tag is used to specify the language of 
     Due to unforeseen weather conditions, the hike has been canceled.
   </p>
   ```
+
+:::
+
+- **`tel:` and `mailto:` href schemes**: used to create clickable links that open a phone call or compose an email when clicked.
+
+:::interactive_editor
+
+```html
+  <a href="tel:+11234567890">Call us</a>
+  <a href="mailto:example@email.com">Email us</a>
+```
 
 :::
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68970

- Added CSS vs `i`/`em` note: since these elements carry meaning, purely presentational italic styling should use CSS instead
- Added `article` element bullet with interactive editor example
- Added `br` element bullet under `address`
- Added `tel:` and `mailto:` href schemes bullet with interactive editor example
- Extended the heading bullet to explain that skipping heading levels disrupts the logical content hierarchy for screen readers and negatively impacts accessibility
- Removed redundant "or acronym" from the `abbr` bullet