### PR TITLE
fix(curriculum): correct flexbox lecture content and markup

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
@@ -319,7 +319,7 @@ The main axis is always horizontal, while the cross axis is always vertical.
 
 ### --feedback--
 
-Think about the distribution of elements within a flex container.
+Think about how the main axis and cross axis are oriented relative to each other.
 
 ---
 
@@ -327,7 +327,7 @@ The main axis is always vertical, while the cross axis is always horizontal.
 
 ### --feedback--
 
-Think about the distribution of elements within a flex container.
+Think about how the main axis and cross axis are oriented relative to each other.
 
 ---
 
@@ -339,7 +339,7 @@ The main axis and cross axis are always parallel to each other.
 
 ### --feedback--
 
-Think about the distribution of elements within a flex container.
+Think about how the main axis and cross axis are oriented relative to each other.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -624,33 +624,37 @@ You can align it to the start of the cross axis with `align-self: flex-start`.
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box special">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: flex-start; 
-  border: 2px solid #444;
-  height: 200px; 
+  align-items: flex-start;
+  border: 2px solid red;
+  height: 200px;
 }
 
-.box {
-  width: 100px;
-  border: 1px solid #888;
-  background-color: lightblue;
-  margin: 4px;
+div {
+  width: 80px;
+  height: 50px;
 }
 
-.special {
-  align-self: flex-start; 
-  background-color: lightcoral;
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
+  align-self: flex-start;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -670,33 +670,37 @@ Or you can align it to the end of the cross axis with `align-self: flex-end`.
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box special">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: flex-start; 
-  border: 2px solid #444;
-  height: 200px; 
+  align-items: flex-start;
+  border: 2px solid red;
+  height: 200px;
 }
 
-.box {
-  width: 100px;
-  border: 1px solid #888;
-  background-color: lightblue;
-  margin: 4px;
+div {
+  width: 80px;
+  height: 50px;
 }
 
-.special {
-  align-self: flex-end; 
-  background-color: lightcoral;
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
+  align-self: flex-end;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -254,7 +254,7 @@ div {
 
 :::
 
-To distribute the elements evenly along the main axis, you can use `justify-content: space-between`. This will add some space between the flex items if needed.
+You can use `justify-content: space-between` to distribute the flex items evenly along the main axis, with the first item placed at the start and the last item placed at the end. The remaining space is then divided evenly between the items, so no extra space is added before the first item or after the last one.
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -586,33 +586,37 @@ You can center it with `align-self: center`.
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box special">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: flex-start; 
-  border: 2px solid #444;
-  height: 200px; 
+  align-items: flex-start;
+  border: 2px solid red;
+  height: 200px;
 }
 
-.box {
-  width: 100px;
-  border: 1px solid #888;
-  background-color: lightblue;
-  margin: 4px;
+div {
+  width: 80px;
+  height: 50px;
 }
 
-.special {
-  align-self: center; 
-  background-color: lightcoral;
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
+  align-self: center;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -503,27 +503,35 @@ To stretch the flex items along the cross axis, you can use `align-items: stretc
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: stretch; 
-  border: 2px solid #444;
-  height: 200px; 
+  align-items: stretch;
+  border: 2px solid red;
+  height: 200px;
 }
 
-.box {
-  width: 100px;           
-  border: 1px solid #888;
-  background-color: lightblue;
+div {
+  width: 80px;
+}
+
+#first-div {
+  background-color: #4d70b2;
+}
+
+#second-div {
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -543,33 +543,38 @@ And finally, you can use the `align-self` property to assign a different alignme
 
 ```html
 <link rel="stylesheet" href="styles.css">
-
-<div class="container">
-  <div class="box">One</div>
-  <div class="box">Two</div>
-  <div class="box special">Three</div>
-</div>
-
+<main>
+  <div id="first-div"></div>
+  <div id="second-div"></div>
+  <div id="third-div"></div>
+</main>
 ```
 
 ```css
-.container {
+main {
   display: flex;
-  align-items: flex-start; 
-  border: 2px solid #444;
-  height: 200px; 
+  align-items: flex-start;
+  border: 2px solid red;
+  height: 200px;
 }
 
-.box {
-  width: 100px;
-  border: 1px solid #888;
-  background-color: lightblue;
-  margin: 4px;
+div {
+  width: 80px;
 }
 
-.special {
-  align-self: stretch; 
-  background-color: lightcoral;
+#first-div {
+  height: 50px;
+  background-color: #4d70b2;
+}
+
+#second-div {
+  height: 50px;
+  background-color: #5c4db2;
+}
+
+#third-div {
+  background-color: #4da3b2;
+  align-self: stretch;
 }
 ```
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -497,7 +497,7 @@ div {
 
 :::
 
-To stretch the flex items along the cross axis, you can use `align-items: stretch`. This also works with elements that are automatically sized, such as those without set `width` or `height`, or with only a minimum `width` or `height`. The flex items will stretch to fill the container in the direction of the cross axis.
+To stretch the flex items along the cross axis, you can use `align-items: stretch`. This only affects flex items whose cross-axis size is `auto`, such as those without a set `width` or `height` in that direction, or with only a minimum `width` or `height`. An item that has an explicit size set along the cross axis will not be affected and will keep that size.
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -7,7 +7,7 @@ dashedName: what-are-some-common-flex-properties
 
 # --interactive--
 
-Flex properties are properties that you can apply to flex containers to determine the distribution of child elements. We'll cover some of the most commonly used ones: `flex-wrap`, `justify-content`, and `align-items`.
+CSS flex properties let you control how flex items are distributed within a flex container, and how individual items can align themselves along the cross axis. We'll cover some of the most commonly used ones: `flex-wrap`, `flex-flow`, `justify-content`, `align-items`, and `align-self`.
 
 Let's start with `flex-wrap`. This property determines how flex items are wrapped within a flex container to fit the available space. `flex-wrap` can take three possible values: `nowrap`, `wrap`, and `wrap-reverse`. `nowrap` is the default value: flex items won't be wrapped onto a new line, even if their width exceeds the container's width.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -108,6 +108,7 @@ The `div` elements will be rearranged in rows when they exceed the width of thei
 ```css
 main {
   width: 200px;
+  height: 100px;
   display: flex;
   flex-flow: column wrap-reverse;
   border: 2px solid red;


### PR DESCRIPTION

Six content fixes across the two lectures in lecture-working-with-css-flexbox:
1. Clarified quiz feedback for the main/cross axis question (previously pointed toward distribution properties instead of orientation)
2. Fixed the flex-flow example so wrap-reverse actually wraps (added height: 100px to constrain the main axis)
3. Distinguished space-between from space-evenly wording (first/last items flush vs. evenly spaced)
4. Scoped the align-items: stretch explanation to auto cross-size items only
5. Broadened the opening paragraph to include flex-flow and align-self, and removed the circular definition
6. Unified markup (main/#first-div/#second-div/#third-div) across all seventeen editors in the second lecture, removing the .container/.box switch and stray blank lines

Verified with pnpm lint-challenges and the full vitest suite. The 5 pre-existing failures (sass, rosetta-code, algorithms, workshop timeouts) are unrelated to this change and occur on main as well." \
  --base main

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69237

<!-- Feel free to add any additional description of changes below this line -->
