### PR TITLE
fix: Refactor sorting example in lecture notes

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
@@ -120,12 +120,16 @@ Similarly, when the `sort` method encounters an empty slot in a sparse array, it
 
 Here is an example that demonstrates this behavior:
 
+:::interactive_editor
+
 ```js
 const arr = [, undefined, "banana", "apple"];
 arr.sort();
 
 console.log(arr); // ["apple", "banana", undefined, empty]
 ```
+
+:::
 
 In this example, the strings `"apple"` and `"banana"` are sorted alphabetically first. Then the `undefined` value is placed after them. Finally, the empty slot is preserved at the very end of the array.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
@@ -120,16 +120,12 @@ Similarly, when the `sort` method encounters an empty slot in a sparse array, it
 
 Here is an example that demonstrates this behavior:
 
-:::interactive_editor
-
 ```js
 const arr = [, undefined, "banana", "apple"];
 arr.sort();
 
 console.log(arr); // ["apple", "banana", undefined, empty]
 ```
-
-:::
 
 In this example, the strings `"apple"` and `"banana"` are sorted alphabetically first. Then the `undefined` value is placed after them. Finally, the empty slot is preserved at the very end of the array.
 

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
@@ -7,7 +7,7 @@ dashedName: step-60
 
 # --description--
 
-Set the `textContent` of the `totalNumberOfItems`, `cartSubTotal`, `cartTaxes`, and `cartTotal` elements all to the number `0`.
+Set the `textContent` of the `totalNumberOfItems` element to `0`, and the `textContent` of the `cartSubTotal`, `cartTaxes`, and `cartTotal` elements to `"$0"`.
 
 # --hints--
 
@@ -19,28 +19,28 @@ const inIf = secondIf.split('}')[0];
 assert.match(inIf, /totalNumberOfItems\.textContent\s*=\s*0/);
 ```
 
-You should set the `textContent` of the `cartSubTotal` element to `0`.
+You should set the `textContent` of the `cartSubTotal` element to `"$0"`.
 
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartSubTotal\.textContent\s*=\s*0/);
+assert.match(inIf, /cartSubTotal\.textContent\s*=\s*("|')\$0\1/);
 ```
 
-You should set the `textContent` of the `cartTaxes` element to `0`.
+You should set the `textContent` of the `cartTaxes` element to `"$0"`.
 
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartTaxes\.textContent\s*=\s*0/);
+assert.match(inIf, /cartTaxes\.textContent\s*=\s*("|')\$0\1/);
 ```
 
-You should set the `textContent` of the `cartTotal` element to `0`.
+You should set the `textContent` of the `cartTotal` element to `"$0"`.
 
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartTotal\.textContent\s*=\s*0/);
+assert.match(inIf, /cartTotal\.textContent\s*=\s*("|')\$0\1/);
 ```
 
 # --seed--


### PR DESCRIPTION
Removed the interactive editor block from the `sort` empty slot example in `673362d7f94d551edb532d24.md` to prevent environment-specific output inconsistencies.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69092