### PR TITLE
fix(curriculum): PowerShell and heading case

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d39d7ed9ef36ff281f3.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d39d7ed9ef36ff281f3.md
@@ -1,6 +1,6 @@
 ---
 id: 68ff6d39d7ed9ef36ff281f3
-title: How can you Install Node on your Computer?
+title: How Can You Install Node on Your Computer?
 challengeType: 19
 dashedName: how-can-you-install-node-on-your-computer
 ---
@@ -17,7 +17,7 @@ Let's see how you can install NVM on macOS/Linux and Windows, and how you can us
 
 On macOS and Linux, you can install NVM directly through a shell script.
 
-But for macOS, note that the official documentation for NVM mentions that “you need to manually install the Xcode command line tools before running the install script, otherwise, it'll fail.”
+But for macOS, note that the official documentation for NVM mentions that "you need to manually install the Xcode command line tools before running the install script, otherwise, it'll fail."
 
 On macOS, you can install Xcode command line tools by running this command in your terminal:
 
@@ -41,7 +41,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 ```
 
-To get the latest version of NVM at the time when you are reading this article, please refer to the official NVM documentation: `https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script`. There, you will find these commands with the latest version number.
+To get the latest version of NVM at the time when you are reading this lesson, please refer to the official NVM documentation: `https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script`. There, you will find these commands with the latest version number.
 
 You might need to restart your terminal when the process is completed to load the new command and the new configuration.
 
@@ -53,7 +53,7 @@ nvm -v
 
 You should see your version of NVM in the output.
 
-## How to install Node.js with NVM on macOS/Linux
+## How to Install Node.js with NVM on macOS/Linux
 
 Now that you have NVM installed on macOS/Linux, you can install Node.js.
 
@@ -95,13 +95,13 @@ Finally, you can check the current version of Node.js with this command:
 node -v
 ```
 
-## How to install NVM on Windows
+## How to Install NVM on Windows
 
 Now let's see how you can install and use NVM on Windows.
 
 Official versions of NVM only support Windows in specific cases. If you have Windows Subsystem for Linux (WSL) set up on your device, you can follow the macOS/Linux guide above to install and use NVM.
 
-However, for Windows itself, there are a few alternatives. One of them is `nvm-windows`, a Node.js version management utility for Windows. This is a completely separate project from the official NVM project. But the purpose of these tools is the same — to help you work with multiple versions of Node.js on the same device.
+However, for Windows itself, there are a few alternatives. One of them is `nvm-windows`, a Node.js version management utility for Windows. This is a completely separate project from the official NVM project. But the purpose of these tools is the same: to help you work with multiple versions of Node.js on the same device.
 
 Before installing `nvm-windows`, you should know that the official repository recommends uninstalling any prior Node installation before installing NVM for Windows. If this is your first time installing Node.js, you should be okay. If you already have other versions of Node.js installed, it is recommended to uninstall them first.
 
@@ -119,7 +119,7 @@ You can check if the installation was successful and see your current version of
 nvm -v
 ```
 
-## How to Install Node.js using NVM for Windows
+## How to Install Node.js Using NVM for Windows
 
 Now that you have `nvm-windows` installed on Windows, you are ready to install Node.js.
 
@@ -155,7 +155,7 @@ nvm use 20
 
 You can also check your current version of Node.js with this command:
 
-```bash
+```powershell
 node -v
 ```
 
@@ -165,25 +165,25 @@ Now that you know how to install NVM and Node.js, let's check out some basic com
 
 Also, while all these commands will work for NVM installed on macOS/Linux, including WSL, they may work differently or may not work at all for `nvm-windows`. We'll leave alternative commands for `nvm-windows` whenever possible.
 
-### How to Adjust Powershell's Execution Policy
+### How to Adjust PowerShell's Execution Policy
 
-If you're running Windows and are following along with Powershell and `nvm-windows`, you may need to adjust Powershell's execution policy. The default execution policy for Powershell is `Restricted`, which is a security measure to prevent scripts from running.
+If you're running Windows and are following along with PowerShell and `nvm-windows`, you may need to adjust PowerShell's execution policy. The default execution policy for PowerShell is `Restricted`, which is a security measure to prevent scripts from running.
 
-First, run Powershell as an administrator by right-clicking on Powershell, then clicking “Run as Administrator“.
+First, run PowerShell as an administrator by right-clicking on PowerShell, then clicking "Run as Administrator".
 
-Then, to see the current execution policy of the current Powershell session, run the following command:
+Then, to see the current execution policy of the current PowerShell session, run the following command:
 
 ```powershell
 Get-ExecutionPolicy
 ```
 
-Finally, to set Powershell's execution policy to `RemoteSigned`, which allows local scripts and `npm` to run, use the following command:
+Finally, to set PowerShell's execution policy to `RemoteSigned`, which allows local scripts and `npm` to run, use the following command:
 
 ```powershell
 Set-ExecutionPolicy RemoteSigned
 ```
 
-Once you've run the command above, you can close the administrator window of Powershell, and open a non-admin Powershell window.
+Once you've run the command above, you can close the administrator window of PowerShell, and open a non-admin PowerShell window.
 
 ### List All Versions
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69395

<!-- Feel free to add any additional description of changes below this line -->

Fixes the Node installation lesson (`how-can-you-install-node-on-your-computer`):

- Title case for the lesson title and three section headings
- Correct product name `PowerShell`
- Straight double quotes instead of curly quotes
- Colon instead of em dash where the curriculum prefers a colon
- `powershell` language tag for the Windows `node -v` code block
- "lesson" instead of "article"

### Local testing

Ran on this branch after `pnpm install` (Node 24 / pnpm 10):

```bash
FCC_CHALLENGE_ID=68ff6d39d7ed9ef36ff281f3 pnpm run test-curriculum-content
```

Result: **passed** (3 tests).

Drafted with AI assistance; reviewed by KesleyDavid.