### PR TITLE
fix(curriculum): check the DOM instead of source text for cafe-menu hints

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f33294a6af5e9188dbdb8f3.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f33294a6af5e9188dbdb8f3.md
@@ -14,10 +14,10 @@ Start by adding some menu content. Add a `main` element within the existing `bod
 
 # --hints--
 
-Your code should have an opening `<main>` tag.
+Your code should have a `main` element.
 
 ```js
-assert.match(code, /<main>/i);
+assert.exists(document.querySelector('main'));
 ```
 
 Your code should have a closing `</main>` tag.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332a88dc25a0fd25c7687a.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332a88dc25a0fd25c7687a.md
@@ -11,10 +11,10 @@ The name of the cafe is `CAMPER CAFE`. So, add an `h1` element within your `main
 
 # --hints--
 
-You should have an opening `<h1>` tag.
+You should have an `h1` element.
 
 ```js
-assert.match(code, /<h1>/i);
+assert.exists(document.querySelector('h1'));
 ```
 
 You should have a closing `</h1>` tag.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332b23c2045fb843337579.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f332b23c2045fb843337579.md
@@ -11,10 +11,10 @@ To let visitors know the cafe was founded in `2020`, add a `p` element below the
 
 # --hints--
 
-You should have an opening `<p>` tag.
+You should have a `p` element.
 
 ```js
-assert.match(code, /<p>/i);
+assert.exists(document.querySelector('p'));
 ```
 
 You should have a closing `</p>` tag.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fad8bf01691e71a30eb.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fad8bf01691e71a30eb.md
@@ -26,7 +26,7 @@ assert.match(code, /<\/style\s*>/);
 Your `style` element should be nested in your `head` element.
 
 ```js
-assert.match(code, /<head\s*>[\w\W\s]*<style\s*>[\w\W\s]*<\/style\s*>[\w\W\s]*<\/head\s*>/i)
+assert.exists(document.querySelector('head > style:not(.fcc-hide-header)'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fbc22624a2976425065.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fbc22624a2976425065.md
@@ -11,10 +11,10 @@ Create an `h2` element in the `section` element and give it the text `Coffee`.
 
 # --hints--
 
-You should have an opening `<h2>` tag.
+You should have an `h2` element.
 
 ```js
-assert.match(code, /<h2\s*>/i);
+assert.exists(document.querySelector('h2'));
 ```
 
 You should have a closing `</h2>` tag.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fc1520b6719f2e35605.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344fc1520b6719f2e35605.md
@@ -11,10 +11,10 @@ There will be two sections on the menu, one for coffees and one for desserts. Ad
 
 # --hints--
 
-You should have an opening `<section>` tag.
+You should have a `section` element.
 
 ```js
-assert.match(code, /<section\s*>/i);
+assert.exists(document.querySelector('section'));
 ```
 
 You should have a closing `</section>` tag.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477ae8466a9a3d2cc953c.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477ae8466a9a3d2cc953c.md
@@ -14,7 +14,7 @@ Now that you have the CSS in the `styles.css` file, go ahead and remove the `sty
 You should not have any `style` tags in your code.
 
 ```js
-assert.notMatch(code, /style/i);
+assert.notExists(document.querySelector('style:not(.fcc-hide-header)'));
 ```
 
 You should not have any CSS selectors in your HTML file.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477cbcb6ba47918c1da92.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3477cbcb6ba47918c1da92.md
@@ -22,21 +22,19 @@ Here is an example:
 Your code should have two `meta` elements.
 
 ```js
-assert.lengthOf(code.match(/<meta.*?\/?>/g),2);
+assert.lengthOf(document.querySelectorAll('meta'), 2);
 ```
 
 Your `meta` element should have a `name` attribute with a value of `viewport`.
 
 ```js
-const meta = document.querySelectorAll('meta');
-assert.exists(meta[0]?.outerHTML?.match(/name=('|")viewport\1/) || meta[1]?.outerHTML?.match(/name=('|")viewport\1/));
+assert.exists(document.querySelector('meta[name="viewport"]'));
 ```
 
 Your `meta` element should have a `content` attribute with a value of `width=device-width, initial-scale=1.0`.
 
 ```js
-const meta = document.querySelectorAll('meta');
-assert.exists(meta[0]?.outerHTML?.match(/content=('|")width=device-width, initial-scale=1.0\1/) || meta[1]?.outerHTML?.match(/content=('|")width=device-width, initial-scale=1.0\1/));
+assert.equal(document.querySelector('meta[name="viewport"]')?.getAttribute('content'), 'width=device-width, initial-scale=1.0');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f35e5c4321f818cdc4bed30.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f35e5c4321f818cdc4bed30.md
@@ -13,10 +13,10 @@ Add an empty `article` element under the `Coffee` heading. It will contain a fla
 
 # --hints--
 
-You should have an opening `<article>` tag.
+You should have an `article` element.
 
 ```js
