### PR TITLE
fix: improve wording in cafe menu step 55

### DIFF
--- a/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3ef6e0e9629bad967cd71e.md
+++ b/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3ef6e0e9629bad967cd71e.md
@@ -7,7 +7,7 @@ dashedName: step-59
 
 # --description--
 
-You can add a <dfn>fallback</dfn> value for the font-family by adding another font name separated by a comma. Fallbacks are used in instances where the initial is not found/available.
+You can add a <dfn>fallback</dfn> value for the `font-family` by adding another font name separated by a comma. A fallback is used when the first font is not available.
 
 Add the fallback font `serif` after the `Impact` font.
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e056bdde6ae6892ba2.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e056bdde6ae6892ba2.md
@@ -9,7 +9,7 @@ dashedName: step-54
 
 It is a bit boring for all the text to have the same `font-family`. You can still have the majority of the text `sans-serif` and make just the `h1` and `h2` elements different using a different selector.
 
-Style both the `h1` and the `h2` elements using a single selector so that these elements' text use `Impact` font.
+Style both the `h1` and the `h2` elements using a single selector list so that these elements' text uses `Impact` font.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69194

Updated the wording in Step 55 of the Cafe Menu workshop by formatting `font-family` as code and improving the fallback description for clarity and correctness.