### PR TITLE
fix(docs): remove stale entry from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Our full-stack web development and machine learning curriculum is completely fre
 - [Reporting Bugs and Issues](#reporting-bugs-and-issues)
 - [Reporting Security Issues and Responsible Disclosure](#reporting-security-issues-and-responsible-disclosure)
 - [Contributing](#contributing)
-- [Platform, Build and Deployment Status](#platform-build-and-deployment-status)
 - [License](#license)
 
 ### Certifications


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69031.

The README's Table of Contents still linked to a "Platform, Build and Deployment Status" section that no longer exists in the document. This removes the stale entry.