### PR TITLE
fix(curriculum): improve wording in workshop cafe menu step 58

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0f8c230bdd2349716.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0f8c230bdd2349716.md
@@ -7,7 +7,7 @@ dashedName: step-58
 
 # --description--
 
-The typography of heading elements (e.g. `h1`, `h2`) is set by default values of users' browsers.
+The typography of heading elements (e.g. `h1`, `h2`) is set by the default values in users' browsers.
 
 Add two new type selectors (`h1` and `h2`). Use the `font-size` property for both, but use the value `40px` for the `h1` and `30px` for the `h2`.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69195

<!-- Feel free to add any additional description of changes below this line -->

## Description

The PR updates the wording in Step 58 of the Workshop Cafe Menu challenge.

The sentence now reads:

"The typography of heading elements (e.g. `h1`, `h2`) is set by the default values in users' browsers."

This improves grammatical correctness and makes it clearer that the default values exist in the browser.
