### PR TITLE
fix(curriculum): correct British spelling to American in Cafe Menu step 64

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3f26fa39591db45e5cd7a0.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3f26fa39591db45e5cd7a0.md
@@ -7,7 +7,7 @@ dashedName: step-64
 
 # --description--
 
-The default properties of an `hr` element will make it appear as a thin light grey line. You can change the height of the line by specifying a value for the `height` property.
+The default properties of an `hr` element will make it appear as a thin light gray line. You can change the height of the line by specifying a value for the `height` property.
 
 Change the height of the `hr` element to `3px`.
 


### PR DESCRIPTION
Closes #69197

The description of Step 64 in the Cafe Menu workshop used the British spelling "grey". The freeCodeCamp curriculum uses American English, so this changes it to "gray".

### Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org/#/).
- [x] My pull request has a descriptive title (not a generic title like `Update index.md`).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.