### PR TITLE
fix(client): correct text direction for language curriculum content in RTL

### DIFF
--- a/client/src/templates/Challenges/components/assignments.tsx
+++ b/client/src/templates/Challenges/components/assignments.tsx
@@ -4,6 +4,7 @@ import { Spacer } from '@freecodecamp/ui';
 
 import ChallengeHeading from './challenge-heading';
 import PrismFormatted from './prism-formatted';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 
 import './assignments.css';
 
@@ -14,14 +15,17 @@ type AssignmentsProps = {
     event: React.ChangeEvent<HTMLInputElement>,
     totalAssignments: number
   ) => void;
+  superBlock?: string;
 };
 
 function Assignments({
   assignments,
   allAssignmentsCompleted,
-  handleAssignmentChange
+  handleAssignmentChange,
+  superBlock
 }: AssignmentsProps): JSX.Element {
   const { t } = useTranslation();
+  const contentLangProps = getChallengeContentLangProps(superBlock);
   return (
     <>
       <ChallengeHeading
@@ -37,7 +41,11 @@ function Assignments({
                 handleAssignmentChange(event, assignments.length)
               }
             />
-            <PrismFormatted className={'video-quiz-option'} text={assignment} />
+            <PrismFormatted
+              className={'video-quiz-option'}
+              text={assignment}
+              {...contentLangProps}
+            />
             <Spacer size='m' />
           </label>
         ))}

--- a/client/src/templates/Challenges/components/challenge-description.tsx
+++ b/client/src/templates/Challenges/components/challenge-description.tsx
@@ -3,6 +3,7 @@ import { initializeMathJax, isMathJaxAllowed } from '../../../utils/math-jax';
 import PrismFormatted from './prism-formatted';
 import './challenge-description.css';
 import { generateGithubLink } from '../../../components/create-github-link';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 
 type Props = {
   description?: string;
@@ -26,15 +27,20 @@ const ChallengeDescription = ({
   }, [superBlock]);
 
   const githubLink = generateGithubLink(challengeId, block);
+  const contentLangProps = getChallengeContentLangProps(superBlock);
   return (
     <div
       className={'challenge-instructions mathjax-support'}
       data-playwright-test-label='challenge-description'
       data-github-link={githubLink}
     >
-      {description && <PrismFormatted text={description} />}
+      {description && (
+        <PrismFormatted text={description} {...contentLangProps} />
+      )}
       {instructions && description && <hr />}
-      {instructions && <PrismFormatted text={instructions} />}
+      {instructions && (
+        <PrismFormatted text={instructions} {...contentLangProps} />
+      )}
     </div>
   );
 };

