### PR TITLE
feat(client): add help category tag to forum help posts

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -232,13 +232,17 @@ function createQuestionEpic(action$, state$, { window }) {
         })
       );
 
+      const tags = window.encodeURIComponent(
+        helpCategory.toLowerCase().replace(/\s+/g, '-')
+      );
+
       const studentCode = window.encodeURIComponent(textMessage);
       const editableRegionCode = window.encodeURIComponent(
         textMessageOnlyEditableRegion
       );
       const altStudentCode = window.encodeURIComponent(altTextMessage);
 
-      const baseURI = `${forumLocation}/new-topic?category=${category}&title=${titleText}&body=`;
+      const baseURI = `${forumLocation}/new-topic?category=${category}&tags=${tags}&title=${titleText}&body=`;
       const defaultURI = `${baseURI}${studentCode}`;
       const onlyEditableRegionURI = `${baseURI}${editableRegionCode}`;
       const altURI = `${baseURI}${altStudentCode}`;

--- a/client/src/templates/Challenges/redux/create-question-epic.test.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.test.js
@@ -60,6 +60,7 @@ describe('create-question-epic', () => {
     expect(windowMock.open.mock.calls[0][0]).toContain(
       'I%20need%20help%20with%20my%20HTML%20heading'
     );
+    expect(windowMock.open.mock.calls[0][0]).toContain('&tags=html-css&');
     expect(result).toEqual(closeModal('help'));
   });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68924

Adds a `tags` parameter to the forum new-topic URL, derived from the challenge `helpCategory` (slugified, e.g. `HTML-CSS` becomes `html-css`), so curriculum help posts arrive pre-tagged with their certification area.

The tags must exist on the forum (or the category must permit tag creation) for the value to stick, and currently the two lists do not match


these are used in the url

<img width="203" height="499" alt="Image" src="https://github.com/user-attachments/assets/3b5fbb53-0e8d-4a0b-b48d-5ed8d962d4b2" />

vs

these are those on the forum
<img width="181" height="237" alt="Image" src="https://github.com/user-attachments/assets/2e4fff04-8208-4897-b8db-7af4a67fa8ba" />
<img width="247" height="193" alt="Image" src="https://github.com/user-attachments/assets/85f45abb-9be0-4108-8238-915da935dd85" />
