### PR TITLE
fix(curriculum): replace regex-based test cases in envelope budget app workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0eb.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0eb.md
@@ -22,12 +22,7 @@ assert.isDefined(budgetForm);
 You should have `document.getElementById('budget-form')` in your code.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(
-  explorer.variables.budgetForm?.value.matches(
-    "document.getElementById('budget-form')"
-  )
-);
+assert.match(code, /document\.getElementById\(\s*('|")budget-form\1\s*\)/g);
 ```
 
 You should assign `document.getElementById('budget-form')` to your `budgetForm` variable.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0eb.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0eb.md
@@ -22,7 +22,12 @@ assert.isDefined(budgetForm);
 You should have `document.getElementById('budget-form')` in your code.
 
 ```js
-assert.match(code, /document\.getElementById\(\s*('|")budget-form\1\s*\)/g);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.variables.budgetForm?.value.matches(
+    "document.getElementById('budget-form')"
+  )
+);
 ```
 
 You should assign `document.getElementById('budget-form')` to your `budgetForm` variable.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ec.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ec.md
@@ -20,7 +20,12 @@ assert.isDefined(incomeInput);
 You should use `document.getElementById()` to get the `#income` element.
 
 ```js
-assert.match(code, /document\.getElementById\(\s*('|")income\1\s*\)/g);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.variables.incomeInput?.value.matches(
+    "document.getElementById('income')"
+  )
+);
 ```
 
 You should assign the `#income` element to `incomeInput`.
@@ -38,7 +43,12 @@ assert.isDefined(rentInput);
 You should use `document.getElementById()` to get the `#rent-amount` element.
 
 ```js
-assert.match(code, /document\.getElementById\(\s*('|")rent-amount\1\s*\)/g);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.variables.rentInput?.value.matches(
+    "document.getElementById('rent-amount')"
+  )
+);
 ```
 
 You should assign the `#rent-amount` element to `rentInput`.
@@ -56,7 +66,12 @@ assert.isDefined(entryDropdown);
 You should use `document.getElementById()` to get the `#entry-dropdown` element.
 
 ```js
-assert.match(code, /document\.getElementById\(\s*('|")entry-dropdown\1\s*\)/g);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.variables.entryDropdown?.value.matches(
+    "document.getElementById('entry-dropdown')"
+  )
+);
 ```
 
 You should assign the `#entry-dropdown` element to `entryDropdown`.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ec.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ec.md
@@ -20,12 +20,7 @@ assert.isDefined(incomeInput);
 You should use `document.getElementById()` to get the `#income` element.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(
-  explorer.variables.incomeInput?.value.matches(
-    "document.getElementById('income')"
-  )
-);
+assert.match(code, /document\.getElementById\(\s*('|")income\1\s*\)/g);
 ```
 
 You should assign the `#income` element to `incomeInput`.
@@ -43,12 +38,7 @@ assert.isDefined(rentInput);
 You should use `document.getElementById()` to get the `#rent-amount` element.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(
-  explorer.variables.rentInput?.value.matches(
-    "document.getElementById('rent-amount')"
-  )
-);
+assert.match(code, /document\.getElementById\(\s*('|")rent-amount\1\s*\)/g);
 ```
 
 You should assign the `#rent-amount` element to `rentInput`.
@@ -66,12 +56,7 @@ assert.isDefined(entryDropdown);
 You should use `document.getElementById()` to get the `#entry-dropdown` element.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(
-  explorer.variables.entryDropdown?.value.matches(
-    "document.getElementById('entry-dropdown')"
-  )
-);
+assert.match(code, /document\.getElementById\(\s*('|")entry-dropdown\1\s*\)/g);
 ```
 
 You should assign the `#entry-dropdown` element to `entryDropdown`.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ed.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ed.md
@@ -20,7 +20,12 @@ assert.isDefined(addEntryButton);
 You should use `document.getElementById()` to get the `#add-entry` element.
 
 ```js
-assert.match(code, /document\.getElementById\(\s*('|")add-entry\1\s*\)/g);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.variables.addEntryButton?.value.matches(
+    "document.getElementById('add-entry')"
+  )
+);
 ```
 
 You should assign the `#add-entry` element to `addEntryButton`.
@@ -38,7 +43,12 @@ assert.isDefined(clearButton);
 You should use `document.getElementById()` to get the `#clear` element.
 
 ```js
-assert.match(code, /document\.getElementById\(\s*('|")clear\1\s*\)/g);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.variables.clearButton?.value.matches(
+    "document.getElementById('clear')"
+  )
+);
 ```
 
 You should assign the `#clear` element to `clearButton`.
@@ -50,19 +60,30 @@ assert.deepEqual(clearButton, document.getElementById('clear'));
 You should declare a variable called `output`.
 
 ```js
-assert.match(code, /const\s+output/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.variables.output);
 ```
 
 You should use `document.getElementById()` to get the `#output` element.
 
 ```js
-assert.match(code, /document\.getElementById\(\s*('|")output\1\s*\)/g);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.variables.output?.value.matches(
+    "document.getElementById('output')"
+  )
+);
 ```
 
 You should assign the `#output` element to `output`.
 
 ```js
-assert.match(code, /const\s+output\s*=\s*document.getElementById\(('|")output\1\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.variables.output?.matches(
+    "const output = document.getElementById('output')"
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ed.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ed.md
@@ -20,12 +20,7 @@ assert.isDefined(addEntryButton);
 You should use `document.getElementById()` to get the `#add-entry` element.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(
-  explorer.variables.addEntryButton?.value.matches(
-    "document.getElementById('add-entry')"
-  )
-);
+assert.match(code, /document\.getElementById\(\s*('|")add-entry\1\s*\)/g);
 ```
 
 You should assign the `#add-entry` element to `addEntryButton`.
@@ -43,12 +38,7 @@ assert.isDefined(clearButton);
 You should use `document.getElementById()` to get the `#clear` element.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(
-  explorer.variables.clearButton?.value.matches(
-    "document.getElementById('clear')"
-  )
-);
+assert.match(code, /document\.getElementById\(\s*('|")clear\1\s*\)/g);
 ```
 
 You should assign the `#clear` element to `clearButton`.
@@ -67,12 +57,7 @@ assert.exists(explorer.variables.output);
 You should use `document.getElementById()` to get the `#output` element.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(
-  explorer.variables.output?.value.matches(
-    "document.getElementById('output')"
-  )
-);
+assert.match(code, /document\.getElementById\(\s*('|")output\1\s*\)/g);
 ```
 
 You should assign the `#output` element to `output`.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ee.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ee.md
@@ -37,7 +37,8 @@ assert.isFalse(isError);
 You should use `let` to declare your `isError` variable.
 
 ```js
-assert.match(code, /let\s+isError\s*=\s*false/g);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(explorer.variables.isError?.matches('let isError = false'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ef.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ef.md
@@ -24,7 +24,10 @@ assert.isFunction(cleanInputString);
 Your `cleanInputString` function should take a `str` parameter.
 
 ```js
-assert.match(cleanInputString?.toString(), /\(\s*str\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.cleanInputString?.parameters;
+assert.lengthOf(parameters, 1);
+assert.equal(parameters[0].toString(), 'str');
 ```
 
 `cleanInputString` should be an empty function.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f0.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f0.md
@@ -22,13 +22,17 @@ Declare a `regex` variable and assign it the value from the example above. In fu
 You should declare a `regex` variable.
 
 ```js
-assert.match(cleanInputString.toString(), /regex\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.cleanInputString?.variables.regex);
 ```
 
 Your `regex` variable should be set to the regular expression `/hello/`.
 
 ```js
-assert.match(cleanInputString.toString(), /regex\s*=\s*\/hello\//);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.cleanInputString?.variables.regex?.value.matches('/hello/')
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f1.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f1.md
@@ -16,7 +16,10 @@ Note that you need to use the backslash `\` character to <dfn>escape</dfn> the `
 Your `regex` variable should be set to the regular expression `/\+-/`.
 
 ```js
-assert.match(cleanInputString.toString(), /regex\s*=\s*\/\\\+-\//);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.cleanInputString?.variables.regex?.value.matches('/\\+-/')
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f2.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f2.md
@@ -16,7 +16,12 @@ Shorthand character classes are preceded with a backslash (`\`). The character c
 Your `regex` variable should be set to the regular expression `/\+-\s/`.
 
 ```js
-assert.match(cleanInputString.toString(), /regex\s*=\s*\/\\\+-\\s\//)
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.cleanInputString?.variables.regex?.value.matches(
+    '/\\+-\\s/'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f3.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f3.md
@@ -28,7 +28,12 @@ assert.match(cleanInputString.toString(), /regex\s*=\s*\/\[\\?\+-\\s\]\//)
 You should not escape the `+` character in your regular expression.
 
 ```js
-assert.match(cleanInputString.toString(), /regex\s*=\s*\/\[\+-\\s\]\//);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.cleanInputString?.variables.regex?.value.matches(
+    '/[+-\\s]/'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f4.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f4.md
@@ -20,7 +20,12 @@ Add the `g` flag to your regex pattern.
 You should add the `g` flag to your `regex` value.
 
 ```js
-assert.match(cleanInputString.toString(), /regex\s*=\s*\/\[\+-\\s\]\/g/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.cleanInputString?.variables.regex?.value.matches(
+    '/[+-\\s]/g'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f5.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f5.md
@@ -42,7 +42,10 @@ assert.match(cleanInputString.toString(), /str\.replace\(\s*regex\s*,\s*("|')\1\
 Your `cleanInputString` function should directly return the result of your `replace` method.
 
 ```js
-assert.match(cleanInputString.toString(), /return\s+str\.replace\(\s*regex\s*,\s*("|')\1\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.allFunctions.cleanInputString?.hasReturn("str.replace(regex, '')")
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f9.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0f9.md
@@ -22,7 +22,10 @@ assert.isFunction(isInvalidInput)
 `isInvalidInput` should take a single `str` parameter.
 
 ```js
-assert.match(isInvalidInput?.toString(), /\(\s*str\s*\)/)
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.isInvalidInput?.parameters;
+assert.lengthOf(parameters, 1);
+assert.equal(parameters[0].toString(), 'str');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fa.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fa.md
@@ -14,13 +14,17 @@ Declare a `regex` variable, and assign it a regex that matches the character `e`
 Your `isInvalidInput` function should have a `regex` variable.
 
 ```js
-assert.match(isInvalidInput.toString(), /regex\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.isInvalidInput?.variables.regex);
 ```
 
 Your `regex` variable should be set to `/e/`.
 
 ```js
-assert.match(isInvalidInput.toString(), /regex\s*=\s*\/e\//);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.isInvalidInput?.variables.regex?.value.matches('/e/')
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fb.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fb.md
@@ -22,7 +22,10 @@ Add the `i` flag to your regex pattern.
 Your `regex` value should have the `i` flag.
 
 ```js
-assert.match(isInvalidInput.toString(), /regex\s*=\s*\/e\/i/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.isInvalidInput?.variables.regex?.value.matches('/e/i')
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fc.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fc.md
@@ -22,7 +22,12 @@ assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\[0-9\]e/);
 You should add the `[0-9]` character class after `e` in your regular expression.
 
 ```js
-assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\[0-9\]e\[0-9\]\//);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.isInvalidInput?.variables.regex?.value.matches(
+    '/[0-9]e[0-9]/i'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fc.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fc.md
@@ -19,7 +19,7 @@ You should add the `[0-9]` character class before `e` in your regular expression
 assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\[0-9\]e/);
 ```
 
-You should add the `[0-9]` character class after `e` in your regular expression.
+You should add the `[0-9]` character class after `e`, so your `regex` value is `/[0-9]e[0-9]/i`.
 
 ```js
 const explorer = await __helpers.Explorer(code);

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fd.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fd.md
@@ -17,7 +17,7 @@ You should add the `+` modifier to the character class before `e` in your regula
 assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\[0-9\]\+e/);
 ```
 
-You should add the `+` modifier to the character class after `e` in your regular expression.
+You should add the `+` modifier to the character class after `e`, so your `regex` value is `/[0-9]+e[0-9]+/i`.
 
 ```js
 const explorer = await __helpers.Explorer(code);

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fd.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fd.md
@@ -20,7 +20,12 @@ assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\[0-9\]\+e/);
 You should add the `+` modifier to the character class after `e` in your regular expression.
 
 ```js
-assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\[0-9\]\+e\[0-9\]\+\//);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.isInvalidInput?.variables.regex?.value.matches(
+    '/[0-9]+e[0-9]+/i'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fe.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fe.md
@@ -20,7 +20,12 @@ assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\\d\+e/);
 You should replace the `[0-9]` character class after `e` with `\d` in your regular expression.
 
 ```js
-assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\\d\+e\\d\+\//);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.isInvalidInput?.variables.regex?.value.matches(
+    '/\\d+e\\d+/i'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fe.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0fe.md
@@ -17,7 +17,7 @@ You should replace the `[0-9]` character class before `e` with `\d` in your regu
 assert.match(isInvalidInput.toString(), /regex\s*=\s*\/\\d\+e/);
 ```
 
-You should replace the `[0-9]` character class after `e` with `\d` in your regular expression.
+You should replace the `[0-9]` character class after `e` with `\d`, so your `regex` value is `/\d+e\d+/i`.
 
 ```js
 const explorer = await __helpers.Explorer(code);

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ff.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c0ff.md
@@ -34,7 +34,10 @@ assert.match(isInvalidInput.toString(), /str\.match\(\s*regex\s*\)/);
 Your `isInvalidInput` function should directly return the result of the `.match()` call.
 
 ```js
-assert.match(isInvalidInput.toString(), /return\s+str\.match\(\s*regex\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.allFunctions.isInvalidInput?.hasReturn('str.match(regex)')
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c104.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c104.md
@@ -28,7 +28,8 @@ assert.isFunction(addEntry);
 Your `addEntry` function should not take any parameters.
 
 ```js
-assert.match(addEntry?.toString(), /\(\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.lengthOf(explorer.allFunctions.addEntry?.parameters, 0);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c105.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c105.md
@@ -19,13 +19,19 @@ Assign the `value` property of `entryDropdown` to a variable called `category`.
 Your `addEntry` function should have a `category` variable.
 
 ```js
-assert.match(addEntry.toString(), /category\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.addEntry?.variables.category);
 ```
 
 Your `category` variable should be assigned the value of `entryDropdown.value`.
 
 ```js
-assert.match(addEntry.toString(), /category\s*=\s*entryDropdown\.value/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.addEntry?.variables.category?.value.matches(
+    'entryDropdown.value'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c106.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c106.md
@@ -18,7 +18,8 @@ Use concatenation to combine the `category` variable, and `' .input-container'` 
 Your `addEntry` function should have a `targetInputContainer` variable.
 
 ```js
-assert.match(addEntry.toString(), /targetInputContainer\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.addEntry?.variables.targetInputContainer);
 ```
 
 Your `targetInputContainer` variable should be set to `document.querySelector()`.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c108.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c108.md
@@ -18,7 +18,8 @@ Declare an `entryNumber` variable and give it the value of `targetInputContainer
 You should have an `entryNumber` variable.
 
 ```js
-assert.match(addEntry.toString(), /entryNumber\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.addEntry?.variables.entryNumber);
 ```
 
 Your `entryNumber` variable should have the value of `targetInputContainer.querySelectorAll()`.
@@ -30,7 +31,12 @@ assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.query
 You should not pass an argument to `querySelectorAll()`.
 
 ```js
-assert.match(addEntry.toString(), /entryNumber\s*=\s*targetInputContainer\.querySelectorAll\(\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.addEntry?.variables.entryNumber?.value.matches(
+    'targetInputContainer.querySelectorAll()'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c10a.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c10a.md
@@ -14,7 +14,8 @@ Now you need to build your dynamic HTML string to add to the webpage. Declare a 
 Your `addEntry` function should have an `HTMLString` variable.
 
 ```js
-assert.match(addEntry.toString(), /HTMLString\s*=/)
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.addEntry?.variables.HTMLString);
 ```
 
 Your `HTMLString` should be an empty template literal.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c10d.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c10d.md
@@ -26,7 +26,9 @@ assert.match(code, /HTMLString\s*=\s*`\n\s*<label\s+for\s*=\s*"\$\{category\}-\$
 Your `input` element should have a `type` attribute set to `text`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputAttributes = HTMLstring.match(/<input\s+.*/)[0];
 assert.match(inputAttributes, /type\s*=\s*"text"/);
 ```
@@ -34,7 +36,9 @@ assert.match(inputAttributes, /type\s*=\s*"text"/);
 Your `input` element should have a `placeholder` attribute set to `Name`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputAttributes = HTMLstring.match(/<input\s+.*/)[0];
 assert.match(inputAttributes, /placeholder\s*=\s*"Name"/);
 ```
@@ -42,7 +46,9 @@ assert.match(inputAttributes, /placeholder\s*=\s*"Name"/);
 Your `input` element should have an `id` attribute set to `${category}-${entryNumber}-name`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputAttributes = HTMLstring.match(/<input\s+.*/)[0];
 assert.match(inputAttributes, /id\s*=\s*"\${category}-\${entryNumber}-name"/);
 ```

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c10e.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c10e.md
@@ -14,21 +14,27 @@ Create another `label` element (on a new line) at the end of your `HTMLString`. 
 You should have two `label` elements in your `HTMLString`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 assert.equal(HTMLstring.match(/<label/g).length, 2);
 ```
 
 Your new `label` element should be on a new line.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 assert.equal(HTMLstring.match(/\n\s*<label/g).length, 2);
 ```
 
 Your new `label` element should come after your `input` element.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputIndex = HTMLstring.indexOf("<input");
 const labelIndex = HTMLstring.lastIndexOf("<label");
 assert.isBelow(inputIndex, labelIndex);
@@ -37,7 +43,9 @@ assert.isBelow(inputIndex, labelIndex);
 Your new `label` element should have a `for` attribute set to `${category}-${entryNumber}-amount`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const label = HTMLstring.match(/<label.*>.*<\/label>/g)[1];
 assert.match(label, /<label\s+for="\$\{category\}-\$\{entryNumber\}-amount"\s*>/);
 ```
@@ -45,7 +53,9 @@ assert.match(label, /<label\s+for="\$\{category\}-\$\{entryNumber\}-amount"\s*>/
 Your new `label` element should have the text `Expense ${entryNumber} Amount`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const label = HTMLstring.match(/<label.*>.*<\/label>/g)[1];
 assert.match(label, /<label\s+for="\$\{category\}-\$\{entryNumber\}-amount"\s*>Expense\s\$\{entryNumber\}\sAmount<\/label>/);
 ```
@@ -53,7 +63,9 @@ assert.match(label, /<label\s+for="\$\{category\}-\$\{entryNumber\}-amount"\s*>E
 You should not modify your existing elements.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 assert.match(HTMLstring, /`\n\s*<label\s+for="\$\{category\}-\$\{entryNumber\}-name"\s*>Expense\s\$\{entryNumber\}\sName<\/label>\n\s*<input\stype="text"\sid="\$\{category\}-\$\{entryNumber\}-name"\splaceholder="Name"\s\/>\n\s*<label\s+for="\$\{category\}-\$\{entryNumber\}-amount"\s*>Expense\s\$\{entryNumber\}\sAmount<\/label>/);
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c10f.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c10f.md
@@ -14,21 +14,27 @@ Finally, on a new line after your second `label`, create another `input` element
 You should have two `input` elements in your `HTMLString`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 assert.equal(HTMLstring.match(/<input/g).length, 2);
 ```
 
 Your new `input` element should be on a new line.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 assert.equal(HTMLstring.match(/\n\s*<input/g).length, 2);
 ```
 
 Your new `input` element should come after your second `label` element.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputIndex = HTMLstring.lastIndexOf("<input");
 const labelIndex = HTMLstring.lastIndexOf("<label");
 assert.isAbove(inputIndex, labelIndex);
@@ -37,7 +43,9 @@ assert.isAbove(inputIndex, labelIndex);
 Your new `input` element should have a `type` attribute set to `number`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputAttributes = HTMLstring.match(/<input\s+[^>]*>/g)[1];
 assert.match(inputAttributes, /type\s*=\s*"number"/);
 ```
@@ -45,7 +53,9 @@ assert.match(inputAttributes, /type\s*=\s*"number"/);
 Your `input` element should have a `placeholder` attribute set to `Amount`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputAttributes = HTMLstring.match(/<input\s+[^>]*>/g)[1];
 assert.match(inputAttributes, /placeholder\s*=\s*"Amount"/);
 ```
@@ -53,7 +63,9 @@ assert.match(inputAttributes, /placeholder\s*=\s*"Amount"/);
 Your `input` element should have an `id` attribute set to `${category}-${entryNumber}-amount`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputAttributes = HTMLstring.match(/<input\s+[^>]*>/g)[1];
 assert.match(inputAttributes, /id\s*=\s*"\${category}-\${entryNumber}-amount"/);
 ```
@@ -61,7 +73,9 @@ assert.match(inputAttributes, /id\s*=\s*"\${category}-\${entryNumber}-amount"/);
 Your new `input` element should have a `min` attribute set to `0`.
 
 ```js
-const HTMLstring = code.split(/HTMLString\s*=/)[1];
+const explorer = await __helpers.Explorer(code);
+const HTMLstring =
+  explorer.functions.addEntry.variables.HTMLString.value.toString();
 const inputAttributes = HTMLstring.match(/<input\s+[^>]*>/g)[1];
 assert.match(inputAttributes, /min\s*=\s*"0"/);
 ```

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c115.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c115.md
@@ -30,7 +30,10 @@ assert.isFunction(getTotalFromInputs);
 Your `getTotalFromInputs` function should take a parameter called `list`.
 
 ```js
-assert.match(getTotalFromInputs?.toString(), /\(\s*list\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.getTotalFromInputs?.parameters;
+assert.lengthOf(parameters, 1);
+assert.equal(parameters[0].toString(), 'list');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c116.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c116.md
@@ -14,20 +14,28 @@ In your new function, declare a `total` variable and assign it the value `0`. Us
 You should declare a `total` variable.
 
 ```js
-assert.match(getTotalFromInputs.toString(), /total\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.getTotalFromInputs?.variables.total);
 ```
 
 Your `total` variable should be assigned the value `0`.
 
 ```js
-assert.match(getTotalFromInputs.toString(), /total\s*=\s*0/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.getTotalFromInputs?.variables.total?.value.matches('0')
+);
 ```
 
 You should declare your `total` variable with `let`.
 
 ```js
-const getTotalFromInputsString = code.split('function getTotalFromInputs')[1];
-assert.match(getTotalFromInputsString, /let\s+total\s*=\s*0/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.getTotalFromInputs?.variables.total?.matches(
+    'let total = 0'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c11b.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c11b.md
@@ -26,7 +26,8 @@ Add an `if` statement that checks if `invalidInputMatch` is truthy.
 You should add an `if` statement to your `getTotalFromInputs` function.
 
 ```js
-const functionCode = code.split(/getTotalFromInputs/)?.[1]?.split(/\}\s*\}/)?.[0];
+const explorer = await __helpers.Explorer(code);
+const functionCode = explorer.functions.getTotalFromInputs.toString();
 assert.match(functionCode, /if\s*\(/);
 ```
 
@@ -39,7 +40,9 @@ assert.match(getTotalFromInputs.toString(), /if\s*\(\s*invalidInputMatch\s*\)/);
 Your `if` statement should be inside your `for` loop.
 
 ```js
-const forCode = code.split(/getTotalFromInputs/)?.[1]?.split(/for\s*\(/)?.[1]?.split(/\}/)?.[0];
+const explorer = await __helpers.Explorer(code);
+const functionCode = explorer.functions.getTotalFromInputs.toString();
+const forCode = functionCode.split(/for\s*\(/)?.[1]?.split(/\}/)?.[0];
 assert.match(forCode, /if\s*\(\s*invalidInputMatch\s*\)/);
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c11c.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c11c.md
@@ -22,13 +22,17 @@ assert.match(getTotalFromInputs.toString(), /if\s*\(\s*invalidInputMatch\s*\)\s*
 You should use a template literal to pass the `"Invalid Input: "` message to the `alert()` function.
 
 ```js
-assert.match(code.split(/function\s+getTotalFromInputs/)[1], /(?:window\.|globalThis\.)?alert\(\s*`Invalid Input: /);
+const explorer = await __helpers.Explorer(code);
+const functionCode = explorer.functions.getTotalFromInputs.toString();
+assert.match(functionCode, /(?:window\.|globalThis\.)?alert\(\s*`Invalid Input: /);
 ```
 
 You should display the first element of the `invalidInputMatch` array after the `"Invalid Input: "` text by using a template literal.
 
 ```js
-assert.match(code.split(/function\s+getTotalFromInputs/)[1], /(?:window\.|globalThis\.)?alert\(\s*`Invalid Input: \${invalidInputMatch\s*\[\s*0\s*\]\s*}`\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const functionCode = explorer.functions.getTotalFromInputs.toString();
+assert.match(functionCode, /(?:window\.|globalThis\.)?alert\(\s*`Invalid Input: \${invalidInputMatch\s*\[\s*0\s*\]\s*}`\s*\)/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c11d.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c11d.md
@@ -16,13 +16,17 @@ Still within your `if` block, set `isError` to `true` and return `null`.
 After your `alert`, you should set `isError` to `true`.
 
 ```js
-assert.match(code.split(/function\s+getTotalFromInputs/)[1], /(?:window\.|globalThis\.)?alert\(\s*`Invalid Input: \${invalidInputMatch\s*\[\s*0\s*\]\s*}`\s*\)\s*;?\s*isError\s*=\s*true/);
+const explorer = await __helpers.Explorer(code);
+const functionCode = explorer.functions.getTotalFromInputs.toString();
+assert.match(functionCode, /(?:window\.|globalThis\.)?alert\(\s*`Invalid Input: \${invalidInputMatch\s*\[\s*0\s*\]\s*}`\s*\)\s*;?\s*isError\s*=\s*true/);
 ```
 
 After you modify `isError`, you should `return` the value `null`.
 
 ```js
-assert.match(code.split(/function\s+getTotalFromInputs/)[1], /(?:window\.|globalThis\.)?alert\(\s*`Invalid Input: \${invalidInputMatch\s*\[\s*0\s*\]\s*}`\s*\)\s*;?\s*isError\s*=\s*true\s*;?\s*return\s+null\s*;?\s*\}/);
+const explorer = await __helpers.Explorer(code);
+const functionCode = explorer.functions.getTotalFromInputs.toString();
+assert.match(functionCode, /(?:window\.|globalThis\.)?alert\(\s*`Invalid Input: \${invalidInputMatch\s*\[\s*0\s*\]\s*}`\s*\)\s*;?\s*isError\s*=\s*true\s*;?\s*return\s+null\s*;?\s*\}/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c11f.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c11f.md
@@ -14,7 +14,8 @@ After your `for` loop has completed, return the `total` value.
 You should `return` the `total` value.
 
 ```js
-assert.match(getTotalFromInputs.toString(), /return\s+total/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(explorer.allFunctions.getTotalFromInputs?.hasReturn('total'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c120.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c120.md
@@ -26,7 +26,10 @@ assert.isFunction(calculateBudget);
 Your `calculateBudget` function should take an `e` argument.
 
 ```js
-assert.match(calculateBudget?.toString(), /\(\s*e\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.calculateBudget?.parameters;
+assert.lengthOf(parameters, 1);
+assert.equal(parameters[0].toString(), 'e');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c122.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c122.md
@@ -16,7 +16,8 @@ Declare a `foodInputs` variable, and give it the value of calling `document.quer
 You should declare a `foodInputs` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /foodInputs\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.foodInputs);
 ```
 
 You should call `document.querySelectorAll()` with `#food input[type='number']`.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c123.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c123.md
@@ -14,7 +14,8 @@ Using that same syntax, query your `number` inputs in the `#utilities` element a
 You should declare a `utilitiesInputs` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /utilitiesInputs\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.utilitiesInputs);
 ```
 
 You should call `document.querySelectorAll()` with `#utilities input[type='number']`.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c124.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c124.md
@@ -14,7 +14,8 @@ Following the same pattern, query for your `number` inputs in the `#entertainmen
 You should declare an `entertainmentInputs` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /entertainmentInputs\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.entertainmentInputs);
 ```
 
 You should call `document.querySelectorAll()` with `#entertainment input[type='number']`.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c125.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c125.md
@@ -16,7 +16,8 @@ Declare a `rent` variable, and assign it the result of calling `getTotalFromInpu
 Your `calculateBudget` function should have a `rent` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /rent\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.rent);
 ```
 
 You should call `getTotalFromInputs` with `[rentInput]` as the argument.
@@ -28,7 +29,12 @@ assert.match(calculateBudget.toString(), /getTotalFromInputs\s*\(\s*\[\s*rentInp
 You should assign the result of `getTotalFromInputs` to `rent`.
 
 ```js
-assert.match(calculateBudget.toString(), /rent\s*=\s*getTotalFromInputs\s*\(\s*\[\s*rentInput\s*\]\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.calculateBudget?.variables.rent?.value.matches(
+    'getTotalFromInputs([rentInput])'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c126.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c126.md
@@ -14,7 +14,8 @@ Now declare a `food` variable, and give it the value of calling `getTotalFromInp
 Your `calculateBudget` function should have a `food` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /food\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.food);
 ```
 
 You should call `getTotalFromInputs` with `foodInputs` as the argument.
@@ -26,7 +27,12 @@ assert.match(calculateBudget.toString(), /getTotalFromInputs\s*\(\s*foodInputs\s
 You should assign the result of `getTotalFromInputs` to `food`.
 
 ```js
-assert.match(calculateBudget.toString(), /food\s*=\s*getTotalFromInputs\s*\(\s*foodInputs\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.calculateBudget?.variables.food?.value.matches(
+    'getTotalFromInputs(foodInputs)'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c127.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c127.md
@@ -14,7 +14,8 @@ Following this same pattern, declare `utilities` and `entertainment` variables f
 Your `calculateBudget` function should have a `utilities` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /utilities\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.utilities);
 ```
 
 You should call `getTotalFromInputs` with `utilitiesInputs` as the argument.
@@ -26,13 +27,19 @@ assert.match(calculateBudget.toString(), /getTotalFromInputs\s*\(\s*utilitiesInp
 You should assign the result of `getTotalFromInputs` to `utilities`.
 
 ```js
-assert.match(calculateBudget.toString(), /utilities\s*=\s*getTotalFromInputs\s*\(\s*utilitiesInputs\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.calculateBudget?.variables.utilities?.value.matches(
+    'getTotalFromInputs(utilitiesInputs)'
+  )
+);
 ```
 
 Your `calculateBudget` function should have an `entertainment` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /entertainment\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.entertainment);
 ```
 
 You should call `getTotalFromInputs` with `entertainmentInputs` as the argument.
@@ -44,7 +51,12 @@ assert.match(calculateBudget.toString(), /getTotalFromInputs\s*\(\s*entertainmen
 You should assign the result of `getTotalFromInputs` to `entertainment`.
 
 ```js
-assert.match(calculateBudget.toString(), /entertainment\s*=\s*getTotalFromInputs\s*\(\s*entertainmentInputs\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.calculateBudget?.variables.entertainment?.value.matches(
+    'getTotalFromInputs(entertainmentInputs)'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c128.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c128.md
@@ -18,7 +18,8 @@ Declare an `income` variable and set it to the result of calling `getTotalFromIn
 Your `calculateBudget` function should have an `income` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /income\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.income);
 ```
 
 You should call `getTotalFromInputs` with `[incomeInput]` as the argument.
@@ -30,7 +31,12 @@ assert.match(calculateBudget.toString(), /getTotalFromInputs\s*\(\s*\[\s*incomeI
 You should assign the result of `getTotalFromInputs` to `income`.
 
 ```js
-assert.match(calculateBudget.toString(), /income\s*=\s*getTotalFromInputs\s*\(\s*\[\s*incomeInput\s*\]\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.calculateBudget?.variables.income?.value.matches(
+    'getTotalFromInputs([incomeInput])'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c12a.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c12a.md
@@ -14,7 +14,8 @@ It is time to start preparing your calculations. Start by declaring an `expenses
 The function should have an `expenses` variable.  
 
 ```js
-assert.match(calculateBudget.toString(), /expenses\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.expenses);
 ```
 
 The `expenses` variable should come after your `if` statement.  
@@ -32,7 +33,12 @@ assert.match(calculateBudget.toString(), /rent\s*\+\s*food\s*\+\s*utilities\s*\+
 You should assign the sum of `rent`, `food`, `utilities`, and `entertainment` to `expenses`.  
 
 ```js
-assert.match(calculateBudget.toString(), /expenses\s*=\s*rent\s*\+\s*food\s*\+\s*utilities\s*\+\s*entertainment\s*;?\s*$/m);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.calculateBudget?.variables.expenses?.value.matches(
+    'rent + food + utilities + entertainment'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c12b.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c12b.md
@@ -14,7 +14,8 @@ Now declare a `netRemaining` variable, and give it the value of subtracting `exp
 Your `calculateBudget` function should have a `netRemaining` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /netRemaining\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.netRemaining);
 ```
 
 You should find the value of `income - expenses`.
@@ -26,7 +27,12 @@ assert.match(calculateBudget.toString(), /income\s*-\s*expenses/);
 You should assign the value of `income - expenses` to `netRemaining`.
 
 ```js
-assert.match(calculateBudget.toString(), /netRemaining\s*=\s*income\s*-\s*expenses/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.calculateBudget?.variables.netRemaining?.value.matches(
+    'income - expenses'
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c12c.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c12c.md
@@ -16,27 +16,33 @@ Declare two variables: `statusText` and `statusClass`. Initialize both as empty 
 Your `calculateBudget` function should have a `statusText` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /statusText\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.statusText);
 ```
 
 Your `calculateBudget` function should have a `statusClass` variable.
 
 ```js
-assert.match(calculateBudget.toString(), /statusClass\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.calculateBudget?.variables.statusClass);
 ```
 
 You should initialize `statusText` and `statusClass` as empty strings.
 
 ```js
-assert.match(code, /statusText\s*=\s*('|")\1/);
-assert.match(code, /statusClass\s*=\s*('|")\1/);
+const explorer = await __helpers.Explorer(code);
+const { statusText, statusClass } = explorer.functions.calculateBudget.variables;
+assert.isTrue(statusText?.value.matches('""'));
+assert.isTrue(statusClass?.value.matches('""'));
 ```
 
 Both variables should be declared using `let`.
 
 ```js
-assert.match(code, /let\s+statusText\s*=\s*('|")\1/);
-assert.match(code, /let\s+statusClass\s*=\s*('|")\1/);
+const explorer = await __helpers.Explorer(code);
+const { statusText, statusClass } = explorer.functions.calculateBudget.variables;
+assert.isTrue(statusText?.matches('let statusText = ""'));
+assert.isTrue(statusClass?.matches('let statusClass = ""'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c139.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c139.md
@@ -14,7 +14,8 @@ You need to get all of the input containers. Declare an `inputContainers` variab
 You should declare an `inputContainers` variable in your `clearForm` function.
 
 ```js
-assert.match(clearForm.toString(), /inputContainers\s*=/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.functions.clearForm?.variables.inputContainers);
 ```
 
 You should use the `querySelectorAll` method to get all of the elements with the class `input-container`.
@@ -26,7 +27,12 @@ assert.match(clearForm.toString(), /document\.querySelectorAll\(\s*('|")\.input-
 You should assign the value of the `querySelectorAll` method to the `inputContainers` variable.
 
 ```js
-assert.match(clearForm.toString(), /inputContainers\s*=\s*document\.querySelectorAll\(\s*('|")\.input-container\1\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.functions.clearForm?.variables.inputContainers?.value.matches(
+    "document.querySelectorAll('.input-container')"
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c13b.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c13b.md
@@ -16,14 +16,16 @@ Inside the loop, set the `innerHTML` property of the `container` to an empty str
 Your `for...of` loop should iterate through the `inputContainers` array. The loop's variable name should be `container`.
 
 ```js
-const clearForm = code.split("function clearForm()")[1];
+const explorer = await __helpers.Explorer(code);
+const clearForm = explorer.functions.clearForm.toString();
 assert.match(clearForm, /for\s*\(\s*(const|let|var)\s+container\s+of\s+inputContainers\s*\)/);
 ```
 
 Your `for...of` loop should set the `innerHTML` property of `container` to an empty string.
 
 ```js
-const clearForm = code.split("function clearForm()")[1];
+const explorer = await __helpers.Explorer(code);
+const clearForm = explorer.functions.clearForm.toString();
 const forOfLoop = clearForm.split("for")[1];
 assert.match(forOfLoop, /container\s*\.\s*innerHTML\s*=\s*(`|'|")\1\s*/);
 ```

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c13c.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c13c.md
@@ -26,8 +26,9 @@ assert.match(clearForm.toString(), /incomeInput\.value\s*=\s*('|"|`)\1/);
 You should modify the `incomeInput` after your `for` loop.
 
 ```js
-const clearForm = code.split("function clearForm()")[1];
-const afterLoop = clearForm.split("}")[1];
+const explorer = await __helpers.Explorer(code);
+const clearFormBody = explorer.functions.clearForm.toString();
+const afterLoop = clearFormBody.split("}")[1];
 assert.match(afterLoop, /incomeInput\.value/);
 ```
 
@@ -46,8 +47,9 @@ assert.match(clearForm.toString(), /rentInput\.value\s*=\s*('|"|`)\1/);
 You should modify the `rentInput` after your `for` loop.
 
 ```js
-const clearForm = code.split("function clearForm()")[1];
-const afterLoop = clearForm.split("}")[1];
+const explorer = await __helpers.Explorer(code);
+const clearFormBody = explorer.functions.clearForm.toString();
+const afterLoop = clearFormBody.split("}")[1];
 assert.match(afterLoop, /rentInput\.value/);
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69074

This replaces regex checks on the camper's source with `__helpers.Explorer` in the Envelope Budget App workshop.

## What changed

- Variable checks now use `explorer.variables` or `explorer.functions.<name>.variables`, so formatting does not break a step.
- Scoping by `code.split('function <name>')` is replaced by `explorer.functions.<name>`. The old split cut on the function name, which also appears at the call site, so it could pick the wrong part of the file.
- Steps 48-50 used `code.split(/HTMLString\s*=/)`, which returned the rest of the file. It now reads the template literal from `explorer.functions.addEntry.variables.HTMLString`.

## Two bugs this also fixes

- Step 16 had `document.getElementById` with an unescaped dot, so any character was accepted in that position.
- Steps 31-33 checked a prefix and stopped before the flag. The value is `/[0-9]e[0-9]/i`, not `/[0-9]e[0-9]/`. The new checks compare the whole value, so the flag is included.

## Note on quotes

`matches()` compares string literals by content, not by raw text, so `'budget-form'` and `"budget-form"` both pass. The seed itself mixes both styles.

## What is NOT replaced, and why

- `addEventListener` and `console.log` checks: these are call expressions. `Explorer` exposes declarations and bodies, not arbitrary calls.
- `for`, `if`, `else` checks: control flow. `getAll` exists but `SyntaxKind` is not exported, so tests cannot reach these nodes.
- `currVal` (Steps 59-60) and `invalidInputMatch`: declared inside the `for...of` loop. `variables` only sees direct statements of a scope.
- Steps 84-87: `output.innerHTML` is a property assignment, not a variable.
- Step 13: splits the HTML source. `Explorer` parses JavaScript.
- Steps 44, 53, 69-71: the current regex allows whitespace or different quoting inside the selector string. `matches()` compares string content exactly, so replacing them would reject input that passes today.
- Steps 22, 31-33, 41, 43: some hints check a prefix on purpose, to accept work in progress. An exact check would fail a camper who typed ahead.

## Testing

Run in `curriculum`:

```
FCC_BLOCK=workshop-envelope-budget-app pnpm test-content
```

491 tests pass. `prettier` and `pnpm lint-challenges` are clean.
