### PR TITLE
fix(curriculum): use Explorer helper in reusable profile card component workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -35,7 +35,7 @@ Your `Card` component should have a `name`, `title`, and `bio` props.
 ```js
 const explorer = await __helpers.Explorer(code);
 const parameters = explorer.allFunctions.Card?.parameters ?? [];
-assert.isTrue(parameters[0].matches("{ name, title, bio }"));
+assert.isTrue(parameters[0]?.matches("{ name, title, bio }"));
 ```
 
 Your `Card` component should return a pair of parentheses with an empty string inside.
@@ -43,7 +43,7 @@ Your `Card` component should return a pair of parentheses with an empty string i
 ```js
 const explorer = await __helpers.Explorer(code);
 const { Card } = explorer.allFunctions;
-assert.isTrue(Card.hasReturn("('')"))
+assert.isTrue(Card?.hasReturn("('')"))
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -22,24 +22,28 @@ You should create and export a `Card` functional component.
 assert.isFunction(window.index.Card);
 ```
 
+Your `Card` component should be exported using the `export` keyword.
+
+```js
+const explorer = await __helpers.Explorer(code);
+const { Card } = explorer.allFunctions;
+assert.isTrue(Card?.toString().trim().startsWith('export'));
+```
+
 Your `Card` component should have a `name`, `title`, and `bio` props.
 
 ```js
-const functionRegex = __helpers.functionRegex("Card", null, { capture: true });
-const match = code.match(functionRegex);
-const functionDefinition = match[0];
-assert.match(functionDefinition, /\{[^{]*name[^{]*\}/);
-assert.match(functionDefinition, /\{[^{]*title[^{]*\}/);
-assert.match(functionDefinition, /\{[^{]*bio[^{]*\}/);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.Card?.parameters ?? [];
+assert.isTrue(parameters[0].matches("{ name, title, bio }"));
 ```
 
 Your `Card` component should return a pair of parentheses with an empty string inside.
 
 ```js
-const functionRegex = __helpers.functionRegex("Card", null, { capture: true });
-const match = code.match(functionRegex);
-const functionDefinition = match[0];
-assert.match(functionDefinition, /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*;?\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const { Card } = explorer.allFunctions;
+assert.isTrue(Card.hasReturn("('')"))
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef11f75254548672d998c.md
@@ -27,7 +27,7 @@ Your `Card` component should be exported using the `export` keyword.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { Card } = explorer.allFunctions;
-assert.isTrue(Card?.toString().trim().startsWith('export'));
+assert.isTrue(Card?.toString().startsWith('export'));
 ```
 
 Your `Card` component should have a `name`, `title`, and `bio` props.

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -22,13 +22,9 @@ assert.isFunction(window.index.App);
 Your `App` component should return a pair of parentheses with an empty string inside.
 
 ```js
-const functionRegex = __helpers.functionRegex("App", null, { capture: true });
-const match = code.match(functionRegex);
-const functionDefinition = match[0];
-assert.match(
-  functionDefinition,
-  /\s*{\s*return\s*\(\s*(''|""|``)\s*\)\s*;?\s*}|\s*=>\s*\(\s*(''|""|``)\s*\)/
-);
+const explorer = await __helpers.Explorer(code);
+const { App } = explorer.allFunctions;
+assert.isTrue(App.hasReturn("('')"))
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165a.md
@@ -24,7 +24,7 @@ Your `App` component should return a pair of parentheses with an empty string in
 ```js
 const explorer = await __helpers.Explorer(code);
 const { App } = explorer.allFunctions;
-assert.isTrue(App.hasReturn("('')"))
+assert.isTrue(App?.hasReturn("('')"))
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68778af56eb5d980a4e2daed.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68778af56eb5d980a4e2daed.md
@@ -23,15 +23,25 @@ Add one object to the array for `Mark`, with the following values:
 You should define a `profiles` array inside the `App` component.
 
 ```js
-assert.match(code, /(const|let)\s+profiles\s*=\s*\[/);
+const explorer = await __helpers.Explorer(code);
+const { profiles } = explorer.allFunctions.App?.variables ?? {};
+assert.exists(profiles);
+const profilesVal = eval(profiles?.value.toString());
+assert.isArray(profilesVal);
 ```
 
 Your profiles array should contain an object that includes all required properties: `id`, `name`, `title`, and `bio`.
 
 ```js
-assert.match(
-  code,
-  /(const|let)\s+profiles\s*=\s*\[\s*{[^}]*id\s*:\s*\d+[^}]*name\s*:\s*["'`][^"'`]+["'`][^}]*title\s*:\s*["'`][^"'`]+["'`][^}]*bio\s*:\s*["'`][^"'`]+["'`][^}]*}\s*\]/s);
+const explorer = await __helpers.Explorer(code);
+const { profiles } = explorer.allFunctions.App?.variables ?? {};
+const profilesVal = eval(profiles?.value.toString());
+assert.deepEqual(profilesVal, [{
+  id: 1,
+  name: "Mark",
+  title: "Front-End developer",
+  bio: "I like to work with different front-end technologies and play video games."
+}]);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68715

This is part of the Naomi's Sprints initiative → replacing regex-based tests with the Explorer AST helper.

- Replaces regex tests with Explorer helper in Reusable Profile Card Component workshop, Steps 1, 4, and 9

**Changes made**

Step 1 - added an export check and swapped the props/return checks:
\`\`\`js
const explorer = await __helpers.Explorer(code);
const { Card } = explorer.allFunctions;
assert.isTrue(Card?.toString().startsWith('export'));
\`\`\`
\`\`\`js
const explorer = await __helpers.Explorer(code);
const parameters = explorer.allFunctions.Card?.parameters ?? [];
assert.isTrue(parameters[0].matches("{ name, title, bio }"));
\`\`\`
\`\`\`js
const explorer = await __helpers.Explorer(code);
const { Card } = explorer.allFunctions;
assert.isTrue(Card.hasReturn("('')"))
\`\`\`

Step 4 - same return check, for `App`:
\`\`\`js
const explorer = await __helpers.Explorer(code);
const { App } = explorer.allFunctions;
assert.isTrue(App.hasReturn("('')"))
\`\`\`

Step 9 - `profiles` array declaration and contents:
\`\`\`js
const explorer = await __helpers.Explorer(code);
const { profiles } = explorer.allFunctions.App?.variables ?? {};
assert.exists(profiles);
const profilesVal = eval(profiles?.value.toString());
assert.isArray(profilesVal);
\`\`\`
\`\`\`js
assert.deepEqual(profilesVal, [{
  id: 1,
  name: "Mark",
  title: "Front-End developer",
  bio: "I like to work with different front-end technologies and play video games."
}]);
\`\`\`

Of the 9 regex-based hints in this workshop, 7 were replaceable with the Explorer helper. Steps 10 (`.map()` call check) and 11 (JSX `key={profile.id}` attribute check) were left as regex as confirmed that current AST helpers can't cover call expressions or JSX attributes.

**Testing**

Ran `FCC_BLOCK='workshop-reusable-profile-card-component' pnpm run test-curriculum-content` — all 61 tests passed.