### PR TITLE
fix(client): highlight search suggestion on mouse hover

### DIFF
--- a/client/src/components/search/searchBar/search-bar.tsx
+++ b/client/src/components/search/searchBar/search-bar.tsx
@@ -141,8 +141,9 @@ export function SearchBar({
       const hoveredIndex = targetText ? hitsTitles.indexOf(targetText) : -1;
 
       setIndex(hoveredIndex);
+    } else {
+      setIndex(-1);
     }
-    setIndex(-1);
   };
 
   const handleMouseLeave = () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69429

<!-- Feel free to add any additional description of changes below this line -->

## Description

Hovering a search suggestion in the navbar dropdown never highlighted the hit. In `client/src/components/search/searchBar/search-bar.tsx`, `handleMouseEnter` always ran `setIndex(-1)` after computing the hovered index, discarding the value and disabling hover selection.

## Change

Move the reset into an `else` branch so it only runs when the mouse target is not a hit:

```tsx
if (e.target instanceof HTMLElement) {
  ...
  setIndex(hoveredIndex);
} else {
  setIndex(-1);
}
```

## Verification

Hovering a suggestion now selects it (same styling as keyboard navigation); hovering/leaving non-hit parts resets the selection.
