### PR TITLE
fix(curriculum): add section headers for CSS combinators lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
@@ -7,13 +7,13 @@ dashedName: what-are-the-different-types-of-css-combinators
 
 # --interactive--
 
-## CSS Combinators Overview
+## CSS Combinators
 
 CSS combinators are used to define the relationship between selectors in CSS. They help in selecting elements based on their relationship to other elements, which allows for more precise and efficient styling.
 
 We will discuss some primary CSS combinators and their use cases, starting with the descendant combinator.
 
-## Descendant Combinator
+### Descendant Combinator
 
 A descendant combinator is used to target elements matched by the second selector if they are nested within an ancestor element that matches the first selector. An ancestor can be a parent, grandparent, or any ancestor further up the document tree.
 
@@ -46,7 +46,7 @@ In this case, the `figure` would be the parent and the `img` would be the child.
 
 If you had multiple images inside a `figure` element, using the descendant combinator would be a good way to apply a solid black border around each of those images.
 
-## Child Combinator
+### Child Combinator
 
 Another type of combinator would be the child combinator.
 
@@ -108,7 +108,7 @@ In the above example, we are only targeting the direct child of `container` clas
 
 Because the other two paragraph elements are nested inside `div` elements, they are not considered direct children of the `container` class and will not get the text color of blue.
 
-## Next-Sibling Combinator
+### Next-Sibling Combinator
 
 Another common combinator would be the next-sibling combinator.
 
@@ -158,7 +158,7 @@ img + figcaption {
 
 In this example, the next-sibling combinator (`+`) selects the `figcaption` element that immediately follows the `img` element. The applied CSS rule adds a `4px solid black border` around the `figcaption`.
 
-## Subsequent-Sibling Combinator
+### Subsequent-Sibling Combinator
 
 Another common combinator is the subsequent-sibling combinator.
 

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc100d59d24da7b4e09c.md
@@ -7,9 +7,13 @@ dashedName: what-are-the-different-types-of-css-combinators
 
 # --interactive--
 
+## CSS Combinators Overview
+
 CSS combinators are used to define the relationship between selectors in CSS. They help in selecting elements based on their relationship to other elements, which allows for more precise and efficient styling.
 
 We will discuss some primary CSS combinators and their use cases, starting with the descendant combinator.
+
+## Descendant Combinator
 
 A descendant combinator is used to target elements matched by the second selector if they are nested within an ancestor element that matches the first selector. An ancestor can be a parent, grandparent, or any ancestor further up the document tree.
 
@@ -41,6 +45,8 @@ Note that a `space` is used between the parent and child selector.
 In this case, the `figure` would be the parent and the `img` would be the child.
 
 If you had multiple images inside a `figure` element, using the descendant combinator would be a good way to apply a solid black border around each of those images.
+
+## Child Combinator
 
 Another type of combinator would be the child combinator.
 
@@ -102,6 +108,8 @@ In the above example, we are only targeting the direct child of `container` clas
 
 Because the other two paragraph elements are nested inside `div` elements, they are not considered direct children of the `container` class and will not get the text color of blue.
 
+## Next-Sibling Combinator
+
 Another common combinator would be the next-sibling combinator.
 
 The next-sibling combinator (`+`) in CSS selects an element that immediately follows a specified sibling element. This combinator is useful when you want to apply styles to an element that directly follows another element, allowing for targeted styling based on the element's position relative to its siblings.
@@ -149,6 +157,8 @@ img + figcaption {
 :::
 
 In this example, the next-sibling combinator (`+`) selects the `figcaption` element that immediately follows the `img` element. The applied CSS rule adds a `4px solid black border` around the `figcaption`.
+
+## Subsequent-Sibling Combinator
 
 Another common combinator is the subsequent-sibling combinator.
 
@@ -201,6 +211,8 @@ h2 ~ p {
 In this example, all paragraph elements following the `h2` element will have the text color green.
 
 The subsequent-sibling combinator (`~`) targets all paragraph siblings that appear after the `h2` element, regardless of whether they are immediate siblings.
+
+## Why CSS Combinators Matter
 
 In conclusion, understanding and using various CSS combinators allows you to apply precise styles to your HTML elements, enhancing the control and flexibility of your design.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69295

Added short, Title Case `##` headers to the `# --interactive--` lecture content for improved scanability, without modifying front matter, code blocks, or the `# --questions--` section.