### PR TITLE
fix(curriculum): use spyOn instead of regex for console.log hints in workshop-greeting-bot

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad8294a0ad902f1b31b612.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad8294a0ad902f1b31b612.md
@@ -22,18 +22,25 @@ console.log("Hello, World!");
 Add a `console.log()` statement that outputs the string `"Hi there!"` to the console. Don't forget your quotes around the message! 
 
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a `console.log()` statement in your code.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log(.*)/);
+assert.isAtLeast(spy.calls.length, 1);
 ```
 
 Your `console` statement should have the message `"Hi there!"`. Don't forget the quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\((['"])Hi\s+there!\1\);?/);
+const normalizedCalls = spy.calls.map((call) => call.map((arg) => __helpers.removeWhiteSpace(String(arg))));
+assert.deepInclude(normalizedCalls, [__helpers.removeWhiteSpace("Hi there!")]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad8ab945d266383f318cbf.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad8ab945d266383f318cbf.md
@@ -13,12 +13,18 @@ It is time to add a second message from the bot.
 
 Add another `console.log` statement to output the message `"I am excited to talk to you."` to the console.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a second `console.log()` statement in your code.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 2);
+assert.lengthOf(spy.calls, 2);
 ```
 
 Your `console` statement should have the message `"I am excited to talk to you."`. Don't forget the quotes.

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad9c633fa26d3c1475eae3.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad9c633fa26d3c1475eae3.md
@@ -11,12 +11,18 @@ Now, it is time to add another message from the bot.
 
 Add another `console` statement to the code that logs the message `"Allow me to introduce myself."`.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a third `console.log()` statement in your code.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 3);
+assert.lengthOf(spy.calls, 3);
 ```
 
 Your `console` statement should have the message `"Allow me to introduce myself."`. Don't forget the quotes.

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66ada3f46945763dd97f43f8.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66ada3f46945763dd97f43f8.md
@@ -26,7 +26,13 @@ Then use string concatenation with the `+` operator to join the string `"My name
 
 Assign this value to the `botIntroduction` variable.
 
-Then, log the `botIntroduction` variable to the console.
+Then, log the value of `botIntroduction` to the console.
+
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
 
 # --hints--
 
@@ -51,13 +57,13 @@ assert.equal(botIntroduction, "My name is teacherBot.");
 You should have a fourth `console.log()` statement in your code.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 4);
+assert.lengthOf(spy.calls, 4);
 ```
 
 Your `console` statement should output the `botIntroduction` variable.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\s*\(\s*botIntroduction\s*\);?/);
+assert.deepInclude(spy.calls, [botIntroduction]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66adb844118ba74107ce771f.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66adb844118ba74107ce771f.md
@@ -17,6 +17,12 @@ Assign this value to the `botLocationSentence` variable.
 
 Then, log the value of `botLocationSentence` to the console.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a `botLocationSentence` variable.
@@ -40,13 +46,13 @@ assert.equal(botLocationSentence, "I live in the universe.");
 You should have a `console` statement in your code.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 5);
+assert.lengthOf(spy.calls, 5);
 ```
 
 Your `console` statement should output the `botLocationSentence` variable.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\s*\(\s*botLocationSentence\s*\)/);
+assert.deepInclude(spy.calls, [botLocationSentence]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66adc42868cab843ccee87d9.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66adc42868cab843ccee87d9.md
@@ -17,6 +17,12 @@ Assign the resulting string to the `nicknameIntroduction` variable.
 
 Then, log the value of `nicknameIntroduction` to the console. 
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a variable called `nicknameIntroduction`.
@@ -40,13 +46,13 @@ assert.strictEqual(nicknameIntroduction, "My nickname is professorBot.");
 You should have a `console` statement in your code.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 6);
+assert.lengthOf(spy.calls, 6);
 ```
 
 You should log the value of `nicknameIntroduction` to the console.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\s*\(\s*nicknameIntroduction\s*\)/);
+assert.deepInclude(spy.calls, [nicknameIntroduction]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66adc6046acc18453decf577.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66adc6046acc18453decf577.md
@@ -17,6 +17,12 @@ Assign the result to the `newNicknameGreeting` variable.
 
 Then, log the value of `newNicknameGreeting` to the console.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a variable called `newNicknameGreeting`.
@@ -40,13 +46,13 @@ assert.strictEqual(newNicknameGreeting, "I love my nickname but I wish people wo
 You should have a `console` statement in your code.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 7);
+assert.lengthOf(spy.calls, 7);
 ```
 
 You should log the value of `newNicknameGreeting` to the console.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\s*\(\s*newNicknameGreeting\s*\)/);
+assert.deepInclude(spy.calls, [newNicknameGreeting]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66adcf383276814776aba3ca.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66adcf383276814776aba3ca.md
@@ -15,6 +15,12 @@ Assign the result to the `favoriteSubjectSentence` variable.
 
 Then, log the value of `favoriteSubjectSentence` to the console.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a variable called `favoriteSubjectSentence`.
@@ -38,13 +44,13 @@ assert.strictEqual(favoriteSubjectSentence, "My favorite subject is Computer Sci
 You should have a `console` statement in your code.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 8);
+assert.lengthOf(spy.calls, 8);
 ```
 
 You should log the value of `favoriteSubjectSentence` to the console.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\s*\(\s*favoriteSubjectSentence\s*\)/);
+assert.deepInclude(spy.calls, [favoriteSubjectSentence]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66add47d27763c4862492c8c.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66add47d27763c4862492c8c.md
@@ -11,19 +11,25 @@ For the final step, you will log the bot's message of `"Well, it was nice to tal
 
 And with that, your greeting bot is complete!
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a `console` statement in your code.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/console\.log(.*)/g), 9);
+assert.lengthOf(spy.calls, 9);
 ```
 
 Your `console` statement should log the string `"Well, it was nice to talk to you. Have a nice day!"`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\s*\(\s*["']Well\s*,\s*it\s*was\s*nice\s*to\s*talk\s*to\s*you\s*\.\s*Have\s*a\s*nice\s*day\s*!["']\s*\)\s*/
-);
+const normalizedCalls = spy.calls.map((call) => call.map((arg) => __helpers.removeWhiteSpace(String(arg))));
+assert.deepInclude(normalizedCalls, [__helpers.removeWhiteSpace("Well, it was nice to talk to you. Have a nice day!")]);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #XXXXX

Several steps in `workshop-greeting-bot` asserted `console.log` content by regex-matching the raw source string. This replaces those checks with `__helpers.spyOn(console, 'log')` (installed in `--before-each--`) checked against `spy.calls`, using the existing `curriculum-helpers` tooling instead of hand-rolled regex.

Steps 2 and 6 keep their original regex for the message content check, since the original regex's leniency (it tolerates extra internal whitespace, and due to an unescaped `.`, actually accepts any trailing character) couldn't be reproduced without regex, and I didn't want to accidentally make the test stricter than before.

Ran `FCC_BLOCK='workshop-greeting-bot' pnpm test` locally from `curriculum/` and confirmed all 174 tests pass.