### PR TITLE
fix(curriculum): check actual logged output and fix wording issues in calculator workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc095dfe1682753d2ab030.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc095dfe1682753d2ab030.md
@@ -7,7 +7,7 @@ dashedName: step-2
 
 # --description--
 
-One of concepts you learned in previous lessons was how to return values from a function.
+One of the concepts you learned in previous lessons was how to return values from a function.
 
 Here is a reminder of how to return a value from a function:
 

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc0a9e06e00b75d6782be9.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc0a9e06e00b75d6782be9.md
@@ -24,18 +24,18 @@ Add a `console.log` statement, and inside it, call the `addTwoAndSeven` function
 
 You should now see the sum of `2` and `7` logged to the console.
 
-# --hints--
-
-You should have a `console.log` in your code.
+# --before-each--
 
 ```js
-assert.match(code, /console\.log(.*)/);
+const spy = __helpers.spyOn(console, 'log');
 ```
 
-You should call the `addTwoAndSeven` function inside the `console.log`.
+# --hints--
+
+You should call the `addTwoAndSeven` function inside a `console.log`.
 
 ```js
-assert.match(code, /console\.log\(\s*addTwoAndSeven\(\s*\)\s*\)/);
+assert.deepInclude(spy.calls, [addTwoAndSeven()]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc0ba5881acb7692cfc4de.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc0ba5881acb7692cfc4de.md
@@ -7,11 +7,17 @@ dashedName: step-4
 
 # --description--
 
-Now, it is time to add another function.
+Now it is time to add another function.
 
 Declare a function called `addThreeAndFour` that returns the sum of `3` and `4`.
 
 Then call the `addThreeAndFour` function inside a `console.log` to see the result.
+
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
 
 # --hints--
 
@@ -39,7 +45,7 @@ assert.match(code, combinedRegex);
 You should call the `addThreeAndFour` function inside a `console.log`.
 
 ```js
-assert.match(code, /console\.log\(\s*addThreeAndFour\(\s*\)\s*\)/);
+assert.deepInclude(spy.calls, [addThreeAndFour()]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc12fa504b0479dac479a0.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc12fa504b0479dac479a0.md
@@ -24,12 +24,18 @@ greetUser("Jane"); // "Hello Jane!"
 
 Add a `console.log` that calls the `calculateSum` function with the arguments `2` and `5`.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a `console.log` that calls the `calculateSum` function with the arguments `2` and `5`.
 
 ```js
-assert.match(code, /console\.log\(calculateSum\(\s*2\s*,\s*5\)\)/);
+assert.deepInclude(spy.calls, [calculateSum(2, 5)]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc14ca14e65e7a9ebecb80.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc14ca14e65e7a9ebecb80.md
@@ -15,7 +15,7 @@ Inside the function, return the difference between the two parameters.
 
 # --hints--
 
-You should have a function called `calculateDifference`.
+You should declare a function called `calculateDifference`.
 
 ```js
 assert.isFunction(calculateDifference);

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc16abc30b367ba1d1f9ef.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc16abc30b367ba1d1f9ef.md
@@ -15,24 +15,30 @@ Then, add a second `console.log` that calls the `calculateDifference` function w
 
 Finally, add a third `console.log` that calls the `calculateDifference` function with the arguments `17` and `9`.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a `console.log` that calls the `calculateDifference` function with the arguments `22` and `5`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateDifference\s*\(\s*22\s*,\s*5\s*\)\s*\)\s*;?/);
+assert.deepInclude(spy.calls, [calculateDifference(22, 5)]);
 ```
 
 You should have a `console.log` that calls the `calculateDifference` function with the arguments `12` and `1`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateDifference\s*\(\s*12\s*,\s*1\s*\)\s*\)\s*;?/);
+assert.deepInclude(spy.calls, [calculateDifference(12, 1)]);
 ```
 
 You should have a `console.log` that calls the `calculateDifference` function with the arguments `17` and `9`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateDifference\s*\(\s*17\s*,\s*9\s*\)\s*\)\s*;?/);
+assert.deepInclude(spy.calls, [calculateDifference(17, 9)]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc172af7159a7c67804544.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc172af7159a7c67804544.md
@@ -15,9 +15,15 @@ Inside the function, return the product of the two parameters.
 
 Then, add a `console.log` that calls the `calculateProduct` function with the arguments `13` and `5`.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
-You should have a function called `calculateProduct`.
+You should declare a function called `calculateProduct`.
 
 ```js
 assert.isFunction(calculateProduct);
@@ -40,7 +46,7 @@ assert.equal(calculateProduct(10, 5), 50);
 You should have a `console.log` that calls the `calculateProduct` function with the arguments `13` and `5`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateProduct\s*\(\s*13\s*,\s*5\s*\)\s*\)\s*;?/);
+assert.deepInclude(spy.calls, [calculateProduct(13, 5)]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc1a3a39aef47d6473cb2f.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc1a3a39aef47d6473cb2f.md
@@ -15,9 +15,15 @@ Inside the function, return the quotient of the two parameters.
 
 Then, add a `console.log` that calls the `calculateQuotient` function with the arguments `7` and `11`.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
-You should have a function called `calculateQuotient`.
+You should declare a function called `calculateQuotient`.
 
 ```js
 assert.isFunction(calculateQuotient);
@@ -40,7 +46,7 @@ assert.equal(calculateQuotient(100, 10), 10);
 You should have a `console.log` that calls the `calculateQuotient` function with the arguments `7` and `11`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateQuotient\s*\(\s*7\s*,\s*11\s*\)\s*\)\s*;?/);
