### PR TITLE
fix(curriculum): clarify Date inputs

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -48,7 +48,7 @@ console.log(specificDate);
 
 :::
 
-This is useful when you need to work with a specific date and time rather than the current date and time. The input always needs to be a string, and the format should be recognizable by the `Date` object.
+This is useful when you need to work with a specific date and time rather than the current date and time. The constructor also accepts a numeric timestamp or separate numeric arguments for the date and time components. String inputs must use a format recognized by the `Date` object.
 
 To get the current date and time, you can use the `Date.now()` method, which returns the number of milliseconds since `January 1, 1970, 00:00:00 UTC`. This is known as the Unix epoch time.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #69170

The lesson said `Date` input must always be a string, even though the constructor also accepts numeric timestamps and separate date and time components. This change lists those input forms and keeps the format requirement specific to string inputs.

Tested with:

- `npx --yes prettier@3.8.2 --check curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md`
- A Node.js smoke check covering string, timestamp, and component constructors; all three produced valid dates