--- a/client/src/templates/Challenges/components/challenge-explanation.tsx
+++ b/client/src/templates/Challenges/components/challenge-explanation.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Spacer } from '@freecodecamp/ui';
+import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import PrismFormatted from './prism-formatted';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 
 import './challenge-explanation.css';
 
 interface ChallengeExplanationProps {
   explanation: string;
+  superBlock: SuperBlocks;
 }
 
 function ChallengeExplanation({
-  explanation
+  explanation,
+  superBlock
 }: ChallengeExplanationProps): JSX.Element {
   const { t } = useTranslation();
 
@@ -21,7 +25,11 @@ function ChallengeExplanation({
           {t('learn.explanation')}
         </summary>
         <Spacer size='m' />
-        <PrismFormatted className={'line-numbers'} text={explanation} />
+        <PrismFormatted
+          className={'line-numbers'}
+          text={explanation}
+          {...getChallengeContentLangProps(superBlock)}
+        />
       </details>
       <Spacer size='m' />
     </>

--- a/client/src/templates/Challenges/components/challenge-transcript.tsx
+++ b/client/src/templates/Challenges/components/challenge-transcript.tsx
@@ -4,18 +4,21 @@ import { Spacer } from '@freecodecamp/ui';
 import store from 'store';
 
 import PrismFormatted from './prism-formatted';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 import './challenge-transcript.css';
 
 interface ChallengeTranscriptProps {
   transcript: string;
   shouldPersistExpanded?: boolean;
   isDialogue?: boolean;
+  superBlock?: string;
 }
 
 function ChallengeTranscript({
   transcript,
   shouldPersistExpanded,
-  isDialogue
+  isDialogue,
+  superBlock
 }: ChallengeTranscriptProps): JSX.Element {
   const { t } = useTranslation();
 
@@ -53,9 +56,14 @@ function ChallengeTranscript({
           <div
             className='transcript-dialogue'
             dangerouslySetInnerHTML={{ __html: transcript }}
+            {...getChallengeContentLangProps(superBlock)}
           />
         ) : (
-          <PrismFormatted className='line-numbers' text={transcript} />
+          <PrismFormatted
+            className='line-numbers'
+            text={transcript}
+            {...getChallengeContentLangProps(superBlock)}
+          />
         )}
       </details>
       <Spacer size='m' />

--- a/client/src/templates/Challenges/components/fill-in-the-blanks.tsx
+++ b/client/src/templates/Challenges/components/fill-in-the-blanks.tsx
@@ -4,6 +4,7 @@ import { Spacer } from '@freecodecamp/ui';
 
 import { parseBlanks, parseAnswer } from '../fill-in-the-blank/parse-blanks';
 import PrismFormatted from '../components/prism-formatted';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 import {
   FillInTheBlankInputType,
   FillInTheBlank
@@ -20,6 +21,7 @@ type FillInTheBlankProps = {
   feedback: string | null;
   showWrong: boolean;
   handleInputChange: (inputIndex: number, value: string) => void;
+  superBlock?: string;
 };
 
 const AnswerText = ({ answer }: { answer: string }) => {
@@ -113,7 +115,8 @@ function FillInTheBlanks({
   showFeedback,
   feedback,
   showWrong,
-  handleInputChange
+  handleInputChange,
+  superBlock
 }: FillInTheBlankProps): JSX.Element {
   const { t } = useTranslation();
 
@@ -142,7 +145,10 @@ function FillInTheBlanks({
       <ChallengeHeading heading={t('learn.fill-in-the-blank.heading')} />
       <Spacer size='xs' />
       <p className='sr-only'>{ariaInputDescription}</p>
-      <div className='fill-in-the-blank-wrap'>
+      <div
+        className='fill-in-the-blank-wrap'
+        {...getChallengeContentLangProps(superBlock)}
+      >
         {paragraphs.map((p, i) => (
           // both keys, i and j, are stable between renders, since
           // the paragraphs are static.
@@ -195,7 +201,12 @@ function FillInTheBlanks({
             <Spacer size='m' />
           </div>
         )}
-        {showFeedback && feedback && <PrismFormatted text={feedback} />}
+        {showFeedback && feedback && (
+          <PrismFormatted
+            text={feedback}
+            {...getChallengeContentLangProps(superBlock)}
+          />
+        )}
       </div>
     </>
   );

--- a/client/src/templates/Challenges/components/multiple-choice-questions.tsx
+++ b/client/src/templates/Challenges/components/multiple-choice-questions.tsx
@@ -9,6 +9,7 @@ import { Question } from '../../../redux/prop-types';
 import { openModal } from '../redux/actions';
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import { initializeMathJax, isMathJaxAllowed } from '../../../utils/math-jax';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 import SpeakingModal from './speaking-modal';
 import ChallengeHeading from './challenge-heading';
 import PrismFormatted from './prism-formatted';
@@ -39,6 +40,7 @@ function MultipleChoiceQuestions({
   superBlock
 }: MultipleChoiceQuestionsProps): JSX.Element {
   const { t } = useTranslation();
+  const contentLangProps = getChallengeContentLangProps(superBlock);
 
   useEffect(() => {
     if (isMathJaxAllowed(superBlock)) {
@@ -85,7 +87,11 @@ function MultipleChoiceQuestions({
       {questions.map((question, questionIndex) => (
         <fieldset key={questionIndex} className='mcq-fieldset'>
           <legend className='mcq-question-text'>
-            <PrismFormatted className={'line-numbers'} text={question.text} />
+            <PrismFormatted
+              className={'line-numbers'}
+              text={question.text}
+              {...contentLangProps}
+            />
           </legend>
           <div className='video-quiz-options'>
             {question.answers.map(({ answer }, answerIndex) => {
@@ -136,6 +142,7 @@ function MultipleChoiceQuestions({
                           text={removeParagraphTags(answer)}
                           useSpan
                           noAria
+                          {...contentLangProps}
                         />
                       </label>
                     </div>
@@ -159,6 +166,7 @@ function MultipleChoiceQuestions({
                               text={removeParagraphTags(feedback)}
                               useSpan
                               noAria
+                              {...contentLangProps}
                             />
                           </p>
                         )}

--- a/client/src/templates/Challenges/components/prism-formatted.tsx
+++ b/client/src/templates/Challenges/components/prism-formatted.tsx
@@ -7,13 +7,17 @@ interface PrismFormattedProps {
   text: string;
   useSpan?: boolean;
   noAria?: boolean;
+  dir?: 'auto' | 'ltr' | 'rtl';
+  lang?: string;
 }
 
 function PrismFormatted({
   className,
   text,
   useSpan,
-  noAria
+  noAria,
+  dir,
+  lang
 }: PrismFormattedProps): JSX.Element {
   const instructionsRef = useRef<HTMLDivElement>(null);
   const ElementName = useSpan ? 'span' : 'div';
@@ -43,6 +47,8 @@ function PrismFormatted({
     <ElementName
       className={className}
       dangerouslySetInnerHTML={{ __html: text }}
+      dir={dir}
+      lang={lang}
       ref={instructionsRef}
     />
   );

--- a/client/src/templates/Challenges/components/scene/scene.css
+++ b/client/src/templates/Challenges/components/scene/scene.css
@@ -51,6 +51,11 @@
   max-height: 60px;
 }
 
+/* Transport controls track time, not text, so they keep their LTR order. */
+[dir='rtl'] .scene-controls {
+  flex-direction: row-reverse;
+}
+
 .scene-btn,
 .scene-btn:hover,
 .scene-btn:focus,

--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -31,10 +31,12 @@ const initDialogue = { label: '', text: '', align: 'left' };
 
 export function Scene({
   scene,
-  sceneSubject
+  sceneSubject,
+  superBlock
 }: {
   scene: FullScene;
   sceneSubject: SceneSubject;
+  superBlock?: string;
 }): JSX.Element {
   const { t } = useTranslation();
   const canPauseRef = useRef(false);
@@ -437,7 +439,11 @@ export function Scene({
           </button>
         )}
       </div>
-      <ChallengeTranscript transcript={transcriptText} isDialogue={true} />
+      <ChallengeTranscript
+        transcript={transcriptText}
+        isDialogue={true}
+        superBlock={superBlock}
+      />
       <Spacer size='m' />
     </Col>
   );

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -26,6 +26,7 @@ import HelpModal from '../components/help-modal';
 import FillInTheBlanks from '../components/fill-in-the-blanks';
 import ChallengeTranscript from '../components/challenge-transcript';
 import PrismFormatted from '../components/prism-formatted';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 import {
   challengeMounted,
   updateChallengeMeta,
@@ -277,23 +278,36 @@ const ShowFillInTheBlank = ({
             </ChallengeTitle>
 
             <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
-              <PrismFormatted text={description} />
+              <PrismFormatted
+                text={description}
+                {...getChallengeContentLangProps(superBlock)}
+              />
               <Spacer size='m' />
             </Col>
 
-            {scene && <Scene scene={scene} sceneSubject={sceneSubject} />}
+            {scene && (
+              <Scene
+                scene={scene}
+                sceneSubject={sceneSubject}
+                superBlock={superBlock}
+              />
+            )}
 
             <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
               {transcript && (
                 <ChallengeTranscript
                   transcript={transcript}
                   isDialogue={true}
+                  superBlock={superBlock}
                 />
               )}
 
               {instructions && (
                 <>
-                  <PrismFormatted text={instructions} />
+                  <PrismFormatted
+                    text={instructions}
+                    {...getChallengeContentLangProps(superBlock)}
+                  />
                   <Spacer size='xs' />
                 </>
               )}
@@ -309,11 +323,15 @@ const ShowFillInTheBlank = ({
                   feedback={feedback}
                   showWrong={showWrong}
                   handleInputChange={handleInputChange}
+                  superBlock={superBlock}
                 />
               </ObserveKeys>
 
               {explanation ? (
-                <ChallegeExplanation explanation={explanation} />
+                <ChallegeExplanation
+                  explanation={explanation}
+                  superBlock={superBlock}
+                />
               ) : (
                 <Spacer size='m' />
               )}

--- a/client/src/templates/Challenges/generic/show.tsx
+++ b/client/src/templates/Challenges/generic/show.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { Container, Col, Row, Spacer } from '@freecodecamp/ui';
 import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
+import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
 import { isEqual } from 'lodash';
 import store from 'store';
 import { ObserveKeys } from 'react-hotkeys';
@@ -31,6 +32,7 @@ import {
 } from '../redux/actions';
 import { isChallengeCompletedSelector } from '../redux/selectors';
 import { getChallengePaths } from '../utils/challenge-paths';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 import Scene from '../components/scene/scene';
 import MultipleChoiceQuestions from '../components/multiple-choice-questions';
 import ChallengeExplanation from '../components/challenge-explanation';
@@ -77,13 +79,17 @@ interface ShowQuizProps {
 
 function renderNodule(
   nodule: ChallengeNode['challenge']['nodules'][number],
-  showInteractiveEditor: boolean
+  showInteractiveEditor: boolean,
+  superBlock: SuperBlocks
 ) {
   switch (nodule.type) {
     case 'paragraph':
       return (
         <Col xs={12} md={10} mdOffset={1} lg={8} lgOffset={2}>
-          <PrismFormatted text={nodule.contents} />
+          <PrismFormatted
+            text={nodule.contents}
+            {...getChallengeContentLangProps(superBlock)}
+          />
         </Col>
       );
     case 'interactiveEditor':
@@ -309,7 +315,7 @@ const ShowGeneric = ({
       {nodules?.map((nodule, i) => {
         return (
           <React.Fragment key={i}>
-            {renderNodule(nodule, showInteractiveEditor)}
+            {renderNodule(nodule, showInteractiveEditor, superBlock)}
           </React.Fragment>
         );
       })}
@@ -330,10 +336,21 @@ const ShowGeneric = ({
         )}
       </Col>
 
-      {scene && <Scene scene={scene} sceneSubject={sceneSubject} />}
+      {scene && (
+        <Scene
+          scene={scene}
+          sceneSubject={sceneSubject}
+          superBlock={superBlock}
+        />
+      )}
 
       <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
-        {transcript && <ChallengeTranscript transcript={transcript} />}
+        {transcript && (
+          <ChallengeTranscript
+            transcript={transcript}
+            superBlock={superBlock}
+          />
+        )}
 
         {instructions && (
           <>
@@ -353,6 +370,7 @@ const ShowGeneric = ({
               assignments={assignments}
               allAssignmentsCompleted={allAssignmentsCompleted}
               handleAssignmentChange={handleAssignmentChange}
+              superBlock={superBlock}
             />
           </ObserveKeys>
         )}
@@ -371,7 +389,10 @@ const ShowGeneric = ({
         )}
 
         {explanation ? (
-          <ChallengeExplanation explanation={explanation} />
+          <ChallengeExplanation
+            explanation={explanation}
+            superBlock={superBlock}
+          />
         ) : null}
 
         {!hasAnsweredMcqCorrectly && (

--- a/client/src/templates/Challenges/quiz/show.tsx
+++ b/client/src/templates/Challenges/quiz/show.tsx
@@ -36,6 +36,7 @@ import {
 } from '../redux/actions';
 import { isChallengeCompletedSelector } from '../redux/selectors';
 import PrismFormatted from '../components/prism-formatted';
+import { getChallengeContentLangProps } from '../../../utils/challenge-content-lang';
 import { usePageLeave } from '../hooks';
 import { sounds } from '../components/scene/scene-assets';
 import ExitQuizModal from './exit-quiz-modal';
@@ -140,6 +141,8 @@ const ShowQuiz = ({
   const [quizId] = useState(Math.floor(Math.random() * quizzes.length));
   const quiz = quizzes[quizId].questions;
 
+  const contentLangProps = getChallengeContentLangProps(superBlock);
+
   // Initialize the data passed to `useQuiz`
   const [initialQuizData] = useState(
     quiz.map(question => {
@@ -151,6 +154,7 @@ const ShowQuiz = ({
               text={removeParagraphTags(distractor)}
               useSpan
               noAria
+              {...contentLangProps}
             />
           ),
           value: index + 1
@@ -164,6 +168,7 @@ const ShowQuiz = ({
             text={removeParagraphTags(question.answer)}
             useSpan
             noAria
+            {...contentLangProps}
           />
         ),
         value: 4
@@ -191,6 +196,7 @@ const ShowQuiz = ({
           <PrismFormatted
             className='quiz-question-label'
             text={question.text}
+            {...contentLangProps}
           />
         ),
         answers: allAnswers,

--- a/client/src/templates/Challenges/video.css
+++ b/client/src/templates/Challenges/video.css
@@ -152,6 +152,12 @@ input:focus-visible + .video-quiz-input-visible {
   flex: 1;
 }
 
+/* LTR answers sit at the far edge; the radio stays at the inline-start. Must be
+   physical: dir='auto' resolves these to LTR, so a logical margin would flip. */
+[dir='rtl'] .mcq-option-label .video-quiz-option[dir='auto'] {
+  margin-right: auto;
+}
+
 .mcq-correct {
   color: var(--success-color);
   border-left-color: var(--success-background);

--- a/client/src/templates/Challenges/video.css
+++ b/client/src/templates/Challenges/video.css
@@ -118,6 +118,11 @@ input:focus-visible + .video-quiz-input-visible {
   border-bottom: 2px solid var(--tertiary-background);
 }
 
+/* Without a speaking button the second column collapses, but its gap survives. */
+.mcq-option-row:not(:has(.mcq-speaking-button-wrapper)) {
+  column-gap: 0;
+}
+
 .mcq-option-row:first-child {
   border-top: 4px solid var(--tertiary-background);
 }

--- a/client/src/utils/challenge-content-lang.ts
+++ b/client/src/utils/challenge-content-lang.ts
@@ -1,0 +1,26 @@
+import {
+  SuperBlocks,
+  languageSuperBlocks,
+  superBlockToSpeechLang
+} from '@freecodecamp/shared/config/curriculum';
+
+interface ChallengeContentLangProps {
+  dir?: 'auto';
+  lang?: string;
+}
+
+/**
+ * Direction props for content written in the language a curriculum teaches,
+ * which need not match the UI. Bidi-neutral punctuation otherwise takes the
+ * page direction and lands on the wrong end of the sentence.
+ */
+export function getChallengeContentLangProps(
+  superBlock?: SuperBlocks | string
+): ChallengeContentLangProps {
+  const languageSuperBlock = languageSuperBlocks.find(
+    slug => slug === superBlock
+  );
+  if (!languageSuperBlock) return {};
+
+  return { dir: 'auto', lang: superBlockToSpeechLang[languageSuperBlock] };
+}


### PR DESCRIPTION
Passes props to selectively apply  LTR styling to RTL parent elements. This is particularly helpful when we have nested element with different languages such as English Certifications in Arabic UI.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

rel https://github.com/freeCodeCamp/freeCodeCamp/issues/67661
