### PR TITLE
fix(curriculum): update hotel feedback form hints

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a94ea5df66236ebed260e8.md
@@ -15,13 +15,13 @@ Inside the `fieldset` element, add a `legend` element with the text of `Was this
 
 # --hints--
 
-You should have a `fieldset` element.
+You should have a second `fieldset` element.
 
 ```js
 assert.lengthOf(document.querySelectorAll('fieldset'), 2);
 ```
 
-You should have a `legend` element inside of your `fieldset` element.
+You should have a `legend` element inside your new `fieldset` element.
 
 ```js
 assert.lengthOf(document.querySelectorAll('fieldset legend'), 2);

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9521bc70162712caf118d.md
@@ -44,7 +44,7 @@ Your `radio` button should have a `name` attribute set to `"hotel-stay"`.
 assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) legend + input[type="radio"]')?.name, 'hotel-stay');
 ```
 
-Your radio button should have a `value` attribute set to `"yes"`.
+Your `radio` button should have a `value` attribute set to `"yes"`.
 
 ```js
 assert.strictEqual(

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a954b2bcddba72076c1857.md
@@ -39,7 +39,7 @@ Your `input` element should have a `name` attribute of `"hotel-stay"`.
 assert.strictEqual(document.querySelector('fieldset:nth-of-type(2) label + input')?.name, 'hotel-stay');
 ```
 
-Your input element should have a `value` attribute set to `"no"`.
+Your `input` element should have a `value` attribute set to `"no"`.
 
 ```js
 assert.strictEqual(

--- a/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
+++ b/curriculum/challenges/english/blocks/workshop-hotel-feedback-form/66a9577022877d72d8f43b4f.md
@@ -15,7 +15,7 @@ Inside the `fieldset` element, add a `legend` element with the text `Why did you
 
 # --hints--
 
-You should have a `fieldset` element.
+You should have a third `fieldset` element.
 
 ```js
 assert.lengthOf(document.querySelectorAll('fieldset'), 3);
@@ -27,7 +27,7 @@ You should have a `legend` element inside the `fieldset` element.
 assert.lengthOf(document.querySelectorAll('fieldset:nth-of-type(3) legend'), 1);
 ```
 
-Your `legend` element should have the text of `Why did you choose to stay at our hotel? (Check all that apply)`. Double check for spelling errors and spacing issues.
+Your `legend` element should have the text of `Why did you choose to stay at our hotel? (Check all that apply)`. Double-check for spelling errors and spacing issues.
 
 ```js
 assert.strictEqual(document.querySelector('fieldset:nth-of-type(3) legend')?.innerText.trim(), 'Why did you choose to stay at our hotel? (Check all that apply)');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69064

<!-- Feel free to add any additional description of changes below this line -->

### Summary

This PR updates the hint wording for the Hotel Feedback Form workshop by:

- Clarifying the second and third `fieldset` hints.
- Updating the `legend` hint wording.
- Fixing formatting for the `radio` and `input` element hints.
- Changing "Double check" to "Double-check".
