### PR TITLE
fix: correct grammar and wording in flex properties lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -9,7 +9,7 @@ dashedName: what-are-some-common-flex-properties
 
 Flex properties are properties that you can apply to flex containers to determine the distribution of child elements. We'll cover some of the most commonly used ones: `flex-wrap`, `justify-content`, and `align-items`.
 
-Let's start with `flex-wrap`. This property determines how flex items are wrapped within a flex container to fit the available space. `flex-wrap` can take three possible values: `nowrap`, `wrap`, and `wrap-reverse`. `nowrap` is the default value—flex items won't be wrapped onto a new line, even if their width exceeds the container's width.
+Let's start with `flex-wrap`. This property determines how flex items are wrapped within a flex container to fit the available space. `flex-wrap` can take three possible values: `nowrap`, `wrap`, and `wrap-reverse`. `nowrap` is the default value. Flex items won't be wrapped onto a new line, even if their width exceeds the container's width.
 
 In the code below, we have three `div` elements. Let's focus on the `width`. The `main` container bordered in red has a `width` of `200px`, while its three child `div` elements combined have a `width` of `240px` (`80px` each):
 
@@ -294,7 +294,7 @@ div {
 
 :::
 
-`justify-content: space-around` distributes flex items evenly within the main axis, adding a space before the first item and after the last item. This additional space is half of the space between each pair of adjacent items. If there's only one item to distribute, it will be centered.
+`justify-content: space-around` distributes flex items evenly along the main axis, adding a space before the first item and after the last item. This additional space is half of the space between each pair of adjacent items. If there's only one item to distribute, it will be centered.
 
 :::interactive_editor
 
@@ -335,7 +335,7 @@ div {
 :::
 
 
-And last but not least, we have `justify-content: space-evenly`, which distributes the items evenly along the main axis. The space between the items and the space before and after the first and last elements, are exactly the same:
+And last but not least, we have `justify-content: space-evenly`, which distributes the items evenly along the main axis. The space between the items and the space before and after the first and last elements are exactly the same:
 
 :::interactive_editor
 
@@ -682,7 +682,7 @@ Or you can align it to the end of the cross axis with `align-self: flex-end`.
 
 :::
 
-There are other flex properties and values that you can choose from to create the responsive layout that you envision, but these are the most commonly-used ones. With these CSS flex properties and your new knowledge of the CSS flex model, you can start creating responsive layouts to create a smooth and inclusive user experience across devices.
+There are other flex properties and values that you can choose from to create the responsive layout that you envision, but these are the most commonly used ones. With these CSS flex properties and your new knowledge of the CSS flex model, you can start creating responsive layouts to create a smooth and inclusive user experience across devices.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -9,7 +9,7 @@ dashedName: what-are-some-common-flex-properties
 
 Flex properties are properties that you can apply to flex containers to determine the distribution of child elements. We'll cover some of the most commonly used ones: `flex-wrap`, `justify-content`, and `align-items`.
 
-Let's start with `flex-wrap`. This property determines how flex items are wrapped within a flex container to fit the available space. `flex-wrap` can take three possible values: `nowrap`, `wrap`, and `wrap-reverse`. `nowrap` is the default value. Flex items won't be wrapped onto a new line, even if their width exceeds the container's width.
+Let's start with `flex-wrap`. This property determines how flex items are wrapped within a flex container to fit the available space. `flex-wrap` can take three possible values: `nowrap`, `wrap`, and `wrap-reverse`. `nowrap` is the default value: flex items won't be wrapped onto a new line, even if their width exceeds the container's width.
 
 In the code below, we have three `div` elements. Let's focus on the `width`. The `main` container bordered in red has a `width` of `200px`, while its three child `div` elements combined have a `width` of `240px` (`80px` each):
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -51,7 +51,6 @@ div {
 
 :::
 
-
 The width of the `div` elements exceeds the width of their container, but by default they will be shrunk to fit the available space. If you do want to wrap them when they exceed the width of their container, you can set `flex-wrap: wrap` on the flex container:
 
 :::interactive_editor
@@ -333,7 +332,6 @@ div {
 ```
 
 :::
-
 
 And last but not least, we have `justify-content: space-evenly`, which distributes the items evenly along the main axis. The space between the items and the space before and after the first and last elements are exactly the same:
 
@@ -764,7 +762,7 @@ Which of the following properties can be combined into the `flex-flow` property?
 
 ## --answers--
 
-`flex-direction` and `justify-content`.
+`flex-direction` and `justify-content`
 
 ### --feedback--
 
@@ -772,7 +770,7 @@ Think about the two main aspects of how flex items are laid out.
 
 ---
 
-`flex-direction` and `align-items`.
+`flex-direction` and `align-items`
 
 ### --feedback--
 
@@ -780,7 +778,7 @@ Think about the two main aspects of how flex items are laid out.
 
 ---
 
-`flex-direction` and `align-content`.
+`flex-direction` and `align-content`
 
 ### --feedback--
 
@@ -788,7 +786,7 @@ Think about the two main aspects of how flex items are laid out.
 
 ---
 
-`flex-direction` and `flex-wrap`.
+`flex-direction` and `flex-wrap`
 
 ## --video-solution--
 


### PR DESCRIPTION
Fixed the wording and grammar issues described in the issue.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69148

<!-- Feel free to add any additional description of changes below this line -->
