### PR TITLE
fix(curriculum): use "$0" when clearing cart totals in steps 60 and 61

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
@@ -16,7 +16,7 @@ You should set the `textContent` of the `totalNumberOfItems` element to `0`.
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /totalNumberOfItems\.textContent\s*=\s*["']?0["']?/);
+assert.match(inIf, /totalNumberOfItems\.textContent\s*=\s*('|"|`)?0\1/);
 ```
 
 You should set the `textContent` of the `cartSubTotal` element to `"$0"`.

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
@@ -32,7 +32,7 @@ You should set the `textContent` of the `cartTaxes` element to `"$0"`.
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartTaxes\.textContent\s*=\s*("|')\$0\1/);
+assert.match(inIf, /cartTaxes\.textContent\s*=\s*('|"|`)\$0\1/);
 ```
 
 You should set the `textContent` of the `cartTotal` element to `"$0"`.

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
@@ -16,7 +16,7 @@ You should set the `textContent` of the `totalNumberOfItems` element to `0`.
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /totalNumberOfItems\.textContent\s*=\s*0/);
+assert.match(inIf, /totalNumberOfItems\.textContent\s*=\s*["']?0["']?/);
 ```
 
 You should set the `textContent` of the `cartSubTotal` element to `"$0"`.

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
@@ -24,7 +24,7 @@ You should set the `textContent` of the `cartSubTotal` element to `"$0"`.
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartSubTotal\.textContent\s*=\s*("|')\$0\1/);
+assert.match(inIf, /cartSubTotal\.textContent\s*=\s*('|"|`)\$0\1/);
 ```
 
 You should set the `textContent` of the `cartTaxes` element to `"$0"`.

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
@@ -7,7 +7,7 @@ dashedName: step-60
 
 # --description--
 
-Set the `textContent` of the `totalNumberOfItems`, `cartSubTotal`, `cartTaxes`, and `cartTotal` elements all to the number `0`.
+Set the `textContent` of the `totalNumberOfItems` element to `0`, and the `textContent` of the `cartSubTotal`, `cartTaxes`, and `cartTotal` elements to `"$0"`.
 
 # --hints--
 
@@ -19,28 +19,28 @@ const inIf = secondIf.split('}')[0];
 assert.match(inIf, /totalNumberOfItems\.textContent\s*=\s*0/);
 ```
 
-You should set the `textContent` of the `cartSubTotal` element to `0`.
+You should set the `textContent` of the `cartSubTotal` element to `"$0"`.
 
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartSubTotal\.textContent\s*=\s*0/);
+assert.match(inIf, /cartSubTotal\.textContent\s*=\s*("|')\$0\1/);
 ```
 
-You should set the `textContent` of the `cartTaxes` element to `0`.
+You should set the `textContent` of the `cartTaxes` element to `"$0"`.
 
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartTaxes\.textContent\s*=\s*0/);
+assert.match(inIf, /cartTaxes\.textContent\s*=\s*("|')\$0\1/);
 ```
 
-You should set the `textContent` of the `cartTotal` element to `0`.
+You should set the `textContent` of the `cartTotal` element to `"$0"`.
 
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartTotal\.textContent\s*=\s*0/);
+assert.match(inIf, /cartTotal\.textContent\s*=\s*("|')\$0\1/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
@@ -40,7 +40,7 @@ You should set the `textContent` of the `cartTotal` element to `"$0"`.
 ```js
 const secondIf = cart.clearCart.toString().split('if')[2];
 const inIf = secondIf.split('}')[0];
-assert.match(inIf, /cartTotal\.textContent\s*=\s*("|')\$0\1/);
+assert.match(inIf, /cartTotal\.textContent\s*=\s*('|"|`)\$0\1/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03b1ed5ab15420c057463.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03b1ed5ab15420c057463.md
@@ -295,9 +295,9 @@ class ShoppingCart {
       this.total = 0;
       productsContainer.innerHTML = "";
       totalNumberOfItems.textContent = 0;
-      cartSubTotal.textContent = 0;
-      cartTaxes.textContent = 0;
-      cartTotal.textContent = 0;
+      cartSubTotal.textContent = "$0";
+      cartTaxes.textContent = "$0";
+      cartTotal.textContent = "$0";
     }
   }
 
@@ -598,9 +598,9 @@ class ShoppingCart {
       this.total = 0;
       productsContainer.innerHTML = "";
       totalNumberOfItems.textContent = 0;
-      cartSubTotal.textContent = 0;
-      cartTaxes.textContent = 0;
-      cartTotal.textContent = 0;
+      cartSubTotal.textContent = "$0";
+      cartTaxes.textContent = "$0";
+      cartTotal.textContent = "$0";
     }
   }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69098

<!-- Feel free to add any additional description of changes below this line -->
Updated the Step 60 instructions to clarify that description, `cartSubTotal`, `cartTaxes`, and `cartTotal` should be set to `"$0"` rather than `0`.