### PR TITLE
fix: Fix CSS flexbox lecture content issues

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
@@ -7,7 +7,7 @@ dashedName: what-is-css-flexbox
 
 # --interactive--
 
-CSS flexbox is a one-dimensional layout model that allows you to arrange elements in rows and columns within a container. You can also control their order and orientation. Web developers use it to create responsive websites and web applications that adapt to different screen sizes and orientations. We refer to flexbox as a one-dimensional layout model because it focuses on arranging elements along a single axis at a time. The axis can be either horizontal or vertical. 
+CSS flexbox is a one-dimensional layout model that allows you to arrange elements in rows or columns within a container. You can also control their order and orientation. Web developers use it to create responsive websites and web applications that adapt to different screen sizes and orientations. We refer to flexbox as a one-dimensional layout model because it focuses on arranging elements along a single axis at a time. The axis can be either horizontal or vertical. 
 
 There are two key concepts that you should know about before you start working with flexbox: flex container and flex item.
 
@@ -25,7 +25,7 @@ This is an example with a `main` container and three child `div` elements:
 </main>
 ```
 
-If you set only the `width`, `height`, and `background-color` of these `div` elements in the CSS stylesheet, every child element will be placed on its own row because the container is not flex by default. 
+If you set only the `width`, `height`, and `background-color` of these `div` elements in the CSS stylesheet, every child element will be placed on its own row because the container is not flex by default (to see the previews, enable the interactive editor):
 
 :::interactive_editor
 
@@ -59,7 +59,7 @@ div {
 
 :::
 
-But if you add `display: flex` to the `main` container, the `div` elements will be rearranged to fit on the same row and they will shrink if necessary (to see the previews, enable the interactive editor):
+But if you add `display: flex` to the `main` container, the `div` elements will be rearranged to fit on the same row and they will shrink if necessary:
 
 :::interactive_editor
 
@@ -101,7 +101,7 @@ By default, a flex container will be a block-level element, so the container its
 
 Now that you know more about flex containers and flex items, you should also know about flex properties. These properties determine how flex items will be arranged, resized, and distributed within the flex container. Some of the most commonly used ones are `flex-direction`, `justify-content`, `align-items`, and `flex-wrap`.
 
-Great. Now let’s talk a little bit about the flex model. This model defines how flex items are arranged within a flex container. Every flex container has two axes:
+Great. Now let's talk a little bit about the flex model. This model defines how flex items are arranged within a flex container. Every flex container has two axes:
 
 - The main axis.
 - The cross axis.
@@ -239,7 +239,7 @@ CSS flexbox is a powerful layout model that provides a flexible and efficient wa
 
 ## --text--
 
-What is the primary purpose of CSS Flexbox?
+What is the primary purpose of CSS flexbox?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69149 

Fix a few copy issues in the CSS Flexbox lecture: correct the opening definition, standardize the apostrophe and quiz casing, and move the interactive editor note to the first example where it belongs.
