### PR TITLE
fix(curriculum): use American spelling for gray in Workshop Cafe Menu

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b25e7ec2405f166b9de1.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b25e7ec2405f166b9de1.md
@@ -9,7 +9,7 @@ dashedName: step-78
 
 You change the properties of a link when the link has been visited by using a <dfn>pseudo-selector</dfn> that looks like `a:visited { propertyName: propertyValue; }`.
 
-Change the color of the footer `Visit our website` link to `grey` when a user has visited the link.
+Change the color of the footer `Visit our website` link to `gray` when a user has visited the link.
 
 # --hints--
 
@@ -20,14 +20,14 @@ const aVisitedStyle = new __helpers.CSSHelp(document).getStyle('a:visited');
 assert.exists(aVisitedStyle);
 ```
 
-You should set the `color` property to `grey`.
+You should set the `color` property to `gray`.
 
 ```js
 const hasColor = new __helpers.CSSHelp(document).getCSSRules().some(x => (x.style.color === 'grey' || x.style.color === 'gray'));
 assert.isTrue(hasColor);
 ```
 
-Your `a:visited` should have a `color` of `grey`.
+Your `a:visited` should have a `color` of `gray`.
 
 ```js
 const aVisitedColor = new __helpers.CSSHelp(document).getStyle('a:visited')?.getPropertyValue('color');

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b3c93c027860d9298dbd.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b3c93c027860d9298dbd.md
@@ -179,7 +179,7 @@ a {
 }
 
 a:visited {
-  color: grey;
+  color: gray;
 }
 
 --fcc-editable-region--

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b45d099f3e621fbbb256.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b45d099f3e621fbbb256.md
@@ -179,7 +179,7 @@ a {
 }
 
 a:visited {
-  color: grey;
+  color: gray;
 }
 
 a:hover {

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b4c81cea7763550e40df.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b4c81cea7763550e40df.md
@@ -171,7 +171,7 @@ a {
 
 --fcc-editable-region--
 a:visited {
-  color: grey;
+  color: gray;
 }
 
 a:hover {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69229

## What changed

This PR updates the Responsive Web Design Workshop Cafe Menu curriculum to use the American English spelling `gray` instead of `grey`.

Specifically:
- Updates the Step 78 instruction and hints.
- Updates the Step 79–81 seed code to use `color: gray;`.
- Leaves the existing test assertions unchanged, since they already accept both `gray` and `grey`.

## Scope

- Updates only learner-facing curriculum text and seed code.
- No changes to tests or challenge behavior.
