### PR TITLE
fix(curriculum): remove stray article in toggle text app step 11

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd59f6581d3a20c9cc6460.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd59f6581d3a20c9cc6460.md
@@ -9,7 +9,7 @@ dashedName: step-11
 
 Now would be a good time to see the updated `isVisible` value.
 
-Below the `setIsVisible(!isVisible);`, log the `isVisible` state variable to the console. 
+Below `setIsVisible(!isVisible);`, log the `isVisible` state variable to the console.
 
 Open up the console and you will notice that the value is not what you expected it to be. 
 


### PR DESCRIPTION
## Description
Removes a stray definite article ("the") before a code statement in the description text of Step 11, so it reads correctly as a code reference rather than a noun phrase.
## Issue
Closes #69390
## Screenshots
N/A — text-only change
## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.