-assert.match(code,/<article>/i);
+assert.exists(document.querySelector('article'));
 ```
 
 You should have a closing `</article>` tag.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3cade99dda4e6071a85dfd.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3cade99dda4e6071a85dfd.md
@@ -11,10 +11,10 @@ You will come back to styling the menu in a few steps, but for now, go ahead and
 
 # --hints--
 
-You should have an opening `section` tag.
+You should have two `section` elements.
 
 ```js
-assert.lengthOf(code.match(/<section>/ig) ,2);
+assert.lengthOf(document.querySelectorAll('section'), 2);
 ```
 
 You should have a closing `section` tag.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e01f288a026d709587.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e01f288a026d709587.md
@@ -26,7 +26,7 @@ Note that the `hr` element is a void element.
 You should add an `hr` element.
 
 ```js
-assert.match(code, /<hr\s?\/?>/i);
+assert.exists(document.querySelector('hr'));
 ```
 
 The `hr` element is a void element, it should not have an end tag `</hr>`.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e07276f782bb46b93d.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e07276f782bb46b93d.md
@@ -11,10 +11,10 @@ Add a `footer` element below the `main` element, where you can add some addition
 
 # --hints--
 
-You should have an opening `<footer>` tag.
+You should have a `footer` element.
 
 ```js
-assert.match(code,(/<footer>/i));
+assert.exists(document.querySelector('footer'));
 ```
 
 You should have a closing `</footer>` tag.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e087d56ed3ffdc36be.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e087d56ed3ffdc36be.md
@@ -14,7 +14,8 @@ Now apply the `established` class to the `Est. 2020` text.
 You should set the `class` of the `p` element to `established`.
 
 ```js
-assert.match(code,/<p class=('|")established\1>/i);
+const established = document.querySelector('.established');
+assert.equal(established?.tagName, 'P');
 ```
 
 Your `established` class should be on the element with the text `Est. 2020`.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e7a4750dd05b5a673920.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e7a4750dd05b5a673920.md
@@ -14,7 +14,7 @@ Now apply the `address` class to the `p` element containing the street address `
 You should apply the `class="address"` attribute.
 
 ```js
-assert.match(code, /class=('|")address\1/i);
+assert.exists(document.querySelector('.address'));
 ```
 
 Your `.address` element should be your `p` element.

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f4701b942c824109626c3d8.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f4701b942c824109626c3d8.md
@@ -14,7 +14,7 @@ Now add the `bottom-line` class to the second `hr` element so the styling is app
 You should add the `class` attribute with the value `bottom-line`.
 
 ```js
-assert.match(code,/class=('|")bottom-line\1/i);
+assert.exists(document.querySelector('.bottom-line'));
 ```
 
 Your `bottom-line` class should be applied to your second `hr` element.


### PR DESCRIPTION
Closes #69075.

Steps 1, 2, 3, 4, 5, 25, 59, and 63 (main/h1/p/section/h2/article/footer/hr) now check document.querySelector(...) for element presence instead of a regex on the source. Closing-tag hints stay as source checks per your note, since the DOM can't tell whether a closing tag was actually written.

Step 6's head/style nesting check and step 11's "no style tags left" check both now query the DOM directly, excluding the environment's own injected .fcc-hide-header style tag so it doesn't cause a false pass or fail.

Step 13's meta count and the viewport name/content checks use real attribute selectors now instead of matching outerHTML with regex. Steps 57, 73, and 85 (established/bottom-line/address) check for the class on the DOM instead of matching it in source.

Left steps 36, 39, 46, and 48 (the whitespace-between-paragraphs checks) as source checks, a DOM version gets awkward there, like you said.

On verification: the real test-content suite needs a live Puppeteer/Chrome connection, and spinning that up wasn't practical here, so I wrote a standalone jsdom and chai script instead, running each changed hint against the actual before/after HTML for its step. All 15 pass in both directions, including the two injected-style-tag edge cases for steps 6 and 11. I didn't run the actual test-content suite.
