### PR TITLE
fix: correct grammar and punctuation in margins and padding lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
@@ -106,7 +106,7 @@ This code example will apply `10px` of `margin` equally to all four sides of the
 
 When using two values, the first value applies to the `top` and `bottom`, while the second value applies to the `left` and `right` sides of the element.
 
-Here is an example of using two values for the margin shorthand:
+Here is an example of using two values for the `margin` shorthand:
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
@@ -78,7 +78,7 @@ p {
 
 In this example, we are assigning spacing values on all four sides of the paragraph element. A solid black border has also been added so you can see the margins better.
 
-Another way to use the `margin` property is with shorthand notation. You can specify one, two, three, or four values at once. Let’s explore these options together.
+Another way to use the `margin` property is with shorthand notation. You can specify one, two, three, or four values at once. Let's explore these options together.
 
 When using a singular value on the `margin` shorthand, that exact value will be applied to all four sides of the target element.
 
@@ -106,7 +106,7 @@ This code example will apply `10px` of `margin` equally to all four sides of the
 
 When using two values, the first value applies to the `top` and `bottom`, while the second value applies to the `left` and `right` sides of the element.
 
-Here is an example of using of two values for the `margin` shorthand:
+Here is an example of using two values for the margin shorthand:
 
 :::interactive_editor
 
@@ -208,7 +208,7 @@ p {
 
 This sets the padding to `10px` for the `top`, `20px` for the `right`, `30px` for the `bottom`, and `40px` for the `left`.
 
-As you can see that, `padding` is applied to the content which is inside the border, unlike `margin` which applies to outside the border.
+As you can see, padding is applied to the content which is inside the border, unlike margin which applies to outside the border.
 
 Just like the `margin` property, you can also choose to use the shorthand for the `padding` property.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69022 

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes the issues reported in #69022 for the "What Are Margins and Padding, and How Do They Work?" lecture.

Changes Made
Replaced the curly apostrophe in "Let's" with a standard straight apostrophe.
Corrected the sentence "Here is an example of using of two values for the margin shorthand:" by removing the extra "of".
Fixed the ungrammatical phrase "As you can see that," to "As you can see," for improved readability and correctness.

These changes improve the grammar, punctuation, and overall clarity of the lecture content while preserving its original meaning.
