### PR TITLE
fix(curriculum): add missing dollar sign to cart row prices in shopping cart workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f01861f813e01564c95315.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f01861f813e01564c95315.md
@@ -7,7 +7,7 @@ dashedName: step-31
 
 # --description--
 
-Inside your `div`, add two `p` elements. Set the text of the second `p` element to be the value of the `price` variable.
+Set the text of the second `p` element to be the value of the `price` variable preceded by a dollar sign (`$`).
 
 # --hints--
 
@@ -22,13 +22,13 @@ assert.strictEqual(div?.children[0].tagName, 'P');
 assert.strictEqual(div?.children[1].tagName, 'P');
 ```
 
-Your second `p` element should have the text of the `price` variable.
+Your second `p` element should have the text of the `price` variable preceded by `$`.
 
 ```js
 const cart = new ShoppingCart();
 cart.addItem(1, products);
 const div = document.querySelector('.product');
-assert.strictEqual(div?.children[1].textContent, '12.99');
+assert.strictEqual(div?.children[1].textContent, '$12.99');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f018f04e487e164dc27bd9.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f018f04e487e164dc27bd9.md
@@ -290,7 +290,7 @@ class ShoppingCart {
           
 --fcc-editable-region--
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f01c9791a0aa1751c73760.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f01c9791a0aa1751c73760.md
@@ -271,7 +271,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0224ceb16dc196d2c860a.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0224ceb16dc196d2c860a.md
@@ -271,7 +271,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f026d041bc6c1a3d5cba0f.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f026d041bc6c1a3d5cba0f.md
@@ -273,7 +273,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0284532742c1b26c7a052.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0284532742c1b26c7a052.md
@@ -271,7 +271,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0289df84a581bbdbd29b7.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0289df84a581bbdbd29b7.md
@@ -267,7 +267,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0295e673b661ccb299e8a.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0295e673b661ccb299e8a.md
@@ -270,7 +270,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f029b96b9e9e1df93be951.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f029b96b9e9e1df93be951.md
@@ -259,7 +259,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02a4ef92d711ec1ff618c.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02a4ef92d711ec1ff618c.md
@@ -292,7 +292,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02b22cce1c11fe9604381.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02b22cce1c11fe9604381.md
@@ -259,7 +259,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02bdeb9b428208b97eb6b.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02bdeb9b428208b97eb6b.md
@@ -276,7 +276,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02c6e18773921ba50aa53.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f02c6e18773921ba50aa53.md
@@ -270,7 +270,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0311f5ea9382388d6124f.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0311f5ea9382388d6124f.md
@@ -256,7 +256,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f033fdb1fbcc254999fcc3.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f033fdb1fbcc254999fcc3.md
@@ -265,7 +265,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03446c2ed3e264be6c7fc.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03446c2ed3e264be6c7fc.md
@@ -259,7 +259,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0348a54a177272071a595.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0348a54a177272071a595.md
@@ -271,7 +271,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f034d012f74627ce538d3a.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f034d012f74627ce538d3a.md
@@ -279,7 +279,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03686c5ea863533ec71f4.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03686c5ea863533ec71f4.md
@@ -261,7 +261,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f036ec91fdf238c90665f5.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f036ec91fdf238c90665f5.md
@@ -259,7 +259,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0370b340915399d31e5eb.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0370b340915399d31e5eb.md
@@ -273,7 +273,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0374d5351223a747c301d.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0374d5351223a747c301d.md
@@ -299,7 +299,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0378e173e3c3b7638b528.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f0378e173e3c3b7638b528.md
@@ -255,7 +255,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f038a0ae041d3c5b0cdf23.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f038a0ae041d3c5b0cdf23.md
@@ -253,7 +253,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f038e671d3f73d5a041973.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f038e671d3f73d5a041973.md
@@ -269,7 +269,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f039dbcef7673e4e758fa3.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f039dbcef7673e4e758fa3.md
@@ -274,7 +274,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03a7143a6ef3f7f3344f0.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03a7143a6ef3f7f3344f0.md
@@ -267,7 +267,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03ac2b428b2404a5a7518.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03ac2b428b2404a5a7518.md
@@ -253,7 +253,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03af535682e4138fdb915.md
@@ -279,7 +279,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03b1ed5ab15420c057463.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f03b1ed5ab15420c057463.md
@@ -271,7 +271,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }
@@ -574,7 +574,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }

--- a/curriculum/challenges/english/blocks/workshop-shopping-cart/63f6721d5110af243ef8f3d9.md
+++ b/curriculum/challenges/english/blocks/workshop-shopping-cart/63f6721d5110af243ef8f3d9.md
@@ -254,7 +254,7 @@ class ShoppingCart {
         <p>
           <span class="product-count" id="product-count-for-id${id}"></span>${name}
         </p>
-        <p>${price}</p>
+        <p>$${price}</p>
       </div>
       `;
   }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69115

Added missing dollar sign `$` to the cart item row price in Step 31 through Step 61 of the shopping cart workshop curriculum.