### PR TITLE
fix(curriculum): stub fetch in fCC Authors Page workshop step 26 tests

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fcc-authors-page/69e14a2fd8ecf9210c0739ee.md
+++ b/curriculum/challenges/english/blocks/workshop-fcc-authors-page/69e14a2fd8ecf9210c0739ee.md
@@ -11,6 +11,12 @@ When calling an asynchronous function, you can either await the function's retur
 
 Add a function call to `initialFetch` in the indicated space in the editor.
 
+# --before-all--
+
+```js
+window.fetch = () => Promise.resolve({json: () => Promise.resolve([{ author: 'Whoever', image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', url: "http://not-a-real-url.nowhere/", bio: 'words go here' }])});
+```
+
 # --hints--
 
 You should call `initialFetch` without any arguments.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

To make the CI faster and more reliable, added the mocking of `fetch` to step 26, the only fetching step of the workshop that was missing it.
