### PR TITLE
fix(learn): correctly mark completed curriculum blocks as complete

### DIFF
--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -156,14 +156,13 @@ export const completionStateSelector = createSelector(
             ({ block: blockName }) => blockName === block
           );
 
-          const completedBlockChallenges = blockChallenges.every(({ id }) =>
-            completedChallengesIds.includes(id)
-          );
-
           return {
             name: block,
             isCompleted:
-              completedBlockChallenges.length === blockChallenges.length
+              blockChallenges.length > 0 &&
+              blockChallenges.every(({ id }) =>
+                completedChallengesIds.includes(id)
+              )
           };
         });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69428

<!-- Feel free to add any additional description of changes below this line -->

## Description

`completionStateSelector` in `client/src/redux/selectors.js` never marked a populated block as complete. `Array.prototype.every` returns a boolean, but the code did:

```js
const completedBlockChallenges = blockChallenges.every(({ id }) => ...);
isCompleted: completedBlockChallenges.length === blockChallenges.length
```

`true.length`/`false.length` are `undefined`, so the comparison was always `false` and every populated block was reported incomplete.

## Change

Compute `isCompleted` from the boolean directly and guard against empty blocks:

```js
isCompleted:
  blockChallenges.length > 0 &&
  blockChallenges.every(({ id }) => completedChallengesIds.includes(id))
```

An empty block (no challenges in the curriculum file) stays `false` instead of being vacuously marked complete.

## Verification

Minimal logic check (buggy vs fixed):

```
buggy: (a => (a.every(x => x.done)).length === a.length)([{done:true},{done:true}]) // false (wrong)
fixed: (a => a.length > 0 && a.every(x => x.done))([{done:true},{done:true}])        // true
```
