### PR TITLE
refactor(curriculum): replace regex with AST helpers in workshop-wildlife-tracker

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ac171928136168654774.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ac171928136168654774.md
@@ -58,7 +58,7 @@ assert.match(code, /console\s*\.\s*log\s*\(\s*getSpecies\s*\(\s*tiger\s*\)\s*\)/
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.getSpecies.hasReturn('animal.species'));
+assert.isTrue(explorer.allFunctions.getSpecies?.hasReturn('animal.species'));
 ```
 
 Calling `getSpecies(tiger)` should return `"Tiger"`.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ac171928136168654774.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ac171928136168654774.md
@@ -43,10 +43,9 @@ The `getSpecies` function should have a single parameter, `animal`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const fn = explorer.allFunctions.getSpecies;
-assert.exists(fn);
-assert.equal(fn.parameters.length, 1);
-assert.equal(fn.parameters[0].toString(), 'animal')
+const { getSpecies } = explorer.allFunctions;
+assert.equal(getSpecies?.parameters.length, 1);
+assert.equal(getSpecies?.parameters[0].toString(), 'animal');
 ```
 
 You should log `getSpecies(tiger)` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ac171928136168654774.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ac171928136168654774.md
@@ -42,8 +42,11 @@ assert.isFunction(getSpecies);
 The `getSpecies` function should have a single parameter, `animal`.
 
 ```js
-const regex = __helpers.functionRegex('getSpecies', ['animal']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const fn = explorer.allFunctions.getSpecies;
+assert.exists(fn);
+assert.equal(fn.parameters.length, 1);
+assert.equal(fn.parameters[0].toString(), 'animal')
 ```
 
 You should log `getSpecies(tiger)` to the console.
