### PR TITLE
fix(curriculum): require const for middlePoint declaration

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-merge-sort-js/69b2762b17d23fbee40a6c00.md
+++ b/curriculum/challenges/english/blocks/workshop-merge-sort-js/69b2762b17d23fbee40a6c00.md
@@ -24,7 +24,7 @@ You should declare a `middlePoint` variable and assign `Math.floor(array.length 
 ```js
 assert.match(
   __helpers.removeJSComments(mergeSort.toString()),
-  /(const|let|var)\s+middlePoint\s*=\s*Math\.floor\(\s*array\.length\s*\/\s*2\s*\)\s*;?/
+  /const\s+middlePoint\s*=\s*Math\.floor\(\s*array\.length\s*\/\s*2\s*\)\s*;?/
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
## Description

This PR fixes the test for Step 2 of the JavaScript Merge Sort workshop.

Previously, the test accepted:

- let middlePoint = Math.floor(array.length / 2);
- var middlePoint = Math.floor(array.length / 2);

However, the lesson instructions explicitly require:

const middlePoint = Math.floor(array.length / 2);

This PR updates the test so that only a const declaration satisfies the requirement.

Fixes #69050
