### PR TITLE
fix(curriculum): correct wording in cafe menu step 22

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed6199b0cdef1d2be8f.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed6199b0cdef1d2be8f.md
@@ -13,11 +13,11 @@ You learned how to work with `class` selectors in previous lessons like this:
 
 ```css
 .class-name {
-  styles
+  property: value;
 }
 ```
 
-Change the existing `#menu` selector into a class selector by replacing `#menu` with a class named `.menu`.
+Change the existing `#menu` selector into a class selector by replacing `#menu` with the class selector `.menu`.
 
 # --hints--
 


### PR DESCRIPTION
Closes #69150.

The CSS placeholder in the description used `styles` instead of a real declaration, `property: value;` like steps 7 and 9 already do. Also rewrote the class/selector line, `.menu` is the selector for the class named `menu`, not a class named `.menu`.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.