### PR TITLE
fix(curriculum): audit workshop-todo-app editable regions (redux)

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
@@ -303,7 +303,6 @@ h1 {
 const taskForm = document.getElementById("task-form");
 const confirmCloseDialog = document.getElementById("confirm-close-dialog");
 const openTaskFormBtn = document.getElementById("open-task-form-btn");
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
@@ -306,7 +306,6 @@ const openTaskFormBtn = document.getElementById("open-task-form-btn");
 const closeTaskFormBtn = document.getElementById("close-task-form-btn");
 const addOrUpdateTaskBtn = document.getElementById("add-or-update-task-btn");
 const cancelBtn = document.getElementById("cancel-btn");
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
@@ -297,7 +297,6 @@ const cancelBtn = document.getElementById("cancel-btn");
 const discardBtn = document.getElementById("discard-btn");
 const tasksContainer = document.getElementById("tasks-container");
 const titleInput = document.getElementById("title-input");
-
 --fcc-editable-region--
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4eaaa9070a66aecbfe603.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4eaaa9070a66aecbfe603.md
@@ -306,5 +306,4 @@ closeTaskFormBtn.addEventListener("click", () => {
 --fcc-editable-region--
 
 --fcc-editable-region--
-
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4eec13546c06d61a63d59.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4eec13546c06d61a63d59.md
@@ -20,7 +20,7 @@ const firstNumLargerThanThree = numbers.findIndex((num) => num > 3);
 console.log(firstNumLargerThanThree); // prints index 2
 ```
 
-Use `const` to declare a variable called `dataArrIndex` and assign it the value of `taskData.findIndex()`. For the `findIndex()` method, pass in an arrow function with `item` as the parameter. 
+Use `const` to declare a variable called `dataArrIndex` and assign it the value of `taskData.findIndex()`. For the `findIndex()` method, pass in an arrow function with `item` as the parameter.
 
 Within the arrow function, check if the `id` property of `item` is strictly equal to the `id` property of `currentTask`.
 
@@ -325,7 +325,7 @@ taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec89ee549ecf802de2b3e2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec89ee549ecf802de2b3e2.md
@@ -316,7 +316,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec8f717b261e824d82d6a5.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec8f717b261e824d82d6a5.md
@@ -18,7 +18,7 @@ const arr = [1, 2, 3];
 arr.unshift(0);
 
 // [0, 1, 2, 3]
-console.log(arr); 
+console.log(arr);
 ```
 
 # --hints--
@@ -33,7 +33,6 @@ assert.equal(taskData.length, 1);
 assert.equal(taskData[0].title, "Test Task");
 taskData.length = 0; currentTask = {};
 ```
-
 
 # --seed--
 
@@ -317,7 +316,6 @@ discardBtn.addEventListener("click", () => {
   confirmCloseDialog.close();
   taskForm.classList.toggle("hidden");
 });
-
 
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9145e424d8835a4e0f28.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9145e424d8835a4e0f28.md
@@ -306,7 +306,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9282cd547785258cecf2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9282cd547785258cecf2.md
@@ -301,7 +301,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -313,13 +312,13 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
   --fcc-editable-region--
   taskData.forEach(({id, title, date, description}));
-
+  
   --fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9343769e8f85c1e17e05.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9343769e8f85c1e17e05.md
@@ -310,7 +310,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -322,15 +321,15 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
   taskData.forEach(({id, title, date, description}) => {
       tasksContainer.innerHTML += `
-      --fcc-editable-region--
-          
-      --fcc-editable-region--
+        --fcc-editable-region--
+        
+        --fcc-editable-region--
       `;
     }
   );

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec94f0de20c086e09b0fc3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec94f0de20c086e09b0fc3.md
@@ -315,7 +315,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -327,16 +326,16 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
   taskData.forEach(({id, title, date, description}) => {
       tasksContainer.innerHTML += `
         <div class="task" id="${id}">
-    --fcc-editable-region--
-        
-    --fcc-editable-region--
+          --fcc-editable-region--
+          
+          --fcc-editable-region--
         </div>
       `;
     }

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec959a76336c8767f5cd4d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec959a76336c8767f5cd4d.md
@@ -315,7 +315,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -327,7 +326,7 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec96761156a187ed32b274.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec96761156a187ed32b274.md
@@ -318,7 +318,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -330,7 +329,7 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9b10356c2d8aa05d9ce1.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9b10356c2d8aa05d9ce1.md
@@ -307,7 +307,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -319,7 +318,7 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
@@ -335,10 +334,9 @@ taskForm.addEventListener("submit", (e) => {
       `;
     }
   );
-  --fcc-editable-region--
 
+  --fcc-editable-region--
+  
   --fcc-editable-region--
 });
