### PR TITLE
fix(client): correct RTL layout on settings, profile and superblock pages

### DIFF
--- a/client/src/client-only-routes/show-settings.css
+++ b/client/src/client-only-routes/show-settings.css
@@ -10,7 +10,7 @@
 
 .settings-sidebar-nav ul {
   list-style-type: none;
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .settings-sidebar-nav > ul > li {
@@ -33,7 +33,7 @@
   font-size: 1rem;
   font-weight: 600;
   margin-bottom: 0.5rem;
-  padding-left: 1rem;
+  padding-inline-start: 1rem;
   text-decoration: none;
   cursor: pointer;
 }
@@ -43,7 +43,8 @@
   width: 100%;
   text-decoration: none;
   cursor: pointer;
-  padding: 0 1rem 0rem 2rem;
+  padding-block: 0;
+  padding-inline: 2rem 1rem;
   font-size: 0.85rem;
 }
 
@@ -51,6 +52,11 @@
 .settings-sidebar-nav .sidebar-nav-anchor-btn.active {
   box-shadow: inset 3px 0 0 0 var(--highlight-color);
   background-color: var(--tertiary-background);
+}
+
+[dir='rtl'] .settings-sidebar-nav .sidebar-nav-section-heading.active,
+[dir='rtl'] .settings-sidebar-nav .sidebar-nav-anchor-btn.active {
+  box-shadow: inset -3px 0 0 0 var(--highlight-color);
 }
 
 @media (max-width: 980px) {

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -11,17 +11,17 @@
   font-weight: 600;
   padding-block: 1em;
   padding-inline: 1.5em;
-  left: -1000px;
+  inset-inline-start: -1000px;
 }
 
 @media screen and (min-width: 980px) {
   .skip-to-content-button:focus {
-    left: 15px;
+    inset-inline-start: 15px;
   }
 }
 
 @media screen and (max-width: 979px) {
   .skip-to-content-button:focus {
-    left: 5px;
+    inset-inline-start: 5px;
   }
 }

--- a/client/src/components/profile/components/camper.css
+++ b/client/src/components/profile/components/camper.css
@@ -54,7 +54,7 @@
 
 .profile-edit-container button {
   position: absolute;
-  right: 18px;
+  inset-inline-end: 18px;
   top: 18px;
 }
 
@@ -105,11 +105,11 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-left: 1rem;
+  margin-inline-start: 1rem;
 }
 
 .camper-badge {
-  margin-right: 1em;
+  margin-inline-end: 1em;
 }
 @media (max-width: 768px) {
   .badge-card-container {

--- a/client/src/components/profile/components/experience-display.tsx
+++ b/client/src/components/profile/components/experience-display.tsx
@@ -119,7 +119,7 @@ export const ExperienceDisplay = ({
               onClick={openAddModal}
               aria-label={t('aria.add-experience')}
               type='button'
-              style={{ marginLeft: 'auto' }}
+              style={{ marginInlineStart: 'auto' }}
             >
               <FontAwesomeIcon icon={faPlus} />
             </Button>

--- a/client/src/components/profile/components/portfolio-projects.tsx
+++ b/client/src/components/profile/components/portfolio-projects.tsx
@@ -78,7 +78,7 @@ export const PortfolioProjects = ({
               onClick={openAddModal}
               aria-label={t('aria.add-portfolio')}
               type='button'
-              style={{ marginLeft: 'auto' }}
+              style={{ marginInlineStart: 'auto' }}
             >
               <FontAwesomeIcon icon={faPlus} />
             </Button>

--- a/client/src/components/settings/toggle-setting.css
+++ b/client/src/components/settings/toggle-setting.css
@@ -81,7 +81,7 @@
 
 .toggle-radio-group input {
   position: absolute;
-  left: -9999px;
+  inset-inline-start: -9999px;
 }
 
 .custom-circle {

--- a/client/src/components/sidebar-panel/sidebar-panel.css
+++ b/client/src/components/sidebar-panel/sidebar-panel.css
@@ -3,7 +3,7 @@
   scrollbar-color: var(--quaternary-background) var(--secondary-background);
   scrollbar-width: thin;
   background-color: var(--secondary-background);
-  border-right: 3px solid var(--tertiary-background);
+  border-inline-end: 3px solid var(--tertiary-background);
   padding: 1rem 0;
   color: var(--primary-color);
   font-size: 1rem;

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -52,7 +52,7 @@
 }
 
 .super-block-accordion .chapter-button-toggle {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .super-block-accordion .chapter-link {
@@ -134,7 +134,7 @@ button .block-header-button-text {
 }
 
 .super-block-accordion .module-button-toggle {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .super-block-accordion .block-header {
@@ -263,7 +263,7 @@ button .block-header-button-text {
 }
 .super-block-accordion .module-panel::before {
   position: absolute;
-  left: 16px;
+  inset-inline-start: 16px;
   width: 1px;
   height: 100%;
   content: '';
@@ -272,7 +272,7 @@ button .block-header-button-text {
 
 .super-block-accordion .accordion-block-expanded::before {
   position: absolute;
-  left: 32px;
+  inset-inline-start: 32px;
   width: 1px;
   height: 100%;
   top: 0;
@@ -328,6 +328,25 @@ button .block-header-button-text {
   .block-header[aria-expanded='false']
   .dropdown-icon {
   transform: rotate(90deg);
+}
+
+[dir='rtl']
+  .super-block-accordion
+  .chapter-panel
+  .chapter-button[aria-expanded='false']
+  .dropdown-icon,
+[dir='rtl']
+  .super-block-accordion
+  .chapter-panel
+  .module-button[aria-expanded='false']
+  .dropdown-icon,
+[dir='rtl']
+  .super-block-accordion
+  .chapter-panel
+  .block-grid
+  .block-header[aria-expanded='false']
+  .dropdown-icon {
+  transform: rotate(-90deg);
 }
 
 .super-block-accordion

--- a/client/src/templates/Introduction/components/super-block-accordion.css
+++ b/client/src/templates/Introduction/components/super-block-accordion.css
@@ -215,6 +215,10 @@ button .block-header-button-text {
   padding-block: 10px;
 }
 
+.super-block-accordion .module-panel .accordion-block-expanded .tags-wrapper {
+  padding-inline: 64px 10px;
+}
+
 .super-block-accordion
   .module-panel
   .accordion-block-expanded

--- a/client/src/templates/Introduction/components/super-block-search.css
+++ b/client/src/templates/Introduction/components/super-block-search.css
@@ -16,7 +16,7 @@
 
 .super-block-search-magnifier {
   position: absolute;
-  left: 10px;
+  inset-inline-start: 10px;
   pointer-events: none;
   display: flex;
   align-items: center;
@@ -29,7 +29,7 @@
 
 .super-block-search-reset-btn {
   position: absolute;
-  right: 6px;
+  inset-inline-end: 6px;
   background: none;
   border: none;
   cursor: pointer;


### PR DESCRIPTION
Fixes RTL layout on the settings, profile and superblock pages: the settings sidebar border and active-item highlight sat on the wrong edge and the page scrolled horizontally, the profile Edit/Add buttons and camper badge did not mirror, and the superblock rulers, dropdown icons, search icons and accordion tags were all on the wrong side.

Each one came from a physical CSS property that does not flip for RTL, so the fix throughout is the logical equivalent. LTR was measured alongside RTL on every change and is unchanged.


Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

rel https://github.com/freeCodeCamp/freeCodeCamp/issues/67661

