### PR TITLE
fix(curriculum): correct Mood Board test assertions

### DIFF
--- a/curriculum/challenges/english/blocks/lab-mood-board/673b3d6b7ef7318eef926d5a.md
+++ b/curriculum/challenges/english/blocks/lab-mood-board/673b3d6b7ef7318eef926d5a.md
@@ -41,7 +41,7 @@ You can use the following images in your Mood Board if you would like:
 You should export a `MoodBoardItem` component.
 
 ```js
-assert.isFunction(window.index.MoodBoardItem, 1);
+assert.isFunction(window.index.MoodBoardItem);
 ```
 
 Your `MoodBoardItem` component should return a `div` with a class of `mood-board-item` at its top-level element.
@@ -83,7 +83,7 @@ Your `MoodBoardItem` component should render an `h3` element with a class of `mo
 You should export a `MoodBoard` component.
 
 ```js
-assert.isFunction(window.index.MoodBoard, 1);
+assert.isFunction(window.index.MoodBoard);
 ```
 
 Your `MoodBoard` component should return a `div` as its top-level element.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69392

The Mood Board lab test assertions were passing an unnecessary second argument to `assert.isFunction`. This updates the assertions to match the expected usage.