### PR TITLE
fix: correct sentence casing in present perfect accessibility lessons

### DIFF
--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671b98e9b7c4854e93044e64.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671b98e9b7c4854e93044e64.md
@@ -62,7 +62,7 @@ Watch the video.
      "startTime": 5.34,
      "finishTime": 9.26,
      "dialogue": {
-       "text": "Yes, for some reason it hasn't been displaying correctly for some users.",
+       "text": "Yes. For some reason, it hasn't been displaying correctly for some users.",
        "align": "right"
      }
    },

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f403c1d4e8a5e046065a0.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f403c1d4e8a5e046065a0.md
@@ -6,7 +6,7 @@ dashedName: task-36
 lang: en-US
 ---
 
-<!-- (Audio) James: Yes. For some reason, It hasn't been displaying correctly for some users.  -->
+<!-- (Audio) James: Yes. For some reason, it hasn't been displaying correctly for some users.  -->
 
 # --instructions--
 
@@ -16,7 +16,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`Yes. For some reason, It BLANK BLANK BLANK correctly for some users.`
+`Yes. For some reason, it BLANK BLANK BLANK correctly for some users.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f403c1d4e8a5e046065a0.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f403c1d4e8a5e046065a0.md
@@ -83,7 +83,7 @@ The sentence is in the negative form of the `Present Perfect Continuous` tense, 
       "startTime": 1,
       "finishTime": 4.92,
       "dialogue": {
-        "text": "Yes, for some reason it hasn't been displaying correctly for some users.",
+        "text": "Yes. For some reason, it hasn't been displaying correctly for some users.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f456994635c6085054cbd.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f456994635c6085054cbd.md
@@ -6,7 +6,7 @@ dashedName: task-37
 lang: en-US
 ---
 
-<!-- (Audio) James: Yes. For some reason, It hasn't been displaying correctly for some users.  -->
+<!-- (Audio) James: Yes. For some reason, it hasn't been displaying correctly for some users.  -->
 
 # --instructions--
 
@@ -16,7 +16,7 @@ Listen to the audio and complete the sentence below.
 
 ## --sentence--
 
-`Yes. For some reason, It hasn't been displaying BLANK for some BLANK.`
+`Yes. For some reason, it hasn't been displaying BLANK for some BLANK.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f456994635c6085054cbd.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/671f456994635c6085054cbd.md
@@ -79,7 +79,7 @@ This noun in the plural form refers to people who interact with a product or ser
       "startTime": 1,
       "finishTime": 4.92,
       "dialogue": {
-        "text": "Yes, for some reason it hasn't been displaying correctly for some users.",
+        "text": "Yes. For some reason, it hasn't been displaying correctly for some users.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/6720cf38beae8c4f1d7af1c0.md
+++ b/curriculum/challenges/english/blocks/learn-present-perfect-while-talking-about-accessibility/6720cf38beae8c4f1d7af1c0.md
@@ -22,7 +22,7 @@ Write the following words or phrases in the correct spot: `rendering consistentl
 
 `Alice: James, have you heard about the BLANK on our video platform?`
 
-`James: Yes. For some reason, It hasn't been BLANK for some users. The captions are misaligned and BLANK, which isn't good for accessibility.`
+`James: Yes. For some reason, it hasn't been BLANK for some users. The captions are misaligned and BLANK, which isn't good for accessibility.`
 
 `Alice: Exactly. Do you know if it's been affecting all the videos or just a few?`
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69378

<!-- Feel free to add any additional description of changes below this line -->

## Summary

Lowercase standalone `I` -> `i` in the `It hasn't been...` sentences across three lessons in the `learn-present-perfect-while-talking-about-accessibility` block:

- `task-36` (`671f403c1d4e8a5e046065a0.md`): dialogue line L9 and fill-in-the-blank sentence L19
- `task-37` (`671f456994635c6085054cbd.md`): dialogue line L9 and fill-in-the-blank sentence L19
- `task-55` (`6720cf38beae8c4f1d7af1c0.md`): sentence line L25