### PR TITLE
fix(curriculum): use prose for count in Step 51

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e04559b939080db057.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e04559b939080db057.md
@@ -7,7 +7,7 @@ dashedName: step-51
 
 # --description--
 
-Since all `4` sides of the menu have the same internal spacing, remove the four properties and use a single `padding` property with the value `20px`.
+Since all four sides of the menu have the same internal spacing, remove the four properties and use a single `padding` property with the value `20px`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69169

<!-- Feel free to add any additional description of changes below this line -->

This PR updates the Step 51 instructions to use the word "four" instead of formatting the count `4` as code, while preserving code formatting for the `padding` property and `20px` value.