### PR TITLE
fix(curriculum): fix grammar and wording issues in mood board lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-mood-board/673b3d6b7ef7318eef926d5a.md
+++ b/curriculum/challenges/english/blocks/lab-mood-board/673b3d6b7ef7318eef926d5a.md
@@ -17,15 +17,15 @@ In this lab, you will create a mood board using reusable React components. The C
 **User Stories:**
 
 1. You should create and export a `MoodBoardItem` component that accepts three props: `color`, `image`, and `description`.
-2. Your `MoodBoardItem` component should return a `div` with the class `mood-board-item` as its top-level element.
+2. Your `MoodBoardItem` component should return a `div` with a class of `mood-board-item` as its top-level element.
 3. You should set the background color of the `.mood-board-item` element to the value of the `color` prop using inline styles.
 4. You should render an `img` element, with a class of `mood-board-image` and its `src` attribute set to the value of the `image` prop, within the `.mood-board-item` element.
-5. You should render an `h3` element, with a class of `mood-board-text` and its text the value of the `description` prop, within the `.mood-board-item` element.
-6. You should create and export a `MoodBoard`.
+5. You should render an `h3` element, with a class of `mood-board-text` and its text set to the value of the `description` prop, within the `.mood-board-item` element.
+6. You should create and export a `MoodBoard` component.
 7. Your `MoodBoard` component should return a `div` as its top-level element.
 8. Your `MoodBoard` component should render an `h1` element with a class of `mood-board-heading` and the text `Destination Mood Board`.
 9. Your `MoodBoard` component should render a `div` with a class of `mood-board`.
-10. Your `MoodBoard` component should render at least three `MoodBoardItem` components within the `.mood-board` element, each should pass `color`, `image`, and `description` props with valid values.
+10. Your `MoodBoard` component should render at least three `MoodBoardItem` components within the `.mood-board` element, each of which should pass `color`, `image`, and `description` props with valid values.
 
 You can use the following images in your Mood Board if you would like:
 
@@ -44,7 +44,7 @@ You should export a `MoodBoardItem` component.
 assert.isFunction(window.index.MoodBoardItem, 1);
 ```
 
-Your `MoodBoardItem` component should return a `div` with a class of `mood-board-item` at its top-level element.
+Your `MoodBoardItem` component should return a `div` with a class of `mood-board-item` as its top-level element.
 
 ```js
 const item = document.getElementsByClassName('mood-board-item')[0];
@@ -52,7 +52,7 @@ assert.exists(item);
 assert.equal(item.tagName, 'DIV');
 ```
 
-The background color of the `.mood-board-item` element should be set to the value of `color` prop using inline styles.
+Your `.mood-board-item` element's background color should be set to the value of the `color` prop using inline styles.
 
 ```js
   const container = await __helpers.prepTestComponent(window.index.MoodBoardItem, { color: "red" });
@@ -102,7 +102,7 @@ assert.equal(heading.tagName, 'H1');
 assert.equal(heading.textContent, 'Destination Mood Board');
 ```
 
-Your `MoodBoard` component should render at least three `MoodBoardItem` components, each should pass `color`, `image`, and `description` props with valid values.
+Your `MoodBoard` component should render at least three `MoodBoardItem` components, each of which should pass `color`, `image`, and `description` props with valid values.
 
 ```js
 const moodboard = document.getElementsByClassName('mood-board')[0];


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Fixes several grammar and wording issues in the Build a Mood Board lab:
- Rewrote a hint that didn't start with "You"/"Your".
- Fixed "at its top-level element" to "as its top-level element".
- Standardized "the class X" to "a class of X" to match the rest of the file.
- Added a missing "set to" in a description bullet.
- Fixed a comma splice, appearing in both the description and its matching hint.
- Added a missing "component" for consistency with a parallel bullet.