### PR TITLE
ci: free up space before tarring client

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -232,6 +232,9 @@ jobs:
           pnpm install
           pnpm run build
 
+      - name: Free up space
+        run: pnpm run clean:packages
+
       - name: Tar Files
         run: tar -czf client-${{ matrix.lang-name-short }}.tar client/public
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This gets us ~1.6GB, which should be enough for now.  There's more we can remove, but the more we remove the longer it takes.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/29953325165/job/89036202372

<!-- Feel free to add any additional description of changes below this line -->
