### PR TITLE
fix(curriculum): correct CSS placeholder and selector wording in Cafe Menu Step 22

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed6199b0cdef1d2be8f.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f356ed6199b0cdef1d2be8f.md
@@ -13,11 +13,11 @@ You learned how to work with `class` selectors in previous lessons like this:
 
 ```css
 .class-name {
-  styles
+  property: value;
 }
 ```
 
-Change the existing `#menu` selector into a class selector by replacing `#menu` with a class named `.menu`.
+Change the existing `#menu` selector into a class selector by replacing `#menu` with the class selector `.menu`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69150

Two description fixes in Step 22 of the Cafe Menu workshop, as triaged in the issue:

1. The CSS example placeholder `styles` is not a valid declaration. Replaced with `property: value;`, matching the shape already used by the earlier examples in the same workshop (Step 7 and Step 9).
2. The instruction called `.menu` "a class named `.menu`", but the class is named `menu` — `.menu` is the selector that targets it (Step 23 already makes this distinction correctly). Reworded to "the class selector `.menu`".

No hints, seeds or solutions are affected — only the `--description--` section.