### PR TITLE
fix(curriculum): replace regex-based test cases in Planets Tablist Workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c3e887d32ea71964cd981.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c3e887d32ea71964cd981.md
@@ -18,12 +18,20 @@ btns.forEach(btn => {
 
 Use the `forEach` method to iterate through the `tabs`. For the callback function, use an arrow function that takes a single parameter, `tab`. 
 
-# --hints--
-
-You should have a `tabs.forEach(tab => {})` in your code.
+# --before-all--
 
 ```js
-assert.match(code, /tabs\.forEach\(\s*tab\s*=>\s*\{/);
+globalThis.__forEachSpy = __helpers.spyOn(NodeList.prototype, 'forEach');
+```
+
+# --hints--
+
+You should call the `forEach` method on `tabs`, passing it a callback function that takes one parameter.
+
+```js
+const [callback] = __forEachSpy.calls[0];
+assert.isFunction(callback);
+assert.equal(callback.length, 1);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c454eb1e7fb7341f1c6ae.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c454eb1e7fb7341f1c6ae.md
@@ -22,12 +22,23 @@ btns.forEach(btn => {
 
 Use the `addEventListener` method to attach a `"click"` event listener to each `tab` button. The second argument of the `addEventListener` method should be an empty arrow function `() => {}` for now.
 
-# --hints--
-
-You should have a `tab.addEventListener('click', () => {})` inside the `forEach` loop.
+# --before-all--
 
 ```js
-assert.match(code, /tab\.addEventListener\(["']click["']\s*,\s*\(\)\s*=>\s*\{\s*/);
+globalThis.__addEventListenerSpy = __helpers.spyOn(EventTarget.prototype, 'addEventListener');
+```
+
+# --hints--
+
+Use the `addEventListener` method to attach a `"click"` event listener to each `tab`. The second argument of the `addEventListener` method should be an empty arrow function `() => {}` for now.
+
+```js
+const clickCalls = __addEventListenerSpy.calls.filter(([type]) => type === 'click');
+assert.equal(clickCalls.length, 3);
+
+const [, callback] = clickCalls[0];
+assert.isFunction(callback);
+assert.equal(callback.length, 0);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c539a33f20877c4ef59d2.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c539a33f20877c4ef59d2.md
@@ -11,14 +11,30 @@ Now it is time to work on displaying the correct panel when a tab is clicked. Ea
 
 Create a variable called `associatedPanel` and assign it the value `tab.getAttribute("aria-controls")`. This will give you the `id` of the panel that corresponds to the clicked tab.
 
-# --hints--
-
-You should have a variable called `associatedPanel` that holds the `id` of the panel associated with the clicked tab.
+# --before-all--
 
 ```js
-assert.match(
-  code,
-  /(?:const|let|var)\s+associatedPanel\s*=\s*tab\.getAttribute\(["']aria-controls["']\);?/
+globalThis.__addEventListenerSpy = __helpers.spyOn(EventTarget.prototype, 'addEventListener');
+```
+
+# --hints--
+
+You should declare a variable called `associatedPanel` and set it to the value returned by calling `getAttribute` on `tab` with `"aria-controls"`.
+
+```js
+const clickCalls = __addEventListenerSpy.calls.filter(([type]) => type === 'click');
+assert.isAtLeast(clickCalls.length, 1);
+const [, callback] = clickCalls[0];
+assert.isFunction(callback);
+
+const explorer = await __helpers.Explorer(`const __cb = ${callback.toString()};`);
+const callbackBody = explorer.variables.__cb?.value;
+assert.exists(callbackBody);
+
+const associatedPanelVar = callbackBody.variables.associatedPanel;
+assert.exists(associatedPanelVar);
+assert.isTrue(
+  associatedPanelVar.value.matches('tab.getAttribute("aria-controls")')
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-planets-tablist/685c560bfde79c78a3f01a64.md
+++ b/curriculum/challenges/english/blocks/workshop-planets-tablist/685c560bfde79c78a3f01a64.md
@@ -11,12 +11,31 @@ Since `associatedPanel` is an `id`, that will allow you to query the document an
 
 Create a new variable called `panel` and assign it the value of `document.getElementById(associatedPanel)`. 
 
+# --before-all--
+
+```js
+globalThis.__addEventListenerSpy = __helpers.spyOn(EventTarget.prototype, 'addEventListener');
+```
+
 # --hints--
 
 You should have a variable called `panel` that holds the panel element associated with the clicked tab.
 
 ```js
-assert.match(code, /(?:const|let|var)\s+panel\s*=\s*document\.getElementById\(associatedPanel\);?/);
+const clickCalls = __addEventListenerSpy.calls.filter(([type]) => type === 'click');
+assert.isAtLeast(clickCalls.length, 1);
+const [, callback] = clickCalls[0];
+assert.isFunction(callback);
+
+const explorer = await __helpers.Explorer(`const __cb = ${callback.toString()};`);
+const callbackBody = explorer.variables.__cb?.value;
+assert.exists(callbackBody);
+
+const panelVar = callbackBody.variables.panel;
+assert.exists(panelVar);
+assert.isTrue(
+  panelVar.value.matches('document.getElementById(associatedPanel)')
+);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org/#/CONTRIBUTING).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68712

This is part of the Naomi's Sprints initiative → replacing regex-based tests with the Explorer AST helper and `spyOn`.

- Replaces regex-based tests with `__helpers.spyOn` and `__helpers.Explorer` in the Planets Tablist workshop, Steps 14, 15, 19, and 20

### Changes made

Steps 14/15 tested `tabs.forEach(...)` and `tab.addEventListener(...)` with regex that only accepted one exact syntax — valid code like `(tab) => {}` or a `function` expression was incorrectly rejected.

Steps 19/20 tested the `associatedPanel`/`panel` declarations the same way. Since both live inside a nested callback, `Explorer` can't reach them directly — it only inspects the immediate scope, not callback-argument bodies.

Fix: a `--before-all--` hook spies on `NodeList.prototype.forEach` (14/19/20) and `EventTarget.prototype.addEventListener` (15/19/20) before the camper's code runs, so hints check real runtime behavior instead of source text. For 19/20, the spy captures the actual click callback, its source is re-wrapped and parsed with `__helpers.Explorer`, letting the AST check descend into the callback's scope — structural, no regex.

Before (Step 14): (similarly step 15)
\`\`\`js
assert.match(code, /tabs\.forEach\(\s*tab\s*=>\s*\{/);
\`\`\`

After (Step 14):
\`\`\`js
assert.equal(__forEachSpy.calls.length, 1);
const [callback] = __forEachSpy.calls[0];
assert.isFunction(callback);
assert.equal(callback.length, 1);
\`\`\`

Before (Step 19): (similarly step 20)
\`\`\`js
assert.match(
  code,
  /(?:const|let|var)\s+associatedPanel\s*=\s*tab\.getAttribute\(["']aria-controls["']\);?/
);
\`\`\`

After (Step 19):
\`\`\`js
const explorer = await __helpers.Explorer(`const __cb = ${callback.toString()};`);
const callbackBody = explorer.variables.__cb?.value;
assert.exists(callbackBody);

const associatedPanelVar = callbackBody.variables.associatedPanel;
assert.exists(associatedPanelVar);
assert.isTrue(
  associatedPanelVar.value.matches('tab.getAttribute("aria-controls")')
);
\`\`\`

### Testing

Ran `FCC_BLOCK='workshop-planets-tablist' pnpm run test-curriculum-content` — all 106 tests passed, including each step's solution check, also tested manually in the browser challenge editor to confirm.