### PR TITLE
fix(curriculum): correct CSS example and selector wording in Cafe Menu step 22

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed6199b0cdef1d2be8f.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed6199b0cdef1d2be8f.md
@@ -13,11 +13,11 @@ You learned how to work with `class` selectors in previous lessons like this:
 
 ```css
 .class-name {
-  styles
+  property: value;
 }
 ```
 
-Change the existing `#menu` selector into a class selector by replacing `#menu` with a class named `.menu`.
+Change the existing `#menu` selector into a class selector by replacing `#menu` with the class selector `.menu`.
 
 # --hints--
 


### PR DESCRIPTION
Closes #69150

Step 22 of the Cafe Menu workshop had two issues in its description:

1. The CSS example used `styles` as a placeholder, which is not a valid declaration. Changed it to `property: value;` to match the shape already used in Steps 7 and 9.
2. The instruction called `.menu` a class name. The class is named `menu`; `.menu` is the selector that targets it. Reworded to "the class selector `.menu`", consistent with Step 23.

### Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org/#/).
- [x] My pull request has a descriptive title (not a generic title like `Update index.md`).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.