### PR TITLE
fix(client): align FEDL v9 intro.json block order with the superblock

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -6287,12 +6287,6 @@
           "You will practice working with Tailwind CSS utility classes for flexbox layouts, colors, breakpoints and more."
         ]
       },
-      "lab-photography-exhibit": {
-        "title": "Design a Photography Exhibit",
-        "intro": [
-          "In this lab, you will practice working with Tailwind CSS by designing a photography exhibit webpage."
-        ]
-      },
       "review-css-libraries-and-frameworks": {
         "title": "CSS Libraries and Frameworks Review",
         "intro": [
@@ -6304,6 +6298,12 @@
         "title": "CSS Libraries and Frameworks Quiz",
         "intro": [
           "Test what you've learned about CSS Libraries and Frameworks with this quiz."
+        ]
+      },
+      "lab-photography-exhibit": {
+        "title": "Design a Photography Exhibit",
+        "intro": [
+          "In this lab, you will practice working with Tailwind CSS by designing a photography exhibit webpage."
         ]
       },
       "lecture-introduction-to-typescript": {
@@ -6372,18 +6372,6 @@
           "In this workshop, you will continue to practice working with TypeScript by building a fortune telling app."
         ]
       },
-      "lab-flashcard-quiz-app": {
-        "title": "Build a Flashcard Quiz App",
-        "intro": [
-          "In this lab, you will practice using TypeScript by building a flashcard quiz app."
-        ]
-      },
-      "lab-digital-pet-game": {
-        "title": "Build a Digital Pet Game",
-        "intro": [
-          "In this lab, you'll practice what you learned about TypeScript and React by building a digital pet game."
-        ]
-      },
       "workshop-build-a-football-player-card-builder": {
         "title": "Build a Football Player Card Builder",
         "intro": [
@@ -6400,6 +6388,18 @@
       "quiz-typescript": {
         "title": "TypeScript Quiz",
         "intro": ["Test what you've learned on TypeScript with this quiz."]
+      },
+      "lab-flashcard-quiz-app": {
+        "title": "Build a Flashcard Quiz App",
+        "intro": [
+          "In this lab, you will practice using TypeScript by building a flashcard quiz app."
+        ]
+      },
+      "lab-digital-pet-game": {
+        "title": "Build a Digital Pet Game",
+        "intro": [
+          "In this lab, you'll practice what you learned about TypeScript and React by building a digital pet game."
+        ]
       },
       "review-front-end-libraries": {
         "title": "Front-End Libraries Review",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Is related to #69399

---

## Summary

Reorders the `front-end-development-libraries-v9` block entries in `client/i18n/locales/english/intro.json` so they match the block order in `curriculum/structure/superblocks/front-end-development-libraries-v9.json`.

In both cases the pattern was the same: a `cert-project` lab was listed *before* the `review`/`quiz` blocks that close the preceding module, whereas the superblock places the module's review and quiz first and the cert-project lab after.

| block moved | now sits after |
|---|---|
| `lab-photography-exhibit` | `quiz-css-libraries-and-frameworks` |
| `lab-flashcard-quiz-app`, `lab-digital-pet-game` | `quiz-typescript` |

Only key order changed — no titles, intro copy, or other superblocks were touched.

## A note on scope

The issue describes `lab-photography-exhibit` and states it is "the only entry out of place". While verifying, I found a second divergence of the identical kind further down the same superblock (the two TypeScript cert-project labs sitting above `review-typescript`/`quiz-typescript`).

I've fixed both, since the issue's stated expected behaviour is that the FEDL v9 entries "appear in the same order as the blocks in `front-end-development-libraries-v9.json`" — and fixing only the first would have left the two files still mismatched. Happy to drop the second change if you'd rather keep this PR strictly to the reported entry.

## Verification

Parsed both files and compared the block sequences programmatically:

- before: 59 blocks in each, same set, first divergence at index 38
- after: 59 blocks in each, **same set and identical order**
- `npx prettier --check client/i18n/locales/english/intro.json` → *All matched files use Prettier code style!*

I also ran the same comparison across all 98 superblocks. `front-end-development-libraries-v9` is now consistent. Worth flagging separately: `back-end-development-and-apis-v9` shows the same class of ordering divergence (first at index 11). I've left it alone as it's outside this issue — happy to open a follow-up issue or PR for it if useful.