### PR TITLE
fix(curriculum): update outdated calc division explanation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
@@ -104,29 +104,29 @@ You would need to add the units, like px.
 calc(100% - 0px)
 ```
 
-You should also know that currently, if you use the multiplication or division operators, one of the operands has to be unitless. For the division operator, specifically the right operand has to be unitless. This would not be a valid expression because both operands have units (pixels). One of the operands, either 5 or 50, must be unitless:
+You should also know that if you use the multiplication operator, one of the operands must be unitless. This would not be a valid expression because both operands have units (pixels):
 
 ```css
 calc(5px * 50px)
 ```
 
-You would need to omit the units in one of them. Both of these alternatives would be valid:
+You would need to omit the unit in one of them. Both of these alternatives would be valid:
 
 ```css
 calc(5 * 50px)
 calc(5px * 50)
 ```
 
-And this is an example with the division operator. This would not be a valid expression since they both have units:
-
-```css
-calc(50% / 5%)
-```
-
-You should remove the unit from the right operand when you have the division operator:
+For the division operator, dividing by a unitless number scales the value and keeps its unit:
 
 ```css
 calc(50% / 5)
+```
+
+Dividing two values with matching units is also valid, but it cancels the units out to return a unitless number (like `10`). Note that unitless values can only be used for certain CSS properties (such as `line-height` or `flex-grow`):
+
+```css
+calc(50% / 5%)
 ```
 
 The `calc()` function can be very helpful for you as a web developer. With this function, you can set property values dynamically to create flexible and responsive designs.

--- a/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
@@ -33,9 +33,9 @@ calc(expression)
 
 The expression is evaluated to calculate the final result. "Evaluated" just means that the values and operators are converted into a single value behind the scenes. The result is assigned to the CSS property where the calculation is being made.
 
-You can perform calculations on values that represent length, angle, time, percentages, numbers, and colors. You can also combine different units like pixels, percentages, and ems.
+You can perform calculations on values that represent length, angle, time, percentages, and numbers. You can also combine different units like pixels, percentages, and ems.
 
-With numbers, all the values in the expression, also called the operands, must have their corresponding units, like `px`, `em`, and percentage (`%`). Depending on the operator, different operands may have different units.
+For addition and subtraction, all the values in the expression, also called the operands, must have their corresponding units, like `px`, `em`, and percentage (`%`). Depending on the operator, different operands may have different units.
 
 You can use the addition (`+`), subtraction (`-`), multiplication (`*`), and division (`/`) operators in the expression.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68985 

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the outdated text that incorrectly claimed `calc(50% / 5%)` is an invalid expression. 

I updated the explanation to correctly state that dividing two matching units in `calc()` is valid and returns a unitless number. I also added a brief note clarifying that these unitless numbers can only be used for certain CSS properties, as suggested by the maintainers.