### PR TITLE
feat(curriculum): add interactive editors to event bubbling lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-the-event-object-and-event-delegation/67338e93b75977a344cf6d40.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-event-object-and-event-delegation/67338e93b75977a344cf6d40.md
@@ -5,7 +5,7 @@ challengeType: 19
 dashedName: how-do-event-bubbling-and-event-delegation-work
 ---
 
-# --description--
+# --interactive--
 
 Event bubbling, or propagation, refers to how an event "bubbles up" to parent objects when triggered. For example, consider this code:
 
@@ -21,12 +21,25 @@ When you click on the `span` element, like you are instructed to, the `span` ele
 
 But what does this actually mean? Well, you could attach an event listener to the `p` element:
 
-```js
-const p = document.querySelector("p");
-p.addEventListener("click", (event) => {
-  console.log(event.target);
-});
+:::interactive_editor
+
+```html
+<p>
+  <span>Click me~!</span>
+</p>
+<script src="index.js"></script>
 ```
+
+```js
+{
+  const p = document.querySelector("p");
+  p.addEventListener("click", (event) => {
+    console.log(event.target);
+  });
+}
+```
+
+:::
 
 Then, when you click on the `span` element you will see the text `Click me~!` logged to the console.
 
@@ -36,20 +49,34 @@ Notice how the target is still the `span` element. This is because the `span` el
 
 Just to be sure how things are working, let's expand our code:
 
-```js
-const p = document.querySelector("p");
-const span = document.querySelector("span");
-p.addEventListener("click", (event) => {
-  console.log("P listener: ");
-  console.log(event.target);
-});
-span.addEventListener("click", (event) => {
-  console.log("Span listener: ");
-  console.log(event.target);
-});
+:::interactive_editor
+
+```html
+<p>
+  <span>Click me~!</span>
+</p>
+<script src="index.js"></script>
 ```
 
+```js
+{
+  const p = document.querySelector("p");
+  const span = document.querySelector("span");
+  p.addEventListener("click", (event) => {
+    console.log("P listener: ");
+    console.log(event.target);
+  });
+  span.addEventListener("click", (event) => {
+    console.log("Span listener: ");
+    console.log(event.target);
+  });
+}
+```
+
+:::
+
 To give you an idea of how the event bubbles up, here's what you'll see in the console after clicking the `span` element:
+
 
 ```html
 "Span listener: "
@@ -60,19 +87,32 @@ To give you an idea of how the event bubbles up, here's what you'll see in the c
 
 Now let's see what happens when you prevent the propagation of an event with `stopPropagation()`. We'll call it in our `span`'s event listener:
 
-```js
-const p = document.querySelector("p");
-const span = document.querySelector("span");
-p.addEventListener("click", (event) => {
-  console.log("P listener: ");
-  console.log(event.target);
-});
-span.addEventListener("click", (event) => {
-  console.log("Span listener: ");
-  console.log(event.target);
-  event.stopPropagation();
-});
+:::interactive_editor
+
+```html
+<p>
+  <span>Click me~!</span>
+</p>
+<script src="index.js"></script>
 ```
+
+```js
+{
+  const p = document.querySelector("p");
+  const span = document.querySelector("span");
+  p.addEventListener("click", (event) => {
+    console.log("P listener: ");
+    console.log(event.target);
+  });
+  span.addEventListener("click", (event) => {
+    console.log("Span listener: ");
+    console.log(event.target);
+    event.stopPropagation();
+  });
+}
+```
+
+:::
 
 And then click our `span` again:
 
@@ -87,14 +127,27 @@ Event delegation can be thought of as the opposite. It's the process of taking a
 
 Going back to our code, let's update it so clicking on a `span` element changes it to red:
 
-```js
-const p = document.querySelector("p");
-const span = document.querySelector("span");
-p.addEventListener("click", (event) => {});
-span.addEventListener("click", (event) => {
-  event.target.style.color = "red";
-});
+:::interactive_editor
+
+```html
+<p>
+  <span>Click me~!</span>
+</p>
+<script src="index.js"></script>
 ```
+
+```js
+{
+  const p = document.querySelector("p");
+  const span = document.querySelector("span");
+  p.addEventListener("click", (event) => {});
+  span.addEventListener("click", (event) => {
+    event.target.style.color = "red";
+  });
+}
+```
+
+:::
 
 But what if you have twenty `span` elements? Or maybe you use JavaScript to create more `span` elements on the fly?
 
@@ -113,6 +166,8 @@ Notice how we no longer have any listener attached to the `span` element at all.
 
 Let's generate a few extra `span` elements and see:
 
+:::interactive_editor
+
 ```html
 <p>
   <span>Click me~!</span>
@@ -120,7 +175,19 @@ Let's generate a few extra `span` elements and see:
   <span>Click me~!</span>
   <span>Click me~!</span>
 </p>
+<script src="index.js"></script>
 ```
+
+```js
+{
+  const p = document.querySelector("p");
+  p.addEventListener("click", (event) => {
+    event.target.style.color = "red";
+  });
+}
+```
+
+:::
 
 Now, each time we click on a `span`, that element's text will become red. 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes ##69139

<!-- Feel free to add any additional description of changes below this line -->
Proposed adding interactive editors throughout the "How Do Event Bubbling, and Event Delegation Work?" lesson to provide learners with hands-on examples for event bubbling and event delegation. This makes it easier to follow the lesson by allowing readers to interact with the code instead of relying solely on static code snippets.