### PR TITLE
fix(curriculum): clarify style tag hint in cafe menu step 10

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477aefa51bfc29327200b.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477aefa51bfc29327200b.md
@@ -27,7 +27,7 @@ Your selector should set the `text-align` property to `center`.
 assert.match(code.slice(code.indexOf('</html>')), /text-align:\s*center;?/);
 ```
 
-Your code should not contain the `<style>` tags.
+Your `styles.css` file should not contain the `<style>` tags.
 
 ```js
 assert.isFalse(/<\/html>(\n|.)*<\/?\s*style\s*>/.test(code));


### PR DESCRIPTION
Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69093

The third hint text for Step 10 in the Cafe Menu workshop incorrectly referenced the learner's code as a whole, when it was supposed to specify the styles.css file.

The step instructs the learner to move their styles from the <style> tags in index.html into styles.css, excluding the opening and closing <style> tags. The <style> tags are only removed from the HTML file in Step 11 but, at Step 10, the HTML file is still expected to contain them.

The hint said: "Your code should not contain the <style> tags." This implies the tags need to be removed from the entire editor, which is incorrect at this stage.

Changes made:
Updated the hint to reference the styles.css file specifically: "Your styles.css file should not contain the <style> tags."