### PR TITLE
fix(curriculum): correct Node.js and title case in block title

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -7284,7 +7284,7 @@
     },
     "blocks": {
       "lecture-working-with-nodejs-and-event-driven-architecture": {
-        "title": "Working with NodeJS and event driven architecture",
+        "title": "Working with Node.js and Event-Driven Architecture",
         "intro": [
           "Learn about Node.js core libraries, how to install Node.js on your computer, and the advantages and disadvantages of using Node.js on the back-end."
         ]


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69397

<!-- Feel free to add any additional description of changes below this line -->

## Summary

Updates the block title for `lecture-working-with-nodejs-and-event-driven-architecture` in `client/i18n/locales/english/intro.json` from `Working with NodeJS and event driven architecture` to `Working with Node.js and Event-Driven Architecture`.

This fixes two issues:
1. **"NodeJS" → "Node.js"**: the correct spelling of the runtime, consistent with the rest of the file (e.g. "Introduction to Node.js", "Learn Node.js REPL") and the block intro text.
2. **Sentence case → title case**: "event driven architecture" → "Event-Driven Architecture", matching the section heading in the Back-End Development and APIs review challenge (`curriculum/challenges/english/blocks/review-back-end-development-and-apis/6a439658bfbe59fcf4b221c7.md`: "Working with Node.js and Event-Driven Architecture").

## Verification

- `client/i18n/locales/english/intro.json` remains valid JSON.
- This is a text-only change; `client/i18n/locales.test.ts` only checks that each curriculum block has a non-empty title, so no tests are affected.
