### PR TITLE
fix(curriculum): improve prose consistency in reusable mega navbar workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6740495ba48aa94e5667b436.md
@@ -10,7 +10,7 @@ demoType: onLoad
 
 In this workshop, you will practice working with React functional components by building a reusable navbar.
 
-All the CSS have been provided for you so you can focus on creating the navbar.
+All the CSS has been provided for you so you can focus on creating the navbar.
 
 Start by defining a `Navbar` functional component. In the next step, you will start to build out the component using JSX.
 
@@ -24,7 +24,7 @@ export function multiply(a, b) {
 }
 ```
 
-Also, React functional components need to start with a capital letter because it is a way to differentiate from regular HTML elements.
+Also, React functional components need to start with a capital letter because that is how React differentiates them from regular HTML elements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/67457ff2dc531fbed928a0f0.md
@@ -24,10 +24,9 @@ const App = () => {
 }
 ```
 
-
 Inside the `Navbar` component, return a `nav` element that has a `className` of `navbar`.
 
-The reason why `className` is used here instead of `class` is because `class` is a reserved keyword in JavaScript. So, React uses `className` as a way to apply classes to elements.
+`className` is used here instead of `class` because `class` is a reserved keyword in JavaScript. So, React uses `className` as a way to apply classes to elements.
 
 # --hints--
 
@@ -37,7 +36,7 @@ You should return a `nav` element.
 assert.exists(document.querySelector('nav'));
 ```
 
-Your `nav` element should have a `className` attribute with the value `navbar`.
+Your `nav` element should have a `className` of `navbar`.
 
 ```js
 assert.equal(document.querySelector('nav')?.getAttribute('class'), 'navbar');

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745c732dbeb7c04f346e6f7.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745c732dbeb7c04f346e6f7.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-Create a `ul` element inside the `nav` element. Inside that `ul` element, create three list items.
+Create a `ul` element inside your `nav` element. Inside that `ul` element, create three `li` elements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745c89fba004707ded84453.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745c89fba004707ded84453.md
@@ -7,17 +7,17 @@ dashedName: step-5
 
 # --description--
 
-Create an anchor element inside the first `li` element. Give the `a` element an `href` attribute of `#` and the text `Dashboard`.
+Create an `a` element inside your first `li` element. Give it an `href` attribute of `#` and the text `Dashboard`.
 
 # --hints--
 
-You should create an `a` element inside the first list item.
+You should create an `a` element inside your first `li` element.
 
 ```js
 assert.exists(document.querySelector('li a'));
 ```
 
-Your `a` element should have its `href` attribute set to `#`.
+Your `a` element should have an `href` attribute of `#`.
 
 ```js
 assert.equal(document.querySelector('a')?.getAttribute('href'), '#');

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745cebbf97ef2129f3b9bab.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745cebbf97ef2129f3b9bab.md
@@ -7,17 +7,17 @@ dashedName: step-6
 
 # --description--
 
-Create another `a` element inside the second `li` element. Give it an `href` attribute of `#` and the text `Widgets`.
+Create another `a` element inside your second `li` element. Give it an `href` attribute of `#` and the text `Widgets`.
 
 # --hints--
 
-You should create an `a` element inside the second list item.
+You should create an `a` element inside your second `li` element.
 
 ```js
 assert.lengthOf(document.querySelectorAll('li a'), 2);
 ```
 
