### PR TITLE
fix: update challenge 359 rounding test case

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a26df3e2988bcdded204895.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a26df3e2988bcdded204895.md
@@ -25,10 +25,10 @@ assert.equal(calculateHandicap([72, 72, 72], [72, 72, 72]), 0);
 assert.equal(calculateHandicap([80, 76, 78, 78], [72, 72, 72, 72]), 6);
 ```
 
-`calculateHandicap([42, 45, 46, 44], [36, 36, 36, 36])` should return `8.3`.
+`calculateHandicap([42, 45, 46, 45], [36, 36, 36, 36])` should return `8.5`.
 
 ```js
-assert.equal(calculateHandicap([42, 45, 46, 44], [36, 36, 36, 36]), 8.3);
+assert.equal(calculateHandicap([42, 45, 46, 45], [36, 36, 36, 36]), 8.5);
 ```
 
 `calculateHandicap([85, 80, 76, 79, 82], [72, 72, 72, 71, 71])` should return `8.8`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a26df3e2988bcdded204895.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a26df3e2988bcdded204895.md
@@ -31,12 +31,12 @@ TestCase().assertEqual(calculate_handicap([80, 76, 78, 78], [72, 72, 72, 72]), 6
 }})
 ```
 
-`calculate_handicap([42, 45, 46, 44], [36, 36, 36, 36])` should return `8.3`.
+`calculate_handicap([42, 45, 46, 45], [36, 36, 36, 36])` should return `8.5`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(calculate_handicap([42, 45, 46, 44], [36, 36, 36, 36]), 8.3)`)
+TestCase().assertEqual(calculate_handicap([42, 45, 46, 45], [36, 36, 36, 36]), 8.5)`)
 }})
 ```
 


### PR DESCRIPTION
## Description

Updates the third test case for Challenge 359 in both the JavaScript and Python daily coding challenges to avoid the rounding boundary at `8.25`.

- Updated the test scores from `[42, 45, 46, 44]` to `[42, 45, 46, 45]`
- Updated the expected result from `8.3` to `8.5`
- Applied the same change to both the JavaScript and Python challenge files

Closes #69279

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.