### PR TITLE
fix(curriculum): fix grammar and terminology consistency in reusable profile card workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Inside your return statement, replace the empty string with a `div` element with a `className` property of `flex-container`.
+Inside your return statement, replace the empty string with a `div` element with a `className` of `flex-container`.
 
 # --hints--
 
@@ -26,7 +26,7 @@ Your `App` component should return a single `div` element.
   assert.lengthOf(testElem.children, 1);
 ```
 
-Your `div` should have a `className` property of `flex-container`.
+Your `div` should have a `className` of `flex-container`.
 
 ```js
   const testElem = await __helpers.prepTestComponent(window.index.App);

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165b.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Inside your return statement, replace the empty string with a `div` element with a `className` of `flex-container`.
+Inside the `return` statement, replace the empty string with a `div` element with a `className` of `flex-container`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165c.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/674ef2d357676e50e469165c.md
@@ -7,7 +7,7 @@ dashedName: step-6
 
 # --description--
 
-Now, put the `Card` component into your `App` component. Give it the `name` prop set to `"Mark"`, the `title` prop set to `"Front-End developer"`, and the `bio` set to `"I like to work with different front-end technologies and play video games."`
+Now, put the `Card` component into your `App` component. Give it the `name` prop set to `"Mark"`, the `title` prop set to `"Front-End developer"`, and the `bio` prop set to `"I like to work with different front-end technologies and play video games."`
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68720c179cd34be6793bfdf6.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68720c179cd34be6793bfdf6.md
@@ -9,7 +9,7 @@ dashedName: step-8
 
 While your application works as expected, you typically would not add multiple `Card` components manually like this.
 
-Remove the three `<Card />` components inside `<div className="flex-container">` element. In the next few steps, you will create an array of data and use the `map()` function to render the `Card` components which is the more common approach in React.
+Remove the three `<Card />` components inside `<div className="flex-container">` element. In the next few steps, you will create an array of data and use the `map()` method to render the `Card` components, which is the more common approach in React.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68720c179cd34be6793bfdf6.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68720c179cd34be6793bfdf6.md
@@ -9,7 +9,7 @@ dashedName: step-8
 
 While your application works as expected, you typically would not add multiple `Card` components manually like this.
 
-Remove the three `<Card />` components inside `<div className="flex-container">` element. In the next few steps, you will create an array of data and use the `map()` method to render the `Card` components, which is the more common approach in React.
+Remove the three `<Card />` components inside the `<div className="flex-container">` element. In the next few steps, you will create an array of data and use the `map()` method to render the `Card` components, which is the more common approach in React.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68778af56eb5d980a4e2daed.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68778af56eb5d980a4e2daed.md
@@ -30,7 +30,7 @@ const profilesVal = eval(profiles?.value.toString());
 assert.isArray(profilesVal);
 ```
 
-Your profiles array should contain an object that includes all required properties: `id`, `name`, `title`, and `bio`.
+Your `profiles` array should contain an object that includes all required properties: `id`, `name`, `title`, and `bio`.
 
 ```js
 const explorer = await __helpers.Explorer(code);

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68779156bd3704b727ba5f38.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/68779156bd3704b727ba5f38.md
@@ -7,7 +7,7 @@ dashedName: step-10
 
 # --description--
 
-As you recall from earlier lessons, you can use the `map` method to iterate through the different objects and render the components dynamically like this:
+As you recall from earlier lessons, you can use the `map()` method to iterate through the different objects and render the components dynamically like this:
 
 ```jsx
 export function App() {

--- a/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/687799aefd1f2af1704065d0.md
+++ b/curriculum/challenges/english/blocks/workshop-reusable-profile-card-component/687799aefd1f2af1704065d0.md
@@ -23,7 +23,7 @@ As you recall from previous lessons, it is best practice to include a `key` prop
 </div>
 ```
 
-The `key` prop helps React identify which items have changed, are added, or are removed. This improves performance and allows for more efficient updates.
+The `key` prop helps React identify which items have changed, been added, or been removed. This improves performance and allows for more efficient updates.
 
 Update the `Card` component to include a `key` prop with the value of `profile.id`.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Fixes several grammar and cross-step consistency issues in the Build a Reusable Profile Card Component workshop:
- Restored a dropped "prop" in a list of props (Step 6).
- Standardized `className` phrasing (Step 5 matched Steps 2/3).
- Standardized `map()` terminology across steps (Steps 8, 10).
- Added a missing comma before a non-restrictive clause (Step 8).
- Added a missing backtick around `profiles` (Step 9).
- Fixed parallel structure in a sentence about the `key` prop (Step 11).