### PR TITLE
fix(client): convey course progress steps to screen reader users in s…

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -158,11 +158,20 @@ const Chapter = ({
       {isLinkChapter && examSlug && (
         <BlockLabelComponent blockLabel={BlockLabel.exam} />
       )}
+      {!comingSoon && !isLinkChapter && (
+        <span className='sr-only'>
+          {' '}
+          {t('learn.steps-completed', {
+            totalSteps,
+            completedSteps
+          })}
+        </span>
+      )}
     </div>
   );
 
   const chapterButtonRightContent = (
-    <div className='chapter-button-right'>
+    <div className='chapter-button-right' aria-hidden='true'>
       {!comingSoon && !isLinkChapter && (
         <span className='chapter-steps'>
           {t('learn.steps-completed', {
@@ -310,6 +319,15 @@ const Module = ({
               <CheckMark isCompleted={isComplete} />
             </span>
             {moduleLabel}
+            {!comingSoon && !!totalSteps && (
+              <span className='sr-only'>
+                {' '}
+                {t('learn.steps-completed', {
+                  totalSteps,
+                  completedSteps
+                })}
+              </span>
+            )}
           </div>
         </button>
         {resetButton}
@@ -322,7 +340,7 @@ const Module = ({
           onClick={toggleOpen}
           type='button'
         >
-          <div className='module-button-right'>
+          <div className='module-button-right' aria-hidden='true'>
             {!comingSoon && !!totalSteps && (
               <span className='module-steps'>
                 {t('learn.steps-completed', {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67770

### Summary of Changes
- Added an `sr-only` span containing `{t('learn.steps-completed', { totalSteps, completedSteps })}` inside `module-button-main` and `chapter-button-left` in `super-block-accordion.tsx` to announce course progress to screen reader users.
- Added `aria-hidden="true"` to `module-button-right` and `chapter-button-right` so screen readers do not announce step counts twice.
- Resolves issue #67770 while keeping visual CSS layouts and existing test suites 100% intact.
