### PR TITLE
fix(api): correct incorrect fallback values in normalizeDate and getPoints

### DIFF
--- a/api/src/utils/normalize.test.ts
+++ b/api/src/utils/normalize.test.ts
@@ -199,6 +199,10 @@ describe('normalize', () => {
     test('should handle string numbers', () => {
       expect(normalizeDate('1696118400000')).toEqual(1696118400000);
     });
+
+    test('should throw an error for an empty string', () => {
+      expect(() => normalizeDate('')).toThrow('Unexpected date value: ""');
+    });
   });
 
   describe('normalizeChallengeType', () => {

--- a/api/src/utils/normalize.ts
+++ b/api/src/utils/normalize.ts
@@ -76,7 +76,7 @@ export const normalizeDate = (date?: Prisma.JsonValue): number => {
     typeof date.$date === 'string'
   ) {
     return new Date(date.$date).getTime();
-  } else if (typeof date === 'string') {
+  } else if (typeof date === 'string' && date.trim() !== '') {
     const parsed = Number(date);
     if (!isNaN(parsed)) {
       // Number() handles invalid strings e.g. '2023-10-01T00:00:00Z'

--- a/api/src/utils/progress.test.ts
+++ b/api/src/utils/progress.test.ts
@@ -30,8 +30,8 @@ describe('utils/progress', () => {
   });
 
   describe('getPoints', () => {
-    test('should return 1 if there are no progressTimestamps', () => {
-      expect(getPoints(null)).toEqual(1);
+    test('should return 0 if there are no progressTimestamps', () => {
+      expect(getPoints(null)).toEqual(0);
     });
     test('should return then number of progressTimestamps if there are any', () => {
       expect(getPoints([0, 1, 2])).toEqual(3);

--- a/api/src/utils/progress.ts
+++ b/api/src/utils/progress.ts
@@ -32,5 +32,5 @@ export const getCalendar = (
 export const getPoints = (
   progressTimestamps: ProgressTimestamp[] | null
 ): number => {
-  return progressTimestamps?.length ?? 1;
+  return progressTimestamps?.length ?? 0;
 };


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Fixes two related fallback bugs in api/src/utils/:
normalizeDate('') was silently returning 0 (epoch) instead of throwing, because Number('') evaluates to 0, which passes the !isNaN check. Added a check that the string isn't empty (after trimming) before parsing it as a number.
getPoints(null) was returning 1 instead of 0 due to an incorrect ?? 1 fallback, inflating a user's point count by one whenever progressTimestamps is null. Changed the fallback to 0.

Updated the existing getPoints test in progress.test.ts (it was asserting the buggy 1 value) and added a new empty-string case to normalize.test.ts. All 22 tests in both files pass.

Closes #69026

<!-- Feel free to add any additional description of changes below this line -->
