### PR TITLE
fix(curriculum): resolve rounding edge case in challenge 359

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a26df3e2988bcdded204895.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6a26df3e2988bcdded204895.md
@@ -25,10 +25,10 @@ assert.equal(calculateHandicap([72, 72, 72], [72, 72, 72]), 0);
 assert.equal(calculateHandicap([80, 76, 78, 78], [72, 72, 72, 72]), 6);
 ```
 
-`calculateHandicap([42, 45, 46, 44], [36, 36, 36, 36])` should return `8.3`.
+`calculateHandicap([42, 45, 46, 45], [36, 36, 36, 36])` should return `8.5`.
 
 ```js
-assert.equal(calculateHandicap([42, 45, 46, 44], [36, 36, 36, 36]), 8.3);
+assert.equal(calculateHandicap([42, 45, 46, 45], [36, 36, 36, 36]), 8.5);
 ```
 
 `calculateHandicap([85, 80, 76, 79, 82], [72, 72, 72, 71, 71])` should return `8.8`.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a26df3e2988bcdded204895.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6a26df3e2988bcdded204895.md
@@ -31,12 +31,12 @@ TestCase().assertEqual(calculate_handicap([80, 76, 78, 78], [72, 72, 72, 72]), 6
 }})
 ```
 
-`calculate_handicap([42, 45, 46, 44], [36, 36, 36, 36])` should return `8.3`.
+`calculate_handicap([42, 45, 46, 45], [36, 36, 36, 36])` should return `8.5`.
 
 ```js
 ({test: () => { runPython(`
 from unittest import TestCase
-TestCase().assertEqual(calculate_handicap([42, 45, 46, 44], [36, 36, 36, 36]), 8.3)`)
+TestCase().assertEqual(calculate_handicap([42, 45, 46, 45], [36, 36, 36, 36]), 8.5)`)
 }})
 ```
 


### PR DESCRIPTION
Fixed the rounding edge case in Challenge 359.

I updated the third test case in both the JavaScript and Python challenge files by changing the input from `[42, 45, 46, 44]` to `[42, 45, 46, 45]` and updated the expected output from `8.3` to `8.5`. This avoids the rounding boundary issue and keeps both implementations consistent.

Fixes #69279

