### PR TITLE
fix(curriculum): title case Node lecture titles

### DIFF
--- a/curriculum/structure/blocks/lecture-working-with-nodejs-and-event-driven-architecture.json
+++ b/curriculum/structure/blocks/lecture-working-with-nodejs-and-event-driven-architecture.json
@@ -6,15 +6,15 @@
   "challengeOrder": [
     {
       "id": "68ff6d2f232c60f0fa68ef86",
-      "title": "What is Node and What are Some Differences Between the Browser and Node Runtime Environment?"
+      "title": "What Is Node and What Are Some Differences Between the Browser and Node Runtime Environment?"
     },
     {
       "id": "68ff6d372ad364f285f0522e",
-      "title": "What are the Advantages and Disadvantages to Using Node on the back-end?"
+      "title": "What Are the Advantages and Disadvantages of Using Node on the Back-End?"
     },
     {
       "id": "68ff6d39d7ed9ef36ff281f3",
-      "title": "How can you Install Node on your Computer?"
+      "title": "How Can You Install Node on Your Computer?"
     }
   ],
   "blockLabel": "lecture"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69396

<!-- Feel free to add any additional description of changes below this line -->

Updates the three `challengeOrder` titles in `lecture-working-with-nodejs-and-event-driven-architecture` to title case so they match neighboring lecture blocks and the writing style guide (including `Back-End` and `of Using` for the second title).

### Local testing

Ran on this branch after `pnpm install` (Node 24 / pnpm 10):

```bash
FCC_BLOCK='lecture-working-with-nodejs-and-event-driven-architecture' pnpm run test-curriculum-content
```

Result: **passed** (3 tests).

Drafted with AI assistance; reviewed by KesleyDavid.