### PR TITLE
fix(curriculum): add missing semicolon to .price declaration in Cafe Menu seeds

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3cade99dda4e6071a85dfd.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3cade99dda4e6071a85dfd.md
@@ -109,7 +109,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e01f288a026d709587.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e01f288a026d709587.md
@@ -171,7 +171,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e03d719d5ac4738993.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e03d719d5ac4738993.md
@@ -115,7 +115,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e04559b939080db057.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e04559b939080db057.md
@@ -139,7 +139,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e050279c7a4a7101d3.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e050279c7a4a7101d3.md
@@ -137,7 +137,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e05473f91f948724ab.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e05473f91f948724ab.md
@@ -116,6 +116,6 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e056bdde6ae6892ba2.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e056bdde6ae6892ba2.md
@@ -135,7 +135,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e06d34faac0447fc44.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e06d34faac0447fc44.md
@@ -127,7 +127,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e07276f782bb46b93d.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e07276f782bb46b93d.md
@@ -142,7 +142,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0819d4f23ca7285e6.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0819d4f23ca7285e6.md
@@ -104,7 +104,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e087d56ed3ffdc36be.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e087d56ed3ffdc36be.md
@@ -129,6 +129,6 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0a81099d9a697b550.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0a81099d9a697b550.md
@@ -167,7 +167,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0b431cc215bb16f55.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0b431cc215bb16f55.md
@@ -141,7 +141,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0e0c3feaebcf647ad.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0e0c3feaebcf647ad.md
@@ -103,7 +103,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0e9629bad967cd71e.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0e9629bad967cd71e.md
@@ -113,7 +113,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0eaa7da26e3d34d78.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0eaa7da26e3d34d78.md
@@ -128,7 +128,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0f8c230bdd2349716.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3ef6e0f8c230bdd2349716.md
@@ -140,6 +140,6 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3f26fa39591db45e5cd7a0.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3f26fa39591db45e5cd7a0.md
@@ -150,7 +150,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459225127805351a6ad057.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459225127805351a6ad057.md
@@ -144,7 +144,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459a7ceb8b5c446656d88b.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459a7ceb8b5c446656d88b.md
@@ -147,6 +147,6 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459cf202c2a3472fae6a9f.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459cf202c2a3472fae6a9f.md
@@ -147,7 +147,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459fd48bdc98491ca6d1a3.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459fd48bdc98491ca6d1a3.md
@@ -145,7 +145,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45a05977e2fa49d9119437.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45a05977e2fa49d9119437.md
@@ -146,6 +146,6 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45a276c093334f0f6e9df4.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45a276c093334f0f6e9df4.md
@@ -185,7 +185,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45a5a7c49a8251f0bdb527.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45a5a7c49a8251f0bdb527.md
@@ -157,7 +157,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45a66d4a2b0453301e5a26.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45a66d4a2b0453301e5a26.md
@@ -166,7 +166,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b0731d39e15d54df4dfc.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b0731d39e15d54df4dfc.md
@@ -161,7 +161,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b25e7ec2405f166b9de1.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b25e7ec2405f166b9de1.md
@@ -161,7 +161,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b3c93c027860d9298dbd.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b3c93c027860d9298dbd.md
@@ -161,7 +161,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b45d099f3e621fbbb256.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b45d099f3e621fbbb256.md
@@ -161,7 +161,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b4c81cea7763550e40df.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b4c81cea7763550e40df.md
@@ -152,7 +152,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b715301bbf667badc04a.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b715301bbf667badc04a.md
@@ -157,7 +157,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e270702a8456a664f0df.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e270702a8456a664f0df.md
@@ -156,7 +156,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e36e745ead58487aabf2.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e36e745ead58487aabf2.md
@@ -163,7 +163,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e7a4750dd05b5a673920.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e7a4750dd05b5a673920.md
@@ -160,7 +160,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e8284aae155c83015dee.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e8284aae155c83015dee.md
@@ -171,7 +171,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46ede1ff8fec5ba656b44c.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46ede1ff8fec5ba656b44c.md
@@ -144,7 +144,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46fc57528aa1c4b5ea7c2e.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46fc57528aa1c4b5ea7c2e.md
@@ -161,7 +161,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f4701b942c824109626c3d8.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f4701b942c824109626c3d8.md
@@ -153,6 +153,6 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f475bb508746c16c9431d42.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f475bb508746c16c9431d42.md
@@ -190,7 +190,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f716ad029ee4053c7027a7a.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f716ad029ee4053c7027a7a.md
@@ -119,7 +119,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f716bee5838c354c728a7c5.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f716bee5838c354c728a7c5.md
@@ -158,6 +158,6 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f7b87422a560036fd03ccff.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f7b87422a560036fd03ccff.md
@@ -118,7 +118,7 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f7b88d37b1f98386f04edc0.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f7b88d37b1f98386f04edc0.md
@@ -97,6 +97,6 @@ h1, h2, p {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/6780e8ef4153930b965cd7b7.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/6780e8ef4153930b965cd7b7.md
@@ -125,6 +125,6 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/6780f0d898362873ac425dc8.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/6780f0d898362873ac425dc8.md
@@ -156,7 +156,7 @@ h1, h2 {
 
 .price {
   text-align: right;
-  width: 25%
+  width: 25%;
 }
 
 /* FOOTER */


### PR DESCRIPTION
Closes #69167

The `.price` declaration in the Cafe Menu workshop seed CSS was missing its terminating semicolon (`width: 25%`), while every other declaration in the same rule is terminated. The unterminated declaration was carried through the seed of every step from Step 42 through Step 87 (46 files).

This adds the missing semicolon (`width: 25%;`) across all 46 affected seeds, so Step 87 no longer differs from Step 88 (whose seed already had the semicolon) on that line.

Each of the 46 files has a single one-line change; no other content is touched.

### Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org/#/).
- [x] My pull request has a descriptive title (not a generic title like `Update index.md`).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.