### PR TITLE
fix(curriculum): correct default browser styles lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acbdd06b44c4cd3bf8713.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acbdd06b44c4cd3bf8713.md
@@ -13,7 +13,7 @@ These default browser styles provide basic formatting to ensure that HTML elemen
 
 However, these styles can vary slightly from one browser to another, which is why it's important to understand them when designing a consistent look for your website.
 
-Let’s take a look at some common default browser styles applied to various HTML elements.
+Let's take a look at some common default browser styles applied to various HTML elements.
 
 Headings are one of the most commonly used HTML elements and are styled by default to have varying sizes and weights.
 
@@ -78,7 +78,7 @@ In the example above, the `blockquote` element will produce an indent on the tex
 
 Another element with default styles is the anchor element (`<a>`), which is styled with a default blue color and underlining to make it recognizable as a link.
 
-Let's take at look at the following HTML example:
+Let's take a look at the following HTML example:
 
 :::interactive_editor
 
@@ -221,7 +221,7 @@ Think about the most common style applied to links on a webpage.
 
 ### --feedback--
 
-Think about the most common style applied to links on a webpage
+Think about the most common style applied to links on a webpage.
 
 ---
 
@@ -229,7 +229,7 @@ Think about the most common style applied to links on a webpage
 
 ### --feedback--
 
-Think about the most common style applied to links on a webpage
+Think about the most common style applied to links on a webpage.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69020

<!-- Feel free to add any additional description of changes below this line -->

Corrected two wording issues in the default browser styles lecture:

- Replaced a curly apostrophe with a straight apostrophe.
- Corrected “take at look” to “take a look.”
- Made the wrong-answer feedback for the anchor-tag question consistent by adding the missing periods.

Verified locally with the curriculum challenge linter, Prettier, focused text assertions, and `git diff --check`.