### PR TITLE
fix(api): allow freecodecamp-os challenges through coderoad endpoints

### DIFF
--- a/api/src/routes/protected/certificate.test.ts
+++ b/api/src/routes/protected/certificate.test.ts
@@ -165,6 +165,7 @@ describe('certificate routes', () => {
             isB1EnglishCert: false,
             isApisMicroservicesCert: false,
             isBackEndCert: false,
+            isBackEndDevApisCertV9: false,
             isCollegeAlgebraPyCertV8: false,
             isDataAnalysisPyCertV7: false,
             isDataVisCert: false,

--- a/api/src/routes/protected/challenge.ts
+++ b/api/src/routes/protected/challenge.ts
@@ -144,7 +144,8 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
       });
 
       if (
-        challengeType === challengeTypes.codeAllyCert &&
+        (challengeType === challengeTypes.codeAllyCert ||
+          challengeType === challengeTypes.freeCodeCampOsCert) &&
         !canSubmitCodeRoadCertProject(projectId, user)
       ) {
         req.log.warn(
@@ -1053,7 +1054,9 @@ async function postCoderoadChallengeCompleted(
   const codeRoadChallenges = challenges.filter(
     ({ challengeType }) =>
       challengeType === challengeTypes.codeAllyPractice ||
-      challengeType === challengeTypes.codeAllyCert
+      challengeType === challengeTypes.codeAllyCert ||
+      challengeType === challengeTypes.freeCodeCampOsPractice ||
+      challengeType === challengeTypes.freeCodeCampOsCert
   );
 
   const challenge = codeRoadChallenges.find(challenge => {
@@ -1110,7 +1113,11 @@ async function postCoderoadChallengeCompleted(
       challenge => challenge.id === challengeId
     );
 
-    if (challengeType === challengeTypes.codeAllyCert && !isCompleted) {
+    if (
+      (challengeType === challengeTypes.codeAllyCert ||
+        challengeType === challengeTypes.freeCodeCampOsCert) &&
+      !isCompleted
+    ) {
       const finalChallenge = {
         id: challengeId,
         completedDate

--- a/api/src/routes/protected/user.test.ts
+++ b/api/src/routes/protected/user.test.ts
@@ -355,6 +355,7 @@ const baseProgressData = {
   is2018FullStackCert: false,
   isFrontEndCert: false,
   isBackEndCert: false,
+  isBackEndDevApisCertV9: false,
   isDataVisCert: false,
   isFullStackCert: false,
   isJavascriptCertV9: false,

--- a/api/src/routes/public/user.test.ts
+++ b/api/src/routes/public/user.test.ts
@@ -203,6 +203,7 @@ const publicUserData = {
   isB1EnglishCert: testUserData.isB1EnglishCert,
   isApisMicroservicesCert: testUserData.isApisMicroservicesCert,
   isBackEndCert: testUserData.isBackEndCert,
+  isBackEndDevApisCertV9: testUserData.isBackEndDevApisCertV9,
   isCheater: testUserData.isCheater,
   isCollegeAlgebraPyCertV8: testUserData.isCollegeAlgebraPyCertV8,
   isDataAnalysisPyCertV7: testUserData.isDataAnalysisPyCertV7,

--- a/api/src/schemas/users/get-public-profile.ts
+++ b/api/src/schemas/users/get-public-profile.ts
@@ -57,6 +57,7 @@ export const getPublicProfile = {
               isB1EnglishCert: Type.Boolean(),
               isApisMicroservicesCert: Type.Boolean(),
               isBackEndCert: Type.Boolean(),
+              isBackEndDevApisCertV9: Type.Boolean(),
               isCheater: Type.Boolean(),
               isCollegeAlgebraPyCertV8: Type.Boolean(),
               isDataAnalysisPyCertV7: Type.Boolean(),

--- a/curriculum/challenges/english/blocks/lab-chat-app/e88448ed3ffd9be6d0699fe7.md
+++ b/curriculum/challenges/english/blocks/lab-chat-app/e88448ed3ffd9be6d0699fe7.md
@@ -4,7 +4,6 @@ title: 'Build a Chat App'
 challengeType: 33
 url: freeCodeCamp/build-a-chat-app
 dashedName: lab-chat-app
-saveSubmissionToDB: true
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/lab-data-sanitizer/27dbeadb5c09d8735941a8ea.md
+++ b/curriculum/challenges/english/blocks/lab-data-sanitizer/27dbeadb5c09d8735941a8ea.md
@@ -4,7 +4,6 @@ title: 'Build a Data Sanitizer'
 challengeType: 33
 url: freeCodeCamp/build-a-data-sanitizer
 dashedName: lab-data-sanitizer
-saveSubmissionToDB: true
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/lab-family-movie-watchlist-api/6a55c79b579b9101d31815f7.md
+++ b/curriculum/challenges/english/blocks/lab-family-movie-watchlist-api/6a55c79b579b9101d31815f7.md
@@ -4,7 +4,6 @@ title: Build a Family Movie Watchlist API
 challengeType: 33
 url: freeCodeCamp/build-a-family-movie-watchlist-api
 dashedName: build-a-family-movie-watchlist-api
-saveSubmissionToDB: true
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/lab-personal-profile-app/b010923c48c8ae2e5bfcf50f.md
+++ b/curriculum/challenges/english/blocks/lab-personal-profile-app/b010923c48c8ae2e5bfcf50f.md
@@ -4,7 +4,6 @@ title: 'Build a Personal Profile App'
 challengeType: 33
 url: freeCodeCamp/build-a-personal-profile-app
 dashedName: lab-personal-profile-app
-saveSubmissionToDB: true
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/lab-prime-number-checker-module/15722224eb735613bc8dd803.md
+++ b/curriculum/challenges/english/blocks/lab-prime-number-checker-module/15722224eb735613bc8dd803.md
@@ -4,7 +4,6 @@ title: 'Build a Prime Number Checker Module'
 challengeType: 33
 url: freeCodeCamp/build-a-prime-number-checker-module
 dashedName: lab-prime-number-checker-module
-saveSubmissionToDB: true
 ---
 
 # --description--

--- a/curriculum/challenges/english/blocks/lab-timestamp-microservice/ba104e7e4a2f6a16f3c168d3.md
+++ b/curriculum/challenges/english/blocks/lab-timestamp-microservice/ba104e7e4a2f6a16f3c168d3.md
@@ -4,7 +4,6 @@ title: 'Build a Timestamp Microservice'
 challengeType: 33
 url: freeCodeCamp/build-a-timestamp-microservice
 dashedName: lab-timestamp-microservice
-saveSubmissionToDB: true
 ---
 
 # --description--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The curriculum change is semi-related, because it causes the challenges to be saved to `user.savedChallenges`, if it exists.