### PR TITLE
fix: div closed and URL converted to uppercase

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e8284aae155c83015dee.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e8284aae155c83015dee.md
@@ -105,7 +105,7 @@ assert.match(imageAltValue, /coffee icon/i);
           <p class="address">123 Free Code Camp Drive</p>
         </address>
       </footer>
-  </div>
+    </div>
   </body>
 </html>
 ```

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e8284aae155c83015dee.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f46e8284aae155c83015dee.md
@@ -9,7 +9,7 @@ dashedName: step-86
 
 The menu looks good, but other than the coffee beans background image, it is mainly just text.
 
-Under the `Coffee` heading, add an image using the url `https://cdn.freecodecamp.org/curriculum/css-cafe/coffee.jpg`. Give the image an `alt` value of `coffee icon`.
+Under the `Coffee` heading, add an image using the URL `https://cdn.freecodecamp.org/curriculum/css-cafe/coffee.jpg`. Give the image an `alt` value of `coffee icon`.
 
 # --hints--
 
@@ -105,6 +105,7 @@ assert.match(imageAltValue, /coffee icon/i);
           <p class="address">123 Free Code Camp Drive</p>
         </address>
       </footer>
+  </div>
   </body>
 </html>
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69231

This PR fixes two issues in Workshop Cafe Menu – Step 86

Adds the missing closing </div> tag for the <div class="menu"> element in the seed HTML.
Updates the instruction text to use URL instead of url
No other changes were made.
