### PR TITLE
fix(client): structure challenge console output

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -84,6 +84,7 @@
     "gatsby-plugin-remove-serviceworker": "1.0.0",
     "gatsby-source-filesystem": "5.16.0",
     "gatsby-transformer-remark": "6.16.0",
+    "htmlparser2": "10.1.0",
     "i18next": "25.10.10",
     "instantsearch.js": "4.95.0",
     "lodash": "4.18.1",

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -67,6 +67,7 @@ import { savedChallengesSelector } from '../../../redux/selectors';
 import { getGuideUrl } from '../utils';
 import { preloadPage } from '../../../../utils/gatsby/page-loading';
 import envData from '../../../../config/env.json';
+import type { ConsoleOutput } from '../utils/console-output';
 import { getChallengePaths } from '../utils/challenge-paths';
 import { challengeHasPreview, isJavaScriptChallenge } from '../utils/build';
 import { XtermTerminal } from './xterm';
@@ -80,7 +81,7 @@ import '../components/test-frame.css';
 
 const mapStateToProps = (state: unknown) => ({
   challengeFiles: challengeFilesSelector(state) as ChallengeFiles,
-  output: consoleOutputSelector(state) as string,
+  output: consoleOutputSelector(state),
   isChallengeCompleted: isChallengeCompletedSelector(state),
   savedChallenges: savedChallengesSelector(state) as SavedChallenge[]
 });
