### PR TITLE
fix(curriculum): correct comma spacing in four challenge descriptions

### DIFF
--- a/curriculum/challenges/english/blocks/lab-counting-cards/68a23004e96a105df3a21fc4.md
+++ b/curriculum/challenges/english/blocks/lab-counting-cards/68a23004e96a105df3a21fc4.md
@@ -21,7 +21,7 @@ Having more high cards remaining in the deck favors the player. When the count i
     - For values between `2` to `10`, the `card` parameter will be a number.
     - For all other values, the `card` parameter will be a string.
 1. The `cardCounter` function should modify the global `count` variable based on certain criteria.
-1. The global `count` variable should be increased by `1` for the cards `2`, `3`,`4`, `5`, or `6`
+1. The global `count` variable should be increased by `1` for the cards `2`, `3`, `4`, `5`, or `6`
 1. The global `count` variable should remain unchanged for the cards `7`, `8`, `9`.
 1. The global `count` variable should be decreased by `1` for the cards `10`, `"J"`, `"Q"`, `"K"`, `"A"`
 1. The `cardCounter` function should return a string with current count and the string `Bet` if the count is positive.

--- a/curriculum/challenges/english/blocks/workshop-colored-markers/61b3183655ec10efd8c0bb07.md
+++ b/curriculum/challenges/english/blocks/workshop-colored-markers/61b3183655ec10efd8c0bb07.md
@@ -9,7 +9,7 @@ dashedName: step-87
 
 The shadows for your green and blue markers will have the same position, blur, and spread. The only difference will be the colors.
 
-In the `.green` and `.blue` CSS rules, update the values for the `box-shadow` properties so `offsetX` is `0`,`offsetY` is `0`, `blurRadius` is `20px`, and `spreadRadius` is `0`. Leave the colors as `green` and `blue` for now.
+In the `.green` and `.blue` CSS rules, update the values for the `box-shadow` properties so `offsetX` is `0`, `offsetY` is `0`, `blurRadius` is `20px`, and `spreadRadius` is `0`. Leave the colors as `green` and `blue` for now.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-colorful-boxes/692f2c20cb7f9e5050b935a7.md
+++ b/curriculum/challenges/english/blocks/workshop-colorful-boxes/692f2c20cb7f9e5050b935a7.md
@@ -9,7 +9,7 @@ dashedName: step-9
 
 Add the property `border` with the value `1px solid #000` to the `.box` selector. The `border` property is used to create a visible outline around an element. It can be customized in terms of `border-width`, `border-style`, and `border-color`. 
 
-In this case ,`1px` is `border-width`, which defines the thickness of the border. `solid` is `border-style` and sets the appearance of the border (solid, dashed, dotted and so on). And `#000` is `border-color`, which defines the color of the border.
+In this case, `1px` is `border-width`, which defines the thickness of the border. `solid` is `border-style` and sets the appearance of the border (solid, dashed, dotted and so on). And `#000` is `border-color`, which defines the color of the border.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f1.md
+++ b/curriculum/challenges/english/blocks/workshop-employee-profile-generator/694bf6eb530e19a9c48c59f1.md
@@ -9,7 +9,7 @@ dashedName: step-5
 
 Now, your address seems incomplete. You also want to add the apartment number where the employee lives, so you should modify the variable.  
 
-When you want to add content to the end of an existing string variable, you can use the **augmented assignment** operator ,`+=`. This is shorter than writing `var = var + 'new text'`. For example:  
+When you want to add content to the end of an existing string variable, you can use the **augmented assignment** operator, `+=`. This is shorter than writing `var = var + 'new text'`. For example:  
 
 ```py
 greeting = 'Hello'


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69047

## Description

This PR fixes four whitespace and punctuation issues in the English curriculum:

- Added a missing space between `3` and `4`
- Added a missing space between `0` and `offsetY`
- Corrected punctuation in `In this case,`
- Corrected punctuation around `operator, \`+=\``

These are documentation-only changes.