### PR TITLE
fix(curriculum): remove redundant page reference from Cafe Menu description

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -8420,7 +8420,7 @@
         "title": "Design a Cafe Menu",
         "intro": [
           "CSS tells the browser how to display your webpage. You can use CSS to set the color, font, size, and other aspects of HTML elements.",
-          "In this workshop, you'll learn CSS by designing a menu page for a cafe webpage."
+          "In this workshop, you'll learn CSS by designing a menu page for a cafe."
         ]
       },
       "lab-business-card": {
@@ -9688,7 +9688,7 @@
         "title": "Design a Cafe Menu",
         "intro": [
           "CSS tells the browser how to display your webpage. You can use CSS to set the color, font, size, and other aspects of HTML elements.",
-          "In this workshop, you'll learn CSS by designing a menu page for a cafe webpage."
+          "In this workshop, you'll learn CSS by designing a menu page for a cafe."
         ]
       },
       "lab-business-card": {


### PR DESCRIPTION
## Description

Removes the redundant word "webpage" from the Cafe Menu workshop catalog description.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69236

<!-- Feel free to add any additional description of changes below this line -->

## Changes

- Updated both workshop descriptions in `client/i18n/locales/english/intro.json`.
- Removed the redundant word `webpage` from the two workshop descriptions.