### PR TITLE
fix(curriculum): handle const arrow function reassignment in cargo manifest validator

### DIFF
--- a/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
+++ b/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
@@ -56,6 +56,8 @@ Example cargo manifest object:
     - If the manifest object is not valid, `Validation error: ${containerId}` and then the object returned by calling `validateManifest()` with the manifest object.
     **Note:** each of these two cases should have two `console.log()` calls.
 
+**Note:** Neither `normalizeUnits`, `validateManifest`, nor `processManifest` should be declared using `const`, since the tests need to reassign them. Also, the tests will take time to complete, so as long as you see `// running tests` in the console, they are being executed.
+
 # --before-each--
 
 ```js
@@ -117,6 +119,16 @@ console.log = () => {};
 ```
 
 # --hints--
+
+Neither `normalizeUnits`, `validateManifest`, nor `processManifest` should be declared using `const`, since the tests need to reassign them.
+
+```js
+assert.doesNotThrow(() => {
+  normalizeUnits = normalizeUnits;
+  validateManifest = validateManifest;
+  processManifest = processManifest;
+});
+```
 
 You should have a function named `normalizeUnits` with a `manifest` parameter.
 

--- a/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
+++ b/curriculum/challenges/english/blocks/lab-cargo-manifest-validator/69a56b5069ca99f7317e6e19.md
@@ -56,7 +56,7 @@ Example cargo manifest object:
     - If the manifest object is not valid, `Validation error: ${containerId}` and then the object returned by calling `validateManifest()` with the manifest object.
     **Note:** each of these two cases should have two `console.log()` calls.
 
-**Note:** Neither `normalizeUnits`, `validateManifest`, nor `processManifest` should be declared using `const`, since the tests need to reassign them. Also, the tests will take time to complete, so as long as you see `// running tests` in the console, they are being executed.
+**Note:** Neither `normalizeUnits`, `validateManifest`, nor `processManifest` should be declared using `const`, since the tests need to reassign them.
 
 # --before-each--
 

--- a/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038fe7da59ca23a5eba82d.md
+++ b/curriculum/challenges/english/blocks/workshop-major-browsers-list/69038fe7da59ca23a5eba82d.md
@@ -14,7 +14,7 @@ Add another `dt` element containing the text `Arc`.
 Below your `dt` element, add a `dd` element with the following text:
 
 ```md
-This is a free Chromium based web browser first released in 2023 by The Browser Company.
+This is a free Chromium-based web browser first released in 2023 by The Browser Company.
 ```
 
 With that last addition, your browser list is complete!
@@ -42,11 +42,11 @@ const ddElements = document.querySelectorAll('dd');
 assert.lengthOf(ddElements, 5);
 ```
 
-Your fifth `dd` element should contain the text `This is a free Chromium based web browser first released in 2023 by The Browser Company.`.
+Your fifth `dd` element should contain the text `This is a free Chromium-based web browser first released in 2023 by The Browser Company.`.
 
 ```js
 const ddElement = document.querySelectorAll('dd')[4];
-assert.strictEqual(ddElement?.textContent.trim(), "This is a free Chromium based web browser first released in 2023 by The Browser Company.");
+assert.strictEqual(ddElement?.textContent.trim(), "This is a free Chromium-based web browser first released in 2023 by The Browser Company.");
 ```
 
 # --seed--
@@ -110,7 +110,7 @@ assert.strictEqual(ddElement?.textContent.trim(), "This is a free Chromium based
       <dd>This is a free web browser first released in 2016 that is based on the Chromium web browser.</dd>
 
       <dt>Arc</dt>
-      <dd>This is a free Chromium based web browser first released in 2023 by The Browser Company.</dd>
+      <dd>This is a free Chromium-based web browser first released in 2023 by The Browser Company.</dd>
     </dl>
   </body>
 </html>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68999

<!-- Feel free to add any additional description of changes below this line -->

### Description
This PR fixes an issue where declaring the required challenge functions using `const` arrow functions causes the test evaluation worker to crash with a "TypeError: Assignment to constant variable" during test execution.

Using Pattern from PR #68583 the fix:
1. Adds a note to the challenge description explicitly advising campers not to declare `normalizeUnits`, `validateManifest`, or `processManifest` using `const`, as the automated tests need to reassign them.
2. Adds an `assert.doesNotThrow()` check as the first hint/test assertion to catch `const` declarations safely and output a clean, educational error message instead of crashing the test runner.

### Affected Page
Lab: Build a Cargo Manifest Validator