### PR TITLE
fix(curriculum): improve fallback wording

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0e9629bad967cd71e.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0e9629bad967cd71e.md
@@ -7,7 +7,7 @@ dashedName: step-55
 
 # --description--
 
-You can add a <dfn>fallback</dfn> value for the font-family by adding another font name separated by a comma. Fallbacks are used in instances where the initial is not found/available.
+You can add a <dfn>fallback</dfn> value for the `font-family` by adding another font name separated by a comma. A fallback is used when the first font is not available.
 
 Add the fallback font `serif` after the `Impact` font.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69194

## Description

This PR updates the wording in Step 55 of the Cafe Menu workshop by:

- formatting `font-family` as inline code
- clarifying that the first font may not be available
- improving grammar and readability