### PR TITLE
fix(curriculum): add backticks around 300px in cafe menu workshop hint

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed63c7807a4f1e6d054.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed63c7807a4f1e6d054.md
@@ -37,7 +37,7 @@ const hasWidth = new __helpers.CSSHelp(document).getCSSRules().some(x => x.style
 assert.isTrue(hasWidth);
 ```
 
-Your `div` should have a width of 300px.
+Your `div` should have a width of `300px`.
 
 ```js
 const divWidth = new __helpers.CSSHelp(document).getStyle("#menu")?.getPropertyValue('width');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
## Description

Added backticks around `300px` in the Step 17 hint of the Cafe Menu workshop to improve formatting consistency.

Closes #69121

<!-- Feel free to add any additional description of changes below this line -->
