### PR TITLE
fix: Improve mobile menu header touch target sizes and spacing

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -242,9 +242,10 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   display: flex;
   font-size: 18px;
   height: var(--header-element-size);
+  min-height: 44px;
   justify-content: center;
-  min-width: var(--header-element-size);
-  padding: 0 4px;
+  min-width: 44px;
+  padding: 0 8px;
 }
 
 @media (min-width: 601px) {
@@ -341,8 +342,9 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   display: flex;
   justify-content: center;
   max-height: var(--header-element-size);
-  min-width: var(--header-element-size);
-  padding: 0 4px;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0 8px;
   text-decoration: none;
 }
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69221

### Additional description of changes
- Updated `client/src/components/Header/components/universal-nav.css` to enforce a minimum touch target size of 44px x 44px on mobile header buttons
(`.exposed-button-nav`, `.lang-button-nav`, `.signup-btn`) per WCAG 2.1 SC 2.5.5 guidelines.
- Increased horizontal button padding from `4px` to `8px` on mobile viewports to prevent accidental mis-clicks between the Menu toggle and adjacent header icons.