### PR TITLE
fix(curriculum): correct casing for undefined and null data types in JavaScript lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md
@@ -187,7 +187,7 @@ This data type is often used in logical statements.
 
 ---
 
-`Undefined`
+`undefined`
 
 ### --feedback--
 
@@ -219,11 +219,11 @@ This data type represents an unassigned variable.
 
 ---
 
-`Undefined`
+`undefined`
 
 ---
 
-`Null`
+`null`
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69016

<!-- Feel free to add any additional description of changes below this line -->

**Description**

Fixes inconsistent casing of the `undefined` and `null` data types in the quiz answers for the "What Is a Data Type, and What Are the Different Data Types in JavaScript?" lecture.

The lecture body introduces these values in lowercase (`undefined`, `null`), but two quiz answer options used capitalized `Undefined`/`Null`, which didn't match the rest of the lesson and could read as a different (non-existent) type name. This PR aligns the quiz answers with the lowercase convention already used in the lecture text.

**Changes**
- `curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md`: changed `Undefined` → `undefined` (2 occurrences) and `Null` → `null` (1 occurrence) in quiz answer options.

No answer indices or `--video-solution--` values were affected — this is a text-only casing fix.
