### PR TITLE
fix(curriculum): correct title case for lecture challenges in Node.js event-driven architecture block

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d2f232c60f0fa68ef86.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d2f232c60f0fa68ef86.md
@@ -1,6 +1,6 @@
 ---
 id: 68ff6d2f232c60f0fa68ef86
-title: What is Node and What are Some Differences Between the Browser and Node Runtime Environment?
+title: What Is Node and What Are Some Differences Between the Browser and Node Runtime Environment?
 challengeType: 19
 dashedName: what-is-node-and-what-are-some-differences-between-the-browser-and-node-runtime-environment
 ---

--- a/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d372ad364f285f0522e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d372ad364f285f0522e.md
@@ -1,6 +1,6 @@
 ---
 id: 68ff6d372ad364f285f0522e
-title: What are the Advantages and Disadvantages to Using Node on the Back-End?
+title: What Are the Advantages and Disadvantages of Using Node on the Back-End?
 challengeType: 19
 dashedName: what-are-the-advantages-and-disadvantages-to-using-node-on-the-back-end
 ---

--- a/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d39d7ed9ef36ff281f3.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d39d7ed9ef36ff281f3.md
@@ -1,6 +1,6 @@
 ---
 id: 68ff6d39d7ed9ef36ff281f3
-title: How can you Install Node on your Computer?
+title: How Can You Install Node on Your Computer?
 challengeType: 19
 dashedName: how-can-you-install-node-on-your-computer
 ---

--- a/curriculum/structure/blocks/lecture-working-with-nodejs-and-event-driven-architecture.json
+++ b/curriculum/structure/blocks/lecture-working-with-nodejs-and-event-driven-architecture.json
@@ -6,15 +6,15 @@
   "challengeOrder": [
     {
       "id": "68ff6d2f232c60f0fa68ef86",
-      "title": "What is Node and What are Some Differences Between the Browser and Node Runtime Environment?"
+      "title": "What Is Node and What Are Some Differences Between the Browser and Node Runtime Environment?"
     },
     {
       "id": "68ff6d372ad364f285f0522e",
-      "title": "What are the Advantages and Disadvantages to Using Node on the back-end?"
+      "title": "What Are the Advantages and Disadvantages of Using Node on the Back-End?"
     },
     {
       "id": "68ff6d39d7ed9ef36ff281f3",
-      "title": "How can you Install Node on your Computer?"
+      "title": "How Can You Install Node on Your Computer?"
     }
   ],
   "blockLabel": "lecture"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69396

<!-- Feel free to add any additional description of changes below this line -->

This PR corrects the title case of the three challenge titles in the `lecture-working-with-nodejs-and-event-driven-architecture` block, updating both the block JSON `challengeOrder` titles and the matching frontmatter titles in the three challenge files. It also fixes the `back-end` -> `Back-End` capitalization and the `to Using` -> `of Using` wording on the second title.