-
-
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9c55fdeef78bacd2fc3b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9c55fdeef78bacd2fc3b.md
@@ -314,7 +314,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -326,7 +325,7 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
@@ -340,7 +339,7 @@ taskForm.addEventListener("submit", (e) => {
           <button type="button" class="btn">Delete</button>
         </div>
       `;
-    } 
+    }
   );
 
   taskForm.classList.toggle("hidden");

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fac365aeb8ad70b69b366f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fac365aeb8ad70b69b366f.md
@@ -320,11 +320,11 @@ const descriptionInput = document.getElementById("description-input");
 const taskData = [];
 let currentTask = {};
 
---fcc-editable-region--
 const reset = () => {
+  --fcc-editable-region--
   
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 openTaskFormBtn.addEventListener("click", () =>
   taskForm.classList.toggle("hidden")
@@ -341,7 +341,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -353,13 +352,12 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fac4d1773e7a719b1254de.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fac4d1773e7a719b1254de.md
@@ -328,7 +328,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -340,13 +339,12 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -355,11 +353,11 @@ taskForm.addEventListener("submit", (e) => {
           <button type="button" class="btn">Delete</button>
         </div>
       `;
-    }   
+    }
   );
 
---fcc-editable-region--
+  --fcc-editable-region--
   taskForm.classList.toggle("hidden");
