### PR TITLE
fix(curriculum): clarify option count in weather app hint

### DIFF
--- a/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
+++ b/curriculum/challenges/english/blocks/lab-weather-app/66f12a88741aeb16b9246c59.md
@@ -333,7 +333,7 @@ assert.strictEqual(
 );
 ```
 
-Inside the `select` element there should be 6 `option` elements, one for each of the following cities: Paris, London, Tokyo, Los Angeles, Chicago, New York.
+In addition to the empty first option, the `select` element should contain 6 `option` elements, one for each of the following cities: Paris, London, Tokyo, Los Angeles, Chicago, New York.
 
 ```js
 ['Paris', 'London', 'Tokyo', 'Los Angeles', 'Chicago', 'New York'].forEach(
@@ -342,7 +342,7 @@ Inside the `select` element there should be 6 `option` elements, one for each of
       `select > option[value="${city.toLowerCase()}"]`
     );
     assert.exists(el);
-    assert.strictEqual(el.innerText.trim(), city);
+    assert.strictEqual(el.textContent.trim(), city);
   }
 );
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

The fourth hint of the Build a Weather App lab read:

> Inside the `select` element there should be 6 `option` elements, one for each of the following cities: Paris, London, Tokyo, Los Angeles, Chicago, New York.

Taken on its own, that `6` reads as the total number of `option` elements the `select` should hold, which contradicts the second user story and the third hint, both of which put the total at seven once the empty first option is counted. Reported on the forum: https://forum.freecodecamp.org/t/build-a-weather-app-build-a-weather-app/796723

The assertion itself was never wrong. It loops the six city names and checks that a matching `option` exists for each, and never counts the children of `select`. Only the wording changes, so the hint now says the 6 city options come in addition to the empty first one.

Also swapped `innerText` for `textContent` in that same assertion.
