### PR TITLE
fix(curriculum): correct Hotel Feedback Form hint tests

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83601cd819e37f0dccd14.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83601cd819e37f0dccd14.md
@@ -23,7 +23,7 @@ Below your `h1` element, add a `p` element. The `p` element's text should be `Th
 You should have an opening `header` tag.
 
 ```js
-assert.match(code, /<header>/i);
+assert.exists(document.querySelector('header'));
 ```
 
 You should have a closing `header` tag.
@@ -35,7 +35,7 @@ assert.match(code, /<\/header>/i);
 You should have an opening `h1` tag.
 
 ```js
-assert.match(code, /<h1>/i);
+assert.exists(document.querySelector('h1'));
 ```
 
 You should have a closing `h1` tag.
@@ -61,7 +61,7 @@ assert.strictEqual(h1?.parentElement.tagName, 'HEADER');
 You should have an opening `p` tag.
 
 ```js
-assert.match(code, /<p>/i);
+assert.exists(document.querySelector('p'));
 ```
 
 You should have a closing `p` tag.
@@ -88,7 +88,7 @@ Your paragraph element should come after your `h1`.
 
 ```js
 const pElement = document.querySelector('p');
-assert.strictEqual(pElement?.previousElementSibling.tagName, 'H1');
+assert.strictEqual(pElement?.previousElementSibling?.tagName, 'H1');
 ```
 
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a8380d911e3f4270d5cadc.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a8380d911e3f4270d5cadc.md
@@ -14,7 +14,7 @@ Now, it is time to add the `main` element which represents the main content of t
 You should have an opening `main` tag.
 
 ```js
-assert.match(code, /<main>/i);
+assert.exists(document.querySelector('main'));
 ```
 
 You should have a closing `main` tag.

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83bdcf425e7446900b7c4.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83bdcf425e7446900b7c4.md
@@ -28,7 +28,7 @@ Inside your `main` element, add a `form` element with an `action` attribute set 
 You should have an opening `form` tag.
 
 ```js
-assert.match(code, /<form.*>/i);
+assert.exists(document.querySelector('form'));
 ```
 
 You should have a closing `form` tag.

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83e5e491625454b6f62c3.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83e5e491625454b6f62c3.md
@@ -26,7 +26,7 @@ Inside your `form` element, add a `fieldset` element.
 You should have an opening `fieldset` tag.
 
 ```js
-assert.match(code, /<fieldset>/i);
+assert.exists(document.querySelector('fieldset'));
 ```
 
 You should have a closing `fieldset` tag.

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83fec026a7a4631e084d2.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83fec026a7a4631e084d2.md
@@ -27,7 +27,7 @@ Inside your `fieldset` element, add a `legend` element with the text `Personal I
 You should have an opening `legend` tag.
 
 ```js
-assert.match(code, /<legend>/);
+assert.exists(document.querySelector('legend'));
 ```
 
 You should have a closing `legend` tag.

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a84111965a0c46df6bbd0a.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a84111965a0c46df6bbd0a.md
@@ -25,7 +25,7 @@ Then below your `label` element, add an `input` element with no attributes. In t
 You should have an opening `label` tag.
 
 ```js
-assert.match(code, /<label.*>/);
+assert.exists(document.querySelector('label'));
 ```
 
 You should have a closing `label` tag.

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a93bbe65a26169dbf3bc39.md
@@ -28,7 +28,8 @@ assert.strictEqual(document.querySelector('fieldset label:nth-of-type(2)')?.inne
 Your `label` element should have a `for` attribute set to the value of `"email"`.
 
 ```js
-assert.strictEqual(document.querySelector('fieldset label[for="email"]')?.getAttribute('for'), 'email');
+const emailLabel = document.querySelector('fieldset label:nth-of-type(2)');
+assert.strictEqual(emailLabel?.getAttribute('for'), 'email');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a93c95bc58e26a8fe95818.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a93c95bc58e26a8fe95818.md
@@ -42,7 +42,7 @@ assert.isNotNull(document.querySelector('input[name="email"]'));
 Your `input` element should have a `required` attribute.
 
 ```js
-assert.strictEqual(document.querySelector('input#email')?.getAttribute('required'), "");
+assert.isTrue(document.querySelector('input#email')?.hasAttribute('required'));
 ```
 
 Your `input` element should have a `placeholder` attribute set to `"example@email.com"`.

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a972137acd1179fa3fe8a0.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a972137acd1179fa3fe8a0.md
@@ -60,7 +60,6 @@ assert.exists(document.querySelector('option[value="good"]'));
 Your `option` element with the `value` of `"good"` should have the text `Good`.
 
 ```js
-
 assert.strictEqual(document.querySelector('option[value="good"]')?.textContent.trim(), 'Good');
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
@@ -63,7 +63,6 @@ assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option
 Your `option` with the `value` of `"good"` should have the text `"Good"`.
 
 ```js
-
 assert.strictEqual(document.querySelector('fieldset:nth-of-type(4) select#food option[value="good"]')?.textContent.trim(), 'Good');
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/67a51d3a8a6fe123b77b0c6e.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/67a51d3a8a6fe123b77b0c6e.md
@@ -21,15 +21,15 @@ Give the name and email inputs a `size` attribute with a value of `"20"`.
 You should give the name `input` a `size` attribute with a value of `"20"`.
 
 ```js
-const label1 = document.querySelector('label:nth-of-type(1) + input');
-assert.strictEqual(label1?.getAttribute('size'), '20');
+const nameInput = document.querySelector('label:nth-of-type(1) + input');
+assert.strictEqual(nameInput?.getAttribute('size'), '20');
 ```
 
 You should give the email `input` a `size` attribute with a value of `"20"`.
 
 ```js
-const label2 = document.querySelector('label:nth-of-type(2) + input');
-assert.strictEqual(label2?.getAttribute('size'), '20');
+const emailInput = document.querySelector('label:nth-of-type(2) + input');
+assert.strictEqual(emailInput?.getAttribute('size'), '20');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69059

## Summary

- use DOM assertions for Hotel Feedback Form opening-tag checks where the DOM already verifies element presence
- guard the Step 1 paragraph sibling check so it fails cleanly instead of throwing
- correct Step 10 and Step 11 attribute assertions
- rename Step 12 test variables to match the input elements they hold
- remove stray blank lines from Step 26 and Step 29 test blocks

## Testing

- `git diff --check`
- `git diff HEAD~1..HEAD --check`
- `CURRICULUM_LOCALE=english FCC_BLOCK=workshop-hotel-feedback-form pnpm test-curriculum-content`
