### PR TITLE
fix: clarify Date constructor inputs

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -48,7 +48,7 @@ console.log(specificDate);
 
 :::
 
-This is useful when you need to work with a specific date and time rather than the current date and time. The input always needs to be a string, and the format should be recognizable by the `Date` object.
+This is useful when you need to work with a specific date and time rather than the current date and time. When you provide a string, its format should be recognizable by the `Date` object.
 
 To get the current date and time, you can use the `Date.now()` method, which returns the number of milliseconds since `January 1, 1970, 00:00:00 UTC`. This is known as the Unix epoch time.
 


### PR DESCRIPTION
## Summary
Clarifies that a date string must be recognizable by the `Date` object, instead of incorrectly implying every `Date` constructor input must be a string.

Closes #69170

## Validation
- `git diff --check`