### PR TITLE
fix(curriculum): remove duplicate const restriction sentence

### DIFF
--- a/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
+++ b/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
@@ -89,8 +89,6 @@ You will use a weather API. The output data has the following format:
 
 1. If the data from `getWeather` are usable, the `showWeather` function should display the weather data in the corresponding elements. If a certain value from the API is `undefined`, you should write `N/A` in the corresponding element.
 
-1. Neither the `getWeather` function nor the `showWeather` function should be declared using `const`, since the tests need to reassign them.
-
 **Note:** Neither the `getWeather` function nor the `showWeather` function should be declared using `const`, since the tests need to reassign them. Also, the tests will take time to complete, so as long as you see `// running tests` in the console, they are being executed.
 
 # --before-all--

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f57723debf9383c75947.md
@@ -7,7 +7,7 @@ dashedName: step-4
 
 # --description--
 
-The `loop` attribute will restart the video once playback is completed. Think of an internet meme that repeats playback. Omitting the `loop` attribute will make the video playback once.
+The `loop` attribute will restart the video once playback is completed. Think of an internet meme that repeats playback. Omitting the `loop` attribute will make the video play once.
 
 The `loop` attribute is a boolean attribute and does not need a value.
 

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f1f6f97af9749a42260a43.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-The `controls` attribute provides playback controls including playback, rewind, and volume control for the `video` element. 
+The `controls` attribute provides play/pause, rewind, and volume control for the `video` element.
 
 The `controls` attribute is a boolean attribute and does not need a value.
 

--- a/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
+++ b/curriculum/challenges/english/blocks/workshop-html-video-player/68f27139bddf9f6bf2821acf.md
@@ -9,7 +9,7 @@ dashedName: step-13
 
 The last `source` element you will add will be for the `video/quicktime` MIME type.
 
-QuickTime is an extensible multimedia architecture created by Apple, which supports playing, streaming, encoding, and transcoding a variety of digital media formats. Not as popular as the MP4 format, you may need it for legacy application support.
+QuickTime is an extensible multimedia architecture created by Apple, which supports playing, streaming, encoding, and transcoding a variety of digital media formats. Though it is not as popular as the MP4 format, you may need it for legacy application support.
 
 Below your third `source` element, add a fourth `source` element and give it a `src` attribute with the value `https://cdn.freecodecamp.org/curriculum/labs/mapmethod.mov` and `type` attribute with the value `video/quicktime`.
 
@@ -73,7 +73,7 @@ assert.strictEqual(source?.getAttribute('type'), 'video/quicktime');
     poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
   >
     <source
-      src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
+    src="https://cdn.freecodecamp.org/curriculum/labs/what-is-the-map-method-and-how-does-it-work.mp4"
       type="video/mp4"
     >
     <source
@@ -98,16 +98,16 @@ assert.strictEqual(source?.getAttribute('type'), 'video/quicktime');
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Working with the HTML Video Element</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working with the HTML Video Element</title>
 </head>
 <body>
   <h1>Working with the HTML Video Element</h1>
   <video
     width="640"
-    controls
     loop
+    controls
     muted
     poster="https://cdn.freecodecamp.org/curriculum/labs/past-event2.jpg"
   >


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

* [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
* [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69000

<!-- Feel free to add any additional description of changes below this line -->

Removed the duplicate user story about not declaring `getWeather` and `showWeather` using `const`. The instruction is already included in the Note, so the duplicate sentence has been removed.

