### PR TITLE
fix(curriculum): add section headers to external fonts lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd8453d1371fdb1510fe5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd8453d1371fdb1510fe5.md
@@ -11,12 +11,16 @@ An external font is a font file that is not included directly within your projec
 
 Google Fonts and Font Squirrel are popular online resources for finding and using free fonts for web development purposes. You can incorporate them into your projects very easily.
 
+## Google Fonts
+
 Let's start with Google Fonts. This is a Google service that offers a collection of fonts, many of which are designed specifically for web development. On the Google Fonts user interface, you can see many different elements. Let's go through them one by one. On the left sidebar, you will find:
 
 - A section to see, find, and filter fonts.
 - A special section on Noto, a collection of high-quality fonts with various weights, widths, and styles that are perfect for communicating in more than 1,000 languages and over 150 writing systems.
 - A section where you can find and download icons for your web projects.
 - A section where you can learn more about fonts and their best practices, followed by frequently asked questions.
+
+## Previewing Google Fonts
 
 To add a Google Font to your website, you should go to the first section (Fonts). You can customize the preview text on the left sidebar, where it says "Preview." Just write the text that you would like to see and it will be updated automatically. This is helpful to preview the font with the text that you already have in mind for your website. You can also adjust the font size and filter the fonts based on their characteristics.
 
@@ -28,11 +32,15 @@ You can customize the font size of the preview text with the blue slider located
 
 <img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/how-do-you-work-with-external-fonts-like-font-squirrel-and-google-fonts-2.png" alt="Google Fonts Roboto Styles page with Specimen, Type tester, Glyphs, and About &amp; license tabs, a blue Get font button, a preview text field showing 'freeCodeCamp' with a font size slider at 48px, and a list of styles including Thin 100, Thin 100 Italic, Light 300, and Light 300 Italic" />
 
+## Using Google Fonts
+
 Once you're ready to add the font to your project, click on the blue "Get font" button at the top. You'll be taken to a summary page where you'll see the fonts that you currently have selected. You can have multiple fonts selected simultaneously.
 
 <img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/how-do-you-work-with-external-fonts-like-font-squirrel-and-google-fonts-3.png" alt="Google Fonts page showing '1 font family selected' with Roboto Static listed, Get embed code and Download all buttons on the right, and a How to use section with All, Design, Develop, and Google products tabs" />
 
 Next, you have to choose if you would like to download the font files to add them to your project as local files or if you would like to use them as external fonts and download them from Google's servers when a user enters your website. Click on "Download all" if you want to download them but if you prefer to use them as external fonts on Google's servers, click on "Get embed code." If you click on "Get embed code," you'll see the instructions that you should follow to add these external fonts to your project.
+
+## Link Google Fonts
 
 For web development projects, you have two options. You can either use a `link` element or `@import`. If you choose the `link` element option, you can copy and paste the HTML snippet and the CSS rules to add them to your project. You should embed the code in the `head` element of your HTML file and add the CSS rules that fit your needs.
 
@@ -141,6 +149,8 @@ Here is an example of using all Roboto styles:
 
 There's a CSS rule for each font style. Each rule assigns the custom fonts with fallback fonts in case the custom fonts are not loaded properly.
 
+## Import Google Fonts
+
 If you choose the `@import` option instead, you will need to add that rule to your CSS file.
 
 <img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/how-do-you-work-with-external-fonts-like-font-squirrel-and-google-fonts-5.png" alt="Google Fonts Embed code page with the @import option selected, showing a style block containing the @import URL rule, a CSS classes section below, and the left sidebar with font style toggles" />
@@ -159,9 +169,13 @@ If you only want to include specific font styles, you also have the option to re
 
 And this is Google Fonts. It's one of the most popular options for finding free and open source fonts for web development projects.
 
+## Font Squirrel
+
 Another great option is Font Squirrel, where you can find and download the custom fonts that you envision for your design.
 
 <img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/how-do-you-work-with-external-fonts-like-font-squirrel-and-google-fonts-7.png" alt="Font Squirrel 'Free Font Utopia' page listing featured free fonts including Acherus Grotesque, Intro Rust, Source Sans Pro, Open Sans, and Questa, each shown with an alphabet specimen and a Download button" />
+
+## Previewing Font Squirrel
 
 If you search for a font and click on a result, you'll see more details about the font, including specimens, test drive, glyphs, and Webfont kit.
 
@@ -172,6 +186,8 @@ If you search for a font and click on a result, you'll see more details about th
 You can also see samples of the different styles and variations of the font, like thin, light, medium, bold, and black.
 
 <img src="https://cdn.freecodecamp.org/curriculum/lecture-transcripts/how-do-you-work-with-external-fonts-like-font-squirrel-and-google-fonts-10.png" alt="Font Squirrel Roboto Specimens section listing all styles with alphabet samples: Roboto Thin, Thin Italic, Light, Light Italic, Regular, Italic, Medium, Medium Italic, Bold, Bold Italic, and Black, each in its respective weight" />
+
+## Using Font Squirrel
 
 Once you've decided on a font that you want to use in your project, go to the "Webfont Kit" tab. Here, you can check if the font's license allows you to use it in `@font-face` CSS embeddings. You can also choose the subset and format.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd8453d1371fdb1510fe5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd8453d1371fdb1510fe5.md
@@ -40,7 +40,7 @@ Once you're ready to add the font to your project, click on the blue "Get font" 
 
 Next, you have to choose if you would like to download the font files to add them to your project as local files or if you would like to use them as external fonts and download them from Google's servers when a user enters your website. Click on "Download all" if you want to download them but if you prefer to use them as external fonts on Google's servers, click on "Get embed code." If you click on "Get embed code," you'll see the instructions that you should follow to add these external fonts to your project.
 
-## Link Google Fonts
+### Link Google Fonts
 
 For web development projects, you have two options. You can either use a `link` element or `@import`. If you choose the `link` element option, you can copy and paste the HTML snippet and the CSS rules to add them to your project. You should embed the code in the `head` element of your HTML file and add the CSS rules that fit your needs.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd8453d1371fdb1510fe5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd8453d1371fdb1510fe5.md
@@ -149,7 +149,7 @@ Here is an example of using all Roboto styles:
 
 There's a CSS rule for each font style. Each rule assigns the custom fonts with fallback fonts in case the custom fonts are not loaded properly.
 
-## Import Google Fonts
+### Import Google Fonts
 
 If you choose the `@import` option instead, you will need to add that rule to your CSS file.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69287 

<!-- Feel free to add any additional description of changes below this line -->
Added section headers for 
- Google Fonts
- Previewing Google Fonts
- Using Google Fonts
- Link Google Fonts
- Import Google Fonts

- Font Squirrel
- Previewing Font Squirrel
- Using Font Squirrel

<img width="856" height="795" alt="image" src="https://github.com/user-attachments/assets/c35f9063-7442-4c85-9ffa-2f915247a0f1" />

<img width="964" height="932" alt="image" src="https://github.com/user-attachments/assets/e61f8ad8-48f2-4b8b-bae6-8068a6a02b0b" />

<img width="882" height="732" alt="image" src="https://github.com/user-attachments/assets/81afa944-0a36-482e-bfe1-beafd901c04e" />

<img width="913" height="793" alt="image" src="https://github.com/user-attachments/assets/f050368a-e362-4909-8366-1b20ccfaa7ac" />

<img width="874" height="754" alt="image" src="https://github.com/user-attachments/assets/4b83cb50-1375-46ae-b34e-ab6116961ef5" />
