### PR TITLE
fix(client): avoid leaking blob URLs in exam results download

### DIFF
--- a/client/src/templates/Challenges/exam/components/exam-results.tsx
+++ b/client/src/templates/Challenges/exam/components/exam-results.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Spacer } from '@freecodecamp/ui';
 
@@ -39,17 +39,18 @@ ${t('learn.exam.percent-correct', { n: percentCorrect })}
 ${t('learn.exam.time', { t: formatSecondsToTime(examTimeInSeconds) })}
 `;
 
-  const blob = new Blob([downloadContent], {
-    type: 'text/plain'
-  });
-  const downloadURL = URL.createObjectURL(blob);
+  const downloadURL = useMemo(() => {
+    const blob = new Blob([downloadContent], {
+      type: 'text/plain'
+    });
+    return URL.createObjectURL(blob);
+  }, [downloadContent]);
 
   useEffect(() => {
     return () => {
       URL.revokeObjectURL(downloadURL);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [downloadURL]);
 
   const examResultsMessage = passed
     ? t('learn.exam.passed-message')


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69431

<!-- Feel free to add any additional description of changes below this line -->

## Description

`ExamResults` created a new blob URL on every render while only the URL created on mount was ever revoked, leaking one `blob:` URL per re-render.

## Change

In `client/src/templates/Challenges/exam/components/exam-results.tsx`, the download URL is now created with `useMemo` (keyed on `downloadContent`) and the cleanup effect runs on unmount or whenever the URL changes, revoking the previous one. The now-unnecessary `eslint-disable` was removed since the effect's dependency is complete.
