### PR TITLE
fix(curriculum): improve wording in declaring-variables lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe8597975ea634042cad8f.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-variables-and-data-types/67fe8597975ea634042cad8f.md
@@ -7,9 +7,9 @@ dashedName: how-do-you-declare-variables-and-what-are-naming-conventions-to-name
 
 # --description--
 
-In Python, variables are like a labelled box for storing and referencing data of different types. To declare variables in Python, you assign a value to an identifier with the assignment (`=`) operator. You don't need to use special keywords like `let` or `const` in JavaScript, or `char` in C#.
+In Python, variables are like labeled boxes for storing and referencing data of different types. To declare variables in Python, you assign a value to an identifier with the assignment (`=`) operator. You don't need to use special keywords like `let` or `const` in JavaScript, or `char` in C#.
 
-In Python, you just write the name of the variable on the left, followed by the assignment operator, and the value you want to assign the variable on the right. Here's an example of how to declare `name` and `age` variables:
+In Python, you just write the name of the variable on the left, followed by the assignment operator, and the value you want to assign to the variable on the right. Here's an example of how to declare `name` and `age` variables:
 
 ```python
 name = 'John Doe'
@@ -22,12 +22,12 @@ When naming variables in Python, there are some important rules you should keep 
 
 - Variable names can only start with a letter or an underscore (`_`), not a number.
 - Variable names can only contain alphanumeric characters (`a-z`, `A-Z`, `0-9`) and underscores (`_`).
-- Variable names are case-sensitive — `age`, `Age`, and `AGE` are all considered unique.
+- Variable names are case-sensitive: `age`, `Age`, and `AGE` are all considered unique.
 - Variable names cannot be one of Python's reserved keywords such as `if`, `class`, or `def`.
 
-If you break any of those rules, your Python program will throw a `SyntaxError`:
+If you break any of those rules, your Python program will raise a `SyntaxError`:
 
-```bash
+```md
     5variable_name = 5
      ^
 SyntaxError: invalid syntax
@@ -35,7 +35,7 @@ SyntaxError: invalid syntax
 
 Now let's go over some common naming conventions for variables in Python.
 
-First, variables names should be in lowercase, with separate words separated by an underscore. This is called snake case:
+First, variable names should be in lowercase, with words separated by an underscore. This is called snake case:
 
 ```python
 my_variable_name = 'freeCodeCamp'
@@ -49,7 +49,7 @@ user_age = 30
 
 This way, you can easily communicate the purpose of a variable to other team members (or to your future self) in a large codebase.
 
-Another convention is to avoid using single-letter variable names. This is very common in Python, but should be avoided because variable names with a single letter communicate no purpose or meaning:
+Another convention is to avoid using single-letter variable names. Single-letter names are common in Python, but they should be avoided because they communicate no purpose or meaning:
 
 ```python
 x = 56 # What do you mean by x?


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69056

Updates the declaring-variables lecture so the wording matches American English, uses Python terminology, and reads more clearly:

- `labelled box` -> `labeled boxes`
- add missing `to` in the assignment sentence
- replace the em dash in the case-sensitivity bullet with a colon
- `throw` -> `raise` for `SyntaxError`
- fix the traceback fence language from `bash` to `md`
- `variables names` / repeated "separate" wording in the snake case paragraph
- clarify the single-letter variable names paragraph so the subject is not self-contradictory