### PR TITLE
fix(curriculum): use Explorer helper in string formatter workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
@@ -37,7 +37,8 @@ assert.equal(camelCasedVersion, lowercaseWord.slice(0, 5));
 You should NOT assign the literal string `"camel"` to the `camelCasedVersion`. Please reread through the instructions for the correct approach.
 
 ```js
-assert.notMatch(code, /camelCasedVersion\s*=(["'])camel(["'])/);
+const explorer = await __helpers.Explorer(code);
+assert.notEqual(explorer.variables.camelCasedVersion?.value.toString(), "'camel'");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
@@ -38,7 +38,7 @@ You should NOT assign the literal string `"camel"` to the `camelCasedVersion`. P
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.notEqual(explorer.variables.camelCasedVersion?.value.toString(), "'camel'");
+assert.notEqual(explorer.variables.camelCasedVersion?.value?.toString(), "'camel'");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68e4276483b0c71658aab1d3.md
@@ -38,7 +38,7 @@ You should NOT assign the literal string `"camel"` to the `camelCasedVersion`. P
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.notEqual(explorer.variables.camelCasedVersion?.value?.toString(), "'camel'");
+assert.isNotTrue(explorer.variables.camelCasedVersion?.value.matches("'camel'"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68f405c8c9df44132c8fe1bb.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68f405c8c9df44132c8fe1bb.md
@@ -34,7 +34,8 @@ assert.equal(camelCasedVersion, lowercaseWord.slice(0, 5) + lowercaseWord[5].toU
 You should NOT assign the literal string `"camelC"` to the `camelCasedVersion`. Please re read through the instructions for the correct approach.
 
 ```js
-assert.notMatch(code, /camelCasedVersion\s*=(["'])camelC(["'])/);
+const explorer = await __helpers.Explorer(code);
+assert.notEqual(explorer.variables.camelCasedVersion?.value.toString(), "'camelC'");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68f405c8c9df44132c8fe1bb.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68f405c8c9df44132c8fe1bb.md
@@ -35,7 +35,7 @@ You should NOT assign the literal string `"camelC"` to the `camelCasedVersion`. 
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.notEqual(explorer.variables.camelCasedVersion?.value.toString(), "'camelC'");
+assert.notEqual(explorer.variables.camelCasedVersion?.value?.toString(), "'camelC'");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68f405c8c9df44132c8fe1bb.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68f405c8c9df44132c8fe1bb.md
@@ -35,7 +35,7 @@ You should NOT assign the literal string `"camelC"` to the `camelCasedVersion`. 
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.notEqual(explorer.variables.camelCasedVersion?.value?.toString(), "'camelC'");
+assert.isNotTrue(explorer.variables.camelCasedVersion?.value.matches("'camelC'"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68f40925d810ae14b2d5a169.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68f40925d810ae14b2d5a169.md
@@ -33,7 +33,8 @@ assert.equal(camelCasedVersion, lowercaseWord.slice(0, 5) + lowercaseWord[5].toU
 You should NOT assign the literal string `"camelCase"` to the `camelCasedVersion`. Please re read through the instructions for the correct approach.
 
 ```js
-assert.notMatch(code, /camelCasedVersion\s*=(["'])camelCase(["'])/);
+const explorer = await __helpers.Explorer(code);
+assert.notEqual(explorer.variables.camelCasedVersion?.value.toString(), "'camelCase'");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68f40925d810ae14b2d5a169.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68f40925d810ae14b2d5a169.md
@@ -34,7 +34,7 @@ You should NOT assign the literal string `"camelCase"` to the `camelCasedVersion
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.notEqual(explorer.variables.camelCasedVersion?.value.toString(), "'camelCase'");
+assert.notEqual(explorer.variables.camelCasedVersion?.value?.toString(), "'camelCase'");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-string-formatter/68f40925d810ae14b2d5a169.md
+++ b/curriculum/challenges/english/blocks/workshop-string-formatter/68f40925d810ae14b2d5a169.md
@@ -34,7 +34,7 @@ You should NOT assign the literal string `"camelCase"` to the `camelCasedVersion
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.notEqual(explorer.variables.camelCasedVersion?.value?.toString(), "'camelCase'");
+assert.isNotTrue(explorer.variables.camelCasedVersion?.value.matches("'camelCase'"));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68813

<!-- Feel free to add any additional description of changes below this line -->
