### PR TITLE
fix(curriculum): correct grammar and library-name capitalization in Introduction to Python lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe81c9c6fd3714343a45ad.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe81c9c6fd3714343a45ad.md
@@ -11,7 +11,7 @@ Python is a general-purpose programming language known for its simplicity and ea
 
 Python is used in many fields like data science and machine learning, web development, scripting and automation, embedded systems, IoT, and much more.
 
-Python is the main language that most data scientists and machine learning engineers currently use. Libraries like Pandas and Numpy make data analysis less tedious, while others like TensorFlow and Scikit-learn make machine learning and working with AI models much more accessible.
+Python is the main language that most data scientists and machine learning engineers currently use. Libraries like Pandas and NumPy make data analysis less tedious, while others like TensorFlow and Scikit-learn make machine learning and working with AI models much more accessible.
 
 In web development, Python frameworks like Django, FastAPI, and Flask let developers build scalable and secure back-end systems with minimal effort. Many social media platforms like Instagram and Pinterest use Python on the back-end.
 

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe81c9c6fd3714343a45ad.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe81c9c6fd3714343a45ad.md
@@ -11,7 +11,7 @@ Python is a general-purpose programming language known for its simplicity and ea
 
 Python is used in many fields like data science and machine learning, web development, scripting and automation, embedded systems, IoT, and much more.
 
-Python is the main language that most data scientist and machine learning engineers currently use. Libraries like Pandas and Numpy make data analysis less tedious, while others like Tensorflow and Scikit make machine learning and working with AI models much more accessible.
+Python is the main language that most data scientists and machine learning engineers currently use. Libraries like Pandas and Numpy make data analysis less tedious, while others like TensorFlow and Scikit make machine learning and working with AI models much more accessible.
 
 In web development, Python frameworks like Django, FastAPI, and Flask let developers build scalable and secure back-end systems with minimal effort. Many social media platforms like Instagram and Pinterest use Python on the back-end.
 

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe81c9c6fd3714343a45ad.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-python/67fe81c9c6fd3714343a45ad.md
@@ -11,7 +11,7 @@ Python is a general-purpose programming language known for its simplicity and ea
 
 Python is used in many fields like data science and machine learning, web development, scripting and automation, embedded systems, IoT, and much more.
 
-Python is the main language that most data scientists and machine learning engineers currently use. Libraries like Pandas and Numpy make data analysis less tedious, while others like TensorFlow and Scikit make machine learning and working with AI models much more accessible.
+Python is the main language that most data scientists and machine learning engineers currently use. Libraries like Pandas and Numpy make data analysis less tedious, while others like TensorFlow and Scikit-learn make machine learning and working with AI models much more accessible.
 
 In web development, Python frameworks like Django, FastAPI, and Flask let developers build scalable and secure back-end systems with minimal effort. Many social media platforms like Instagram and Pinterest use Python on the back-end.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69013

Fixed the typos and capitalizations in the Python introductory lectures, such as scientist -> scientists, Tensorflow -> TensorFlow, Scikit -> Scikit-learn.