---fcc-editable-region--
+  --fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fac6a497811572b338e5e5.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fac6a497811572b338e5e5.md
@@ -327,13 +327,12 @@ closeTaskFormBtn.addEventListener("click", () => {
 
 cancelBtn.addEventListener("click", () => confirmCloseDialog.close());
 
---fcc-editable-region--
 discardBtn.addEventListener("click", () => {
   confirmCloseDialog.close();
+  --fcc-editable-region--
   taskForm.classList.toggle("hidden");
+  --fcc-editable-region--
 });
---fcc-editable-region--
-
 
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
@@ -346,13 +345,12 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faca774fd9fd74bc084cc9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faca774fd9fd74bc084cc9.md
@@ -340,12 +340,11 @@ openTaskFormBtn.addEventListener("click", () =>
   taskForm.classList.toggle("hidden")
 );
 
---fcc-editable-region--
 closeTaskFormBtn.addEventListener("click", () => {
+  --fcc-editable-region--
   confirmCloseDialog.showModal();
-  
+  --fcc-editable-region--
 });
---fcc-editable-region--
 
 cancelBtn.addEventListener("click", () => confirmCloseDialog.close());
 
@@ -365,13 +364,12 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
- taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -380,8 +378,8 @@ taskForm.addEventListener("submit", (e) => {
           <button type="button" class="btn">Delete</button>
         </div>
       `;
-    }
-  );
+  }
+);
 
   reset();
 });

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fad07f43a101779cb8692a.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fad07f43a101779cb8692a.md
@@ -301,7 +301,6 @@ let currentTask = {};
 
 --fcc-editable-region--
 
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";
@@ -343,13 +342,13 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
+--fcc-editable-region--
 
- taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -358,8 +357,8 @@ taskForm.addEventListener("submit", (e) => {
           <button type="button" class="btn">Delete</button>
         </div>
       `;
-    }
-  );
+  }
+);
 
   reset();
 });

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fad9cd2eeb1e7ca2ca8c8b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fad9cd2eeb1e7ca2ca8c8b.md
@@ -314,7 +314,6 @@ const addOrUpdateTask = () => {
 
 --fcc-editable-region--
 
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";
@@ -347,9 +346,8 @@ discardBtn.addEventListener("click", () => {
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -360,6 +358,7 @@ taskForm.addEventListener("submit", (e) => {
       `;
     }
   );
+--fcc-editable-region--
 
   reset();
 });

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fadae4f2d51b7d5d8b98d8.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fadae4f2d51b7d5d8b98d8.md
@@ -315,14 +315,13 @@ const addOrUpdateTask = () => {
   }
 
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
 };
 
 const updateTaskContainer = () => {
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -331,7 +330,7 @@ const updateTaskContainer = () => {
           <button type="button" class="btn">Delete</button>
         </div>
       `;
-    } 
+    }
   );
 };
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fadff23375f27ff06c6d40.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fadff23375f27ff06c6d40.md
@@ -313,15 +313,14 @@ const addOrUpdateTask = () => {
   if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
-  
+
   updateTaskContainer();
   reset();
 };
 
 const updateTaskContainer = () => {
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fae068bcdc9c805bd8399e.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fae068bcdc9c805bd8399e.md
@@ -325,17 +325,16 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
-          --fcc-editable-region--
+        --fcc-editable-region--
           <button type="button" class="btn">Edit</button>
-          <button type="button" class="btn">Delete</button> 
-          --fcc-editable-region--
+          <button type="button" class="btn">Delete</button>
+        --fcc-editable-region--
         </div>
       `;
     }

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -317,9 +317,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf0418e828c0114a558a7.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf0418e828c0114a558a7.md
@@ -306,24 +306,24 @@ const addOrUpdateTask = () => {
   if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
-  
+
   updateTaskContainer();
   reset();
 };
 
 const updateTaskContainer = () => {
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button type="button" class="btn">Edit</button>
-          <button type="button" class="btn">Delete</button> 
+          <button type="button" class="btn">Delete</button>
         </div>
       `;
     }

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
@@ -320,9 +320,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
- taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -331,15 +330,15 @@ const updateTaskContainer = () => {
           <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
-    }
-  );
+  }
+);
 };
 
---fcc-editable-region--
 const deleteTask = (buttonEl) => {
-
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf874364ec308f875f636.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf874364ec308f875f636.md
@@ -341,29 +341,29 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
 
---fcc-editable-region--
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
+
+  --fcc-editable-region--
   
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
@@ -317,9 +317,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -331,7 +330,6 @@ const updateTaskContainer = () => {
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
@@ -320,9 +320,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -335,7 +334,6 @@ const updateTaskContainer = () => {
   );
 };
 
-
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -345,11 +343,11 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 };
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
-
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1061ca838611ed6a7d6b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1061ca838611ed6a7d6b.md
@@ -312,21 +312,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -337,13 +335,15 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 };
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
-  const dataArrIndex = taskData.findIndex((item) => item.id === buttonEl.parentElement.id);
-  
+  const dataArrIndex = taskData.findIndex(
+    (item) => item.id === buttonEl.parentElement.id
+  );
 
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1321e189a6136d200f77.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1321e189a6136d200f77.md
@@ -327,21 +327,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -352,17 +350,17 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 };
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
   currentTask = taskData[dataArrIndex];
-  
 
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1436adef3e145b4c3501.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1436adef3e145b4c3501.md
@@ -314,21 +314,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -339,9 +337,8 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 };
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -350,9 +347,11 @@ const editTask = (buttonEl) => {
   titleInput.value = currentTask.title;
   dateInput.value = currentTask.date;
   descriptionInput.value = currentTask.description;
+
+  --fcc-editable-region--
   
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb14d890415c14f93069ce.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb14d890415c14f93069ce.md
@@ -314,9 +314,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -329,7 +328,6 @@ const updateTaskContainer = () => {
   );
 };
 
