### PR TITLE
fix(curriculum): fix grammar and terminology consistency in fruit search app workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/67ec2f7924ade2450c06bcd8.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/67ec2f7924ade2450c06bcd8.md
@@ -20,7 +20,7 @@ You should have a `div` element.
 assert.lengthOf(document.querySelectorAll("div"), 2);
 ```
 
-Your `div` element should have an `id` called `search-container`.
+Your `div` element should have an `id` of `search-container`.
 
 ```js
 const el = document.getElementById("search-container");

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/67ec46b46f232344ebf3c114.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/67ec46b46f232344ebf3c114.md
@@ -11,7 +11,7 @@ Next, you will create a form where users can search for fruits. Inside the `#sea
 
 # --hints--
 
-You should have a `form` element inside the `search-container` element.
+You should have a `form` element inside the `#search-container` element.
 
 ```js
 const searchContainer = document.getElementById("search-container");

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/67ec4a95b609c071f7747be0.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/67ec4a95b609c071f7747be0.md
@@ -22,7 +22,7 @@ assert.exists(label);
 assert.strictEqual(label.tagName, "LABEL");
 ```
 
-The `label` element should have an `htmlFor` attribute with the value of `"search-input"`.
+Your `label` element should have an `htmlFor` attribute with the value of `"search-input"`.
 
 ```js
 const label = document.querySelector("form label");

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/67f8ef57b9974052e5ef6b30.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/67f8ef57b9974052e5ef6b30.md
@@ -7,7 +7,7 @@ dashedName: step-12
 
 # --description--
 
-Inside the `#results` element, use a ternary operator to check if the length of `results` array is greater than zero. If it is, map over the items and display each one in a `p` element with a class of `result-item`. Be sure to include a `key` attribute with each paragraph as well.
+Inside the `#results` element, use a ternary operator to check if the length of the `results` array is greater than zero. If it is, map over the items and display each one in a `p` element with a class of `result-item`. Be sure to include a `key` attribute with each paragraph as well.
 
 If `results` is empty, render a `p` element with the message `No results found`.
 

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/67f8fd20d0afc3e03122453a.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/67f8fd20d0afc3e03122453a.md
@@ -9,11 +9,11 @@ dashedName: step-13
 
 Next, you will make your app get fruit names from the API when a user types in the input.
 
-First, add a `useEffect` hook so that it runs whenever the `query` state changes. Make sure to pass an arrow function as the first argument to `useEffect`, and include `query` in the dependency array.
+First, add a `useEffect` Hook so that it runs whenever the `query` state changes. Make sure to pass an arrow function as the first argument to `useEffect`, and include `query` in the dependency array.
 
 # --hints--
 
-You should use the `useEffect` hook.
+You should use the `useEffect` Hook.
 
 ```js
 const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;
@@ -23,7 +23,7 @@ const fruitsSearchString = exports.FruitsSearch.toString();
 assert.match(fruitsSearchString, /useEffect\((\(\)|function)\s*(=>|\(\))\s*\{\s*\}\s*/);
 ```
 
-You should include `query` in the dependency array of your `useEffect` hook.
+You should include `query` in the dependency array of your `useEffect` Hook.
 
 ```js
 const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/67f90485c192d92ba3ba7e34.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/67f90485c192d92ba3ba7e34.md
@@ -21,7 +21,7 @@ const fruitsSearchString = exports.FruitsSearch.toString();
 assert.match(fruitsSearchString, /if\s*\(\s*query\.trim\(\)\s*===\s*['"]{2}\s*\)/);
 ```
 
-If `query.trim() === ''` is true, call `setResults()` with an empty array, then use the `return` keyword after that.
+You should call `setResults()` with an empty array and use the `return` keyword after that when `query.trim() === ''` is true.
 
 ```js
 const script = [...document.querySelectorAll("script")].find((s) => s.dataset.src ===  "index.jsx").innerText;

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/67f90574263ebf363f9edd1d.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/67f90574263ebf363f9edd1d.md
@@ -19,7 +19,7 @@ You should call `setTimeout` and store the return value in a variable called `ti
 assert.match(code, /(const|let|var)\s+timeoutId\s*=\s*setTimeout\s*\(/s);
 ```
 
-`setTimeout` should have an empty callback function and a delay value of `700`.
+Your `setTimeout` call should have an empty callback function and a delay value of `700`.
 
 ```js
 assert.match(code, /(const|let|var)\s+timeoutId\s*=\s*setTimeout\s*\(\s*\(\s*\)\s*=>\s*\{\s*\}\s*,\s*700\s*\)/);

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/68140ab94fd0ea19c62ca87e.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/68140ab94fd0ea19c62ca87e.md
@@ -9,11 +9,11 @@ dashedName: step-21
 
 Below your `timeoutId` variable, return a cleanup function that clears the timeout using `clearTimeout(timeoutId)`. This prevents multiple delayed fetches from stacking up. Make sure your cleanup function is an arrow function with an implicit return.
 
-And with that your Fruit Search app is complete! Try out your fruit search app by typing in the name of a fruit like `apple` or `pear` to see the results appear.
+And with that, your Fruit Search app is complete! Try out your fruit search app by typing in the name of a fruit like `apple` or `pear` to see the results appear.
 
 # --hints--
 
-You should return an arrow function that calls `clearTimeout(timeoutId)` at the end of the `useEffect` hook.
+You should return an arrow function that calls `clearTimeout(timeoutId)` at the end of the `useEffect` Hook.
 
 ```js
 assert.match(

--- a/curriculum/challenges/english/blocks/workshop-fruit-search-app/68245535872ded3cc2900fa8.md
+++ b/curriculum/challenges/english/blocks/workshop-fruit-search-app/68245535872ded3cc2900fa8.md
@@ -11,7 +11,7 @@ Pass the `handleSubmit` function to the `onSubmit` prop of the `form` element so
 
 # --hints--
 
-The `handleSubmit` function should be the value of the `onSubmit` attribute of the `form` element.
+Your `form` element's `onSubmit` attribute should be set to the `handleSubmit` function.
 
 ```js
 assert.match(code, /<form\s+onSubmit\s*=\s*{handleSubmit}/);


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Fixes several grammar and cross-step consistency issues in the Build a Fruit Search App workshop:
- Rewrote four hints that didn't start with "You"/"Your".
- Standardized "hook" capitalization to "Hook" to match the majority of steps.
- Standardized "id called X" to "id of X" to match every other instance in the workshop.
- Added a missing `#` on an element reference to match the with-hash/no-hash convention used elsewhere.
- Added a missing "the" before an array reference.
- Added a missing comma after an introductory phrase in the closing line.