### PR TITLE
fix(curriculum): restore whitespace-tolerant message check in greeting bot steps 2 and 6

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad8ab945d266383f318cbf.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad8ab945d266383f318cbf.md
@@ -30,7 +30,11 @@ assert.lengthOf(logSpy.calls, 2);
 Your `console` statement should have the message `"I am excited to talk to you."`. Don't forget the quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /("|')I\s+am\s+excited\s+to\s+talk\s+to\s+you.\1/);
+assert.isTrue(
+  logSpy.calls.some(
+    (call) => /I\s+am\s+excited\s+to\s+talk\s+to\s+you\s*\./.test(call[0])
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad8ab945d266383f318cbf.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad8ab945d266383f318cbf.md
@@ -30,7 +30,7 @@ assert.lengthOf(logSpy.calls, 2);
 Your `console` statement should have the message `"I am excited to talk to you."`. Don't forget the quotes.
 
 ```js
-assert.deepInclude(logSpy.calls, ["I am excited to talk to you."]);
+assert.match(__helpers.removeJSComments(code), /("|')I\s+am\s+excited\s+to\s+talk\s+to\s+you.\1/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad9c633fa26d3c1475eae3.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad9c633fa26d3c1475eae3.md
@@ -28,7 +28,11 @@ assert.lengthOf(logSpy.calls, 3);
 Your `console` statement should have the message `"Allow me to introduce myself."`. Don't forget the quotes.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /("|')Allow\s+me\s+to\s+introduce\s+myself.\1/);
+assert.isTrue(
+  logSpy.calls.some(
+    (call) => /Allow\s+me\s+to\s+introduce\s+myself\s*\./.test(call[0])
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad9c633fa26d3c1475eae3.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-bot/66ad9c633fa26d3c1475eae3.md
@@ -28,7 +28,7 @@ assert.lengthOf(logSpy.calls, 3);
 Your `console` statement should have the message `"Allow me to introduce myself."`. Don't forget the quotes.
 
 ```js
-assert.deepInclude(logSpy.calls, ["Allow me to introduce myself."]);
+assert.match(__helpers.removeJSComments(code), /("|')Allow\s+me\s+to\s+introduce\s+myself.\1/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #XXXXX

#69132 replaced the regex-based `console.log` content checks in `workshop-greeting-bot` with `assert.deepInclude(logSpy.calls, [...])`, which requires an exact string match.

For steps 2 and 6 specifically, the original regex used `\s+` between words in the message, tolerating extra internal whitespace in the logged string. The new exact-match check is stricter than the original test allowed for.

This reverts just the message-content hint in those two steps back to the original regex, so the test doesn't accept less than it did before. The count-based hints in the same steps (already exact-count checks before and after #69132) are untouched.

Update: per review feedback, the message-content checks for steps 2 and 6 now check the actual logged value (via the existing `logSpy`) instead of just checking whether the string appears somewhere in the source, which the original regex did not verify.