@@ -119,7 +120,7 @@ interface ShowClassicProps extends Pick<PreviewProps, 'previewMounted'> {
   initVisibleEditors: () => void;
   isChallengeCompleted: boolean;
   isDailyCodingChallenge?: boolean;
-  output: string;
+  output: ConsoleOutput[];
   pageContext: PageContext | DailyCodingChallengePageContext;
   updateChallengeMeta: (arg0: ChallengeMeta) => void;
   openModal: (modal: string) => void;

--- a/client/src/templates/Challenges/components/output.test.tsx
+++ b/client/src/templates/Challenges/components/output.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createFormattedOutput,
+  createTextOutput
+} from '../utils/console-output';
+import Output from './output';
+
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string) => key
+  }
+}));
+
+describe('<Output />', () => {
+  it('renders the default output when the console is empty', () => {
+    render(<Output defaultOutput='Default output' output={[]} />);
+
+    expect(screen.getByRole('region')).toHaveTextContent('Default output');
+  });
+
+  it('renders user output as text without interpreting HTML', () => {
+    render(
+      <Output
+        defaultOutput=''
+        output={[
+          createTextOutput('Dolce &amp; <code>Gabbana</code> <script />')
+        ]}
+      />
+    );
+
+    const output = screen.getByRole('region');
+    expect(output).toHaveTextContent(
+      'Dolce &amp; <code>Gabbana</code> <script />'
+    );
+    expect(
+      screen.queryByText('Gabbana', { selector: 'code' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders supported formatting in test feedback', () => {
+    render(
+      <Output
+        defaultOutput=''
+        output={[
+          createFormattedOutput(
+            '<p>Use <code>&lt;main&gt;</code> and <strong>try again</strong>.</p>'
+          )
+        ]}
+      />
+    );
+
+    const output = screen.getByRole('region');
+    expect(output).toHaveTextContent('Use <main> and try again.');
+    expect(screen.getByText('<main>', { selector: 'code' })).toBeVisible();
+    expect(screen.getByText('try again', { selector: 'strong' })).toBeVisible();
+  });
+
+  it('separates console entries with new lines', () => {
+    render(
+      <Output
+        defaultOutput=''
+        output={[createTextOutput('first'), createTextOutput('second')]}
+      />
+    );
+
+    expect(screen.getByRole('region').textContent).toBe('first\nsecond');
+  });
+});

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -1,29 +1,49 @@
-import { isEmpty } from 'lodash-es';
 import React from 'react';
-import sanitizeHtml from 'sanitize-html';
 import i18next from 'i18next';
 
+import type { ConsoleOutput, ConsoleOutputNode } from '../utils/console-output';
 import './output.css';
 
 interface OutputProps {
   defaultOutput: string;
-  output: string;
+  output: ConsoleOutput[];
 }
 
 function Output({ defaultOutput, output }: OutputProps): JSX.Element {
-  const message = sanitizeHtml(!isEmpty(output) ? output : defaultOutput, {
-    allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
-  });
+  const messages = output.length
+    ? output
+    : [{ type: 'text' as const, value: defaultOutput }];
+
   return (
     <pre
       className='output-text'
       data-playwright-test-label='output-text'
-      dangerouslySetInnerHTML={{ __html: message }}
       role='region'
       aria-label={i18next.t('learn.editor-tabs.console')}
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
-    />
+    >
+      {messages.map((message, index) => (
+        <React.Fragment key={index}>
+          {index > 0 ? '\n' : null}
+          {message.type === 'text'
+            ? message.value
+            : message.nodes.map(renderNode)}
+        </React.Fragment>
+      ))}
+    </pre>
+  );
+}
+
+function renderNode(node: ConsoleOutputNode, index: number): React.ReactNode {
+  if (node.type === 'text') {
+    return node.value;
+  }
+
+  return React.createElement(
+    node.tag,
+    { key: index },
+    node.children.map(renderNode)
   );
 }
 

--- a/client/src/templates/Challenges/projects/backend/show.tsx
+++ b/client/src/templates/Challenges/projects/backend/show.tsx
@@ -37,6 +37,7 @@ import {
 
 import { getGuideUrl } from '../../utils';
 import { getChallengePaths } from '../../utils/challenge-paths';
+import type { ConsoleOutput } from '../../utils/console-output';
 import SolutionForm from '../solution-form';
 import ProjectToolPanel from '../tool-panel';
 
@@ -49,7 +50,7 @@ const mapStateToProps = createSelector(
   isChallengeCompletedSelector,
   isSignedInSelector,
   (
-    output: string,
+    output: ConsoleOutput[],
     tests: Test[],
     isChallengeCompleted: boolean,
     isSignedIn: boolean
@@ -82,7 +83,7 @@ interface BackEndProps {
   initTests: (tests: Test[]) => void;
   isChallengeCompleted: boolean;
   isSignedIn: boolean;
-  output: string;
+  output: ConsoleOutput[];
   pageContext: {
     challengeMeta: ChallengeMeta;
   };

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -14,6 +14,7 @@ export const actionTypes = createTypes(
     'initLogs',
     'initVisibleEditors',
     'updateConsole',
+    'updateConsoleMarkup',
     'updateChallengeMeta',
     'updateFile',
     'updateSolutionFormValues',

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -17,6 +17,9 @@ export const updateChallengeMeta = createAction(
 );
 export const updateFile = createAction(actionTypes.updateFile);
 export const updateConsole = createAction(actionTypes.updateConsole);
+export const updateConsoleMarkup = createAction(
+  actionTypes.updateConsoleMarkup
+);
 export const updateLogs = createAction(actionTypes.updateLogs);
 export const updateSolutionFormValues = createAction(
   actionTypes.updateSolutionFormValues

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import { escape, isEmpty } from 'lodash-es';
+import { isEmpty } from 'lodash-es';
 import { channel } from 'redux-saga';
 import {
   call,
@@ -52,6 +52,7 @@ import {
   openModal,
   setProjectPreviewLoading,
   updateConsole,
+  updateConsoleMarkup,
   updateLogs,
   updateTests
 } from './actions';
@@ -172,10 +173,8 @@ export function* executeChallengeSaga({ payload }) {
 }
 
 function* takeEveryConsole(channel) {
-  // TODO: move all stringifying and escaping into the reducer so there is a
-  // single place responsible for formatting the console output.
   yield takeEvery(channel, function* (args) {
-    yield put(updateConsole(escape(args)));
+    yield put(updateConsole(args));
   });
 }
 
@@ -239,7 +238,7 @@ export function* executeTests(testRunner, tests, testTimeout = 5000) {
       }
 
       const withIndex = newTest.message.replace(/<p>/, `<p>${i + 1}. `);
-      yield put(updateConsole(withIndex));
+      yield put(updateConsoleMarkup(withIndex));
     } finally {
       testResults.push(newTest);
     }
@@ -332,7 +331,7 @@ function* previewChallengeSaga() {
     // If the preview fails, the most useful thing to do is to show the learner
     // what the error is. As such, we replace whatever is in the console with
     // the error message.
-    yield put(initConsole(escape(err)));
+    yield put(initConsole(err));
   }
 }
 

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.test.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.test.js
@@ -66,7 +66,7 @@ describe('executeTests generator', () => {
 
     return expectSaga(executeTests, mockTestRunner, tests)
       .put({
-        type: 'challenge.updateConsole',
+        type: 'challenge.updateConsoleMarkup',
         payload: '<p>1. learn.indentation-error</p>'
       })
       .returns([

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -3,6 +3,10 @@ import { handleActions } from 'redux-actions';
 
 import { getLines } from '@freecodecamp/shared/utils/get-lines';
 import { getTargetEditor } from '../utils/get-target-editor';
+import {
+  createFormattedOutput,
+  createTextOutput
+} from '../utils/console-output';
 import { actionTypes, ns } from './action-types';
 import codeStorageEpic from './code-storage-epic';
 import completionEpic from './completion-epic';
@@ -144,11 +148,18 @@ export const reducer = handleActions(
     }),
     [actionTypes.initConsole]: (state, { payload }) => ({
       ...state,
-      consoleOut: payload ? [payload] : []
+      consoleOut: payload ? [createTextOutput(payload)] : []
     }),
     [actionTypes.updateConsole]: (state, { payload }) => ({
       ...state,
-      consoleOut: state.consoleOut.concat(payload)
+      consoleOut:
+        payload == null || payload === ''
+          ? state.consoleOut
+          : state.consoleOut.concat(createTextOutput(payload))
+    }),
+    [actionTypes.updateConsoleMarkup]: (state, { payload }) => ({
+      ...state,
+      consoleOut: state.consoleOut.concat(createFormattedOutput(payload))
     }),
     [actionTypes.initLogs]: state => ({
       ...state,
@@ -162,7 +173,10 @@ export const reducer = handleActions(
       ...state,
       consoleOut: isEmpty(state.logsOut)
         ? state.consoleOut
-        : state.consoleOut.concat(payload, state.logsOut)
+        : state.consoleOut.concat(
+            createTextOutput(payload),
+            createTextOutput(state.logsOut.join('\n'))
+          )
     }),
     [actionTypes.initVisibleEditors]: state => {
       let persistingVisibleEditors = {};

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -13,6 +13,7 @@ import {
   getCompletedPercentage,
   getCurrentBlockIds
 } from '../../../utils/get-completion-percentage';
+import { truncateConsoleOutput } from '../utils/console-output';
 import { ns } from './action-types';
 
 export const challengeFilesSelector = state => state[ns].challengeFiles;
@@ -22,10 +23,11 @@ export const challengeHooksSelector = state => state[ns].challengeHooks;
 export const challengeTestsSelector = state => state[ns].challengeTests;
 export const consoleOutputSelector = state => {
   const TRUNCATE_AT = 500000;
-  const out = state[ns].consoleOut?.join('\n');
-  return out?.length > TRUNCATE_AT
-    ? `${out.substring(0, TRUNCATE_AT)} Logs truncated. See browser console for more`
-    : out;
+  return truncateConsoleOutput(
+    state[ns].consoleOut ?? [],
+    TRUNCATE_AT,
+    'Logs truncated. See browser console for more'
+  );
 };
 export const isChallengeCompletedSelector = createSelector(
   [

--- a/client/src/templates/Challenges/utils/console-output.test.ts
+++ b/client/src/templates/Challenges/utils/console-output.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createFormattedOutput,
+  createTextOutput,
+  getConsoleOutputText,
+  truncateConsoleOutput
+} from './console-output';
+
+describe('console output helpers', () => {
+  it('converts allowed markup into structured output', () => {
+    expect(
+      createFormattedOutput(
+        '<p>Use <code>&lt;main&gt;</code> and <em>retry</em>.</p>'
+      )
+    ).toEqual({
+      type: 'formatted',
+      nodes: [
+        { type: 'text', value: 'Use ' },
+        {
+          type: 'element',
+          tag: 'code',
+          children: [{ type: 'text', value: '<main>' }]
+        },
+        { type: 'text', value: ' and ' },
+        {
+          type: 'element',
+          tag: 'em',
+          children: [{ type: 'text', value: 'retry' }]
+        },
+        { type: 'text', value: '.' }
+      ]
+    });
+  });
+
+  it('drops unsupported elements', () => {
+    expect(
+      getConsoleOutputText(
+        createFormattedOutput(
+          '<span>visible</span><script>not visible</script>'
+        )
+      )
+    ).toBe('visible');
+  });
+
+  it('truncates text without flattening entries that fit', () => {
+    const formatted = createFormattedOutput('<code>first</code>');
+
+    expect(
+      truncateConsoleOutput(
+        [formatted, createTextOutput('second')],
+        9,
+        ' truncated'
+      )
+    ).toEqual([formatted, { type: 'text', value: 'sec truncated' }]);
+  });
+});

--- a/client/src/templates/Challenges/utils/console-output.ts
+++ b/client/src/templates/Challenges/utils/console-output.ts
@@ -1,0 +1,136 @@
+import { ElementType, parseDocument } from 'htmlparser2';
+
+const allowedTags = ['b', 'code', 'em', 'i', 'strong', 'wbr'] as const;
+
+export type ConsoleOutputTag = (typeof allowedTags)[number];
+
+export type ConsoleOutputNode =
+  | {
+      type: 'text';
+      value: string;
+    }
+  | {
+      type: 'element';
+      tag: ConsoleOutputTag;
+      children: ConsoleOutputNode[];
+    };
+
+export type ConsoleOutput =
+  | {
+      type: 'text';
+      value: string;
+    }
+  | {
+      type: 'formatted';
+      nodes: ConsoleOutputNode[];
+    };
+
+const allowedTagSet = new Set<string>(allowedTags);
+
+export function createTextOutput(value: unknown): ConsoleOutput {
+  return { type: 'text', value: stringifyConsoleValue(value) };
+}
+
+export function createFormattedOutput(value: unknown): ConsoleOutput {
+  const document = parseDocument(String(value), { decodeEntities: true });
+
+  return {
+    type: 'formatted',
+    nodes: toConsoleOutputNodes(document.children)
+  };
+}
+
+export function getConsoleOutputText(output: ConsoleOutput): string {
+  return output.type === 'text' ? output.value : getNodeText(output.nodes);
+}
+
+export function truncateConsoleOutput(
+  output: ConsoleOutput[],
+  maxLength: number,
+  suffix: string
+): ConsoleOutput[] {
+  let remaining = maxLength;
+  const truncated: ConsoleOutput[] = [];
+
+  for (const entry of output) {
+    const separatorLength = truncated.length ? 1 : 0;
+    const text = getConsoleOutputText(entry);
+
+    if (separatorLength + text.length <= remaining) {
+      truncated.push(entry);
+      remaining -= separatorLength + text.length;
+      continue;
+    }
+
+    const available = Math.max(remaining - separatorLength, 0);
+    if (available) {
+      truncated.push(createTextOutput(text.slice(0, available) + suffix));
+    } else {
+      const lastEntry = truncated.at(-1);
+      if (lastEntry?.type === 'text') {
+        lastEntry.value += suffix;
+      } else {
+        truncated.push(createTextOutput(suffix));
+      }
+    }
+    return truncated;
+  }
+
+  return truncated;
+}
+
+function toConsoleOutputNodes(
+  nodes: ReturnType<typeof parseDocument>['children']
+): ConsoleOutputNode[] {
+  return nodes.flatMap(node => {
+    if (node.type === ElementType.Text) {
+      return [{ type: 'text' as const, value: node.data }];
+    }
+
+    if (node.type !== ElementType.Tag) {
+      return [];
+    }
+
+    const children = toConsoleOutputNodes(node.children);
+
+    if (!allowedTagSet.has(node.name)) {
+      return children;
+    }
+
+    return [
+      {
+        type: 'element' as const,
+        tag: node.name as ConsoleOutputTag,
+        children
+      }
+    ];
+  });
+}
+
+function getNodeText(nodes: ConsoleOutputNode[]): string {
+  return nodes
+    .map(node =>
+      node.type === 'text' ? node.value : getNodeText(node.children)
+    )
+    .join('');
+}
+
+function stringifyConsoleValue(value: unknown): string {
+  if (value == null) return '';
+  if (value instanceof Error) return value.toString();
+  if (Array.isArray(value)) return value.map(stringifyConsoleValue).join(',');
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return Object.prototype.toString.call(value);
+    }
+  }
+  if (typeof value === 'symbol') return value.toString();
+  if (typeof value === 'function') return value.toString();
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return value.toString();
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return '';
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       gatsby-transformer-remark:
         specifier: 6.16.0
         version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4(jiti@2.6.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.9.3))
+      htmlparser2:
+        specifier: 10.1.0
+        version: 10.1.0
       i18next:
         specifier: 25.10.10
         version: 25.10.10(typescript@5.9.3)


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63788

This separates plain console logs from formatted curriculum feedback. User output is rendered as React text, so HTML entities and tags stay literal. Test feedback is parsed into a serializable node structure and rendered with the existing supported inline formatting, removing `dangerouslySetInnerHTML` from the console.

Validation:
- 11 focused unit tests pass
- TypeScript check passes
- ESLint passes for all changed source files
- Prettier and `git diff --check` pass