### PR TITLE
fix(curriculum): correct Cafe Menu hint assertions

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e050279c7a4a7101d3.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e050279c7a4a7101d3.md
@@ -30,7 +30,7 @@ assert.isTrue(hasPaddingTop);
 You should set the `padding-bottom` property to `20px`.
 
 ```js
-const hasPaddingBottom = new __helpers.CSSHelp(document).getCSSRules().some(x => x.style['padding-top'] === '20px');
+const hasPaddingBottom = new __helpers.CSSHelp(document).getCSSRules().some(x => x.style['padding-bottom'] === '20px');
 assert.isTrue(hasPaddingBottom);
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e05473f91f948724ab.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e05473f91f948724ab.md
@@ -17,6 +17,7 @@ You should set the `font-family` property to `sans-serif`.
 
 ```js
 const hasFontFamily = new __helpers.CSSHelp(document).getCSSRules().some(x => x.style['font-family'] === 'sans-serif');
+assert.isTrue(hasFontFamily);
 ```
 
 Your `body` should have a `font-family` of `sans-serif`.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b0731d39e15d54df4dfc.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b0731d39e15d54df4dfc.md
@@ -24,6 +24,7 @@ You should set the `color` property to `black`.
 
 ```js
 const hasColor = new __helpers.CSSHelp(document).getCSSRules().some(x => x.style.color === 'black');
+assert.isTrue(hasColor);
 ```
 
 Your `a` element should have a `color` of `black`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69072

## Summary

- correct the Step 50 `padding-bottom` hint to check `padding-bottom`
- add the missing assertion for the Step 53 `font-family` hint
- add the missing assertion for the Step 77 link color hint

## Testing

- `git diff --check`
- `git diff HEAD~1..HEAD --check`
- `CURRICULUM_LOCALE=english FCC_BLOCK=workshop-cafe-menu pnpm test-curriculum-content`
