### PR TITLE
fix(curriculum): clarify Cafe Menu workshop Step 48 section hint

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f716bee5838c354c728a7c5.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f716bee5838c354c728a7c5.md
@@ -45,7 +45,7 @@ You should have four new `.price` elements.
 assert.lengthOf(prices, 4);
 ```
 
-Your `section` element should have eight `p` elements.
+Your second `section` element should have eight `p` elements.
 
 ```js
 assert.lengthOf(paragraphs, 8);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69168

## Description

This PR updates the Step 48 hint in the Cafe Menu workshop to specify that the assertion checks the second `section` element.

Previously, the hint referred to "Your `section` element", which was ambiguous because the page contains two `section` elements. This change makes the hint consistent with the earlier hint and clearer for learners.


