### PR TITLE
fix(curriculum): Node advantages lesson accuracy and quotes

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d372ad364f285f0522e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-nodejs-and-event-driven-architecture/68ff6d372ad364f285f0522e.md
@@ -1,6 +1,6 @@
 ---
 id: 68ff6d372ad364f285f0522e
-title: What are the Advantages and Disadvantages to Using Node on the Back-End?
+title: What Are the Advantages and Disadvantages of Using Node on the Back-End?
 challengeType: 19
 dashedName: what-are-the-advantages-and-disadvantages-to-using-node-on-the-back-end
 ---
@@ -11,7 +11,7 @@ One of the great advantages of Node.js is that you can implement both the front-
 
 Node's architecture is another advantage. It has a non-blocking, event-driven architecture that is great for developing real-time applications, where responsiveness and efficiency are essential for creating a good user experience.
 
-This is where the concept of “threads” becomes very important. A thread is a path of execution within a process, like a computer program that is currently running.
+This is where the concept of "threads" becomes very important. A thread is a path of execution within a process, that is, a computer program that is currently running.
 
 Node's architecture relies on a single thread and event loop that can effectively handle a large number of simultaneous requests and input/output operations. This makes it perfect for applications that require handling multiple requests simultaneously.
 
@@ -25,13 +25,13 @@ And finally, in terms of costs, Node.js has the great advantage of being free an
 
 On the other hand, Node.js does have certain disadvantages or limitations that you should be aware of.
 
-As you learned, it only runs one thread at a time, which means that it can only handle one operation at a time. While its architecture allows it to be efficient for handling concurrent (simultaneous) requests, CPU-intensive tasks may block the main thread and result in performance issues.
+As you learned, it runs your JavaScript on a single thread, which means it can only execute one piece of your code at a time. While its architecture allows it to be efficient for handling concurrent (simultaneous) requests, CPU-intensive tasks may block the main thread and result in performance issues.
 
 Examples of CPU-intensive tasks include complex mathematical operations, image and video processing, and cryptography. There are ways to overcome this, but they usually increase the complexity of the application.
 
-Node.js also relies on asynchronous programming. In asynchronous programming, a task that may take a long time to run is started, but instead of waiting until it's completed, the main program continues running while the asynchronous task runs in parallel. When the task is completed, the program handles the result.
+Node.js also relies on asynchronous programming. In asynchronous programming, a task that may take a long time to run is started, but instead of waiting until it's completed, the main program continues running while the asynchronous task runs in the background. When the task is completed, the program handles the result.
 
-This process often involves what we know as “callbacks,” which are functions that define what happens when the asynchronous operations are completed. The asynchronous nature of Node.js can potentially make the code more difficult to read, understand, and debug.
+This process often involves what we know as "callbacks," which are functions that define what happens when the asynchronous operations are completed. The asynchronous nature of Node.js can potentially make the code more difficult to read, understand, and debug.
 
 And finally, you should also be careful when choosing packages from `npm`, the Node package manager, because some of them may not be constantly maintained, so they may introduce vulnerabilities into your own application. As a developer, you should evaluate each package carefully and check if it follows quality and security best practices.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69394

<!-- Feel free to add any additional description of changes below this line -->

Updates the Node advantages/disadvantages lecture per the issue:

1. Title case + `of Using` (instead of `to Using`)
2. Single-thread wording: one piece of JS at a time (not “one operation at a time”)
3. Async tasks run “in the background” (not “in parallel”)
4. Straight quotes around `"threads"`; process clause uses “that is,”
5. Straight quotes around `"callbacks,"`

Only the challenge MD file is changed. Structure-block title case for this lecture is covered separately by #69405.

Drafted with AI assistance; reviewed by KesleyDavid.