### PR TITLE
fix(curriculum): refactor sorting example in lecture notes

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md
@@ -120,16 +120,12 @@ Similarly, when the `sort` method encounters an empty slot in a sparse array, it
 
 Here is an example that demonstrates this behavior:
 
-:::interactive_editor
-
 ```js
 const arr = [, undefined, "banana", "apple"];
 arr.sort();
 
 console.log(arr); // ["apple", "banana", undefined, empty]
 ```
-
-:::
 
 In this example, the strings `"apple"` and `"banana"` are sorted alphabetically first. Then the `undefined` value is placed after them. Finally, the empty slot is preserved at the very end of the array.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69092

<!-- Feel free to add any additional description of changes below this line -->
Removed the `:::interactive_editor` and `:::` tags from the `sort` empty slot example so it uses standard markdown formatting instead.
