### PR TITLE
fix(curriculum): use counterclockwise spelling consistently

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e6ff50d756c9b6935e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/697a49e6ff50d756c9b6935e.md
@@ -10,7 +10,7 @@ dashedName: challenge-181
 Given a snowboarder's starting stance and a rotation in degrees, determine their landing stance.
 
 - A snowboarder's stance is either `"Regular"` or `"Goofy"`.
-- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counter-clockwise rotation.
+- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counterclockwise rotation.
 - The landing stance flips every 180 degrees of rotation.
 
 For example, given `"Regular"` and `90`, return `"Regular"`. Given `"Regular"` and `180` degrees, return `"Goofy"`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e6ff50d756c9b6935e.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/697a49e6ff50d756c9b6935e.md
@@ -10,7 +10,7 @@ dashedName: challenge-181
 Given a snowboarder's starting stance and a rotation in degrees, determine their landing stance.
 
 - A snowboarder's stance is either `"Regular"` or `"Goofy"`.
-- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counter-clockwise rotation.
+- Trick rotations are multiples of 90 degrees. Positive indicates clockwise rotation, and negative indicate counterclockwise rotation.
 - The landing stance flips every 180 degrees of rotation.
 
 For example, given `"Regular"` and `90`, return `"Regular"`. Given `"Regular"` and `180` degrees, return `"Goofy"`.

--- a/curriculum/challenges/english/blocks/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69995.md
+++ b/curriculum/challenges/english/blocks/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69995.md
@@ -9,7 +9,7 @@ dashedName: step-43
 
 Rotate each rectangle to give them more of an imperfect, hand-painted look.
 
-Use the `transform` property on the `.one` selector to `rotate` it counter clockwise by 0.6 degrees.
+Use the `transform` property on the `.one` selector to `rotate` it counterclockwise by 0.6 degrees.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69997.md
+++ b/curriculum/challenges/english/blocks/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69997.md
@@ -7,7 +7,7 @@ dashedName: step-45
 
 # --description--
 
-Rotate `.three` counter clockwise by 0.2 degrees.
+Rotate `.three` counterclockwise by 0.2 degrees.
 
 With this final step, your Rothko painting is now complete.
 

--- a/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f3a61000cf542c50feb9.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f3a61000cf542c50feb9.md
@@ -8,7 +8,7 @@ dashedName: problem-58-spiral-primes
 
 # --description--
 
-Starting with 1 and spiralling anticlockwise in the following way, a square spiral with side length 7 is formed.
+Starting with 1 and spiralling counterclockwise in the following way, a square spiral with side length 7 is formed.
 
 <div style='text-align: center;'>
   <strong><span style='color: red;'>37</span></strong> 36 35 34 33 32 <strong><span style='color: red;'>31</span></strong><br>

--- a/curriculum/challenges/english/blocks/project-euler-problems-101-to-200/5900f3ec1000cf542c50feff.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-101-to-200/5900f3ec1000cf542c50feff.md
@@ -8,7 +8,7 @@ dashedName: problem-128-hexagonal-tile-differences
 
 # --description--
 
-A hexagonal tile with number 1 is surrounded by a ring of six hexagonal tiles, starting at "12 o'clock" and numbering the tiles 2 to 7 in an anti-clockwise direction.
+A hexagonal tile with number 1 is surrounded by a ring of six hexagonal tiles, starting at "12 o'clock" and numbering the tiles 2 to 7 in an counterclockwise direction.
 
 New rings are added in the same fashion, with the next rings being numbered 8 to 19, 20 to 37, 38 to 61, and so on. The diagram below shows the first three rings.
 

--- a/curriculum/challenges/english/blocks/project-euler-problems-101-to-200/5900f3ec1000cf542c50feff.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-101-to-200/5900f3ec1000cf542c50feff.md
@@ -8,7 +8,7 @@ dashedName: problem-128-hexagonal-tile-differences
 
 # --description--
 
-A hexagonal tile with number 1 is surrounded by a ring of six hexagonal tiles, starting at "12 o'clock" and numbering the tiles 2 to 7 in an counterclockwise direction.
+A hexagonal tile with number 1 is surrounded by a ring of six hexagonal tiles, starting at "12 o'clock" and numbering the tiles 2 to 7 in a counterclockwise direction.
 
 New rings are added in the same fashion, with the next rings being numbered 8 to 19, 20 to 37, 38 to 61, and so on. The diagram below shows the first three rings.
 

--- a/curriculum/challenges/english/blocks/project-euler-problems-201-to-300/5900f43f1000cf542c50ff51.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-201-to-300/5900f43f1000cf542c50ff51.md
@@ -8,7 +8,7 @@ dashedName: problem-208-robot-walks
 
 # --description--
 
-A robot moves in a series of one-fifth circular arcs (72°), with a free choice of a clockwise or an counterclockwise arc for each step, but no turning on the spot.
+A robot moves in a series of one-fifth circular arcs (72°), with a free choice of a clockwise or a counterclockwise arc for each step, but no turning on the spot.
 
 One of 70932 possible closed paths of 25 arcs starting northward is
 

--- a/curriculum/challenges/english/blocks/project-euler-problems-201-to-300/5900f43f1000cf542c50ff51.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-201-to-300/5900f43f1000cf542c50ff51.md
@@ -8,7 +8,7 @@ dashedName: problem-208-robot-walks
 
 # --description--
 
-A robot moves in a series of one-fifth circular arcs (72°), with a free choice of a clockwise or an anticlockwise arc for each step, but no turning on the spot.
+A robot moves in a series of one-fifth circular arcs (72°), with a free choice of a clockwise or an counterclockwise arc for each step, but no turning on the spot.
 
 One of 70932 possible closed paths of 25 arcs starting northward is
 

--- a/curriculum/challenges/english/blocks/workshop-rothko-painting/60a3e3396c7b40068ad69995.md
+++ b/curriculum/challenges/english/blocks/workshop-rothko-painting/60a3e3396c7b40068ad69995.md
@@ -9,7 +9,7 @@ dashedName: step-42
 
 Rotate each rectangle to give them more of an imperfect, hand-painted look.
 
-Use the `transform` property on the `.one` selector to `rotate` it counter clockwise by 0.6 degrees.
+Use the `transform` property on the `.one` selector to `rotate` it counterclockwise by 0.6 degrees.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-rothko-painting/60a3e3396c7b40068ad69997.md
+++ b/curriculum/challenges/english/blocks/workshop-rothko-painting/60a3e3396c7b40068ad69997.md
@@ -7,7 +7,7 @@ dashedName: step-44
 
 # --description--
 
-Rotate `.three` counter clockwise by 0.2 degrees.
+Rotate `.three` counterclockwise by 0.2 degrees.
 
 With this final step, your Rothko painting is now complete.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #69007

## Description
Replaces inconsistent `counter clockwise` / `counter-clockwise` wording with `counterclockwise` in the Rothko painting workshops and related daily coding challenge descriptions, as requested on the issue.