### PR TITLE
fix(curriculum): improve string concatenation lecture wording

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-strings/672d49b2fb76df5f1d6117af.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-strings/672d49b2fb76df5f1d6117af.md
@@ -40,12 +40,12 @@ let firstName = "John";
 let lastName = "Doe";
 
 let fullName = firstName + lastName; 
-console.log(fullName); // "JohnDoe"
+console.log(fullName); // JohnDoe
 ```
 
 :::
 
-Whenever you use the `+` operator to concatenate strings, it is important to double check for any potential spacing issues.
+Whenever you use the `+` operator to concatenate strings, it is important to double-check for any potential spacing issues.
 
 If you need to add or append to an existing string, then you can use the `+=` operator. This is helpful when you want to build upon a string by adding more text to it over time.
 
@@ -57,14 +57,14 @@ Here's an example of appending one string to another using the `+=` operator:
 let greeting = 'Hello';
 greeting += ', John!';
 
-console.log(greeting); // "Hello, John!"
+console.log(greeting); // Hello, John!
 ```
 
 :::
 
-It is important to remember that strings are immutable which means once a string is created you can not alter it.
+It is important to remember that strings are immutable, which means that once a string is created, you cannot alter it.
 
-In this case, the original string of `Hello` is not modified. Instead, greeting now references the new string of `Hello, John!`
+In this case, the original string of `Hello` is not modified. Instead, `greeting` now references the new string of `Hello, John!`.
 
 Another way you can concatenate strings is to use the `concat()` method.
 
@@ -90,7 +90,7 @@ console.log(result); // Hello World
 
 In this example, we use the `concat()` method to join `str1`, a space (`' '`), and `str2` into a single string.
 
-To conclude, `+` operator is best for simple concatenation, especially when you need to combine a few strings or variables.
+To conclude, the `+` operator is best for simple concatenation, especially when you need to combine a few strings or variables.
 
 The `+=` operator is useful when building up a string step by step or appending new content to an existing string variable.
 
@@ -185,7 +185,6 @@ Refer back to the third example given in this lesson.
 ## --text--
 
 Which of the following is the correct method to concatenate multiple strings?
-
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69054

This corrects punctuation, wording, inline-code formatting, example output comments, and an extra blank line in the String Concatenation lecture.

Tested with `CURRICULUM_LOCALE=english FCC_BLOCK=lecture-introduction-to-strings pnpm run test-curriculum-content` (7 tests passed).