### PR TITLE
fix(curriculum): change answer options for unclear functions question

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-functions/672d269da46786225e3fe3fd.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-functions/672d269da46786225e3fe3fd.md
@@ -4,7 +4,6 @@ title: What Is the Purpose of Functions, and How Do They Work?
 challengeType: 19
 dashedName: what-is-the-purpose-of-functions-and-how-do-they-work
 ---
-
 # --interactive--
 
 Functions are reusable pieces of code that perform a specific task or calculate a value. Think of functions as a machine that takes some input, does some operations on it, and then produces an output. Here is an example of declaring a function:
@@ -31,7 +30,7 @@ greet(); // "Hello, Jessica!"
 
 :::
 
-Now the message of `Hello, Jessica!` will be logged to the console. But what if we wanted the message to say `Hello, Nick!` or `Hello, Anna!`? We don't want to write a new function each time we greet a different user. Instead, we can create a reusable function that uses function parameters and arguments. 
+Now the message of `Hello, Jessica!` will be logged to the console. But what if we wanted the message to say `Hello, Nick!` or `Hello, Anna!`? We don't want to write a new function each time we greet a different user. Instead, we can create a reusable function that uses function parameters and arguments.
 
 Parameters act as placeholders for the values that will be passed to the function when it is called. They allow functions to accept input and work with that input. Arguments are the actual values passed to the function when it is called. Here is an updated version of the `greet` function that uses parameters and arguments:
 
@@ -48,9 +47,9 @@ greet("Nick"); // Hello, Nick!
 
 :::
 
-The `name` serves as the parameter while the strings `Alice` and `Nick` serve as the arguments. Now we have a reusable function that can be used dozens of times throughout our code with different arguments. 
+The `name` serves as the parameter while the strings `Alice` and `Nick` serve as the arguments. Now we have a reusable function that can be used dozens of times throughout our code with different arguments.
 
-When a function finishes its execution, it will always return a value. By default, the return value will be `undefined`. Here is an example: 
+When a function finishes its execution, it will always return a value. By default, the return value will be `undefined`. Here is an example:
 
 :::interactive_editor
 
@@ -95,7 +94,7 @@ console.log(sum(3, 4)); // 7
 
 :::
 
-In this example, we have a `const` variable called `sum` and we are assigning it an anonymous function that returns the sum of `num1` and `num2`. We are then able to call `sum` and pass in the numbers `3` and `4` to get the result of `7`. 
+In this example, we have a `const` variable called `sum` and we are assigning it an anonymous function that returns the sum of `num1` and `num2`. We are then able to call `sum` and pass in the numbers `3` and `4` to get the result of `7`.
 
 Functions support default parameters, allowing you to set default values for parameters. These default values are used if the function is called without an argument for that parameter. Here's an example:
 
@@ -174,7 +173,7 @@ function sum(num1, num2) {
 ## --answers--
 
 ```js
-()sum>
+(1, 2)sum>
 ```
 
 ### --feedback--
@@ -184,7 +183,7 @@ Review the section where function calls were discussed.
 ---
 
 ```js
-()sum()
+(1, 2)sum(1, 2)
 ```
 
 ### --feedback--
@@ -194,13 +193,13 @@ Review the section where function calls were discussed.
 ---
 
 ```js
-sum()
+sum(1, 2)
 ```
 
 ---
 
 ```js
-<sum>
+<(1, 2)sum>
 ```
 
 ### --feedback--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68744

<!-- Feel free to add any additional description of changes below this line -->

Adjusted the answers to the simple function call question so they now read out as:

## --answers--

```js
(1, 2)sum>
```

### --feedback--

Review the section where function calls were discussed.

---

```js
(1, 2)sum(1, 2)
```

### --feedback--

Review the section where function calls were discussed.

---

```js
sum(1, 2)
```

---

```js
<(1, 2)sum>
```

### --feedback--

Review the section where function calls were discussed.