### PR TITLE
fix(curriculum): start hint text with You/Your in reusable footer lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-reusable-footer/673b02b03134b04637bf7055.md
+++ b/curriculum/challenges/english/blocks/lab-reusable-footer/673b02b03134b04637bf7055.md
@@ -53,7 +53,7 @@ Your `footer` element should contain at least three unordered lists.
 assert.isAtLeast(document.querySelectorAll('ul').length, 3);
 ```
 
-Each of your unordered lists should have at least two list items.
+Your unordered lists should each have at least two list items.
 
 ```js
 const uls = [...document.querySelectorAll('ul')];
@@ -84,7 +84,7 @@ const links = document.querySelectorAll('a[href="#"]');
 assert.isAtLeast(links.length, 3);
 ```
 
-None of your links should be empty.
+Your links should not be empty.
 
 ```js
 const links = [...document.querySelectorAll('a[href="#"]')];


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Two hint description lines in the Build a Reusable Footer lab didn't start with "You"/"Your" as required by curriculum style. Reworded them accordingly.