+assert.deepInclude(spy.calls, [calculateQuotient(7, 11)]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc1ccfefdd727e18c2ab20.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc1ccfefdd727e18c2ab20.md
@@ -7,18 +7,24 @@ dashedName: step-14
 
 # --description--
 
-Your `calculateQuotient` appears to be working correctly but there is one case that you have not tested yet.
+Your `calculateQuotient` appears to be working correctly, but there is one case that you have not tested yet.
 
 Add a `console.log` that calls the `calculateQuotient` function with the arguments `3` and `0`.
 
 Make sure to take a close look at the output of this call.
+
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
 
 # --hints--
 
 You should have a `console.log` that calls the `calculateQuotient` function with the arguments `3` and `0`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateQuotient\s*\(\s*3\s*,\s*0\s*\)\s*\)\s*;?/);
+assert.deepInclude(spy.calls, [calculateQuotient(3, 0)]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc21d23238dc8240a8a182.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc21d23238dc8240a8a182.md
@@ -28,7 +28,7 @@ Declare a function called `calculateSquare` that takes a `num` parameter and ret
 
 # --hints--
 
-You should have a function called `calculateSquare`.
+You should declare a function called `calculateSquare`.
 
 ```js
 assert.isFunction(calculateSquare);

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc26907ff6908402af0149.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc26907ff6908402af0149.md
@@ -13,18 +13,24 @@ Add a `console.log` that calls the `calculateSquare` function with the argument 
 
 Then, add another `console.log` that calls the `calculateSquare` function with the argument of `9`.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a `console.log` that calls the `calculateSquare` function with the argument of `2`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateSquare\s*\(\s*2\s*\)\s*\)/);
+assert.deepInclude(spy.calls, [calculateSquare(2)]);
 ```
 
 You should have a `console.log` that calls the `calculateSquare` function with the argument of `9`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateSquare\s*\(\s*9\s*\)\s*\)/);
+assert.deepInclude(spy.calls, [calculateSquare(9)]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc2739f687e484d50bb6f1.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc2739f687e484d50bb6f1.md
@@ -26,7 +26,7 @@ Declare a function called `calculateSquareRoot` that takes a `num` parameter and
 
 # --hints--
 
-You should have a function called `calculateSquareRoot`.
+You should declare a function called `calculateSquareRoot`.
 
 ```js
 assert.isFunction(calculateSquareRoot);

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cc281d687975858049fd8d.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cc281d687975858049fd8d.md
@@ -15,18 +15,24 @@ Then, add a second `console.log` that calls the `calculateSquareRoot` function w
 
 And with those changes, your calculator app is complete!
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a `console.log` that calls the `calculateSquareRoot` function with the argument of `25`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateSquareRoot\s*\(\s*25\s*\)\s*\)/);
+assert.deepInclude(spy.calls, [calculateSquareRoot(25)]);
 ```
 
 You should have a `console.log` that calls the `calculateSquareRoot` function with the argument of `100`.
 
 ```js
-assert.match(code, /console\.log\s*\(\s*calculateSquareRoot\s*\(\s*100\s*\)\s*\)/);
+assert.deepInclude(spy.calls, [calculateSquareRoot(100)]);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-calculator/66cdf76685e4cb5a8726e27b.md
+++ b/curriculum/challenges/english/blocks/workshop-calculator/66cdf76685e4cb5a8726e27b.md
@@ -13,18 +13,24 @@ Add another `console.log` that calls the `calculateSum` function with the argume
 
 Below that `console.log`, add another `console.log` that calls the `calculateSum` function with the arguments `5` and `5`.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+```
+
 # --hints--
 
 You should have a `console.log` that calls the `calculateSum` function with the arguments `10` and `10`.
 
 ```js
-assert.match(code, /console\.log\(calculateSum\(10\s*,\s*10\)\)/);
+assert.deepInclude(spy.calls, [calculateSum(10, 10)]);
 ```
 
 You should have a `console.log` that calls the `calculateSum` function with the arguments `5` and `5`.
 
 ```js
-assert.match(code, /console\.log\(calculateSum\(5\s*,\s*5\)\)/);
+assert.deepInclude(spy.calls, [calculateSum(5, 5)]);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #XXXXX

A collection of fixes to the `workshop-calculator` workshop:

- Added `--before-each--` with a spy across steps 3, 4, 8, 9, 11, 12, 13, 14, 17, and 19, and replaced every "console.log calls X" regex check (which only proved the call text existed in source, not that it ran) with `assert.deepInclude(spy.calls, [expectedValue])`, computed by calling the student's own function. This also resolves inconsistent regex whitespace/semicolon leniency that existed across these steps, since there's no more regex to be inconsistent.
- Dropped step 3's redundant near-no-op first hint.
- Standardized "have a function" to "declare a function" in steps 10, 12, 13, 16, and 18, matching steps 1, 4, and 6.
- Fixed a missing article in step 2 ("One of concepts").
- Dropped a stray "Now," comma in step 4 to match steps 11/12.
- Added a missing comma before "but" in step 14.