### PR TITLE
fix(curriculum): correct Step 67 description in Cafe Menu workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459cf202c2a3472fae6a9f.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459cf202c2a3472fae6a9f.md
@@ -7,7 +7,7 @@ dashedName: step-67
 
 # --description--
 
-Notice how the thickness of the line looks bigger? The default value of a property named `border-width` is `1px` for all edges of `hr` elements. By changing the border to the same color as the background, the total height of the line is `5px` (`3px` plus the top and bottom border width of `1px`).
+Notice how the thickness of the line looks bigger? The default value of a property named `border-width` is `1px` for all edges of `hr` elements. The total height has been `5px` since Step 64, where the `height` was set to `3px` on top of the default `1px` borders. Recoloring the border in this step only made the existing edges visible; it did not change the total height.
 
 Change the `height` property of the `hr` to `2px`, so the total height of it becomes `4px`.
 

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459cf202c2a3472fae6a9f.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f459cf202c2a3472fae6a9f.md
@@ -7,7 +7,7 @@ dashedName: step-67
 
 # --description--
 
-Notice how the thickness of the line looks bigger? The default value of a property named `border-width` is `1px` for all edges of `hr` elements. The total height has been `5px` since Step 64, where the `height` was set to `3px` on top of the default `1px` borders. Recoloring the border in this step only made the existing edges visible; it did not change the total height.
+Notice how the thickness of the line looks bigger? The default value of a property named `border-width` is `1px` for all edges of `hr` elements. The total height of the line has always been `5px` (`3px` plus the top and bottom border width of `1px`); coloring the border made those edges visible.
 
 Change the `height` property of the `hr` to `2px`, so the total height of it becomes `4px`.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69225

## Description

This PR corrects the description for Step 67 of the Cafe Menu workshop.

The previous wording implied that changing the border color changed the total height of the `hr` element. The updated description clarifies that the total height was established in Step 64 when `height` was set to `3px`, and that changing the border color in this step only makes the existing borders visible.