### PR TITLE
fix(curriculum): fix wording issues and simplify log checks in sentence maker lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
+++ b/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
@@ -26,7 +26,7 @@ In this lab, you will create two different stories using a sentence template. Yo
 
 1. You should declare a `firstStory` variable.
    
-1. You should use the following story template to create the first story and assign it to the `firstStory` variable: `"Once upon a time, there was a(n) [adjective] [noun] who loved to eat [noun2]. The [noun] lived in a [place] and had [adjective2] nostrils that blew fire when it was [verb]."`;
+1. You should use the following story template to create the first story and assign it to the `firstStory` variable: `"Once upon a time, there was a(n) [adjective] [noun] who loved to eat [noun2]. The [noun] lived in a [place] and had [adjective2] nostrils that blew fire when it was [verb]."`
 
 1. You should output your first story to the console using the message `"First story: [firstStory]"`.
 
@@ -34,10 +34,17 @@ In this lab, you will create two different stories using a sentence template. Yo
 
 1. You should declare a `secondStory` variable.
 
-1. Create another story using the same template and assign it to the `secondStory` variable.
+1. You should create another story using the same template and assign it to the `secondStory` variable.
 
 1. You should output your second story to the console using the message `"Second story: [secondStory]"`.
 
+
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+const getLogs = () => spy.calls.map(call => call?.[0]);
+```
 
 # --hints--
 
@@ -142,12 +149,10 @@ assert.match(
 );
 ```
 
-You should log your first story using the message `"First story: [firstStory]"`.
+You should output your first story to the console using the message `"First story: [firstStory]"`.
 
 ```js
-const condition1 = /console\.log\(\s*["']First\s+story:\s+["']\s*\+\s*firstStory\s*\);?/gm.test(code);
-const condition2 = /console\.log\(\s*`First\s+story:\s+\$\{firstStory\}`\s*\);?/gm.test(code);
-assert.isTrue(condition1 || condition2);
+assert.include(getLogs(), `First story: ${firstStory}`);
 ```
 
 You should declare a `secondStory` variable.
@@ -208,15 +213,13 @@ assert.match(
 );
 ```
 
-You should log your second story using the format `"Second story: [secondStory]"`.
+You should output your second story to the console using the message `"Second story: [secondStory]"`.
 
 ```js
-const condition1 = /console\.log\(\s*["']Second\s+story:\s+["']\s*\+\s*secondStory\s*\);?/gm.test(code);
-const condition2 = /console\.log\(\s*`Second\s+story:\s+\$\{secondStory\}`\s*\);?/gm.test(code);
-assert.isTrue(condition1 || condition2);
+assert.include(getLogs(), `Second story: ${secondStory}`);
 ```
 
-The `firstStory` should not be the same as the `secondStory`.
+Your `firstStory` should not be the same as your `secondStory`.
 
 ```js
 assert.notEqual(firstStory, secondStory);

--- a/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
+++ b/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
@@ -43,7 +43,7 @@ In this lab, you will create two different stories using a sentence template. Yo
 
 ```js
 const spy = __helpers.spyOn(console, 'log');
-const getLogs = () => spy.calls.map(call => call?.[0]);
+const getLogs = () => spy.calls.map(call => call.join(' '));
 ```
 
 # --hints--

--- a/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
+++ b/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
@@ -7,7 +7,7 @@ dashedName: build-a-sentence-maker
 
 # --description--
 
-In this lab, you will create two different stories using a sentence template. You will use variables to store different parts of the story and then output the stories to the console.
+In this lab, you will create two different stories using a sentence template. You will use variables to store different parts of the story and then log the stories to the console.
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab.
 
@@ -28,7 +28,7 @@ In this lab, you will create two different stories using a sentence template. Yo
    
 1. You should use the following story template to create the first story and assign it to the `firstStory` variable: `"Once upon a time, there was a(n) [adjective] [noun] who loved to eat [noun2]. The [noun] lived in a [place] and had [adjective2] nostrils that blew fire when it was [verb]."`
 
-1. You should output your first story to the console using the message `"First story: [firstStory]"`.
+1. You should log your first story to the console using the message `"First story: [firstStory]"`.
 
 1. You should assign new values to your `adjective`, `noun`, `verb`, `place`, `adjective2`, and `noun2` variables.
 
@@ -36,7 +36,7 @@ In this lab, you will create two different stories using a sentence template. Yo
 
 1. You should create another story using the same template and assign it to the `secondStory` variable.
 
-1. You should output your second story to the console using the message `"Second story: [secondStory]"`.
+1. You should log your second story to the console using the message `"Second story: [secondStory]"`.
 
 
 # --before-each--
@@ -149,7 +149,7 @@ assert.match(
 );
 ```
 
-You should output your first story to the console using the message `"First story: [firstStory]"`.
+You should log your first story to the console using the message `"First story: [firstStory]"`.
 
 ```js
 assert.include(getLogs(), `First story: ${firstStory}`);
@@ -213,7 +213,7 @@ assert.match(
 );
 ```
 
-You should output your second story to the console using the message `"Second story: [secondStory]"`.
+You should log your second story to the console using the message `"Second story: [secondStory]"`.
 
 ```js
 assert.include(getLogs(), `Second story: ${secondStory}`);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69186

A few small fixes to the `lab-sentence-maker` lab:

- Removed a stray trailing semicolon left over from pasting the JS string literal into the story-template prose.
- Fixed user story 8 and the final hint, which were the only ones in the file not starting with "You should" / "Your".
- Aligned "output ... to the console" wording between the description and its matching hints (which said "log ...").
- Replaced the dual-regex (string concatenation vs. template literal) checks for the logged story messages with a single assertion against the actual logged output, using `__helpers.spyOn` in `--before-each--` (same pattern already used in `workshop-greeting-bot` and `lab-javascript-trivia-bot`). This is simpler and strictly more lenient: it accepts any code that produces the correct output, not just the two source patterns the old regexes anticipated.
- Fixes #69186: `console.log("First story:", firstStory)` (comma-separated arguments) was still failing after the change above, because the helper only read the first argument of each `console.log` call. The helper now joins all arguments with a space, matching what `console.log` actually displays, so both the comma form and the concatenated form pass.