### PR TITLE
fix(a11y): convey course progress steps to screen reader users

### DIFF
--- a/client/src/templates/Introduction/components/block.css
+++ b/client/src/templates/Introduction/components/block.css
@@ -86,6 +86,14 @@
   background-color: transparent;
 }
 
+/* Reserves the reset button's layout box on rows where it does not apply (comingSoon/link
+   chapters, comingSoon modules), so the main button's content does not shift when it grows to
+   fill the gap. `visibility: hidden` keeps the box without making it hoverable, focusable, or
+   visible to assistive tech — it wins over the opacity rules above regardless of hover state. */
+.block-reset-button--placeholder {
+  visibility: hidden;
+}
+
 @media screen and (max-width: 767px) {
   .block-reset-button {
     display: none;

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -32,11 +32,7 @@
 .super-block-accordion .module-header-wrapper .module-button-main {
   flex: 1;
   min-width: 0;
-}
-
-.super-block-accordion .chapter-header-wrapper .chapter-button-toggle,
-.super-block-accordion .module-header-wrapper .module-button-toggle {
-  flex-shrink: 0;
+  justify-content: space-between;
 }
 
 .super-block-accordion .chapter-header-wrapper {
@@ -49,10 +45,6 @@
   padding: 16px;
   display: flex;
   align-items: center;
-}
-
-.super-block-accordion .chapter-button-toggle {
-  padding-left: 0;
 }
 
 .super-block-accordion .chapter-link {
@@ -131,10 +123,6 @@ button .block-header-button-text {
   font-weight: normal;
   gap: 10px;
   color: var(--primary-color);
-}
-
-.super-block-accordion .module-button-toggle {
-  padding-left: 0;
 }
 
 .super-block-accordion .block-header {

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -35,6 +35,11 @@
   justify-content: space-between;
 }
 
+.super-block-accordion .chapter-button-right,
+.super-block-accordion .module-button-right {
+  flex-shrink: 0;
+}
+
 .super-block-accordion .chapter-header-wrapper {
   background-color: var(--primary-background);
 }

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -610,8 +610,12 @@ describe('SuperBlockAccordion', () => {
     );
 
     // When expandAll=true, both chapters are open so their module main buttons are visible
-    expect(screen.getByRole('button', { name: 'mod-one' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'mod-two' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-one/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-two/ })
+    ).toBeInTheDocument();
   });
 
   it('should not render a module when all its challenges are filtered out', () => {
@@ -639,11 +643,13 @@ describe('SuperBlockAccordion', () => {
     );
 
     // mod-one has a challenge — its main module button should render
-    expect(screen.getByRole('button', { name: 'mod-one' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^mod-one/ })
+    ).toBeInTheDocument();
 
     // mod-two has no challenges — its main module button should not render
     expect(
-      screen.queryByRole('button', { name: 'mod-two' })
+      screen.queryByRole('button', { name: /^mod-two/ })
     ).not.toBeInTheDocument();
   });
 

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -611,10 +611,10 @@ describe('SuperBlockAccordion', () => {
 
     // When expandAll=true, both chapters are open so their module main buttons are visible
     expect(
-      screen.getByRole('button', { name: /^mod-one/ })
+      screen.getByRole('button', { name: 'mod-one learn.steps-completed' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /^mod-two/ })
+      screen.getByRole('button', { name: 'mod-two learn.steps-completed' })
     ).toBeInTheDocument();
   });
 
@@ -644,7 +644,7 @@ describe('SuperBlockAccordion', () => {
 
     // mod-one has a challenge — its main module button should render
     expect(
-      screen.getByRole('button', { name: /^mod-one/ })
+      screen.getByRole('button', { name: 'mod-one learn.steps-completed' })
     ).toBeInTheDocument();
 
     // mod-two has no challenges — its main module button should not render

--- a/client/src/templates/Introduction/components/super-block-accordion.test.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.test.tsx
@@ -207,7 +207,7 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
+    // module-button-right is a plain div inside the main toggle button, not a separate button.
     const moduleRight = screen.getByTestId('module-button-right');
     const moduleSteps = within(moduleRight).getByText(
       /learn\.steps-completed/i
@@ -246,7 +246,7 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
+    // module-button-right is a plain div inside the main toggle button, not a separate button.
     const moduleRight = screen.getByTestId('module-button-right');
     expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
   });
@@ -281,7 +281,7 @@ describe('SuperBlockAccordion', () => {
       />
     );
 
-    // The module-button-right is now a separate toggle button with the testid
+    // module-button-right is a plain div inside the main toggle button, not a separate button.
     const moduleRight = screen.getByTestId('module-button-right');
     expect(within(moduleRight).queryByText(/steps/i)).not.toBeInTheDocument();
   });

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -117,9 +117,6 @@ const Chapter = ({
   const panelId = `chapter-panel-${dashedName}`;
   const isComplete = completedSteps === totalSteps && totalSteps > 0;
   const chapterLabel = t(`intro:${superBlock}.chapters.${dashedName}`);
-  const toggleLabel = open
-    ? t('intro:misc-text.collapse')
-    : t('intro:misc-text.expand');
   const showResetButton = !comingSoon && !isLinkChapter;
   const isResetDisabled = completedSteps === 0;
 
@@ -202,19 +199,9 @@ const Chapter = ({
           type='button'
         >
           {chapterButtonLeftContent}
-        </button>
-        {resetButton}
-        <button
-          aria-controls={panelId}
-          aria-expanded={open}
-          aria-label={`${toggleLabel} ${chapterLabel}`}
-          className='chapter-button chapter-button-toggle'
-          data-playwright-test-label='chapter-button-toggle'
-          onClick={toggleOpen}
-          type='button'
-        >
           {chapterButtonRightContent}
         </button>
+        {resetButton}
       </div>
       {open && (
         <ul className='chapter-panel' id={panelId}>
@@ -255,9 +242,6 @@ const Module = ({
   const panelId = `module-panel-${dashedName}`;
   const isComplete = totalSteps === 0 ? false : completedSteps === totalSteps;
   const moduleLabel = t(`intro:${superBlock}.modules.${dashedName}`);
-  const toggleLabel = open
-    ? t('intro:misc-text.collapse')
-    : t('intro:misc-text.expand');
   const { note, intro } = t(`intro:${superBlock}.module-intros.${dashedName}`, {
     returnObjects: true
   }) as {
@@ -311,18 +295,10 @@ const Module = ({
             </span>
             {moduleLabel}
           </div>
-        </button>
-        {resetButton}
-        <button
-          aria-controls={panelId}
-          aria-expanded={open}
-          aria-label={`${toggleLabel} ${moduleLabel}`}
-          className='module-button module-button-toggle'
-          data-testid='module-button-right'
-          onClick={toggleOpen}
-          type='button'
-        >
-          <div className='module-button-right'>
+          <div
+            className='module-button-right'
+            data-testid='module-button-right'
+          >
             {!comingSoon && !!totalSteps && (
               <span className='module-steps'>
                 {t('learn.steps-completed', {
@@ -333,6 +309,7 @@ const Module = ({
             )}
           </div>
         </button>
+        {resetButton}
       </div>
       {open && (
         <ul className='module-panel' id={panelId}>

--- a/client/src/templates/Introduction/components/super-block-accordion.tsx
+++ b/client/src/templates/Introduction/components/super-block-accordion.tsx
@@ -131,19 +131,32 @@ const Chapter = ({
 
   const toggleOpen = () => setOpen(o => !o);
 
-  const resetButton = showResetButton ? (
+  // Always render the same button markup so the row keeps a fixed-width slot for it:
+  // `chapter-button-main` uses `justify-content: space-between` and would otherwise grow to
+  // fill the gap on comingSoon/link chapters, shifting the chevron out of line with rows that
+  // do have a reset button. `visibility: hidden` reserves the layout box without making the
+  // placeholder hoverable, focusable, or visible to assistive tech.
+  const resetButton = (
     <button
-      className='block-reset-button'
-      onClick={handleResetClick}
-      aria-label={t('learn.reset-progress-aria-chapter', {
-        chapterLabel
-      })}
+      className={
+        showResetButton
+          ? 'block-reset-button'
+          : 'block-reset-button block-reset-button--placeholder'
+      }
+      onClick={showResetButton ? handleResetClick : undefined}
+      aria-label={
+        showResetButton
+          ? t('learn.reset-progress-aria-chapter', { chapterLabel })
+          : undefined
+      }
+      aria-hidden={!showResetButton}
+      tabIndex={showResetButton ? undefined : -1}
       type='button'
-      disabled={isResetDisabled}
+      disabled={!showResetButton || isResetDisabled}
     >
       <Reset />
     </button>
-  ) : null;
+  );
 
   const chapterButtonLeftContent = (
     <div className='chapter-button-left'>
@@ -264,17 +277,28 @@ const Module = ({
 
   const toggleOpen = () => setOpen(o => !o);
 
-  const resetButton = showResetButton ? (
+  // Same fixed-slot reasoning as the Chapter component above.
+  const resetButton = (
     <button
-      className='block-reset-button'
-      onClick={handleResetClick}
-      aria-label={t('learn.reset-progress-aria-module', { moduleLabel })}
+      className={
+        showResetButton
+          ? 'block-reset-button'
+          : 'block-reset-button block-reset-button--placeholder'
+      }
+      onClick={showResetButton ? handleResetClick : undefined}
+      aria-label={
+        showResetButton
+          ? t('learn.reset-progress-aria-module', { moduleLabel })
+          : undefined
+      }
+      aria-hidden={!showResetButton}
+      tabIndex={showResetButton ? undefined : -1}
       type='button'
-      disabled={isResetDisabled}
+      disabled={!showResetButton || isResetDisabled}
     >
       <Reset />
     </button>
-  ) : null;
+  );
 
   return (
     <li>

--- a/e2e/super-block-page.spec.ts
+++ b/e2e/super-block-page.spec.ts
@@ -321,7 +321,7 @@ test.describe('Super Block Page - Search Lessons', () => {
     await page.goto('/learn/javascript-v9/');
 
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/ })
     ).toBeVisible();
 
     await page
@@ -332,7 +332,7 @@ test.describe('Super Block Page - Search Lessons', () => {
       page.getByRole('heading', { name: 'Build a Greeting Bot' })
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/ })
     ).not.toBeVisible();
     await expect(
       page.getByText(
@@ -343,7 +343,7 @@ test.describe('Super Block Page - Search Lessons', () => {
     await page.getByRole('button', { name: 'Clear search terms' }).click();
 
     await expect(
-      page.getByRole('button', { name: /^Booleans and Numbers$/ })
+      page.getByRole('button', { name: /^Booleans and Numbers/ })
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
### Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #67770

## Summary

The recent accordion redesign gave each chapter/module row two sibling `<button>` elements (a "main" button and a "toggle" button), both sharing the same `aria-expanded`/`aria-controls`. The progress text ("X of Y steps complete") lived only inside the second button, which screen readers don't reliably announce alongside the first — so users lost the step-count announcement that used to work before the redesign.

This PR merges the toggle button's content (progress text + dropdown icon) into the single main button for both `Chapter` and `Module`, so the accessible name of the one remaining button includes the full label and progress text.

**Note on layout:** collapsing the two buttons also moves the reset icon. It used to sit between the label and the progress text; now it sits to the right of the chevron, since a button can't be nested inside another button. This is an intentional tradeoff of the fix, not an oversight — see the alignment fix below for how the layout keeps rows visually consistent.

## Changes

- `super-block-accordion.tsx`: removed the redundant `chapter-button-toggle` / `module-button-toggle` buttons; their content now renders inside the `-main` button.
- `super-block-accordion.css`: dropped the now-unused toggle-button rules; added `justify-content: space-between` to the `-main` buttons to preserve the existing visual layout (label left, progress/icon right).
- `super-block-accordion.test.tsx`: updated two assertions that relied on an exact accessible-name match (`'mod-one'`) to a prefix match, since the button's name now legitimately includes the progress text too; also fixed 3 stale comments left over from the toggle-button consolidation.
- `block.css` / `super-block-accordion.tsx` (added in response to review): the reset button is now always rendered, hidden with `visibility: hidden` plus `aria-hidden="true"` and `tabIndex={-1}` on rows where it doesn't apply (comingSoon/link chapters, comingSoon modules). This reserves its layout slot so the chevron stays aligned across rows that mix "has a reset button" and "doesn't" — previously the button was `null` on those rows, so the row's `justify-content: space-between` let the chevron drift ~30-40px depending on whether a reset button occupied the far end of the row.

## Verification of the chevron-alignment fix

Measured directly (not eyeballed) with a mixed-structure render (one normal chapter + one comingSoon chapter) plus a `getBoundingClientRect()` check on the chevron:

- **Before:** chevron right-edge at `676.02px` (row with reset button) vs `707.99px` (row without) — a 32px drift, matching what was flagged.
- **After:** both rows measure `676.02px` — pixel-identical.

Also confirmed against the real bundled app (chapter list on `/learn/back-end-development-and-apis-v9/`, JS build, not a mock): the placeholder reset button renders with `aria-hidden="true"`, `tabIndex=-1`, `visibility: hidden`, and 1 focusable element per row (down from what would be 2 if the placeholder were focusable) — so it reserves the slot without being reachable by keyboard or exposed to assistive tech.

## Test plan

- [x] `pnpm test src/templates/Introduction/components/super-block-accordion.test.tsx` — all 16 tests pass
- [x] `tsc --noEmit` on the client package shows no new errors introduced by this change
- [x] Automated accessibility-tree verification (see above): accessible names, `aria-expanded`, `aria-hidden`, and focusable-element counts checked programmatically against the real bundled app
- [ ] Manual verification with an actual screen reader (NVDA/VoiceOver) — still needs a human pass; I don't have a way to operate assistive tech software myself, so this box stays unchecked until I (or a reviewer) run it by ear