### PR TITLE
fix(curriculum): restore missing closing div in step 88 cafe menu

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f475e1c7f71a61d913836c6.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f475e1c7f71a61d913836c6.md
@@ -46,57 +46,58 @@ assert.match(lastImage?.alt, /pie icon/i);
   </head>
   <body>
     <div class="menu">
-      <main>
-        <h1>CAMPER CAFE</h1>
-        <p class="established">Est. 2020</p>
-        <hr>
-        <section>
-          <h2>Coffee</h2>
-          <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/coffee.jpg" alt="coffee icon"/>
-          <article class="item">
-            <p class="flavor">French Vanilla</p><p class="price">3.00</p>
-          </article>
-          <article class="item">
-            <p class="flavor">Caramel Macchiato</p><p class="price">3.75</p>
-          </article>
-          <article class="item">
-            <p class="flavor">Pumpkin Spice</p><p class="price">3.50</p>
-          </article>
-          <article class="item">
-            <p class="flavor">Hazelnut</p><p class="price">4.00</p>
-          </article>
-          <article class="item">
-            <p class="flavor">Mocha</p><p class="price">4.50</p>
-          </article>
-        </section>
-        <section>
-          <h2>Desserts</h2>
---fcc-editable-region--
-          
---fcc-editable-region--
-          <article class="item">
-            <p class="dessert">Donut</p><p class="price">1.50</p>
-          </article>
-          <article class="item">
-            <p class="dessert">Cherry Pie</p><p class="price">2.75</p>
-          </article>
-          <article class="item">
-            <p class="dessert">Cheesecake</p><p class="price">3.00</p>
-          </article>
-          <article class="item">
-            <p class="dessert">Cinnamon Roll</p><p class="price">2.50</p>
-          </article>
-        </section>
-      </main>
-      <hr class="bottom-line">
-      <footer>
-        <address>
-          <p>
-            <a href="https://www.freecodecamp.org" target="_blank">Visit our website</a>
-          </p>
-          <p class="address">123 Free Code Camp Drive</p>
-        </address>
-      </footer>
+        <main>
+          <h1>CAMPER CAFE</h1>
+          <p class="established">Est. 2020</p>
+          <hr>
+          <section>
+            <h2>Coffee</h2>
+            <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/coffee.jpg" alt="coffee icon"/>
+            <article class="item">
+              <p class="flavor">French Vanilla</p><p class="price">3.00</p>
+            </article>
+            <article class="item">
+              <p class="flavor">Caramel Macchiato</p><p class="price">3.75</p>
+            </article>
+            <article class="item">
+              <p class="flavor">Pumpkin Spice</p><p class="price">3.50</p>
+            </article>
+            <article class="item">
+              <p class="flavor">Hazelnut</p><p class="price">4.00</p>
+            </article>
+            <article class="item">
+              <p class="flavor">Mocha</p><p class="price">4.50</p>
+            </article>
+          </section>
+          <section>
+            <h2>Desserts</h2>
+  --fcc-editable-region--
+            
+  --fcc-editable-region--
+            <article class="item">
+              <p class="dessert">Donut</p><p class="price">1.50</p>
+            </article>
+            <article class="item">
+              <p class="dessert">Cherry Pie</p><p class="price">2.75</p>
+            </article>
+            <article class="item">
+              <p class="dessert">Cheesecake</p><p class="price">3.00</p>
+            </article>
+            <article class="item">
+              <p class="dessert">Cinnamon Roll</p><p class="price">2.50</p>
+            </article>
+          </section>
+        </main>
+        <hr class="bottom-line">
+        <footer>
+          <address>
+            <p>
+              <a href="https://www.freecodecamp.org" target="_blank">Visit our website</a>
+            </p>
+            <p class="address">123 Free Code Camp Drive</p>
+          </address>
+        </footer>
+      </div>
   </body>
 </html>
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69234

### Description of Changes

Restored the missing closing `</div>` tag in the seed code for Step 88 of the Learn Basic CSS by Building a Cafe Menu workshop and reformatted the HTML snippet