### PR TITLE
fix(curriculum): fix plural possessive typo in Cafe Menu step 37

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3cade94c6576e7f7b7953f.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3cade94c6576e7f7b7953f.md
@@ -7,7 +7,7 @@ dashedName: step-37
 
 # --description--
 
-Now go ahead and change both the `flavor` and `price` class' widths to be `50%` again.
+Now go ahead and change both the `flavor` and `price` classes' widths to be `50%` again.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:


- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #69154

In Step 37 of the Cafe Menu workshop, updated the instructions to use the correct plural possessive form (`classes'`) instead of the singular possessive (`class'`) when referring to both the `flavor` and `price` classes.