### PR TITLE
fix(curriculum): use counterclockwise spelling consistently

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e6ff50d756c9b6935e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e6ff50d756c9b6935e.md
@@ -10,7 +10,7 @@ dashedName: challenge-181
 Given a snowboarder's starting stance and a rotation in degrees, determine their landing stance.
 
 - A snowboarder's stance is either `"Regular"` or `"Goofy"`.
-- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counter-clockwise rotation.
+- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counterclockwise rotation.
 - The landing stance flips every 180 degrees of rotation.
 
 For example, given `"Regular"` and `90`, return `"Regular"`. Given `"Regular"` and `180` degrees, return `"Goofy"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e6ff50d756c9b6935e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e6ff50d756c9b6935e.md
@@ -10,7 +10,7 @@ dashedName: challenge-181
 Given a snowboarder's starting stance and a rotation in degrees, determine their landing stance.
 
 - A snowboarder's stance is either `"Regular"` or `"Goofy"`.
-- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counterclockwise rotation.
+- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicates counterclockwise rotation.
 - The landing stance flips every 180 degrees of rotation.
 
 For example, given `"Regular"` and `90`, return `"Regular"`. Given `"Regular"` and `180` degrees, return `"Goofy"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e6ff50d756c9b6935e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e6ff50d756c9b6935e.md
@@ -10,7 +10,7 @@ dashedName: challenge-181
 Given a snowboarder's starting stance and a rotation in degrees, determine their landing stance.
 
 - A snowboarder's stance is either `"Regular"` or `"Goofy"`.
-- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counter-clockwise rotation.
+- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counterclockwise rotation.
 - The landing stance flips every 180 degrees of rotation.
 
 For example, given `"Regular"` and `90`, return `"Regular"`. Given `"Regular"` and `180` degrees, return `"Goofy"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e6ff50d756c9b6935e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e6ff50d756c9b6935e.md
@@ -10,7 +10,7 @@ dashedName: challenge-181
 Given a snowboarder's starting stance and a rotation in degrees, determine their landing stance.
 
 - A snowboarder's stance is either `"Regular"` or `"Goofy"`.
-- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counterclockwise rotation.
+- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicates counterclockwise rotation.
 - The landing stance flips every 180 degrees of rotation.
 
 For example, given `"Regular"` and `90`, return `"Regular"`. Given `"Regular"` and `180` degrees, return `"Goofy"`.

--- a/curriculum/challenges/english/blocks/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69995.md
+++ b/curriculum/challenges/english/blocks/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69995.md
@@ -9,7 +9,7 @@ dashedName: step-43
 
 Rotate each rectangle to give them more of an imperfect, hand-painted look.
 
-Use the `transform` property on the `.one` selector to `rotate` it counter clockwise by 0.6 degrees.
+Use the `transform` property on the `.one` selector to `rotate` it counterclockwise by 0.6 degrees.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69997.md
+++ b/curriculum/challenges/english/blocks/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69997.md
@@ -7,7 +7,7 @@ dashedName: step-45
 
 # --description--
 
-Rotate `.three` counter clockwise by 0.2 degrees.
+Rotate `.three` counterclockwise by 0.2 degrees.
 
 With this final step, your Rothko painting is now complete.
 

--- a/curriculum/challenges/english/blocks/workshop-rothko-painting/60a3e3396c7b40068ad69995.md
+++ b/curriculum/challenges/english/blocks/workshop-rothko-painting/60a3e3396c7b40068ad69995.md
@@ -9,7 +9,7 @@ dashedName: step-42
 
 Rotate each rectangle to give them more of an imperfect, hand-painted look.
 
-Use the `transform` property on the `.one` selector to `rotate` it counter clockwise by 0.6 degrees.
+Use the `transform` property on the `.one` selector to `rotate` it counterclockwise by 0.6 degrees.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-rothko-painting/60a3e3396c7b40068ad69997.md
+++ b/curriculum/challenges/english/blocks/workshop-rothko-painting/60a3e3396c7b40068ad69997.md
@@ -7,7 +7,7 @@ dashedName: step-44
 
 # --description--
 
-Rotate `.three` counter clockwise by 0.2 degrees.
+Rotate `.three` counterclockwise by 0.2 degrees.
 
 With this final step, your Rothko painting is now complete.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69007

<!-- Feel free to add any additional description of changes below this line -->

Updates curriculum wording to use the American English spelling `counterclockwise`:

- Replaces `counter clockwise` in the Rothko painting workshop and the older CSS box model Rothko challenge
- Replaces `counter-clockwise` in the related daily coding challenges (JS and Python)

Project Euler challenge text is left unchanged, since those keep the original Project Euler wording.

