### PR TITLE
fix(curriculum): use Explorer helper in mega navbar workshop step 1

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
@@ -31,7 +31,9 @@ Also, React functional components need to start with a capital letter because it
 You should use the `export` keyword to export the `Navbar` component.
 
 ```js
-assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\{\s*/);
+const explorer = await __helpers.Explorer(code);
+const { Navbar } = explorer.allFunctions;
+assert.isTrue(Navbar?.toString().startsWith("export"));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68714

This is part of the Naomi's Sprints initiative → replacing regex-based tests with the Explorer AST helper.

- Replaces regex test with Explorer helper in Reusable Mega Navbar workshop, Step 1

**Changes made**

Before:
\`\`\`js
assert.match(code, /export\s+(const|function)\s+Navbar\s*(=\s*)?\(\)\s*(=>\s*)?\{\s*/);
\`\`\`

After:
\`\`\`js
const explorer = await __helpers.Explorer(code);
const { Navbar } = explorer.allFunctions;
assert.isTrue(Navbar?.toString().startsWith("export"));
\`\`\`

Only 1 regex-based test case existed in this workshop (11 steps total), so this is a single-file change.

**Testing**

Ran `FCC_BLOCK='workshop-reusable-mega-navbar' pnpm run test-curriculum-content` — all 56 tests passed.