### PR TITLE
fix: correct Step 29 hotel feedback form hints

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a97ca8c4cbae7d0bb6e0ad.md
@@ -181,11 +181,11 @@ assert.exists(document.querySelector('fieldset:nth-of-type(4) select#food option
           <label for="service">How was the service?</label>
 
           <select name="service" id="service">
-            <option value="poor">Poor</option>
-            <option value="satisfactory">Satisfactory</option>
-            <option value="good">Good</option>
-            <option value="very-good">Very Good</option>
-            <option selected value="excellent">Excellent</option>
+            <option value="Poor">Poor</option>
+            <option value="Satisfactory">Satisfactory</option>
+            <option value="Good">Good</option>
+            <option value="Very Good">Very Good</option>
+            <option selected value="Excellent">Excellent</option>
           </select>
 
           <label for="food">How was the food?</label>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69067

<!-- Feel free to add any additional description of changes below this line -->

## Description

Updated Step 29 of the Hotel Feedback Form workshop to fix text inconsistencies and incorrect attribute wording.

Changes made:
- Updated the `selected` attribute hint to correctly describe it as a boolean attribute.
- Removed unnecessary quotes around option text in hints.
- Updated the section headings to match the wording pattern used in Step 26.
- Made the `value` attribute hints consistent with the existing wording in the step.

These changes only update curriculum text and do not affect any tests or functionality.