### PR TITLE
fix(curriculum): use prose for count in Step 51

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e04559b939080db057.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e04559b939080db057.md
@@ -7,7 +7,7 @@ dashedName: step-51
 
 # --description--
 
-Since all `4` sides of the menu have the same internal spacing, remove the four properties and use a single `padding` property with the value `20px`.
+Since all four sides of the menu have the same internal spacing, remove the four properties and use a single `padding` property with the value `20px`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69169

### Summary
Replaced the code-formatted `4` with the prose word "four" in Step 51 of the Cafe Menu workshop to match the rest of the sentence and improve clarity.
