### PR TITLE
fix(curriculum): clarify h2 margin instruction wording

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f47fe7e31980053a8d4403b.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f47fe7e31980053a8d4403b.md
@@ -7,7 +7,7 @@ dashedName: step-89
 
 # --description--
 
-It would be nice if the vertical space between the `h2` elements and their associated icons was smaller. The `h2` elements have default top and bottom margin space, So you could change the bottom margin of the h2 elements to 0 or some other value.
+It would be nice if the vertical space between the `h2` elements and their associated icons was smaller. The `h2` elements have default top and bottom margin space, so you could change the bottom margin of the `h2` elements to `0` or some other value.
 
 There is an easier way, simply add a negative top margin to the `img` elements to pull them up from their current positions. Negative values are created using a `-` in front of the value. To complete this workshop, go ahead and use a negative top margin of `25px` in the `img` type selector.
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f47fe7e31980053a8d4403b.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f47fe7e31980053a8d4403b.md
@@ -7,11 +7,11 @@ dashedName: step-89
 
 # --description--
 
-It would be nice if the vertical space between the `h2` elements and their associated icons was smaller. The `h2` elements have default top and bottom margin space, so you could change the bottom margin of the `h2` elements to say `0` or another number.
+It would be nice if the vertical space between the `h2` elements and their associated icons was smaller. The `h2` elements have default top and bottom margin space, So you could change the bottom margin of the h2 elements to 0 or some other value.
 
 There is an easier way, simply add a negative top margin to the `img` elements to pull them up from their current positions. Negative values are created using a `-` in front of the value. To complete this workshop, go ahead and use a negative top margin of `25px` in the `img` type selector.
 
-Congratulations! You have completed the Cafe Menu workshop. 
+Congratulations! You have completed the Cafe Menu workshop.  
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f47fe7e31980053a8d4403b.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f47fe7e31980053a8d4403b.md
@@ -11,7 +11,7 @@ It would be nice if the vertical space between the `h2` elements and their assoc
 
 There is an easier way, simply add a negative top margin to the `img` elements to pull them up from their current positions. Negative values are created using a `-` in front of the value. To complete this workshop, go ahead and use a negative top margin of `25px` in the `img` type selector.
 
-Congratulations! You have completed the Cafe Menu workshop.  
+Congratulations! You have completed the Cafe Menu workshop.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69235

### Description of Changes

Updated conversational filler and imprecise wording in the instruction text for clarity and technical accuracy:
- Replaced "say 0" with "0" to remove speech filler.
- Replaced "another number" with "some other value" to reflect valid CSS length units.