### PR TITLE
fix: correct punctuation errors in CSS lecture descriptions

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acbbe2891564c4e316164.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acbbe2891564c4e316164.md
@@ -84,7 +84,7 @@ Here is an example of styling multiple selectors (to interact with the example, 
 
 In this selector list, there is an `id` selector targeting the HTML element with the `id` value of `title`. All `id` selectors must start with a hash `#` symbol.
 
-Then there is a comma followed by a `class` selector that targets all HTML elements with the `class` value of `subheading`. All class selectors must start with a dot `.`.
+Then there is a comma followed by a `class` selector that targets all HTML elements with the `class` value of `subheading`. All class selectors must start with a dot (`.`).
 
 The entire selector list will receive the same styling, with the text color set to `navy`.
 

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acbbe2891564c4e316164.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acbbe2891564c4e316164.md
@@ -84,7 +84,7 @@ Here is an example of styling multiple selectors (to interact with the example, 
 
 In this selector list, there is an `id` selector targeting the HTML element with the `id` value of `title`. All `id` selectors must start with a hash `#` symbol.
 
-Then there is a comma followed by a `class` selector that targets all HTML elements with the `class` value of `subheading`. All class selectors must start with a dot `.`
+Then there is a comma followed by a `class` selector that targets all HTML elements with the `class` value of `subheading`. All class selectors must start with a dot `.`.
 
 The entire selector list will receive the same styling, with the text color set to `navy`.
 

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acbf7490c054d213a8c1f.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acbf7490c054d213a8c1f.md
@@ -56,7 +56,7 @@ Here's an example of internal CSS:
 
 In the above example, the internal CSS applies blue text to all `p` elements on the page.
 
-Internal CSS is best used when you need to apply styles to a specific page rather than across multiple pages. It’s useful for single-page websites or when the styles don't need to be reused elsewhere.
+Internal CSS is best used when you need to apply styles to a specific page rather than across multiple pages. It's useful for single-page websites or when the styles don't need to be reused elsewhere.
 
 However, there are some downsides, such as not promoting reusability across multiple pages. Additionally, like inline CSS, it mixes HTML and CSS, making the code harder to maintain in larger projects.
 

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acbf7490c054d213a8c1f.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acbf7490c054d213a8c1f.md
@@ -11,7 +11,7 @@ CSS can be applied to a webpage in three main ways: inline, internal, or externa
 
 Each method has its own use case, advantages, and limitations, and knowing when to use each one is essential for writing clean, efficient, and maintainable code.
 
-Let’s break down the three types of CSS and when you should use them.
+Let's break down the three types of CSS and when you should use them.
 
 Inline CSS is written directly within an HTML element using the `style` attribute. It applies styles to a specific element.
 
@@ -56,7 +56,7 @@ Here's an example of internal CSS:
 
 In the above example, the internal CSS applies blue text to all `p` elements on the page.
 
-Internal CSS is best used when you need to apply styles to a specific page rather than across multiple pages. It’s useful for single-page websites or when the styles don’t need to be reused elsewhere.
+Internal CSS is best used when you need to apply styles to a specific page rather than across multiple pages. It’s useful for single-page websites or when the styles don't need to be reused elsewhere.
 
 However, there are some downsides, such as not promoting reusability across multiple pages. Additionally, like inline CSS, it mixes HTML and CSS, making the code harder to maintain in larger projects.
 

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc3f6f3e3c4e31ec3e12.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc3f6f3e3c4e31ec3e12.md
@@ -56,7 +56,7 @@ Let's take a look at an example.
 
 In the above example, we have a `div` with a class of `container`. Inside that `div` element, we have two `span` elements.
 
-Each of the span elements is set to `display:inline-block` and has a width and height set as well.
+Each of the span elements is set to `display: inline-block` and has a width and height set as well.
 
 The inline-block elements will appear side by side because they behave like inline elements, but they also have a specified width and height, which gives them block-like properties.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69024

<!-- Feel free to add any additional description of changes below this line -->
- Added missing period after closing backtick in the CSS anatomy lecture description
- Replaced curly apostrophes with straight apostrophes in the inline/internal/external CSS lecture description
- Added missing space after colon in `display: inline-block` code snippet in the inline-block lecture description
