### PR TITLE
fix(curriculum): clarify spacing description in Cafe Menu Step 82

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b715301bbf667badc04a.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b715301bbf667badc04a.md
@@ -7,7 +7,7 @@ dashedName: step-82
 
 # --description--
 
-The menu text `CAMPER CAFE` has a different space from the top than the address's space at the bottom of the menu. This is due to the browser having some default top margin for the `h1` element.
+The space above the menu text `CAMPER CAFE` does not match the space below the address at the bottom of the menu. This is due to the browser having some default top margin for the `h1` element.
 
 Change the top margin of the `h1` element to `0` to remove all the top margin.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #69230

## Description

This PR updates the wording in the Cafe Menu Step 82 workshop description to clarify that the spacing above the `CAMPER CAFE` heading should match the spacing below the address at the bottom of the menu.