### PR TITLE
fix(curriculum): correct CSS indentation in workshop cafe menu

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344f9c805cd193c33d829c.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f344f9c805cd193c33d829c.md
@@ -11,7 +11,7 @@ In previous lessons, you learned how to add `CSS` properties and values like thi
 
 ```css
 element {
- property: value;
+  property: value;
 }
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69082 

<!-- Feel free to add any additional description of changes below this line -->

## Description

Fixed the CSS example indentation in Workshop Cafe Menu Step 7.

The declaration is now indented with two spaces to match the curriculum formatting.