### PR TITLE
fix(client): stop leaking 'undefined' into timed-out test messages

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -258,30 +258,30 @@ export function* executeTests(testRunner, tests, testTimeout = 5000) {
         throw err;
       }
     } catch (err) {
-      const { actual, expected, type } = err;
-
-      newTest.message = text
-        .replace('--fcc-expected--', expected)
-        .replace('--fcc-actual--', actual);
       if (err === 'timeout') {
         newTest.err = 'Test timed out';
-        newTest.message = `${newTest.message} (${newTest.err})`;
+        newTest.message = `${text} (${newTest.err})`;
       } else {
-        const { message, stack } = err;
+        const { actual, expected, type, message, stack } = err;
+
+        newTest.message = text
+          .replace('--fcc-expected--', expected)
+          .replace('--fcc-actual--', actual);
+
         newTest.err = message + '\n' + stack;
         newTest.stack = stack;
-      }
 
-      if (
-        type === 'IndentationError' ||
-        type === 'SyntaxError' ||
-        type === 'NameError'
-      ) {
-        const msgKey =
-          type === 'IndentationError'
-            ? 'learn.indentation-error'
-            : 'learn.syntax-error';
-        newTest.message = `<p>${i18next.t(msgKey)}</p>`;
+        if (
+          type === 'IndentationError' ||
+          type === 'SyntaxError' ||
+          type === 'NameError'
+        ) {
+          const msgKey =
+            type === 'IndentationError'
+              ? 'learn.indentation-error'
+              : 'learn.syntax-error';
+          newTest.message = `<p>${i18next.t(msgKey)}</p>`;
+        }
       }
 
       const withIndex = newTest.message.replace(/<p>/, `<p>${i + 1}. `);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69430

<!-- Feel free to add any additional description of changes below this line -->

## Description

When a challenge test timed out, `executeTests` threw the string `'timeout'`. The catch block destructured it before checking for the timeout case, so the `--fcc-expected--` / `--fcc-actual--` placeholders were replaced with the literal text `undefined`, producing messages like:

```
Your function should return undefined but returned undefined. (Test timed out)
```

## Change

Restructured the catch block in `client/src/templates/Challenges/redux/execute-challenge-saga.js`:

- The `err === 'timeout'` branch now uses the original `text` and skips placeholder replacement entirely.
- Destructuring and error/stack handling moved into the non-timeout branch.

## Verification

Verified the message construction for the timeout, generic failure, and `IndentationError`/`SyntaxError`/`NameError` paths. Timeout output no longer contains `undefined`:

```
Your function should return --fcc-expected-- but it returned --fcc-actual--. (Test timed out)
```
