### PR TITLE
fix(curriculum): close div and fix wording

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f475bb508746c16c9431d42.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f475bb508746c16c9431d42.md
@@ -7,9 +7,9 @@ dashedName: step-87
 
 # --description--
 
-The image you added is not centered horizontally like the `Coffee` heading above it. `img` elements are "like" inline elements.
+The image you added is not centered horizontally like the `Coffee` heading above it. `img` elements are inline-level elements, so they sit in the flow of text.
 
-To make the image behave like block-level elements such as headings, create an `img` type selector. Set the `display` property to `block`, and use `margin-left` and `margin-right` properties to center it horizontally.
+To make the image behave like a block-level element such as a heading, create an `img` type selector. Set the `display` property to `block`, and use `margin-left` and `margin-right` properties to center it horizontally.
 
 # --hints--
 
@@ -120,6 +120,7 @@ assert.equal(imgMarginRight, 'auto');
           <p class="address">123 Free Code Camp Drive</p>
         </address>
       </footer>
+    </div>
   </body>
 </html>
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69233

<!-- Feel free to add any additional description of changes below this line -->

Step 87's seed HTML opens `<div class="menu">` but never closes it. The seed block has one `<div>` and no `</div>`, going straight from `</footer>` to `</body>`. Step 89's seed already includes `</div>` after `</footer>`, so as it stands the tag reappears without the learner ever being asked to add it. I added `    </div>` between them, matching Step 89's indentation.

I also fixed the two description issues from the issue: removed the quotes around "like", since an `img` is an inline-level element and the sentence can state that directly, and made the comparison singular because the subject is a single image.

Tested locally: `pnpm test-curriculum-content` passes (964 files, 55,739 tests), and the `workshop-cafe-menu` block on its own passes 446 tests.