### PR TITLE
fix(curriculum): typo in cafe menu step 27

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3c866d5414453fc2d7b480.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3c866d5414453fc2d7b480.md
@@ -7,7 +7,7 @@ dashedName: step-27
 
 # --description--
 
-Starting below the existing coffee/price pair, add the following coffee and prices using `article` elements with two nested `p` elements inside each.
+Starting below the existing coffee/price pair, add the following coffees and prices using `article` elements with two nested `p` elements inside each.
 
 ```md
 Caramel Macchiato 3.75


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69152

<!-- Feel free to add any additional description of changes below this line -->
Updated the description of Step 27 of the Cafe Menu workshop to use "coffees" (plural) instead of "coffee" (singular). Verified the change via the challenge editor and confirmed the diff locally.