@@ -55,7 +58,8 @@ assert.match(code, /console\s*\.\s*log\s*\(\s*getSpecies\s*\(\s*tiger\s*\)\s*\)/
 `getSpecies` should access the species property using dot notation.
 
 ```js
-assert.match(code, /animal\.species/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(explorer.allFunctions.getSpecies.hasReturn('animal.species'));
 ```
 
 Calling `getSpecies(tiger)` should return `"Tiger"`.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ac171928136168654774.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ac171928136168654774.md
@@ -57,8 +57,7 @@ assert.match(code, /console\s*\.\s*log\s*\(\s*getSpecies\s*\(\s*tiger\s*\)\s*\)/
 `getSpecies` should access the species property using dot notation.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.getSpecies?.hasReturn('animal.species'));
+assert.match(code, /animal\.species/);
 ```
 
 Calling `getSpecies(tiger)` should return `"Tiger"`.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ad1cdc249e185aaeedbd.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ad1cdc249e185aaeedbd.md
@@ -49,8 +49,12 @@ assert.isFunction(addHabitat);
 The `addHabitat` function should have two parameters: `animal` and `habitat`.
 
 ```js
-const regex = __helpers.functionRegex('addHabitat', ['animal', 'habitat']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const fn = explorer.allFunctions.addHabitat;
+assert.exists(fn);
+assert.equal(fn.parameters.length, 2);
+assert.equal(fn.parameters[0].toString(), 'animal');
+assert.equal(fn.parameters[1].toString(), 'habitat');
 ```
 
 The `addHabitat` function should return the updated `animal` object.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ad1cdc249e185aaeedbd.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999ad1cdc249e185aaeedbd.md
@@ -50,11 +50,10 @@ The `addHabitat` function should have two parameters: `animal` and `habitat`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const fn = explorer.allFunctions.addHabitat;
-assert.exists(fn);
-assert.equal(fn.parameters.length, 2);
-assert.equal(fn.parameters[0].toString(), 'animal');
-assert.equal(fn.parameters[1].toString(), 'habitat');
+const { addHabitat } = explorer.allFunctions;
+assert.equal(addHabitat?.parameters.length, 2);
+assert.equal(addHabitat?.parameters[0].toString(), 'animal');
+assert.equal(addHabitat?.parameters[1].toString(), 'habitat');
 ```
 
 The `addHabitat` function should return the updated `animal` object.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999adc72c02812a28c01e31.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999adc72c02812a28c01e31.md
@@ -43,8 +43,12 @@ assert.isFunction(updateAge);
 The `updateAge` function should have two parameters: `animal` and `newAge`.
 
 ```js
-const regex = __helpers.functionRegex('updateAge', ['animal', 'newAge']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const fn = explorer.allFunctions.updateAge;
+assert.exists(fn);
+assert.equal(fn.parameters.length, 2);
+assert.equal(fn.parameters[0].toString(), 'animal');
+assert.equal(fn.parameters[1].toString(), 'newAge');
 ```
 
 The `updateAge` function should return the updated `animal` object.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999adc72c02812a28c01e31.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999adc72c02812a28c01e31.md
@@ -44,11 +44,10 @@ The `updateAge` function should have two parameters: `animal` and `newAge`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const fn = explorer.allFunctions.updateAge;
-assert.exists(fn);
-assert.equal(fn.parameters.length, 2);
-assert.equal(fn.parameters[0].toString(), 'animal');
-assert.equal(fn.parameters[1].toString(), 'newAge');
+const { updateAge } = explorer.allFunctions;
+assert.equal(updateAge?.parameters.length, 2);
+assert.equal(updateAge?.parameters[0].toString(), 'animal');
+assert.equal(updateAge?.parameters[1].toString(), 'newAge');
 ```
 
 The `updateAge` function should return the updated `animal` object.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0198d18d402c36cc5fe.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0198d18d402c36cc5fe.md
@@ -46,10 +46,9 @@ The `removeEndangeredStatus` function should have a single parameter, `animal`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const fn = explorer.allFunctions.removeEndangeredStatus;
-assert.exists(fn);
-assert.equal(fn.parameters.length, 1);
-assert.equal(fn.parameters[0].toString(), 'animal');
+const { removeEndangeredStatus } = explorer.allFunctions;
+assert.equal(removeEndangeredStatus?.parameters.length, 1);
+assert.equal(removeEndangeredStatus?.parameters[0].toString(), 'animal');
 ```
 
 The `removeEndangeredStatus` function should return the updated `animal` object.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0198d18d402c36cc5fe.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0198d18d402c36cc5fe.md
@@ -45,8 +45,11 @@ assert.isFunction(removeEndangeredStatus);
 The `removeEndangeredStatus` function should have a single parameter, `animal`.
 
 ```js
-const regex = __helpers.functionRegex('removeEndangeredStatus', ['animal']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const fn = explorer.allFunctions.removeEndangeredStatus;
+assert.exists(fn);
+assert.equal(fn.parameters.length, 1);
+assert.equal(fn.parameters[0].toString(), 'animal');
 ```
 
 The `removeEndangeredStatus` function should return the updated `animal` object.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b07c34c2cde21ee6e1d8.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b07c34c2cde21ee6e1d8.md
@@ -58,8 +58,7 @@ assert.equal(hasHabitat?.parameters[0].toString(), 'animal');
 `hasHabitat` should use the `hasOwnProperty` method to check for the `habitat` property.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.hasHabitat?.hasReturn('animal.hasOwnProperty("habitat")'));
+assert.match(code, /animal\.hasOwnProperty\s*\(\s*["']habitat["']\s*\)/);
 ```
 
 You should log `hasHabitat(tiger)` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b07c34c2cde21ee6e1d8.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b07c34c2cde21ee6e1d8.md
@@ -59,7 +59,7 @@ assert.equal(hasHabitat?.parameters[0].toString(), 'animal');
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.hasHabitat.hasReturn('animal.hasOwnProperty("habitat")'));
+assert.isTrue(explorer.allFunctions.hasHabitat?.hasReturn('animal.hasOwnProperty("habitat")'));
 ```
 
 You should log `hasHabitat(tiger)` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b07c34c2cde21ee6e1d8.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b07c34c2cde21ee6e1d8.md
@@ -50,10 +50,9 @@ The `hasHabitat` function should have a single parameter, `animal`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const fn = explorer.allFunctions.hasHabitat;
-assert.exists(fn);
-assert.equal(fn.parameters.length, 1);
-assert.equal(fn.parameters[0].toString(), 'animal');
+const { hasHabitat } = explorer.allFunctions;
+assert.equal(hasHabitat?.parameters.length, 1);
+assert.equal(hasHabitat?.parameters[0].toString(), 'animal');
 ```
 
 `hasHabitat` should use the `hasOwnProperty` method to check for the `habitat` property.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b07c34c2cde21ee6e1d8.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b07c34c2cde21ee6e1d8.md
@@ -49,14 +49,18 @@ assert.isFunction(hasHabitat);
 The `hasHabitat` function should have a single parameter, `animal`.
 
 ```js
-const regex = __helpers.functionRegex('hasHabitat', ['animal']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const fn = explorer.allFunctions.hasHabitat;
+assert.exists(fn);
+assert.equal(fn.parameters.length, 1);
+assert.equal(fn.parameters[0].toString(), 'animal');
 ```
 
 `hasHabitat` should use the `hasOwnProperty` method to check for the `habitat` property.
 
 ```js
-assert.match(code, /animal\.hasOwnProperty\s*\(\s*["']habitat["']\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(explorer.allFunctions.hasHabitat.hasReturn('animal.hasOwnProperty("habitat")'));
 ```
 
 You should log `hasHabitat(tiger)` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0d79ea938edcb032237.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0d79ea938edcb032237.md
@@ -55,8 +55,7 @@ assert.equal(getProperty?.parameters[1].toString(), 'propertyName');
 `getProperty` should use bracket notation to access the property.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.getProperty?.hasReturn('animal[propertyName]'));
+assert.match(code, /animal\s*\[\s*propertyName\s*\]/);
 ```
 
 You should log `getProperty(tiger, "species")` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0d79ea938edcb032237.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0d79ea938edcb032237.md
@@ -45,14 +45,19 @@ assert.isFunction(getProperty);
 The `getProperty` function should have two parameters: `animal` and `propertyName`.
 
 ```js
-const regex = __helpers.functionRegex('getProperty', ['animal', 'propertyName']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const fn = explorer.allFunctions.getProperty;
+assert.exists(fn);
+assert.equal(fn.parameters.length, 2);
+assert.equal(fn.parameters[0].toString(), 'animal');
+assert.equal(fn.parameters[1].toString(), 'propertyName');
 ```
 
 `getProperty` should use bracket notation to access the property.
 
 ```js
-assert.match(code, /animal\s*\[\s*propertyName\s*\]/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(explorer.allFunctions.getProperty.hasReturn('animal[propertyName]'))
 ```
 
 You should log `getProperty(tiger, "species")` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0d79ea938edcb032237.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0d79ea938edcb032237.md
@@ -46,11 +46,10 @@ The `getProperty` function should have two parameters: `animal` and `propertyNam
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const fn = explorer.allFunctions.getProperty;
-assert.exists(fn);
-assert.equal(fn.parameters.length, 2);
-assert.equal(fn.parameters[0].toString(), 'animal');
-assert.equal(fn.parameters[1].toString(), 'propertyName');
+const { getProperty } = explorer.allFunctions;
+assert.equal(getProperty?.parameters.length, 2);
+assert.equal(getProperty?.parameters[0].toString(), 'animal');
+assert.equal(getProperty?.parameters[1].toString(), 'propertyName');
 ```
 
 `getProperty` should use bracket notation to access the property.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0d79ea938edcb032237.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/6999b0d79ea938edcb032237.md
@@ -56,7 +56,7 @@ assert.equal(getProperty?.parameters[1].toString(), 'propertyName');
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.getProperty.hasReturn('animal[propertyName]'))
+assert.isTrue(explorer.allFunctions.getProperty?.hasReturn('animal[propertyName]'));
 ```
 
 You should log `getProperty(tiger, "species")` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
@@ -54,7 +54,7 @@ assert.equal(getAge?.parameters[0].toString(), 'animal');
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.getAge.hasReturn('animal.age'))
+assert.isTrue(explorer.allFunctions.getAge?.hasReturn('animal.age'));
 ```
 
 You should log `getAge(tiger)` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
@@ -44,14 +44,18 @@ assert.isFunction(getAge);
 The `getAge` function should have a single parameter, `animal`.
 
 ```js
-const regex = __helpers.functionRegex('getAge', ['animal']);
-assert.match(__helpers.removeJSComments(code), regex);
+const explorer = await __helpers.Explorer(code);
+const fn = explorer.allFunctions.getAge;
+assert.exists(fn);
+assert.equal(fn.parameters.length, 1);
+assert.equal(fn.parameters[0].toString(), 'animal');
 ```
 
 `getAge` should access the `age` property using dot notation.
 
 ```js
-assert.match(code, /animal\.age/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(explorer.allFunctions.getAge.hasReturn('animal.age'))
 ```
 
 You should log `getAge(tiger)` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
@@ -53,8 +53,7 @@ assert.equal(getAge?.parameters[0].toString(), 'animal');
 `getAge` should access the `age` property using dot notation.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.getAge?.hasReturn('animal.age'));
+assert.match(code, /animal\.age/);
 ```
 
 You should log `getAge(tiger)` to the console.

--- a/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
+++ b/curriculum/challenges/english/blocks/workshop-wildlife-tracker/699a00de9f564bb0effaa14d.md
@@ -45,10 +45,9 @@ The `getAge` function should have a single parameter, `animal`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const fn = explorer.allFunctions.getAge;
-assert.exists(fn);
-assert.equal(fn.parameters.length, 1);
-assert.equal(fn.parameters[0].toString(), 'animal');
+const { getAge } = explorer.allFunctions;
+assert.equal(getAge?.parameters.length, 1);
+assert.equal(getAge?.parameters[0].toString(), 'animal');
 ```
 
 `getAge` should access the `age` property using dot notation.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68725

Replaces regex-based tests with the `Explorer` helper class in the Wildlife Tracker Workshop.

Changes:
- Converted `functionRegex` + `getFunctionParams`-based checks to
  `explorer.allFunctions.<fn>.parameters` for function existence and
  parameter validation.
- Converted return-value regex checks (e.g. dot/bracket notation,
  `hasOwnProperty` calls) to `explorer.allFunctions.<fn>.hasReturn(...)`.

Tested locally using `pnpm run test-curriculum-content`, scoped per
challenge via `FCC_CHALLENGE_ID`, for every modified step - all tests
pass against the reference solutions.