### PR TITLE
fix(curriculum): fix grammar and hint-style consistency in OTP generator lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -16,11 +16,11 @@ In this lab, you will generate a 6-digit OTP (One-Time Password) and display it 
 
 1. You should use the `useEffect` hook to manage the countdown timer.
 2. Your `OTPGenerator` component should return a `div` element with the class name `container`.
-3. The `div` having the class `container` should include the following elements:
+3. Your `div` with the class `container` should include the following elements:
 
     - An `h1` element with the ID `otp-title` and text `"OTP Generator"`.
     - An `h2` element with the ID `otp-display` that either displays the message `"Click 'Generate OTP' to get a code"` or shows the generated OTP if one is available.
-    - A `p` element with the ID `otp-timer` and `aria-live` attribute set to a valid value that:
+    - A `p` element with the ID `otp-timer` and an `aria-live` attribute set to a valid value that:
         - Starts off empty.
         - Displays `"Expires in: X seconds"` after the button is clicked, where `X` represents the remaining time before the OTP expires.
         - Shows the message `"OTP expired. Click the button to generate a new OTP."` once the countdown reaches `0`.
@@ -28,7 +28,7 @@ In this lab, you will generate a 6-digit OTP (One-Time Password) and display it 
     - The `"Generate OTP"` button must be disabled while the countdown is active.
 
 4. You should ensure the countdown timer stops automatically once it reaches `0` seconds to prevent unnecessary updates.
-5. The generated OTP should be 6 digits long.
+5. Your generated OTP should be 6 digits long.
 
 # --before-all--
 
@@ -57,7 +57,7 @@ const containerDiv = document.querySelector('.container');
 assert.exists(containerDiv);
 ```
 
-The `.container` should contain an `h1` element with the ID `otp-title` the text `"OTP Generator"`.
+Your `.container` should contain an `h1` element with the ID `otp-title` and the text `"OTP Generator"`.
 
 ```js
 const h1 = document.querySelector(".container h1#otp-title");
@@ -65,20 +65,20 @@ assert.exists(h1);
 assert.equal(h1.textContent, "OTP Generator");
 ```
 
-The `.container` should contain an `h2` element with the ID `otp-display` that displays the OTP when generated. 
+Your `.container` should contain an `h2` element with the ID `otp-display` that displays the OTP when generated. 
 
 ```js
 const h2 = document.querySelector(".container h2#otp-display");
 assert.exists(h2);
 ```
 
-Initially, the `h2` inside `.container` should display the message `"Click 'Generate OTP' to get a code"`.
+Your `h2` inside `.container` should initially display the message `"Click 'Generate OTP' to get a code"`.
 
 ```js
 assert.strictEqual(document.querySelector('.container h2#otp-display').textContent.trim(), "Click 'Generate OTP' to get a code");
 ```
 
-The `.container` element should contain a `p` element with the ID `otp-timer`.
+Your `.container` element should contain a `p` element with the ID `otp-timer`.
 
 ```js
 const container = document.querySelector('.container');
@@ -88,7 +88,7 @@ assert.strictEqual(pElements.length, 1);
 assert.strictEqual(pElements[0].id, "otp-timer", "The p element should have the id otp-timer");
 ```
 
-The `p` element should have an `aria-live` attribute set to `assertive` or `polite`.
+Your `p` element should have an `aria-live` attribute set to `assertive` or `polite`.
 
 ```js
 const pElement = document.querySelector('.container p');
@@ -96,14 +96,14 @@ assert.exists(pElement?.ariaLive);
 assert.oneOf(pElement?.ariaLive, ["assertive", "polite"]);
 ```
 
-Initially, the `p` element should be empty.
+Your `p` element should initially be empty.
 
 ```js
 const pElement = document.querySelector('.container p');
 assert.strictEqual(pElement?.innerText, "", "The `p` element should be empty");
 ```
 
-The `.container` should contain a `button` element with the ID `generate-otp-button` and text `"Generate OTP"`. 
+Your `.container` should contain a `button` element with the ID `generate-otp-button` and text `"Generate OTP"`. 
 
 ```js
 const button = document.querySelector('.container button#generate-otp-button').textContent;
@@ -111,7 +111,7 @@ assert.exists(button);
 assert.strictEqual(button, 'Generate OTP');
 ```
 
-When the button is clicked, it should display a new OTP in the `h2` element with id `otp-display`.
+Your `h2` element with ID `otp-display` should display a new OTP when the button is clicked.
 
 ```js
 try {
@@ -131,7 +131,7 @@ await clock.runAllAsync();
 }
 ```
 
-The generated OTP should be 6 digits long.
+Your generated OTP should be 6 digits long.
 
 ```js
   try {
@@ -149,7 +149,7 @@ await clock.runAllAsync();
 ```
 
 
-When the button is clicked, the `p` element with id of `otp-timer` should show a 5-second countdown.
+Your `p` element with ID of `otp-timer` should show a 5-second countdown when the button is clicked.
 
 ```js
   try {
@@ -170,7 +170,7 @@ await clock.runAllAsync();
 }
 ```
 
-The message in the `p` element with id `otp-timer` should update every second to show the remaining time.
+Your `p` element with ID `otp-timer` should update its message every second to show the remaining time.
 
 ```js
 const button = document.querySelector(".container button#generate-otp-button");
@@ -183,7 +183,7 @@ p = document.querySelector(".container p#otp-timer");
 assert.match(p.textContent, /Expires in: 4 seconds/, "Countdown should update to 4 seconds after 1 second");
 ```
 
-The `"Generate OTP"` button should be disabled while the countdown timer is running.
+Your `"Generate OTP"` button should be disabled while the countdown timer is running.
 
 ```js
 try {
@@ -197,7 +197,7 @@ try {
 }
 ```
 
-The `"Generate OTP"` button should be enabled once the countdown timer reaches 0.
+Your `"Generate OTP"` button should be enabled once the countdown timer reaches 0.
 
 ```js
 
@@ -208,7 +208,7 @@ await clock.tickAsync(6000);
 assert.isFalse(button.disabled);
 ```
 
-When the countdown timer reaches `0`, you should display the message `OTP expired. Click the button to generate a new OTP.`.
+You should display the message `OTP expired. Click the button to generate a new OTP.` when the countdown timer reaches `0`.
 
 ```js
   const button = document.querySelector(".container button#generate-otp-button");


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Fixes grammar and hint-style consistency issues in the Build a One-Time Password Generator lab:
- Rewrote 14 hints that opened with "The"/"Initially"/"When" instead of "You"/"Your".
- Aligned the description's user story list to the same "You"/"Your" style used elsewhere in the file.
- Added a missing "and" between two requirements in a hint.
- Added a missing "an" article before `aria-live` attribute.
- Reworded "having the class" to "with the class" for clearer phrasing.
- Standardized "id" capitalization to "ID" to match the majority of the file.

Note: a hint's regex check for the `useState`/`useEffect`/`useRef` destructuring has a leniency bug (it also accepts keeping only one of the three names), and another hint's OTP regex only checks for the presence of any digit. Both left as-is per the audit's guidance not to change assertion grading behavior without being explicitly asked to.