### PR TITLE
fix(curriculum): update description for cafe menu step 25

### DIFF
--- a/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f35e5c4321f818cdc4bed30.md
+++ b/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f35e5c4321f818cdc4bed30.md
@@ -9,7 +9,7 @@ dashedName: step-29
 
 Now that things look good, it's time to start adding some menu items.
 
-Add an empty `article` element under the `Coffee` heading. It will contain a flavor and price of each coffee you currently offer.
+Add an empty `article` element under the `Coffee` heading. It will contain the flavor and price of one of the coffees you currently offer.
 
 
 # --hints--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f35e5c4321f818cdc4bed30.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f35e5c4321f818cdc4bed30.md
@@ -9,7 +9,7 @@ dashedName: step-25
 
 Now that things look good, it's time to start adding some menu items.
 
-Add an empty `article` element under the `Coffee` heading. It will contain a flavor and price of each coffee you currently offer.
+Add an empty `article` element under the `Coffee` heading. It will contain the flavor and price of one of the coffees you currently offer.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69151

The description for Step 25 of the Cafe Menu workshop implies that a single `article` element will hold the flavor and price of *each* coffee on the menu. This PR updates the description to correctly specify that the `article` element will hold the flavor and price of *one* of the coffees, clarifying the intent for learners.