### PR TITLE
refactor(curriculum): replace regex tests with Explorer helpers and behavioural tests in workshop-todo-app

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e4c4ec263b62ae7bf54d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e4c4ec263b62ae7bf54d.md
@@ -19,7 +19,9 @@ Begin by accessing the `task-form`, `confirm-close-dialog`, and `open-task-form-
 You should declare a `const` variable named `taskForm`.
 
 ```js
-assert.match(code, /const\s+taskForm\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { taskForm } = explorer.variables;
+assert.isTrue(taskForm.toString().startsWith('const'));
 ```
 
 Your `taskForm` variable should reference the `task-form` element.
@@ -31,7 +33,9 @@ assert.strictEqual(taskForm, document.getElementById('task-form'));
 You should declare a `const` variable named `confirmCloseDialog`.
 
 ```js
-assert.match(code, /const\s+confirmCloseDialog\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { confirmCloseDialog } = explorer.variables;
+assert.isTrue(confirmCloseDialog.toString().startsWith('const'));
 ```
 
 Your `confirmCloseDialog` variable should reference the `confirm-close-dialog` element.
@@ -43,7 +47,9 @@ assert.strictEqual(confirmCloseDialog, document.getElementById('confirm-close-di
 You should declare a `const` variable named `openTaskFormBtn`.
 
 ```js
-assert.match(code, /const\s+openTaskFormBtn\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { openTaskFormBtn } = explorer.variables;
+assert.isTrue(openTaskFormBtn.toString().startsWith('const'));
 ```
 
 Your `openTaskFormBtn` variable should reference the `open-task-form-btn` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e4c4ec263b62ae7bf54d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e4c4ec263b62ae7bf54d.md
@@ -21,7 +21,7 @@ You should declare a `const` variable named `taskForm`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { taskForm } = explorer.variables;
-assert.isTrue(taskForm.toString().startsWith('const'));
+assert.isTrue(taskForm?.toString()?.startsWith('const'));
 ```
 
 Your `taskForm` variable should reference the `task-form` element.
@@ -35,7 +35,7 @@ You should declare a `const` variable named `confirmCloseDialog`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { confirmCloseDialog } = explorer.variables;
-assert.isTrue(confirmCloseDialog.toString().startsWith('const'));
+assert.isTrue(confirmCloseDialog?.toString()?.startsWith('const'));
 ```
 
 Your `confirmCloseDialog` variable should reference the `confirm-close-dialog` element.
@@ -49,7 +49,7 @@ You should declare a `const` variable named `openTaskFormBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { openTaskFormBtn } = explorer.variables;
-assert.isTrue(openTaskFormBtn.toString().startsWith('const'));
+assert.isTrue(openTaskFormBtn?.toString()?.startsWith('const'));
 ```
 
 Your `openTaskFormBtn` variable should reference the `open-task-form-btn` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e4c4ec263b62ae7bf54d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e4c4ec263b62ae7bf54d.md
@@ -21,7 +21,7 @@ You should declare a `const` variable named `taskForm`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { taskForm } = explorer.variables;
-assert.isTrue(taskForm?.toString()?.startsWith('const'));
+assert.isTrue(taskForm?.toString().startsWith('const'));
 ```
 
 Your `taskForm` variable should reference the `task-form` element.
@@ -35,7 +35,7 @@ You should declare a `const` variable named `confirmCloseDialog`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { confirmCloseDialog } = explorer.variables;
-assert.isTrue(confirmCloseDialog?.toString()?.startsWith('const'));
+assert.isTrue(confirmCloseDialog?.toString().startsWith('const'));
 ```
 
 Your `confirmCloseDialog` variable should reference the `confirm-close-dialog` element.
@@ -49,7 +49,7 @@ You should declare a `const` variable named `openTaskFormBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { openTaskFormBtn } = explorer.variables;
-assert.isTrue(openTaskFormBtn?.toString()?.startsWith('const'));
+assert.isTrue(openTaskFormBtn?.toString().startsWith('const'));
 ```
 
 Your `openTaskFormBtn` variable should reference the `open-task-form-btn` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
@@ -14,7 +14,9 @@ You need to access more elements with the `getElementById()` method. This time y
 You should declare a `const` variable named `closeTaskFormBtn`.
 
 ```js
-assert.match(code, /const\s+closeTaskFormBtn\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { closeTaskFormBtn } = explorer.variables;
+assert.isTrue(closeTaskFormBtn.toString().startsWith('const'));
 ```
 
 Your `closeTaskFormBtn` variable should reference the `close-task-form-btn` element.
@@ -26,7 +28,9 @@ assert.strictEqual(closeTaskFormBtn, document.getElementById('close-task-form-bt
 You should declare a `const` variable named `addOrUpdateTaskBtn`.
 
 ```js
-assert.match(code, /const\s+addOrUpdateTaskBtn\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { addOrUpdateTaskBtn } = explorer.variables;
+assert.isTrue(addOrUpdateTaskBtn.toString().startsWith('const'));
 ```
 
 Your `addOrUpdateTaskBtn` variable should reference the `add-or-update-task-btn` element.
@@ -38,7 +42,9 @@ assert.strictEqual(addOrUpdateTaskBtn, document.getElementById('add-or-update-ta
 You should declare a `const` variable named `cancelBtn`.
 
 ```js
-assert.match(code, /const\s+cancelBtn\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { cancelBtn } = explorer.variables;
+assert.isTrue(cancelBtn.toString().startsWith('const'));
 ```
 
 Your `cancelBtn` variable should reference the `cancel-btn` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
@@ -16,7 +16,7 @@ You should declare a `const` variable named `closeTaskFormBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { closeTaskFormBtn } = explorer.variables;
-assert.isTrue(closeTaskFormBtn.toString().startsWith('const'));
+assert.isTrue(closeTaskFormBtn?.toString()?.startsWith('const'));
 ```
 
 Your `closeTaskFormBtn` variable should reference the `close-task-form-btn` element.
@@ -30,7 +30,7 @@ You should declare a `const` variable named `addOrUpdateTaskBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { addOrUpdateTaskBtn } = explorer.variables;
-assert.isTrue(addOrUpdateTaskBtn.toString().startsWith('const'));
+assert.isTrue(addOrUpdateTaskBtn?.toString()?.startsWith('const'));
 ```
 
 Your `addOrUpdateTaskBtn` variable should reference the `add-or-update-task-btn` element.
@@ -44,7 +44,7 @@ You should declare a `const` variable named `cancelBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { cancelBtn } = explorer.variables;
-assert.isTrue(cancelBtn.toString().startsWith('const'));
+assert.isTrue(cancelBtn?.toString()?.startsWith('const'));
 ```
 
 Your `cancelBtn` variable should reference the `cancel-btn` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6c86954de67a3e44ee3.md
@@ -16,7 +16,7 @@ You should declare a `const` variable named `closeTaskFormBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { closeTaskFormBtn } = explorer.variables;
-assert.isTrue(closeTaskFormBtn?.toString()?.startsWith('const'));
+assert.isTrue(closeTaskFormBtn?.toString().startsWith('const'));
 ```
 
 Your `closeTaskFormBtn` variable should reference the `close-task-form-btn` element.
@@ -30,7 +30,7 @@ You should declare a `const` variable named `addOrUpdateTaskBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { addOrUpdateTaskBtn } = explorer.variables;
-assert.isTrue(addOrUpdateTaskBtn?.toString()?.startsWith('const'));
+assert.isTrue(addOrUpdateTaskBtn?.toString().startsWith('const'));
 ```
 
 Your `addOrUpdateTaskBtn` variable should reference the `add-or-update-task-btn` element.
@@ -44,7 +44,7 @@ You should declare a `const` variable named `cancelBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { cancelBtn } = explorer.variables;
-assert.isTrue(cancelBtn?.toString()?.startsWith('const'));
+assert.isTrue(cancelBtn?.toString().startsWith('const'));
 ```
 
 Your `cancelBtn` variable should reference the `cancel-btn` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
@@ -16,7 +16,7 @@ You should declare a `const` variable named `discardBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { discardBtn } = explorer.variables;
-assert.isTrue(discardBtn.toString().startsWith('const'));
+assert.isTrue(discardBtn?.toString()?.startsWith('const'));
 ```
 
 Your `discardBtn` variable should reference the `discard-btn` element.
@@ -30,7 +30,7 @@ You should declare a `const` variable named `tasksContainer`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { tasksContainer } = explorer.variables;
-assert.isTrue(tasksContainer.toString().startsWith('const'));
+assert.isTrue(tasksContainer?.toString()?.startsWith('const'));
 ```
 
 Your `tasksContainer` variable should reference the `tasks-container` element.
@@ -44,7 +44,7 @@ You should declare a `const` variable named `titleInput`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { titleInput } = explorer.variables;
-assert.isTrue(titleInput.toString().startsWith('const'));
+assert.isTrue(titleInput?.toString()?.startsWith('const'));
 ```
 
 Your `titleInput` variable should reference the `title-input` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
@@ -16,7 +16,7 @@ You should declare a `const` variable named `discardBtn`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { discardBtn } = explorer.variables;
-assert.isTrue(discardBtn?.toString()?.startsWith('const'));
+assert.isTrue(discardBtn?.toString().startsWith('const'));
 ```
 
 Your `discardBtn` variable should reference the `discard-btn` element.
@@ -30,7 +30,7 @@ You should declare a `const` variable named `tasksContainer`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { tasksContainer } = explorer.variables;
-assert.isTrue(tasksContainer?.toString()?.startsWith('const'));
+assert.isTrue(tasksContainer?.toString().startsWith('const'));
 ```
 
 Your `tasksContainer` variable should reference the `tasks-container` element.
@@ -44,7 +44,7 @@ You should declare a `const` variable named `titleInput`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { titleInput } = explorer.variables;
-assert.isTrue(titleInput?.toString()?.startsWith('const'));
+assert.isTrue(titleInput?.toString().startsWith('const'));
 ```
 
 Your `titleInput` variable should reference the `title-input` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e6fe78b5aa67ef2fc3e7.md
@@ -14,7 +14,9 @@ Next, access the `discard-btn`, `tasks-container`, and `title-input` elements us
 You should declare a `const` variable named `discardBtn`.
 
 ```js
-assert.match(code, /const\s+discardBtn\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { discardBtn } = explorer.variables;
+assert.isTrue(discardBtn.toString().startsWith('const'));
 ```
 
 Your `discardBtn` variable should reference the `discard-btn` element.
@@ -26,7 +28,9 @@ assert.strictEqual(discardBtn, document.getElementById('discard-btn'));
 You should declare a `const` variable named `tasksContainer`.
 
 ```js
-assert.match(code, /const\s+tasksContainer\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { tasksContainer } = explorer.variables;
+assert.isTrue(tasksContainer.toString().startsWith('const'));
 ```
 
 Your `tasksContainer` variable should reference the `tasks-container` element.
@@ -38,7 +42,9 @@ assert.strictEqual(tasksContainer, document.getElementById('tasks-container'));
 You should declare a `const` variable named `titleInput`.
 
 ```js
-assert.match(code, /const\s+titleInput\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { titleInput } = explorer.variables;
+assert.isTrue(titleInput.toString().startsWith('const'));
 ```
 
 Your `titleInput` variable should reference the `title-input` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
@@ -16,7 +16,7 @@ You should declare a `const` variable named `dateInput`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { dateInput } = explorer.variables;
-assert.isTrue(dateInput?.toString()?.startsWith('const'));
+assert.isTrue(dateInput?.toString().startsWith('const'));
 ```
 
 Your `dateInput` variable should reference the `date-input` element.
@@ -30,7 +30,7 @@ You should declare a `const` variable named `descriptionInput`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { descriptionInput } = explorer.variables;
-assert.isTrue(descriptionInput?.toString()?.startsWith('const'));
+assert.isTrue(descriptionInput?.toString().startsWith('const'));
 ```
 
 Your `descriptionInput` variable should reference the `description-input` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
@@ -14,7 +14,9 @@ The last set of elements you need to get from the HTML file are the `date-input`
 You should declare a `const` variable named `dateInput`.
 
 ```js
-assert.match(code, /const\s+dateInput\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { dateInput } = explorer.variables;
+assert.isTrue(dateInput.toString().startsWith('const'));
 ```
 
 Your `dateInput` variable should reference the `date-input` element.
@@ -26,7 +28,9 @@ assert.strictEqual(dateInput, document.getElementById('date-input'));
 You should declare a `const` variable named `descriptionInput`.
 
 ```js
-assert.match(code, /const\s+descriptionInput\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { descriptionInput } = explorer.variables;
+assert.isTrue(descriptionInput.toString().startsWith('const'));
 ```
 
 Your `descriptionInput` variable should reference the `description-input` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e7241f52bb682eeb8211.md
@@ -16,7 +16,7 @@ You should declare a `const` variable named `dateInput`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { dateInput } = explorer.variables;
-assert.isTrue(dateInput.toString().startsWith('const'));
+assert.isTrue(dateInput?.toString()?.startsWith('const'));
 ```
 
 Your `dateInput` variable should reference the `date-input` element.
@@ -30,7 +30,7 @@ You should declare a `const` variable named `descriptionInput`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { descriptionInput } = explorer.variables;
-assert.isTrue(descriptionInput.toString().startsWith('const'));
+assert.isTrue(descriptionInput?.toString()?.startsWith('const'));
 ```
 
 Your `descriptionInput` variable should reference the `description-input` element.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e74d0fb4f0687bf4145d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e74d0fb4f0687bf4145d.md
@@ -18,7 +18,7 @@ You should have a `const` variable called `taskData`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { taskData } = explorer.variables;
-assert.isTrue(taskData?.toString()?.startsWith('const'));
+assert.isTrue(taskData?.toString().startsWith('const'));
 ```
 
 You should assign an array to your `taskData` constant.
@@ -38,7 +38,7 @@ You should use `let` to create a `currentTask` variable.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { currentTask } = explorer.variables;
-assert.isTrue(currentTask?.toString()?.startsWith('let'));
+assert.isTrue(currentTask?.toString().startsWith('let'));
 ```
 
 You should assign an object to your `currentTask` variable.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e74d0fb4f0687bf4145d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e74d0fb4f0687bf4145d.md
@@ -18,7 +18,7 @@ You should have a `const` variable called `taskData`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { taskData } = explorer.variables;
-assert.isTrue(taskData.toString().startsWith('const'));
+assert.isTrue(taskData?.toString()?.startsWith('const'));
 ```
 
 You should assign an array to your `taskData` constant.
@@ -38,7 +38,7 @@ You should use `let` to create a `currentTask` variable.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { currentTask } = explorer.variables;
-assert.isTrue(currentTask.toString().startsWith('let'));
+assert.isTrue(currentTask?.toString()?.startsWith('let'));
 ```
 
 You should assign an object to your `currentTask` variable.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64e4e74d0fb4f0687bf4145d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64e4e74d0fb4f0687bf4145d.md
@@ -16,7 +16,9 @@ Use `let` to create a `currentTask` variable and set it to an empty object. This
 You should have a `const` variable called `taskData`.
 
 ```js
-assert.match(code, /const\s+taskData\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { taskData } = explorer.variables;
+assert.isTrue(taskData.toString().startsWith('const'));
 ```
 
 You should assign an array to your `taskData` constant.
@@ -34,7 +36,9 @@ assert.isEmpty(taskData);
 You should use `let` to create a `currentTask` variable.
 
 ```js
-assert.match(code, /let\s+currentTask/);
+const explorer = await __helpers.Explorer(code);
+const { currentTask } = explorer.variables;
+assert.isTrue(currentTask.toString().startsWith('let'));
 ```
 
 You should assign an object to your `currentTask` variable.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ec9c55fdeef78bacd2fc3b.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ec9c55fdeef78bacd2fc3b.md
@@ -18,13 +18,19 @@ Use arrow syntax to create a `reset` function and set it to a pair of curly brac
 You should use `const` and arrow syntax to create a `reset` function.
 
 ```js
-assert.match(code, /const\s+reset\s*=\s*\(\s*\)\s*=>\s*\{\s*/)
+const explorer = await __helpers.Explorer(code);
+const { reset } = explorer.variables;
+assert.exists(explorer.allFunctions.reset);
+assert.isTrue(reset?.toString().startsWith('const'));
+assert.isFalse(reset?.value.toString().startsWith('function'));
 ```
 
 Your `reset` function should be empty.
 
 ```js
-assert.match(reset.toString(), /\(\s*\)\s*=>\s*\{\s*\}/);
+const explorer = await __helpers.Explorer(code);
+const { reset } = explorer.allFunctions;
+assert.isTrue(reset?.matches("const reset = () => {}"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -20,7 +20,9 @@ assert.match(code, /const\s+deleteTask\s*=\s*(\(.*\)|[^\s()]+)\s*=>\s*/);
 Your `deleteTask` function should take a `buttonEl` parameter.
 
 ```js
-const explorer = await __helpers.Explorer(code);
+const { deleteTask } = explorer.allFunctions;
+assert.lengthOf(deleteTask?.parameters, 1);
+assert.equal(deleteTask?.parameters[0].toString(), "buttonEl");
 const { deleteTask } = explorer.allFunctions;
 const parameters = deleteTask?.parameters;
 assert.equal(parameters?.[0]?.toString(), "buttonEl");

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -21,8 +21,9 @@ Your `deleteTask` function should take a `buttonEl` parameter.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const parameters = explorer.allFunctions.deleteTask.parameters;
-assert.equal(parameters[0]?.toString(), "buttonEl");
+const { deleteTask } = explorer.allFunctions;
+const parameters = deleteTask?.parameters;
+assert.equal(parameters?.[0]?.toString(), "buttonEl");
 ```
 
 Your `deleteTask` function should be empty.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -20,11 +20,10 @@ assert.match(code, /const\s+deleteTask\s*=\s*(\(.*\)|[^\s()]+)\s*=>\s*/);
 Your `deleteTask` function should take a `buttonEl` parameter.
 
 ```js
-const { deleteTask } = explorer.allFunctions;
-assert.lengthOf(deleteTask?.parameters, 1);
-assert.equal(deleteTask?.parameters[0].toString(), "buttonEl");
+const explorer = await __helpers.Explorer(code);
 const { deleteTask } = explorer.allFunctions;
 const parameters = deleteTask?.parameters;
+assert.lengthOf(parameters, 1);
 assert.equal(parameters?.[0]?.toString(), "buttonEl");
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -20,7 +20,9 @@ assert.match(code, /const\s+deleteTask\s*=\s*(\(.*\)|[^\s()]+)\s*=>\s*/);
 Your `deleteTask` function should take a `buttonEl` parameter.
 
 ```js
-assert.match(deleteTask.toString(), /\(?\s*buttonEl\s*\)?/);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.deleteTask.parameters;
+assert.equal(parameters[0]?.toString(), "buttonEl");
 ```
 
 Your `deleteTask` function should be empty.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -28,7 +28,7 @@ const explorer = await __helpers.Explorer(code);
 const { deleteTask } = explorer.allFunctions;
 const parameters = deleteTask?.parameters;
 assert.lengthOf(parameters, 1);
-assert.equal(parameters?.[0]?.toString(), "buttonEl");
+assert.equal(parameters[0].toString(), "buttonEl");
 ```
 
 Your `deleteTask` function should be empty.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faedcd16a1e985c4c2dc94.md
@@ -14,7 +14,11 @@ Create a `deleteTask` function using arrow syntax. Pass `buttonEl` as the parame
 You should use `const` and arrow syntax to create a `deleteTask` function.
 
 ```js
-assert.match(code, /const\s+deleteTask\s*=\s*(\(.*\)|[^\s()]+)\s*=>\s*/);
+const explorer = await __helpers.Explorer(code);
+const { deleteTask } = explorer.variables;
+assert.exists(explorer.allFunctions.deleteTask);
+assert.isTrue(deleteTask?.toString().startsWith('const'));
+assert.isFalse(deleteTask?.value.toString().startsWith('function'));
 ```
 
 Your `deleteTask` function should take a `buttonEl` parameter.
@@ -30,7 +34,13 @@ assert.equal(parameters?.[0]?.toString(), "buttonEl");
 Your `deleteTask` function should be empty.
 
 ```js
-assert.match(deleteTask.toString(), /(?:\(\s*buttonEl\s*\)\s*\{\s*\}|\(?\s*buttonEl\s*\)?\s*=>\s*\{\s*\})/);
+const validExpressions = [
+  "const deleteTask = (buttonEl) => {}",
+  "const deleteTask = buttonEl => {}"
+];
+const explorer = await __helpers.Explorer(code);
+const { deleteTask } = explorer.allFunctions;
+assert.isTrue(validExpressions.some(expression => deleteTask?.matches(expression)));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
@@ -16,7 +16,13 @@ Create a `dataArrIndex` variable and set its value using the `findIndex()` metho
 You should not alter the `deleteTask` function signature.
 
 ```js
-assert.match(code, /const\s+deleteTask\s*=\s*\(\s*buttonEl\s*\)\s*=>/)
+const explorer = await __helpers.Explorer(code);
+const { deleteTask } = explorer.variables;
+const parameters = explorer.allFunctions.deleteTask?.parameters;
+assert.isTrue(deleteTask?.toString().startsWith('const'));
+assert.isFalse(deleteTask?.value.toString().startsWith('function'));
+assert.lengthOf(parameters, 1);
+assert.equal(parameters?.[0]?.toString(), "buttonEl");
 ```
 
 Your `deleteTask` function should use `taskData.findIndex()` to find the task index.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64faf65b22ad8d07df9be14d.md
@@ -22,7 +22,7 @@ const parameters = explorer.allFunctions.deleteTask?.parameters;
 assert.isTrue(deleteTask?.toString().startsWith('const'));
 assert.isFalse(deleteTask?.value.toString().startsWith('function'));
 assert.lengthOf(parameters, 1);
-assert.equal(parameters?.[0]?.toString(), "buttonEl");
+assert.equal(parameters[0].toString(), "buttonEl");
 ```
 
 Your `deleteTask` function should use `taskData.findIndex()` to find the task index.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
@@ -23,6 +23,7 @@ Your `editTask` function should take a `buttonEl` parameter.
 const explorer = await __helpers.Explorer(code);
 const { editTask } = explorer.allFunctions;
 const parameters = editTask?.parameters;
+assert.lengthOf(parameters, 1);
 assert.equal(parameters?.[0]?.toString(), "buttonEl");
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
@@ -20,7 +20,9 @@ assert.match(code, /const\s+editTask\s*=\s*(\(.*\)|[^\s()]+)\s*=>\s*\{\s*/)
 Your `editTask` function should take a `buttonEl` parameter.
 
 ```js
-assert.match(editTask.toString(), /\(?\s*buttonEl\s*\)?/);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.editTask.parameters;
+assert.equal(parameters[0]?.toString(), "buttonEl");
 ```
 
 Your `editTask` function should be empty.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
@@ -21,8 +21,9 @@ Your `editTask` function should take a `buttonEl` parameter.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const parameters = explorer.allFunctions.editTask.parameters;
-assert.equal(parameters[0]?.toString(), "buttonEl");
+const { editTask } = explorer.allFunctions;
+const parameters = editTask?.parameters;
+assert.equal(parameters?.[0]?.toString(), "buttonEl");
 ```
 
 Your `editTask` function should be empty.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
@@ -28,7 +28,7 @@ const explorer = await __helpers.Explorer(code);
 const { editTask } = explorer.allFunctions;
 const parameters = editTask?.parameters;
 assert.lengthOf(parameters, 1);
-assert.equal(parameters?.[0]?.toString(), "buttonEl");
+assert.equal(parameters[0].toString(), "buttonEl");
 ```
 
 Your `editTask` function should be empty.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fafac95328110a69bcb75f.md
@@ -14,7 +14,11 @@ Use arrow syntax to create an `editTask` function. Pass in `buttonEl` as the par
 You should use `const` and arrow syntax to create an `editTask` function.
 
 ```js
-assert.match(code, /const\s+editTask\s*=\s*(\(.*\)|[^\s()]+)\s*=>\s*\{\s*/)
+const explorer = await __helpers.Explorer(code);
+const { editTask } = explorer.variables;
+assert.exists(explorer.allFunctions.editTask);
+assert.isTrue(editTask?.toString().startsWith('const'));
+assert.isFalse(editTask?.value.toString().startsWith('function'));
 ```
 
 Your `editTask` function should take a `buttonEl` parameter.
@@ -30,7 +34,13 @@ assert.equal(parameters?.[0]?.toString(), "buttonEl");
 Your `editTask` function should be empty.
 
 ```js
-assert.match(editTask.toString(), /(?:\(\s*buttonEl\s*\)\s*\{\s*\}|\(?\s*buttonEl\s*\)?\s*=>\s*\{\s*\})/);
+const validExpressions = [
+  "const editTask = (buttonEl) => {}",
+  "const editTask = buttonEl => {}"
+];
+const explorer = await __helpers.Explorer(code);
+const { editTask } = explorer.allFunctions;
+assert.isTrue(validExpressions.some(expression => editTask?.matches(expression)));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
@@ -22,7 +22,7 @@ const parameters = explorer.allFunctions.editTask?.parameters;
 assert.isTrue(editTask?.toString().startsWith('const'));
 assert.isFalse(editTask?.value.toString().startsWith('function'));
 assert.lengthOf(parameters, 1);
-assert.equal(parameters?.[0]?.toString(), "buttonEl");
+assert.equal(parameters[0].toString(), "buttonEl");
 ```
 
 Your `editTask` function should use `taskData.findIndex()` to find the task index.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb0fa0968f2b113b2d90e9.md
@@ -16,7 +16,13 @@ Create a `dataArrIndex` variable. For its value, utilize the `findIndex()` metho
 You should not alter the `editTask` function signature.
 
 ```js
-assert.match(code, /const\s+editTask\s*=\s*\(\s*buttonEl\s*\)\s*=>/)
+const explorer = await __helpers.Explorer(code);
+const { editTask } = explorer.variables;
+const parameters = explorer.allFunctions.editTask?.parameters;
+assert.isTrue(editTask?.toString().startsWith('const'));
+assert.isFalse(editTask?.value.toString().startsWith('function'));
+assert.lengthOf(parameters, 1);
+assert.equal(parameters?.[0]?.toString(), "buttonEl");
 ```
 
 Your `editTask` function should use `taskData.findIndex()` to find the task index.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1c4dc0feb219149a7c7d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1c4dc0feb219149a7c7d.md
@@ -18,9 +18,7 @@ Then, update the `if` condition to also require that `formInputValuesUpdated` is
 You should declare a `formInputValuesUpdated` variable using `const`.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-const { formInputValuesUpdated } = explorer.variables;
-assert.isTrue(formInputValuesUpdated.toString().startsWith('const'));
+assert.match(code, /const\s+formInputValuesUpdated\s*=/)
 ```
 
 When editing a task and the input values match the current task, clicking the close button should not open the confirmation dialog.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb1c4dc0feb219149a7c7d.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb1c4dc0feb219149a7c7d.md
@@ -18,7 +18,9 @@ Then, update the `if` condition to also require that `formInputValuesUpdated` is
 You should declare a `formInputValuesUpdated` variable using `const`.
 
 ```js
-assert.match(code, /const\s+formInputValuesUpdated\s*=/)
+const explorer = await __helpers.Explorer(code);
+const { formInputValuesUpdated } = explorer.variables;
+assert.isTrue(formInputValuesUpdated.toString().startsWith('const'));
 ```
 
 When editing a task and the input values match the current task, clicking the close button should not open the confirmation dialog.

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e2.md
@@ -22,13 +22,13 @@ A `myTaskArr` array has been provided for you. Use the `setItem()` method to sav
 Your `localStorage.setItem()` should have a key of `"data"`.
 
 ```js
-assert.match(code, /localStorage\.setItem\(\s*("|')data\1/)
+assert.isNotNull(localStorage.getItem('data'));
 ```
 
 Your `localStorage.setItem()` should have a value of `myTaskArr`.
 
 ```js
-assert.match(code, /localStorage\.setItem\(\s*("|')data\1\s*,\s*myTaskArr\s*\)\s*;?/)
+assert.strictEqual(localStorage.getItem('data'), String(myTaskArr));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fefebad99209211ec30537.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fefebad99209211ec30537.md
@@ -16,13 +16,13 @@ To fix this, convert `data` to a string before saving it by using `JSON.stringif
 Your `localStorage.setItem()` should have a key of `"data"`.
 
 ```js
-assert.match(code, /localStorage\.setItem\(\s*("|')data\1/)
+assert.isNotNull(localStorage.getItem('data'));
 ```
 
 You should wrap `JSON.stringify()` around `myTaskArr`.
 
 ```js
-assert.match(code, /localStorage\.setItem\(\s*("|')data\1\s*,\s*JSON\.stringify\(\s*myTaskArr\s*\)\s*\)\s*;?/)
+assert.strictEqual(localStorage.getItem('data'), JSON.stringify(myTaskArr));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64ff068e0426eb288874ed79.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64ff068e0426eb288874ed79.md
@@ -16,7 +16,7 @@ Remove the `data` item from local storage and open the console to observe the re
 You should use `localStorage.removeItem()` to remove the `data` item from the browser's local storage.
 
 ```js
-assert.match(code, /localStorage\.removeItem\(\s*('|")data\1\s*\)\s*;?/)
+assert.isNull(localStorage.getItem('data'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-todo-app/650048b0764f9c1b798200e2.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/650048b0764f9c1b798200e2.md
@@ -16,7 +16,9 @@ Set `taskData` to the retrieval of `data` from local storage **or** an empty arr
 `taskData` should be initialised from `localStorage` using `JSON.parse` and `localStorage.getItem("data")`, falling back to an empty array.
 
 ```js
-assert.match(code, /taskData\s*=\s*JSON\.parse\(\s*localStorage\.getItem\(\s*('|")data\1\s*\)\s*\)\s*\|\|\s*\[\s*\]/)
+const explorer = await __helpers.Explorer(code);
+const { taskData } = explorer.variables;
+assert.isTrue(taskData?.value.matches('JSON.parse(localStorage.getItem("data")) || []'));
 ```
 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68723

<!-- Feel free to add any additional description of changes below this line -->
I’ve made the changes to the files wherever I felt Explorer or other robust testing could be used. If I’ve missed any files or made any changes incorrectly, please let me know so I can update them accordingly. I’m relatively new to this, so I’m still getting familiar with everything and figuring things out along the way. 

I have also ran the test's locally .
