### PR TITLE
fix(curriculum): add section headers to loops and iteration lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-loops/67329f7f3d1bd75c17896c66.md
@@ -13,6 +13,8 @@ An example of a loop would be when you are designing a program that needs to pri
 
 Another example would be when you are designing a game and you want to move a character across the screen. You could use a loop to move the character a certain number of pixels each time the loop runs. 
 
+## The `for` Loop Syntax
+
 In JavaScript, there are several types of loops that you can use. In this lesson, we will cover the `for` loop. Here is the basic syntax for a `for` loop:
 
 ```js
@@ -28,6 +30,8 @@ The condition statement is evaluated before each iteration of the loop. An itera
 If the condition is true, the code block inside the loop is executed. If the condition is false, the loop stops and you move on to the next block of code.
 
 The last part of the loop is the increment/decrement statement. This statement is executed after each iteration of the loop. It is typically used to increment or decrement the counter variable.
+
+## Tracing a `for` Loop
 
 :::interactive_editor
 
@@ -51,7 +55,11 @@ Then we check the condition again which is to check if `i` is less than `5`. Sin
 
 We keep repeating this process until the condition is false. In this case, when `i` is `5`, the condition is false, and the loop stops.
 
+## Infinite Loops
+
 When you're working with loops you should be careful not to create a condition that is always true. If you do, the loop will run forever and your program will crash. This is known as an infinite loop.
+
+## Nested Loops
 
 It is possible to create nested `for` loops. A nested loop is when you place one loop inside of another. We will see examples of when you might want to do this later on.
 


### PR DESCRIPTION
Add ## Title Case headers to break up the --interactive-- body into logical sections (for loop syntax, tracing a for loop, infinite loops, nested loops), following the convention established in the sort method lecture. No prose changes, --questions-- untouched.

Closes #69337

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69337

<!-- Feel free to add any additional description of changes below this line -->
