### PR TITLE
fix(challenge-parser): throw helpful error when fill-in-the-blank sentence has no BLANK token

### DIFF
--- a/tools/challenge-parser/parser/__fixtures__/with-fill-in-the-blank-no-blank-token.md
+++ b/tools/challenge-parser/parser/__fixtures__/with-fill-in-the-blank-no-blank-token.md
@@ -1,0 +1,17 @@
+# --description--
+
+This sentence does not contain a BLANK token but a blank is declared.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`This sentence has no blank to fill in.`
+
+## --blanks--
+
+`are`
+
+### --feedback--
+
+The blank section declares an answer that has no matching token.

--- a/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js
+++ b/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js
@@ -88,7 +88,9 @@ function plugin() {
         if (!sentence)
           throw Error('sentence is missing from fill in the blank');
         if (!blanks) throw Error('blanks are missing from fill in the blank');
-        if (sentence.match(/BLANK/g).length !== blanks.length)
+
+        const blankMatches = sentence.match(/BLANK/g);
+        if (blankMatches?.length !== blanks.length)
           throw Error(`Number of BLANKs doesn't match the number of answers.`);
 
         // For 'pinyin-to-hanzi' inputType, all answers must be of type 'hanzi-pinyin'.

--- a/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.test.js
+++ b/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.test.js
@@ -9,6 +9,7 @@ describe('fill-in-the-blanks plugin', () => {
     mockFillInTheBlankBadSentence,
     mockFillInTheBlankBadParagraph,
     mockFillInTheBlankMultipleBlanks,
+    mockFillInTheBlankNoBlankToken,
     mockChineseFillInTheBlankAST,
     mockChineseFillInTheBlankNoPinyinAST,
     mockChineseFillInTheBlankNoHanziAST,
@@ -34,6 +35,9 @@ describe('fill-in-the-blanks plugin', () => {
     );
     mockFillInTheBlankMultipleBlanks = await parseFixture(
       'with-fill-in-the-blank-many-blanks.md'
+    );
+    mockFillInTheBlankNoBlankToken = await parseFixture(
+      'with-fill-in-the-blank-no-blank-token.md'
     );
     mockChineseFillInTheBlankAST = await parseFixture(
       'with-chinese-fill-in-the-blank.md'
@@ -246,6 +250,12 @@ Example of good formatting:
     file.data.lang = 'zh-CN';
     expect(() => {
       plugin(mockChineseFillInTheBlankBlankAnswerMismatchAST, file);
+    }).toThrow(`Number of BLANKs doesn't match the number of answers.`);
+  });
+
+  it('should throw a helpful error when the sentence has no BLANK token', () => {
+    expect(() => {
+      plugin(mockFillInTheBlankNoBlankToken, file);
     }).toThrow(`Number of BLANKs doesn't match the number of answers.`);
   });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69432

<!-- Feel free to add any additional description of changes below this line -->

## Description

When a fill-in-the-blank challenge declared blanks but the sentence had no `BLANK` token, the parser crashed with a confusing `TypeError` (`Cannot read properties of null (reading 'length')`) instead of the author-facing validation error.

## Change

In `tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js`, the count check now uses optional chaining so a missing `BLANK` token produces the intended error:

```js
const blankMatches = sentence.match(/BLANK/g);
if (blankMatches?.length !== blanks.length)
  throw Error(`Number of BLANKs doesn't match the number of answers.`);
```

Added `with-fill-in-the-blank-no-blank-token.md` fixture and a test asserting the helpful error.

## Verification

Ran the plugin test suite in a scratch install (17 tests):

- **Before fix**: new test fails with `TypeError: Cannot read properties of null (reading 'length')`.
- **After fix**: all 17 tests pass.
