### PR TITLE
fix(curriculum): remove stray assertion args, add mood-board test, fix hint text

### DIFF
--- a/curriculum/challenges/english/blocks/lab-mood-board/673b3d6b7ef7318eef926d5a.md
+++ b/curriculum/challenges/english/blocks/lab-mood-board/673b3d6b7ef7318eef926d5a.md
@@ -41,7 +41,7 @@ You can use the following images in your Mood Board if you would like:
 You should export a `MoodBoardItem` component.
 
 ```js
-assert.isFunction(window.index.MoodBoardItem, 1);
+assert.isFunction(window.index.MoodBoardItem);
 ```
 
 Your `MoodBoardItem` component should return a `div` with a class of `mood-board-item` as its top-level element.
@@ -83,7 +83,7 @@ Your `MoodBoardItem` component should render an `h3` element with a class of `mo
 You should export a `MoodBoard` component.
 
 ```js
-assert.isFunction(window.index.MoodBoard, 1);
+assert.isFunction(window.index.MoodBoard);
 ```
 
 Your `MoodBoard` component should return a `div` as its top-level element.
@@ -102,7 +102,15 @@ assert.equal(heading.tagName, 'H1');
 assert.equal(heading.textContent, 'Destination Mood Board');
 ```
 
-Your `MoodBoard` component should render at least three `MoodBoardItem` components, each of which should pass `color`, `image`, and `description` props with valid values.
+Your `MoodBoard` component should render a `div` with a class of `mood-board`.
+
+```js
+const moodboard = document.getElementsByClassName('mood-board')[0];
+assert.exists(moodboard);
+assert.equal(moodboard.tagName, 'DIV');
+```
+
+Your `MoodBoard` component should render at least three `MoodBoardItem` components within the `.mood-board` element, each of which should pass `color`, `image`, and `description` props with valid values.
 
 ```js
 const moodboard = document.getElementsByClassName('mood-board')[0];


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69392

- Remove stray `1` argument from `assert.isFunction` calls for `MoodBoardItem` and `MoodBoard` exports
- Add dedicated test for user story 9 (`MoodBoard` renders `div.mood-board`)
- Update hint for user story 10 to include "within the `.mood-board` element"

### Changes

1. **Stray assertion argument** — Removed stray `1` from `assert.isFunction` calls for `MoodBoardItem` and `MoodBoard` exports.
2. **Missing test for user story 9** — Added dedicated test and hint: `Your MoodBoard component should render a div with a class of mood-board.`
3. **Incomplete hint text for user story 10** — Updated hint text to: `Your MoodBoard component should render at least three MoodBoardItem components within the .mood-board element, each of which should pass color, image, and description props with valid values.`