### PR TITLE
fix(client/a11y): add sr-only for course progress

### DIFF
--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -310,6 +310,14 @@ const Module = ({
               <CheckMark isCompleted={isComplete} />
             </span>
             {moduleLabel}
+            {!comingSoon && !!totalSteps && (
+              <span className='sr-only'>
+                {`, ${t('learn.steps-completed', {
+                  totalSteps,
+                  completedSteps
+                })}`}
+              </span>
+            )}
           </div>
         </button>
         {resetButton}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67770

<!-- Feel free to add any additional description of changes below this line -->
### Description
This PR addresses an accessibility issue where screen reader users were not being informed of their course progress steps on the curriculum page. 

**Root Cause:**
The progress information (e.g. "X/Y steps completed") was being rendered inside a secondary toggle button (`module-button-right`), separate from the primary module button (`module-button-main`). Screen readers reading the main interactive element were completely missing the progress context.

**Proposed Changes:**
- Injected a screen-reader-only (`sr-only`) span directly into the primary `module-button-main` element in `super-block-accordion.tsx` containing the translated progress text.
- This ensures that assistive technologies seamlessly announce the module title *and* the user's progress simultaneously upon focusing the main button, without disrupting the visual DOM layout for sighted users.
