### PR TITLE
fix(curriculum): correct example reference

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd525b0e575b1e5abf4c03.md
+++ b/curriculum/challenges/english/blocks/workshop-toggle-text-app/67cd525b0e575b1e5abf4c03.md
@@ -16,7 +16,7 @@ const [isUserLoggedIn, setIsUserLoggedIn] = useState(false);
 setIsUserLoggedIn(!isUserLoggedIn);
 ```
 
-The following example is using the set function called `setIsUserLoggedIn` to update the login status for the user. It is common practice to use the logical NOT (`!`) operator to toggle between `true` and `false`. Since the initial value is `false`, applying the `!` operator will change it to `true`.
+The above example is using the set function called `setIsUserLoggedIn` to update the login status for the user. It is common practice to use the logical NOT (`!`) operator to toggle between `true` and `false`. Since the initial value is `false`, applying the `!` operator will change it to `true`.
 
 Inside of the `handleToggleVisibility` function, use `setIsVisible` to update the visibility state using the logical NOT (`!`) operator. 
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69389 

Step 9 of the Toggle Text App workshop said "The following example" but the referenced code block sits above this text. I changed it to "The above example" as requested by the issue. Following that I ran the curriculum content tests for this challenge in GitHub Codespaces and all 6 passed.
