### PR TITLE
fix: update challenge 359 rounding test case

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a26df3e2988bcdded204895.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a26df3e2988bcdded204895.md
@@ -25,10 +25,10 @@ assert.equal(calculateHandicap([72, 72, 72], [72, 72, 72]), 0);
 assert.equal(calculateHandicap([80, 76, 78, 78], [72, 72, 72, 72]), 6);
 ```
 
-`calculateHandicap([42, 45, 46, 44], [36, 36, 36, 36])` should return `8.3`.
+`calculateHandicap([42, 45, 46, 45], [36, 36, 36, 36])` should return `8.5`.
 
 ```js
-assert.equal(calculateHandicap([42, 45, 46, 44], [36, 36, 36, 36]), 8.3);
+assert.equal(calculateHandicap([42, 45, 46, 45], [36, 36, 36, 36]), 8.5);
 ```
 
 `calculateHandicap([85, 80, 76, 79, 82], [72, 72, 72, 71, 71])` should return `8.8`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a26df3e2988bcdded204895.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a26df3e2988bcdded204895.md
@@ -31,12 +31,12 @@ TestCase().assertEqual(calculate_handicap([80, 76, 78, 78], [72, 72, 72, 72]), 6
 }})
 ```
 
-`calculate_handicap([42, 45, 46, 44], [36, 36, 36, 36])` should return `8.3`.
+`calculate_handicap([42, 45, 46, 45], [36, 36, 36, 36])` should return `8.5`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(calculate_handicap([42, 45, 46, 44], [36, 36, 36, 36]), 8.3)`)
+TestCase().assertEqual(calculate_handicap([42, 45, 46, 45], [36, 36, 36, 36]), 8.5)`)
 }})
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b715301bbf667badc04a.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f45b715301bbf667badc04a.md
@@ -7,7 +7,7 @@ dashedName: step-82
 
 # --description--
 
-The menu text `CAMPER CAFE` has a different space from the top than the address's space at the bottom of the menu. This is due to the browser having some default top margin for the `h1` element.
+The space above the menu text `CAMPER CAFE` does not match the space below the address at the bottom of the menu. This is due to the browser having some default top margin for the `h1` element.
 
 Change the top margin of the `h1` element to `0` to remove all the top margin.
 


### PR DESCRIPTION
## Description

Updates the third test case for Challenge 359 in both the JavaScript and Python daily coding challenges to avoid the rounding boundary at `8.25`.

### Changes

- Updated the test scores from `[42, 45, 46, 44]` to `[42, 45, 46, 45]`
- Updated the expected result from `8.3` to `8.5`
- Applied the same change to both the JavaScript and Python challenge files

Closes freeCodeCamp/freeCodeCamp#69279