### PR TITLE
fix(curriculum): allow a corner header cell in availability table lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -13,8 +13,8 @@ demoType: onClick
 **User Stories:**
 
 1. You should have a table with at least three columns and five rows, headers included.
-1. Cells in the first row should be table headers containing days of the week.
-1. Cells in the first column should be table headers with a `class` of `time` and should contain time values as their text.
+1. The first row should have table header cells containing days of the week.
+1. The first column should have table header cells with a `class` of `time` containing time values as their text.
 1. All data cells should have the `class` of `available-#`, where `#` is a number from `0` to `5` that specifies the number of available people at that time.
 1. Your table should have a `caption` element with the text `Weekly Meeting Availability Schedule`.
 1. All table header cells in the first row (the days of the week) should have a `scope` attribute with the value `col`.
@@ -89,7 +89,7 @@ assert.isAtLeast(document.querySelectorAll('tr[class~="half"]').length, 2);
 const firstColumnData = [...document.querySelectorAll('tr th:first-child')];
 assert.isNotEmpty(firstColumnData);
 for (let cell of firstColumnData) {
-    if (cell.innerText.match(/\d/)?.length) {
+    if (cell.textContent.match(/\d/)?.length) {
         assert.isTrue(cell.classList.contains('time'));
     }
 }
@@ -101,7 +101,7 @@ You should have at least four `th` elements with the class of `time` that contai
 const timeClass = document.querySelectorAll('.time');
 assert.isAtLeast(timeClass.length, 4);
 for (let cell of timeClass) {
-    assert.match(cell.innerText, /\d/)
+    assert.match(cell.textContent, /\d/)
 }
 ```
 
@@ -389,7 +389,7 @@ headers.forEach(header => {
 All table header cells in the first column should have a `scope` attribute with the value `row`.
 
 ```js
-const timeHeaders = [...document.querySelectorAll('tr > th:first-child')];
+const timeHeaders = [...document.querySelectorAll('th.time')];
 assert.isNotEmpty(timeHeaders);
 timeHeaders.forEach(header => {
     assert.equal(header.getAttribute('scope'), 'row');

--- a/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
+++ b/curriculum/challenges/english/blocks/lab-availability-table/66b36358ed4f261d64840c24.md
@@ -89,7 +89,7 @@ assert.isAtLeast(document.querySelectorAll('tr[class~="half"]').length, 2);
 const firstColumnData = [...document.querySelectorAll('tr th:first-child')];
 assert.isNotEmpty(firstColumnData);
 for (let cell of firstColumnData) {
-    if (cell.textContent.match(/\d/)?.length) {
+    if (cell.innerText.match(/\d/)?.length) {
         assert.isTrue(cell.classList.contains('time'));
     }
 }
@@ -101,7 +101,7 @@ You should have at least four `th` elements with the class of `time` that contai
 const timeClass = document.querySelectorAll('.time');
 assert.isAtLeast(timeClass.length, 4);
 for (let cell of timeClass) {
-    assert.match(cell.textContent, /\d/)
+    assert.match(cell.innerText, /\d/)
 }
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

The row-scope test in the Build an Availability Table lab selected every `tr > th:first-child`. That includes the corner cell of a header row that also holds the day names, so a camper who builds the conventional layout below is asked for `scope="row"` on the same cell the col-scope test asks for `scope="col"`:

```html
<tr>
  <th scope="col">Time</th>
  <th scope="col">Monday</th>
  <th scope="col">Tuesday</th>
  <th scope="col">Wednesday</th>
</tr>
```

There is no way out of it. Adding `class="time"` to the corner cell drops it from the col-scope test, but then the test that requires every `.time` cell to contain a digit fails on the text `Time`.

The row-scope test now targets `th.time`, which is what user story 7 already describes as the first-column headers. The reference solution passes unchanged.

User stories 2 and 3 read as covering every cell in the first row and first column, which is what made the corner cell look illegal. Reworded to describe the day headers and the time headers instead.
