### PR TITLE
fix(css-grid): clarify ambiguous quiz questions

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
+++ b/curriculum/challenges/english/blocks/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
@@ -773,11 +773,11 @@ How would you create a grid with 3 equal columns and a `20px` gap between them?
 
 #### --text--
 
-What does `repeat(3, minmax(100px, 1fr))` create?
+What does `grid-template-columns: repeat(3, minmax(100px, 1fr))` create?
 
 #### --distractors--
 
-Three columns that can't shrink below `100px`.
+Three columns that can't grow beyond `100px`.
 
 ---
 
@@ -901,7 +901,7 @@ Offsets it by 2 pixels.
 
 ---
 
-Positions it starting at the second vertical grid line.
+Positions it starting at the second row line.
 
 #### --answer--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

### Description

Clarifies three ambiguous CSS Grid quiz questions by:
- Including the full `grid-template-columns` property in the question.
- Correcting the distractor describing `minmax()`.
- Correcting the grid line terminology from "vertical grid line" to "row line".

Closes #69456

### Testing

- `pnpm test-curriculum-content`
- 1017 test files passed.
- 56012 tests passed.