### PR TITLE
fix(curriculum): add section headers to aria-live lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-aria-expanded-aria-live-and-common-aria-states/672a54dff9dc439089f1a219.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-aria-expanded-aria-live-and-common-aria-states/672a54dff9dc439089f1a219.md
@@ -15,6 +15,8 @@ Because the reading focus for screen readers can only be at one place at a time,
 
 There are three possible values for this attribute, based on the priority of the information.
 
+## The `assertive` Value
+
 If you set `aria-live` to the value `assertive` that means that the update is very important. It has the highest priority, so the user should be notified immediately.
 
 This means that the screen reader will interrupt any announcement it is currently making to announce the content change in the live region. Such interruptions can be extremely disruptive, so the `assertive` value should only be used for time-sensitive or critical notifications.
@@ -80,6 +82,8 @@ document.addEventListener("DOMContentLoaded", () => {
 ```
 
 :::
+
+## The `polite` Value
 
 The next value in order of priority is `polite`.
 
@@ -147,9 +151,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
 :::
 
+## The `off` Value
+
 The lowest priority value for `aria-live` is `off` which means that the update will not be announced unless the content is in an element that currently has keyboard focus. Realistically, this value is almost never used as the use case is very narrow and it is not implemented consistently (if at all) across screen readers. If you need live regions, plan on using `polite` for everything except critical messages that need `assertive`.
 
+## Default Live Regions from ARIA Roles
+
 It's also important to note that the `aria-live` attribute is not required if the updated information is contained in an element with an ARIA role of `alert`, `log`, `marquee`, `status`, or `timer`, as these roles already have default `aria-live` values. But the default value can be changed by explicitly setting `aria-live` on the element.
+
+## Choosing the Right Value
 
 Choosing the right `aria-live` value depends on the priority of the updated information.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #69338

### Description

Adds `##` section headers to the lecture body of "What Is the aria-live Attribute, and How Does It Work?" to break the ~530-word unbroken block into scannable sections.

Headers added:
- The `assertive` Value
- The `polite` Value
- The `off` Value
- Default Live Regions from ARIA Roles
- Choosing the Right Value

No prose was rewritten - only headers were inserted. Front matter, code blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below.

<img width="530" height="144" alt="Screenshot 2026-08-07 at 7 35 03 PM" src="https://github.com/user-attachments/assets/183652d6-d932-4da5-9d62-b553e0f17f57" />
<img width="525" height="129" alt="Screenshot 2026-08-07 at 7 35 40 PM" src="https://github.com/user-attachments/assets/a78be83b-8327-443d-b934-466b42476fd2" />
<img width="525" height="552" alt="Screenshot 2026-08-07 at 7 36 39 PM" src="https://github.com/user-attachments/assets/5de792a6-ad77-4e30-9cf5-b5cedff454ff" />
