### PR TITLE
fix(curriculum): fix CSS example indentation in Cafe Menu Step 7

### DIFF
--- a/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f344f9c805cd193c33d829c.md
+++ b/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f344f9c805cd193c33d829c.md
@@ -11,7 +11,7 @@ You can add style to an element by specifying it in the `style` element and sett
 
 ```css
 element {
- property: value;
+  property: value;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344f9c805cd193c33d829c.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344f9c805cd193c33d829c.md
@@ -11,7 +11,7 @@ In previous lessons, you learned how to add `CSS` properties and values like thi
 
 ```css
 element {
- property: value;
+  property: value;
 }
 ```
 


### PR DESCRIPTION
## Description
This PR resolves issue #69082 by fixing the CSS declaration indentation from one space to two spaces in Step 7 of the Cafe Menu workshop/course:
- `curriculum/challenges/english/blocks/workshop-cafe-menu/5f344f9c805cd193c33d829c.md`
- `curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f344f9c805cd193c33d829c.md`