### PR TITLE
fix(client): use span for donate FAQ titles

### DIFF
--- a/client/src/components/Donation/donation-text-components.tsx
+++ b/client/src/components/Donation/donation-text-components.tsx
@@ -89,7 +89,7 @@ const FaqItem = (
         aria-controls={`donate-faq-content-${key}`}
       >
         <Caret />
-        <h3>{title}</h3>
+        <span className='faq-question-title'>{title}</span>
       </button>
       {isExpanded && (
         <div className='map-challenges-ul' id={`donate-faq-content-${key}`}>

--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -586,8 +586,10 @@ a.patreon-button:hover {
   margin-inline-start: 0.25em;
 }
 
-.faq-item h3 {
+.faq-item .faq-question-title {
+  color: var(--secondary-color);
   font-size: 1rem;
+  font-weight: 700;
   line-height: 1.5;
   margin: 0;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69262

<!-- Feel free to add any additional description of changes below this line -->

Replaces the `h3` nested inside the donate FAQ `button` with a `span`, since heading elements are not valid descendants of a `button`. The `.faq-item h3` rule is now `.faq-item .faq-question-title`.

The original `h3` was inheriting `color: var(--secondary-color)` and `font-weight: 700` from the global `h3` rule in `global.css`, which a `span` does not get. Both are now set explicitly on the class so the titles render identically.

Verified the rendered output against the previous markup; computed `font-size`, `font-weight`, `color`, `line-height`, and `margin` all match, and the expand/collapse behavior and `aria-expanded`/`aria-controls` attributes are unchanged.