-
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -339,7 +337,6 @@ const deleteTask = (buttonEl) => {
   taskData.splice(dataArrIndex, 1);
 };
 
---fcc-editable-region--
 const editTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -353,15 +350,16 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-
+  --fcc-editable-region--
+  
+  --fcc-editable-region--
 };
---fcc-editable-region--
 
 const reset = () => {
   titleInput.value = "";
   dateInput.value = "";
   descriptionInput.value = "";
-  taskForm.classList.add("hidden");
+  taskForm.classList.toggle("hidden");
   currentTask = {};
 };
 
@@ -387,6 +385,7 @@ discardBtn.addEventListener("click", () => {
 
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
+
   addOrUpdateTask();
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb154a7c48cd159924bb18.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb154a7c48cd159924bb18.md
@@ -321,11 +321,10 @@ const addOrUpdateTask = () => {
     description: descriptionInput.value,
   };
 
-  --fcc-editable-region--
   if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
+  --fcc-editable-region--
   }
-
   --fcc-editable-region--
 
   updateTaskContainer();
@@ -335,9 +334,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -350,7 +348,6 @@ const updateTaskContainer = () => {
   );
 };
 
-
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -361,7 +358,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1c4dc0feb219149a7c7d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1c4dc0feb219149a7c7d.md
@@ -358,9 +358,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -373,7 +372,6 @@ const updateTaskContainer = () => {
   );
 };
 
