### PR TITLE
fix(curriculum): improve Flexbox lecture content and examples

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
@@ -319,7 +319,7 @@ The main axis is always horizontal, while the cross axis is always vertical.
 
 ### --feedback--
 
-Think about the distribution of elements within a flex container.
+Think about how the main axis and cross axis are positioned relative to each other.
 
 ---
 
@@ -327,7 +327,7 @@ The main axis is always vertical, while the cross axis is always horizontal.
 
 ### --feedback--
 
-Think about the distribution of elements within a flex container.
+Think about how the main axis and cross axis are positioned relative to each other.
 
 ---
 
@@ -339,7 +339,7 @@ The main axis and cross axis are always parallel to each other.
 
 ### --feedback--
 
-Think about the distribution of elements within a flex container.
+Think about how the main axis and cross axis are positioned relative to each other.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -520,7 +520,7 @@ main {
 
 div {
   width: 80px;
-  height: auto;
+  height: 50px;
 }
 
 #first-div {
@@ -533,6 +533,7 @@ div {
 
 #third-div {
   background-color: #4da3b2;
+  height: auto;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -7,7 +7,7 @@ dashedName: what-are-some-common-flex-properties
 
 # --interactive--
 
-Flex properties are properties that you can apply to flex containers to determine the distribution of child elements. We'll cover some of the most commonly used ones: `flex-wrap`, `justify-content`, and `align-items`.
+Flex properties control how elements behave inside a flex layout, from container-level distribution to item-level self-alignment. We'll cover some of the most commonly used ones in this lesson: `flex-wrap`, `flex-flow`, `justify-content`, `align-items`, and `align-self`.
 
 Let's start with `flex-wrap`. This property determines how flex items are wrapped within a flex container to fit the available space. `flex-wrap` can take three possible values: `nowrap`, `wrap`, and `wrap-reverse`. `nowrap` is the default value: flex items won't be wrapped onto a new line, even if their width exceeds the container's width.
 
@@ -108,6 +108,7 @@ The `div` elements will be rearranged in rows when they exceed the width of thei
 ```css
 main {
   width: 200px;
+  height: 120px;
   display: flex;
   flex-flow: column wrap-reverse;
   border: 2px solid red;
@@ -253,7 +254,7 @@ div {
 
 :::
 
-To distribute the elements evenly along the main axis, you can use `justify-content: space-between`. This will add some space between the flex items if needed.
+To distribute the elements along the main axis with no space at the edges, you can use `justify-content: space-between`. The first item sits at the start of the main axis, the last item sits at the end, and any remaining space is distributed between adjacent items.
 
 :::interactive_editor
 
@@ -496,33 +497,41 @@ div {
 
 :::
 
-To stretch the flex items along the cross axis, you can use `align-items: stretch`. This also works with elements that are automatically sized, such as those without set `width` or `height`, or with only a minimum `width` or `height`. The flex items will stretch to fill the container in the direction of the cross axis.
+To stretch the flex items along the cross axis, you can use `align-items: stretch`. This only affects items whose size on the cross axis is `auto`; items with an explicit size on the cross axis (for example, a set `height` in a row container) won't stretch. The affected items will fill the container in the direction of the cross axis.
 
 :::interactive_editor
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: stretch; 
+  align-items: stretch;
+  height: 200px;
   border: 2px solid #444;
-  height: 200px; 
 }
 
-.box {
-  width: 100px;           
-  border: 1px solid #888;
-  background-color: lightblue;
+div {
+  width: 80px;
+}
+
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
 }
 ```
 
@@ -534,33 +543,37 @@ And finally, you can use the `align-self` property to assign a different alignme
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box special">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: flex-start; 
+  align-items: flex-start;
+  height: 200px;
   border: 2px solid #444;
-  height: 200px; 
 }
 
-.box {
-  width: 100px;
-  border: 1px solid #888;
-  background-color: lightblue;
-  margin: 4px;
+div {
+  width: 80px;
+  height: 50px;
 }
 
-.special {
-  align-self: stretch; 
-  background-color: lightcoral;
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
+  align-self: stretch;
 }
 ```
 
@@ -572,33 +585,37 @@ You can center it with `align-self: center`.
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box special">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: flex-start; 
+  align-items: flex-start;
+  height: 200px;
   border: 2px solid #444;
-  height: 200px; 
 }
 
-.box {
-  width: 100px;
-  border: 1px solid #888;
-  background-color: lightblue;
-  margin: 4px;
+div {
+  width: 80px;
+  height: 50px;
 }
 
-.special {
-  align-self: center; 
-  background-color: lightcoral;
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
+  align-self: center;
 }
 ```
 
@@ -610,33 +627,37 @@ You can align it to the start of the cross axis with `align-self: flex-start`.
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box special">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: flex-start; 
+  align-items: flex-start;
+  height: 200px;
   border: 2px solid #444;
-  height: 200px; 
 }
 
-.box {
-  width: 100px;
-  border: 1px solid #888;
-  background-color: lightblue;
-  margin: 4px;
+div {
+  width: 80px;
+  height: 50px;
 }
 
-.special {
-  align-self: flex-start; 
-  background-color: lightcoral;
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
+  align-self: flex-start;
 }
 ```
 
@@ -648,33 +669,37 @@ Or you can align it to the end of the cross axis with `align-self: flex-end`.
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box special">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: flex-start; 
+  align-items: flex-start;
+  height: 200px;
   border: 2px solid #444;
-  height: 200px; 
 }
 
-.box {
-  width: 100px;
-  border: 1px solid #888;
-  background-color: lightblue;
-  margin: 4px;
+div {
+  width: 80px;
+  height: 50px;
 }
 
-.special {
-  align-self: flex-end; 
-  background-color: lightcoral;
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
+  align-self: flex-end;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -11,7 +11,7 @@ Flex properties control how elements behave inside a flex layout, from container
 
 Let's start with `flex-wrap`. This property determines how flex items are wrapped within a flex container to fit the available space. `flex-wrap` can take three possible values: `nowrap`, `wrap`, and `wrap-reverse`. `nowrap` is the default value: flex items won't be wrapped onto a new line, even if their width exceeds the container's width.
 
-In the code below, we have three `div` elements. Let's focus on the `width`. The `main` container bordered in red has a `width` of `200px`, while its three child `div` elements combined have a `width` of `240px` (`80px` each):
+In the code below, we have three `div` elements. Let's focus on the `width`. The bordered `main` container has a `width` of `200px`, while its three child `div` elements combined have a `width` of `240px` (`80px` each):
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -108,8 +108,8 @@ The `div` elements will be rearranged in rows when they exceed the width of thei
 ```css
 main {
   width: 200px;
-  display: flex;
   height: 120px;
+  display: flex;
   flex-flow: column wrap-reverse;
   border: 2px solid #444;
 }

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -28,7 +28,7 @@ In the code below, we have three `div` elements. Let's focus on the `width`. The
 main {
   width: 200px;
   display: flex;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -69,7 +69,7 @@ main {
   width: 200px;
   display: flex;
   flex-wrap: wrap;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -108,10 +108,10 @@ The `div` elements will be rearranged in rows when they exceed the width of thei
 ```css
 main {
   width: 200px;
-  height: 120px;
   display: flex;
+  height: 120px;
   flex-flow: column wrap-reverse;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -151,7 +151,7 @@ Great. Now let's talk about `justify-content`. `justify-content` aligns the chil
 main {
   display: flex;
   justify-content: flex-start;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -191,7 +191,7 @@ With `justify-content: flex-end`, flex items are aligned to the end of the main 
 main {
   display: flex;
   justify-content: flex-end;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -231,7 +231,7 @@ To center the flex items along the main axis, you can use `justify-content: cent
 main {
   display: flex;
   justify-content: center;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -271,7 +271,7 @@ To distribute the elements along the main axis with no space at the edges, you c
 main {
   display: flex;
   justify-content: space-between;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -311,7 +311,7 @@ div {
 main {
   display: flex;
   justify-content: space-around;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -351,7 +351,7 @@ And last but not least, we have `justify-content: space-evenly`, which distribut
 main {
   display: flex;
   justify-content: space-evenly;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -389,10 +389,10 @@ Great. Now you know how to distribute flex items along the main axis. But you ma
 
 ```css
 main {
-  height: 300px;
   display: flex;
+  height: 300px;
   align-items: center;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -430,10 +430,10 @@ In this example, the flex items are centered along the cross axis, which is vert
 
 ```css
 main {
-  height: 300px;
   display: flex;
+  height: 300px;
   align-items: flex-start;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -471,10 +471,10 @@ The opposite is `align-items: flex-end`. This will align flex items to the end o
 
 ```css
 main {
-  height: 300px;
   display: flex;
+  height: 300px;
   align-items: flex-end;
-  border: 2px solid red;
+  border: 2px solid #444;
 }
 
 div {
@@ -513,13 +513,14 @@ To stretch the flex items along the cross axis, you can use `align-items: stretc
 ```css
 main {
   display: flex;
+  height: 300px;
   align-items: stretch;
-  height: 200px;
   border: 2px solid #444;
 }
 
 div {
   width: 80px;
+  height: auto;
 }
 
 #first-div {
@@ -553,8 +554,8 @@ And finally, you can use the `align-self` property to assign a different alignme
 ```css
 main {
   display: flex;
+  height: 300px;
   align-items: flex-start;
-  height: 200px;
   border: 2px solid #444;
 }
 
@@ -595,8 +596,8 @@ You can center it with `align-self: center`.
 ```css
 main {
   display: flex;
+  height: 300px;
   align-items: flex-start;
-  height: 200px;
   border: 2px solid #444;
 }
 
@@ -637,8 +638,8 @@ You can align it to the start of the cross axis with `align-self: flex-start`.
 ```css
 main {
   display: flex;
+  height: 300px;
   align-items: flex-start;
-  height: 200px;
   border: 2px solid #444;
 }
 
@@ -679,8 +680,8 @@ Or you can align it to the end of the cross axis with `align-self: flex-end`.
 ```css
 main {
   display: flex;
+  height: 300px;
   align-items: flex-start;
-  height: 200px;
   border: 2px solid #444;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69237 

<!-- Feel free to add any additional description of changes below this line -->
## Description

This PR fixes six learner-facing content issues across two Flexbox lectures in the Responsive Web Design curriculum. The updates improve conceptual accuracy, ensure the `flex-flow` example behaves as described, and make the interactive examples more consistent throughout the lesson.

### Changes made

- Updated the quiz feedback on main-axis/cross-axis orientation so incorrect answers guide learners toward the perpendicular relationship.
- Fixed the `flex-flow: column wrap-reverse` example by constraining the container height so reverse wrapping is demonstrated correctly.
- Clarified the difference between `justify-content: space-between` and `justify-content: space-evenly`, including how edge spacing differs.
- Corrected the `align-items: stretch` explanation to clarify that stretching only applies when an item's cross-axis size is `auto`.
- Rewrote the opening overview to describe both container-level and item-level flex properties, including `flex-flow` and `align-self`.
- Updated the later interactive examples to use the same container/child markup pattern as the earlier examples and removed formatting inconsistencies for easier comparison.

