### PR TITLE
fix(curriculum): update hyphenation of Man-in-the-Middle in English dialogue files

### DIFF
--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675ecedbb04f6ca6dd620f0e.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675ecedbb04f6ca6dd620f0e.md
@@ -79,7 +79,7 @@ This word in the plural form means actions by hackers or criminals to harm a com
       "startTime": 1,
       "finishTime": 3.8,
       "dialogue": {
-        "text": "Hi, Brian. I've heard about these man in the middle attacks.",
+        "text": "Hi, Brian. I've heard about these Man-in-the-Middle attacks.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675ed59b1e938bb2443585a5.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675ed59b1e938bb2443585a5.md
@@ -89,7 +89,7 @@ Anna mentions `Man-in-the-Middle attacks` and asks about the time they `usually 
       "startTime": 1,
       "finishTime": 3.8,
       "dialogue": {
-        "text": "Hi, Brian. I've heard about these man in the middle attacks.",
+        "text": "Hi, Brian. I've heard about these Man-in-the-Middle attacks.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675fe6a1e81c4ba00f415364.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675fe6a1e81c4ba00f415364.md
@@ -86,7 +86,7 @@ This phrase of two words refers to rules or procedures designed to keep systems,
       "startTime": 3.2,
       "finishTime": 6.96,
       "dialogue": {
-        "text": "and the steps we're taking to prevent man in the middle attacks.",
+        "text": "and the steps we're taking to prevent Man-in-the-Middle attacks.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675feaafa5546fab32aa0736.md
+++ b/curriculum/challenges/english/blocks/learn-future-continuous-while-describing-actions/675feaafa5546fab32aa0736.md
@@ -98,7 +98,7 @@ Brian's statement clearly shows that security protocols and measures to prevent 
       "startTime": 3.2,
       "finishTime": 6.96,
       "dialogue": {
-        "text": "and the steps we're taking to prevent man in the middle attacks.",
+        "text": "and the steps we're taking to prevent Man-in-the-Middle attacks.",
         "align": "center"
       }
     },


### PR DESCRIPTION
## Description
This PR resolves issue #69080 by updating dialogue text from `man in the middle` to `Man-in-the-Middle` across the 4 specified English curriculum challenge files:
- `675ed59b1e938bb2443585a5.md`
- `675feaafa5546fab32aa0736.md`
- `675fe6a1e81c4ba00f415364.md`
- `675ecedbb04f6ca6dd620f0e.md`