### PR TITLE
fix(curriculum): remove extra period in learn how to plan future events

### DIFF
--- a/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67531709d628ef047202e6ae.md
+++ b/curriculum/challenges/english/blocks/learn-how-to-plan-future-events/67531709d628ef047202e6ae.md
@@ -12,7 +12,7 @@ Watch the video below to understand the context of the upcoming lessons.
 
 # --assignment--
 
-Watch the video..
+Watch the video.
 
 # --scene--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69361

<!-- Feel free to add any additional description of changes below this line -->

Removed the extra period from "Watch the video.." in `67531709d628ef047202e6ae.md` as requested in the issue.