### PR TITLE
fix(curriculum): correct grammar and formatting in hotel feedback form workshop

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -7665,7 +7665,7 @@
         "title": "Build a Hotel Feedback Form",
         "intro": [
           "In this workshop, you will build a Hotel Feedback Form.",
-          "You will practice working with labels, inputs, fieldsets, legends, textareas and buttons."
+          "You will practice working with the <code>label</code>, <code>input</code>, <code>fieldset</code>, <code>legend</code>, <code>textarea</code>, and <code>button</code> elements."
         ]
       },
       "lecture-working-with-tables": {
@@ -8247,7 +8247,7 @@
         "title": "Build a Hotel Feedback Form",
         "intro": [
           "In this workshop, you will build a Hotel Feedback Form.",
-          "You will practice working with labels, inputs, fieldsets, legends, textareas and buttons."
+          "You will practice working with the <code>label</code>, <code>input</code>, <code>fieldset</code>, <code>legend</code>, <code>textarea</code>, and <code>button</code> elements."
         ]
       },
       "lecture-working-with-tables": {

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a8380d911e3f4270d5cadc.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a8380d911e3f4270d5cadc.md
@@ -7,7 +7,7 @@ dashedName: step-2
 
 # --description--
 
-Now, it is time to add the `main` element which represents the main content of the page.
+Now, it is time to add the `main` element, which represents the main content of the page.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83e5e491625454b6f62c3.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83e5e491625454b6f62c3.md
@@ -7,14 +7,14 @@ dashedName: step-4
 
 # --description--
 
-Forms consist of `inputs` where users can input their data. You can group related inputs together using the `fieldset` element. 
+Forms consist of `input` elements where users can enter their data. You can group related inputs together using the `fieldset` element. 
 
 Here is an example of using a `fieldset` element:
 
 ```html
 <form action="/example-url">
   <fieldset>
-  <!-- inputs go inside here-->
+    <!-- inputs go inside here -->
   </fieldset>
 </form>
 ```

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83fec026a7a4631e084d2.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a83fec026a7a4631e084d2.md
@@ -15,7 +15,7 @@ Here is an example of using a `legend` element:
 <form action="/example-url">
   <fieldset>
     <legend>Personal Information</legend>
-    <!-- inputs go inside here-->
+    <!-- inputs go inside here -->
   </fieldset>
 </form>
 ```

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a930b20f589b6664c51cb0.md
@@ -7,7 +7,7 @@ dashedName: step-7
 
 # --description--
 
-When a user provides their full name, the `input` will accept plaintext.
+When a user provides their full name, the `input` will accept plain text.
 
 In previous lessons, you learned how to work with the `type` attribute like this:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

### Description
This PR resolves several small text, grammar, and formatting inconsistencies in the **Build a Hotel Feedback Form** workshop:
- **Step 2**: Added a missing comma before "which" in the description.
- **Step 4**: Singularized the `input` code token, replaced the duplicate "input" verb with "enter", and fixed the indentation/spacing of the comment in the code example.
- **Step 5**: Added missing spacing before the closing syntax `-->` in the code example comment.
- **Step 7**: Changed "plaintext" to "plain text" in the description.
- **intro.json**: Tagged the list of HTML elements with `<code>`, added the Oxford comma, and corrected the phrasing in both occurrences of the block intro.

Closes #69062

<!-- Feel free to add any additional description of changes below this line -->
