### PR TITLE
fix(curriculum): Toggle Text Step 13 semicolon

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd61c24bfc0a240132fd2f.md
@@ -246,7 +246,7 @@ export const ToggleApp = () => {
   
   const handleToggleVisibility = () => {
     setIsVisible(!isVisible);
-  }
+  };
   
   return (
     <div id="toggle-container">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69391

<!-- Feel free to add any additional description of changes below this line -->

Restores the missing semicolon after the `handleToggleVisibility` arrow function in the Step 13 `--solutions--` block so it matches the seed (`};`).

### Local testing

Ran on this branch after `pnpm install` (Node 24 / pnpm 10):

```bash
FCC_CHALLENGE_ID=67cd61c24bfc0a240132fd2f pnpm run test-curriculum-content
```

Result: **passed** (6 tests), including seed-fail and solution-pass checks.

Drafted with AI assistance; reviewed by KesleyDavid.