### PR TITLE
fix(curriculum): remove duplicate const restriction from weather app lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
+++ b/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
@@ -89,8 +89,6 @@ You will use a weather API. The output data has the following format:
 
 1. If the data from `getWeather` are usable, the `showWeather` function should display the weather data in the corresponding elements. If a certain value from the API is `undefined`, you should write `N/A` in the corresponding element.
 
-1. Neither the `getWeather` function nor the `showWeather` function should be declared using `const`, since the tests need to reassign them.
-
 **Note:** Neither the `getWeather` function nor the `showWeather` function should be declared using `const`, since the tests need to reassign them. Also, the tests will take time to complete, so as long as you see `// running tests` in the console, they are being executed.
 
 # --before-all--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69000

<!-- Feel free to add any additional description of changes below this line -->

Removes the duplicate user story about declaring `getWeather`/`showWeather` with `const` from the Build a Weather App lab description. The restriction remains only in the Note.