### PR TITLE
fix(curriculum): name section in step 48 hint

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f716bee5838c354c728a7c5.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f716bee5838c354c728a7c5.md
@@ -45,7 +45,7 @@ You should have four new `.price` elements.
 assert.lengthOf(prices, 4);
 ```
 
-Your `section` element should have eight `p` elements.
+Your second `section` element should have eight `p` elements.
 
 ```js
 assert.lengthOf(paragraphs, 8);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69168

<!-- Feel free to add any additional description of changes below this line -->

Updated the Step 48 hint to specify `second section` instead of just `section`, since the page has two `section` elements by this step and the assertion scopes to the last one. This matches the wording of the first hint in the same file.