-
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -384,7 +382,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -414,9 +412,10 @@ openTaskFormBtn.addEventListener("click", () =>
 closeTaskFormBtn.addEventListener("click", () => {
   const formInputsContainValues = titleInput.value || dateInput.value || descriptionInput.value;
   --fcc-editable-region--
-
+  
+  
   if (formInputsContainValues) {
-    --fcc-editable-region--
+  --fcc-editable-region--
     confirmCloseDialog.showModal();
   } else {
     reset();

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e2.md
@@ -321,21 +321,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -347,7 +345,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -359,7 +357,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e3.md
@@ -22,7 +22,6 @@ Click the "Check Your Code" button to proceed to the next step.
 This step has no tests. Click the "Check Your Code" button to continue.
 
 ```js
-
 ```
 
 # --seed--
@@ -315,21 +314,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -341,7 +338,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -353,7 +350,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {
@@ -404,4 +401,3 @@ localStorage.setItem("data", myTaskArr);
 
 --fcc-editable-region--
 ```
-

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fefebad99209211ec30537.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fefebad99209211ec30537.md
@@ -315,21 +315,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -341,7 +339,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -353,7 +351,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ff0313700dad264d19dfe4.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ff0313700dad264d19dfe4.md
@@ -315,21 +315,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -341,7 +339,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -353,7 +351,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ff04cc33779427a6412449.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ff04cc33779427a6412449.md
@@ -317,21 +317,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -343,7 +341,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -355,7 +353,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ff068e0426eb288874ed79.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ff068e0426eb288874ed79.md
@@ -309,21 +309,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -335,7 +333,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -347,7 +345,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ff24b80431f62ec6b93f65.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ff24b80431f62ec6b93f65.md
@@ -325,9 +325,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -340,7 +339,6 @@ const updateTaskContainer = () => {
   );
 };
 
-
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -351,7 +349,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/65003986d17d1e1865b269c0.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/65003986d17d1e1865b269c0.md
@@ -313,8 +313,9 @@ const addOrUpdateTask = () => {
   } else {
     taskData[dataArrIndex] = taskObj;
   }
-  --fcc-editable-region--
 
+  --fcc-editable-region--
+  
   --fcc-editable-region--
   updateTaskContainer();
   reset();
@@ -323,21 +324,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -349,7 +348,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -361,7 +360,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/650046832f92c01a35834bca.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/650046832f92c01a35834bca.md
@@ -320,21 +320,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -344,12 +342,12 @@ const deleteTask = (buttonEl) => {
   buttonEl.parentElement.remove();
   taskData.splice(dataArrIndex, 1);
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -361,7 +359,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/650048b0764f9c1b798200e2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/650048b0764f9c1b798200e2.md
@@ -313,9 +313,8 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
@@ -328,7 +327,6 @@ const updateTaskContainer = () => {
   );
 };
 
-
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
@@ -340,7 +338,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/65004ba581d03d1d5628b41c.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/65004ba581d03d1d5628b41c.md
@@ -323,21 +323,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -350,7 +348,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -362,7 +360,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {

--- a/curriculum/challenges/english/blocks/workshop-todo-app/650300a25b6f72964ab8aca6.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/650300a25b6f72964ab8aca6.md
@@ -308,14 +308,13 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {
     --fcc-editable-region--
-    id: `${titleInput.value.toLowerCase().split(' ').join('-')}`,  
+    id: `${titleInput.value.toLowerCase().split(' ').join('-')}`
     --fcc-editable-region--
   };
   console.log(taskObj);

--- a/curriculum/challenges/english/blocks/workshop-todo-app/65099dbd8f137d58e5c0ff16.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/65099dbd8f137d58e5c0ff16.md
@@ -315,7 +315,6 @@ discardBtn.addEventListener("click", () => {
   taskForm.classList.toggle("hidden");
 });
 
-
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
@@ -327,21 +326,21 @@ taskForm.addEventListener("submit", (e) => {
     description: descriptionInput.value,
   };
 
-   if (dataArrIndex === -1) {
+  if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
   }
 
   taskData.forEach(({id, title, date, description}) => {
-        tasksContainer.innerHTML += `
-          <div class="task" id="${id}">
-            <p><strong>Title:</strong> ${title}</p>
-            <p><strong>Date:</strong> ${date}</p>
-    --fcc-editable-region--
-            
-    --fcc-editable-region--
-          </div>
-        `;
-      }
-    );
+      tasksContainer.innerHTML += `
+        <div class="task" id="${id}">
+          <p><strong>Title:</strong> ${title}</p>
+          <p><strong>Date:</strong> ${date}</p>
+          --fcc-editable-region--
+          
+          --fcc-editable-region--
+        </div>
+      `;
+    }
+  );
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d86150a52ced178d567f3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d86150a52ced178d567f3.md
@@ -7,7 +7,7 @@ dashedName: step-12
 
 # --description--
 
-When a user creates a task, it should be saved in an object. 
+When a user creates a task, it should be saved in an object.
 
 Create a `const` variable called `taskObj` and assign it the value of an empty object.
 
@@ -322,9 +322,8 @@ taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
-
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d8ca387f989d6b25a3343.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d8ca387f989d6b25a3343.md
@@ -7,7 +7,7 @@ dashedName: step-13
 
 # --description--
 
-Inside your `taskObj`, add an `id` property name. For the value use the value of the `titleInput`. 
+Inside your `taskObj`, add an `id` property name. For the value use the value of the `titleInput`.
 
 To see the new result, click on the `"Add New Task"` button. Then add a title and click on the `"Add Task"` button. Open up the console to see the result.
 
@@ -312,12 +312,11 @@ taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
-
---fcc-editable-region--
   const taskObj = {
-
+    --fcc-editable-region--
+    
+    --fcc-editable-region--
   };
   console.log(taskObj);
---fcc-editable-region--
 });
 ```

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d8d7bb2424cd7cdf90ec1.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d8d7bb2424cd7cdf90ec1.md
@@ -7,7 +7,7 @@ dashedName: step-14
 
 # --description--
 
-The user should be able to input a title with upper and lowercase letters. But for the `id`, the value should be all lowercase. 
+The user should be able to input a title with upper and lowercase letters. But for the `id`, the value should be all lowercase.
 
 Update your `titleInput.value` to be all lowercase. You can use the `toLowerCase()` method to do this.
 
@@ -312,7 +312,6 @@ taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
-
   const taskObj = {
     --fcc-editable-region--
     id: titleInput.value

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d90b0ec1ef7da914c5e65.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d90b0ec1ef7da914c5e65.md
@@ -308,7 +308,6 @@ taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
-
   const taskObj = {
     --fcc-editable-region--
     id: titleInput.value.toLowerCase()

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d936a55565add0a27199b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d936a55565add0a27199b.md
@@ -306,7 +306,6 @@ taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
-
   const taskObj = {
     --fcc-editable-region--
     id: titleInput.value.toLowerCase().split(" ")

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d9535e86fd2deb351aeb9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d9535e86fd2deb351aeb9.md
@@ -7,7 +7,7 @@ dashedName: step-17
 
 # --description--
 
-There is one last thing you will need to do to make this `id` unique. 
+There is one last thing you will need to do to make this `id` unique.
 
 But first, place the entire value below inside an embedded expression `${}`.
 
@@ -314,11 +314,10 @@ taskForm.addEventListener("submit", (e) => {
   e.preventDefault();
 
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
-
   const taskObj = {
-  --fcc-editable-region--
+    --fcc-editable-region--
     id: titleInput.value.toLowerCase().split(" ").join("-")
-  --fcc-editable-region--
+    --fcc-editable-region--
   };
   console.log(taskObj);
 });

--- a/curriculum/challenges/english/blocks/workshop-todo-app/660d9cb6cc6415e6ca0509d8.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/660d9cb6cc6415e6ca0509d8.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-Now that you have finished testing your `taskObj`, you can remove the `console.log(taskObj)` statement. 
+Now that you have finished testing your `taskObj`, you can remove the `console.log(taskObj)` statement.
 
 # --hints--
 
@@ -299,7 +299,6 @@ discardBtn.addEventListener("click", () => {
   confirmCloseDialog.close();
   taskForm.classList.toggle("hidden");
 });
-
 
 taskForm.addEventListener("submit", (e) => {
   e.preventDefault();

--- a/curriculum/challenges/english/blocks/workshop-todo-app/6632420f81f3cc554a5e540b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/6632420f81f3cc554a5e540b.md
@@ -315,21 +315,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
       `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -342,7 +340,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -354,12 +352,12 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
   titleInput.value = "";
   dateInput.value = "";

--- a/curriculum/challenges/english/blocks/workshop-todo-app/66ad0f178ed5791ed898fe56.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/66ad0f178ed5791ed898fe56.md
@@ -296,8 +296,9 @@ let currentTask = {};
 
 const addOrUpdateTask = () => {
   --fcc-editable-region--
-
+  
   --fcc-editable-region--
+
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {
     id: `${titleInput.value.toLowerCase().split(" ").join("-")}-${Date.now()}`,
@@ -320,21 +321,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        (tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
-      `);
+      `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -347,7 +346,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -359,7 +358,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {
@@ -403,4 +402,3 @@ taskForm.addEventListener("submit", (e) => {
   addOrUpdateTask();
 });
 ```
-

--- a/curriculum/challenges/english/blocks/workshop-todo-app/671682cd6d7aa95f0078f35f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/671682cd6d7aa95f0078f35f.md
@@ -7,9 +7,9 @@ dashedName: step-65
 
 # --description--
 
-It is time to work on the final issue. If there is a to-do task with a special character like a quote inside of the name or description of the item, the application breaks. While it appears otherwise, the correct item will appear missing.  
+It is time to work on the final issue. If there is a to-do task with a special character like a quote inside of the name or description of the item, the application breaks. While it appears otherwise, the correct item will appear missing.
 
-In order to fix this, we need to create a function called `removeSpecialChars` that takes a string as input and removes all special characters. 
+In order to fix this, we need to create a function called `removeSpecialChars` that takes a string as input and removes all special characters.
 
 # --hints--
 
@@ -19,19 +19,19 @@ You should define a `removeSpecialChars` function.
 assert.isFunction(removeSpecialChars);
 ```
 
-Your `removeSpecialChars` should remove single quotes. 
+Your `removeSpecialChars` should remove single quotes.
 
 ```js
 assert.strictEqual(removeSpecialChars("quincy's dance party"),"quincys dance party");
 ```
 
-Your `removeSpecialChars` should remove double quotes. 
+Your `removeSpecialChars` should remove double quotes.
 
 ```js
 assert.strictEqual(removeSpecialChars(`"Literature" report due`),"Literature report due");
 ```
 
-Your `removeSpecialChars` should remove underscores. 
+Your `removeSpecialChars` should remove underscores.
 
 ```js
 assert.strictEqual(removeSpecialChars(`Naomi has a __gif__ folder`),"Naomi has a gif folder");
@@ -310,10 +310,11 @@ let currentTask = {};
 --fcc-editable-region--
 
 const addOrUpdateTask = () => {
-   if(!titleInput.value.trim()){
+  if (!titleInput.value.trim()) {
     alert("Please provide a title");
     return;
   }
+
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {
     id: `${titleInput.value.toLowerCase().split(" ").join("-")}-${Date.now()}`,
@@ -336,21 +337,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        (tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
-      `);
+      `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -363,7 +362,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -375,7 +374,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {
@@ -419,4 +418,3 @@ taskForm.addEventListener("submit", (e) => {
   addOrUpdateTask();
 });
 ```
-

--- a/curriculum/challenges/english/blocks/workshop-todo-app/67168a7243b6396cb69c1bdf.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/67168a7243b6396cb69c1bdf.md
@@ -7,15 +7,15 @@ dashedName: step-66
 
 # --description--
 
-Finally, it is time to call the `removeSpecialChars` on the `id` property in your `taskObj`. 
+Finally, it is time to call the `removeSpecialChars` function on the `id` property in your `taskObj`.
 
-This will help prevent issues caused by special characters in HTML element IDs. 
+This will help prevent issues caused by special characters in HTML element IDs.
 
-With that you have completed the project. 
+With that you have completed the project.
 
 # --hints--
 
-You should call `removeSpecialChars` on `titleInput.value` when assigning the `id`. 
+You should call `removeSpecialChars` on `titleInput.value` when assigning the `id`.
 
 ```js
 assert.match(code,  /\s*id:\s*`\$\{removeSpecialChars\(titleInput\.value\)\.toLowerCase\(\s*\)\.split\(\s*('|")\s{1}\1\s*\)\.join\(\s*('|")-\2\s*\)\}-\$\{Date\.now\(\s*\)\}`\s*/)
@@ -290,23 +290,24 @@ const taskData = JSON.parse(localStorage.getItem("data")) || [];
 let currentTask = {};
 
 const removeSpecialChars = (val) => {
-  return val.trim().replace(/[^A-Za-z0-9\-\s]/g, '');
+  return val.trim().replace(/[^A-Za-z0-9\-\s]/g, "");
 };
 
 const addOrUpdateTask = () => {
-   if(!titleInput.value.trim()){
+  if (!titleInput.value.trim()) {
     alert("Please provide a title");
     return;
   }
+
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
-  --fcc-editable-region--
   const taskObj = {
+    --fcc-editable-region--
     id: `${titleInput.value.toLowerCase().split(" ").join("-")}-${Date.now()}`,
+    --fcc-editable-region--
     title: titleInput.value,
     date: dateInput.value,
     description: descriptionInput.value,
   };
-  --fcc-editable-region--
 
   if (dataArrIndex === -1) {
     taskData.unshift(taskObj);
@@ -322,21 +323,19 @@ const addOrUpdateTask = () => {
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        (tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
-      `);
+      `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -349,7 +348,7 @@ const deleteTask = (buttonEl) => {
 };
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -361,7 +360,7 @@ const editTask = (buttonEl) => {
 
   addOrUpdateTaskBtn.innerText = "Update Task";
 
-  taskForm.classList.toggle("hidden");  
+  taskForm.classList.toggle("hidden");
 };
 
 const reset = () => {
@@ -405,8 +404,6 @@ taskForm.addEventListener("submit", (e) => {
   addOrUpdateTask();
 });
 ```
-
-
 
 # --solutions--
 
@@ -675,14 +672,15 @@ const taskData = JSON.parse(localStorage.getItem("data")) || [];
 let currentTask = {};
 
 const removeSpecialChars = (val) => {
-  return val.trim().replace(/[^A-Za-z0-9\-\s]/g, '')
-}
+  return val.trim().replace(/[^A-Za-z0-9\-\s]/g, "");
+};
 
 const addOrUpdateTask = () => {
-  if(!titleInput.value.trim()){
+  if (!titleInput.value.trim()) {
     alert("Please provide a title");
     return;
   }
+
   const dataArrIndex = taskData.findIndex((item) => item.id === currentTask.id);
   const taskObj = {
     id: `${removeSpecialChars(titleInput.value).toLowerCase().split(" ").join("-")}-${Date.now()}`,
@@ -698,28 +696,26 @@ const addOrUpdateTask = () => {
   }
 
   localStorage.setItem("data", JSON.stringify(taskData));
-  updateTaskContainer()
-  reset()
+  updateTaskContainer();
+  reset();
 };
 
 const updateTaskContainer = () => {
   tasksContainer.innerHTML = "";
 
-  taskData.forEach(
-    ({ id, title, date, description }) => {
-        (tasksContainer.innerHTML += `
+  taskData.forEach(({id, title, date, description}) => {
+      tasksContainer.innerHTML += `
         <div class="task" id="${id}">
           <p><strong>Title:</strong> ${title}</p>
           <p><strong>Date:</strong> ${date}</p>
           <p><strong>Description:</strong> ${description}</p>
           <button onclick="editTask(this)" type="button" class="btn">Edit</button>
-          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button> 
+          <button onclick="deleteTask(this)" type="button" class="btn">Delete</button>
         </div>
-      `)
+      `;
     }
   );
 };
-
 
 const deleteTask = (buttonEl) => {
   const dataArrIndex = taskData.findIndex(
@@ -729,10 +725,10 @@ const deleteTask = (buttonEl) => {
   buttonEl.parentElement.remove();
   taskData.splice(dataArrIndex, 1);
   localStorage.setItem("data", JSON.stringify(taskData));
-}
+};
 
 const editTask = (buttonEl) => {
-    const dataArrIndex = taskData.findIndex(
+  const dataArrIndex = taskData.findIndex(
     (item) => item.id === buttonEl.parentElement.id
   );
 
@@ -743,10 +739,10 @@ const editTask = (buttonEl) => {
   descriptionInput.value = currentTask.description;
 
   addOrUpdateTaskBtn.innerText = "Update Task";
-  
 
-  taskForm.classList.toggle("hidden");  
-}
+
+  taskForm.classList.toggle("hidden");
+};
 
 const reset = () => {
   addOrUpdateTaskBtn.innerText = "Add Task";
@@ -755,7 +751,7 @@ const reset = () => {
   descriptionInput.value = "";
   taskForm.classList.toggle("hidden");
   currentTask = {};
-}
+};
 
 if (taskData.length) {
   updateTaskContainer();
@@ -780,7 +776,7 @@ cancelBtn.addEventListener("click", () => confirmCloseDialog.close());
 
 discardBtn.addEventListener("click", () => {
   confirmCloseDialog.close();
-  reset()
+  reset();
 });
 
 taskForm.addEventListener("submit", (e) => {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

ref #67721

## Summary
- target: ```workshop-todo-app``` (in the JavaScript V9 curriculum)
- adjusts editable region markers throughout including proper indentation
- fixes content drift and discrepancies across seeds
- aims for a consistent seed format and style
- cleans up whitespace, semicolons, line breaks, quotes, and other layout styles
- corrects grammar in a couple of instructions

The last step in the series (67) containing the full seed and solution:
https://www.freecodecamp.org/learn/javascript-v9/workshop-todo-app/step-67