### PR TITLE
fix(curriculum): format price class as code in step 41

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f47633757ae3469f2d33d2e.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f47633757ae3469f2d33d2e.md
@@ -9,7 +9,7 @@ dashedName: step-41
 
 If you make the width of the page preview smaller, you will notice at some point, some of the text on the left starts wrapping around to the next line. This is because the width of the `p` elements on the left side can only take up `50%` of the space.
 
-Since the prices on the right have significantly fewer characters, update the `flavor` class `width` to `75%` and the price class `width` to `25%`.
+Since the prices on the right have significantly fewer characters, update the `flavor` class `width` to `75%` and the `price` class `width` to `25%`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69166

<!-- Feel free to add any additional description of changes below this line -->

Added backticks around the `price` class name in the Step 41 instruction to match the formatting of the `flavor` class name in the same sentence.