### PR TITLE
fix(curriculum): fix css example and selector in step 22

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed6199b0cdef1d2be8f.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed6199b0cdef1d2be8f.md
@@ -13,11 +13,11 @@ You learned how to work with `class` selectors in previous lessons like this:
 
 ```css
 .class-name {
-  styles
+  property: value;
 }
 ```
 
-Change the existing `#menu` selector into a class selector by replacing `#menu` with a class named `.menu`.
+Change the existing `#menu` selector into a class selector by replacing `#menu` with the class selector `.menu`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69150

<!-- Feel free to add any additional description of changes below this line -->

Two fixes in the Step 22 description:

1. The CSS example used `styles` as a placeholder, which is not a valid declaration. Changed it to `property: value;`, matching the shape used in Steps 7 and 9.

2. The instruction called `.menu` a "class named `.menu`". Changed it to "the class selector `.menu`", since `.menu` is the selector, not the class name. Step 23 makes this distinction correctly.