-Your `a` element should have its `href` attribute set to `#`.
+Your `a` element should have an `href` attribute of `#`.
 
 ```js
 assert.equal(document.querySelectorAll('a')[1]?.getAttribute('href'), '#');

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745d799beeb822076a4da9d.md
@@ -7,19 +7,19 @@ dashedName: step-7
 
 # --description--
 
-Inside the third list item, create a `button` element with an `aria-expanded` attribute set to `false`. Also, set the text of the `button` to `Apps`.
+Inside your third `li` element, create a `button` element with an `aria-expanded` attribute of `false`. Also, set the text of the `button` to `Apps`.
 
 The `aria-expanded` attribute will communicate to screen reader users that the button triggers an expandable submenu.
 
 # --hints--
 
-You should create a `button` element inside the third list item.
+You should create a `button` element inside your third `li` element.
 
 ```js
 assert.exists(document.querySelector('li:nth-of-type(3) button'));
 ```
 
-Your `button` element should have an `aria-expanded` attribute set to `false`.
+Your `button` element should have an `aria-expanded` attribute of `false`.
 
 ```js
 assert.equal(

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745d9df333efe2543a1f457.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-Still inside the third `li` element, create a `ul` element for the popup. Give it a `className` of `sub-menu` and an `aria-label` of `Apps`.
+Still inside your third `li` element, create a `ul` element for the popup. Give it a `className` of `sub-menu` and an `aria-label` of `Apps`.
 
 # --hints--
 
@@ -17,13 +17,13 @@ You should create a `ul` element inside your third `li` element.
 assert.exists(document.querySelector('li ul'));
 ```
 
-You should set the `className` attribute of your `ul` element to `sub-menu`.
+Your `ul` element should have a `className` of `sub-menu`.
 
 ```js
 assert.equal(document.querySelector('li ul')?.getAttribute('class'), 'sub-menu');
 ```
 
-You should set the `aria-label` attribute of your `ul` element to `Apps`.
+Your `ul` element should have an `aria-label` of `Apps`.
 
 ```js
 assert.equal(document.querySelector('li ul')?.getAttribute('aria-label'), 'Apps');

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745dce846995b2a466594be.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745dce846995b2a466594be.md
@@ -7,11 +7,11 @@ dashedName: step-9
 
 # --description--
 
-Create three new list items inside your `ul.sub-menu` element.
+Create three new `li` elements inside your `ul` element with a `className` of `sub-menu`.
 
 # --hints--
 
-You should create three new list items inside your `ul` element with the `className` of `sub-menu`.
+You should create three new `li` elements inside your `ul` element with a `className` of `sub-menu`.
 
 ```js
 assert.lengthOf(document.querySelectorAll('.sub-menu li'), 3);

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745de9ce925b92d72df713a.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745de9ce925b92d72df713a.md
@@ -7,11 +7,11 @@ dashedName: step-10
 
 # --description--
 
-Inside each `li` element, create an anchor element with an `href` attribute set to `#`.
+Inside each of the three new `li` elements, create an `a` element with an `href` attribute of `#`.
 
 # --hints--
 
-You should create a new `a` element inside each list item and set its `href` attribute to `#`.
+You should create a new `a` element with an `href` attribute of `#` inside each of the three new `li` elements.
 
 ```js
 assert.equal(document.querySelectorAll('li a')[2]?.getAttribute('href'), '#');

--- a/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745e2aca895c935168e7d91.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-mega-navbar/6745e2aca895c935168e7d91.md
@@ -7,25 +7,25 @@ dashedName: step-11
 
 # --description--
 
-To finish things up, set a text of `Calendar` for the first anchor tag, `Chat` for the second, and `Email` for the third one.
+To finish things up, set the text of the first `a` element to `Calendar`, the second to `Chat`, and the third to `Email`.
 
-With that, you mega navbar component is complete!
+With that, your `Navbar` component is complete!
 
 # --hints--
 
-You should set a text of `Calendar` for the first anchor element.
+You should set the text of the first `a` element to `Calendar`.
 
 ```js
 assert.equal(document.querySelectorAll('li a')[2]?.textContent, 'Calendar');
 ```
 
-You should set a text of `Chat` for the second anchor element.
+You should set the text of the second `a` element to `Chat`.
 
 ```js
 assert.equal(document.querySelectorAll('li a')[3]?.textContent, 'Chat');
 ```
 
-You should set a text of `Email` for the third anchor element.
+You should set the text of the third `a` element to `Email`.
 
 ```js
 assert.equal(document.querySelectorAll('li a')[4]?.textContent, 'Email');


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This is a prose-only pass over the eleven steps of the Reusable Mega Navbar workshop. No assertion logic was touched, and `FCC_BLOCK='workshop-reusable-mega-navbar' pnpm test` passes (156 tests across 11 files).

**Grammar and typos**

- Step 1: "All the CSS **have** been provided" to "has been provided".
- Step 11: "With that, **you** mega navbar component is complete!" to "your `Navbar` component is complete!".
- Step 2: "**The reason why** `className` is used here instead of `class` **is because** ..." reduced to "`className` is used here instead of `class` because ...".
- Step 1: "because it is a way to differentiate from regular HTML elements" had no referent for "it" and no object for "differentiate from"; now "because that is how React differentiates them from regular HTML elements".

**Clarity**

- Step 10 said "Inside each `li` element, create an anchor element ...", but six `li` elements exist at that point and only the three new submenu ones are inside the editable region. It now reads "Inside each of the three new `li` elements ...".

**Consistency across steps**

- One name for the anchor: `a` element, replacing a mix of "anchor element", "anchor tag", and `a` element (Step 5 switched forms mid-sentence).
- One name for list items: `li` element, replacing a mix with "list item" that also disagreed between several descriptions and their own hints.
- One phrasing for attribute instructions and hints: "an `X` attribute of `Y`", replacing an even split between "attribute of" and "attribute set to".
- One phrasing for the three `className` hints, which previously used three different constructions ("a `className` attribute with the value", "a `className` of", "set the `className` attribute of ... to").
- "your" rather than "the" when referring to the camper's own markup, matching what the hints already did.
- Step 9 used the CSS selector notation `ul.sub-menu` in prose; it now spells the element out the way its own hint does.
- Step 11's three hints reworded from "You should set a text of `X` for the ... anchor element" to "You should set the text of the ... `a` element to `X`".

**Formatting**

- Step 2 had a stray double blank line after a code block; every other step uses one.