### PR TITLE
fix: add the missing keyword in var explanation

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d49959621885e9d3e672c.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d49959621885e9d3e672c.md
@@ -82,7 +82,7 @@ You should use `let` when you need to declare variables that will be reassigned 
 
 Use `const` when you want to declare variables that should remain constant, like configuration values or settings that shouldn't be changed accidentally.
 
-You can also use the `var` keyword, but it's not as recommended anymore. The `var` is kind of like `let`, except it has a wider scope, which is more likely to cause problems in your program.
+You can also use the `var` keyword, but it's not as recommended anymore. The `var` keyword is kind of like `let`, except it has a wider scope, which is more likely to cause problems in your program.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69017

This pull request adds the missing word "keyword" to the explanation of `var`.