### PR TITLE
fix(curriculum): clarify Step 34 width property wording

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3c866d0fc037f7311b4ac8.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3c866d0fc037f7311b4ac8.md
@@ -9,7 +9,7 @@ dashedName: step-34
 
 That's closer, but the price didn't stay over on the right. This is because `inline-block` elements only take up the width of their content.
 
-To spread them out, add a `width` property to the `flavor` and `price` class selectors that have a value of `50%` each.
+To spread them out, add a `width` property with a value of `50%` to both the `flavor` and `price` class selectors.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69153 

<!-- Feel free to add any additional description of changes below this line -->

This PR updates the wording in Step 34 of the Cafe Menu workshop to clarify that the `50%` value applies to the `width` property rather than the `flavor` and `price` class selectors.