### PR TITLE
feat(client): add catalog data to external curriculum build

### DIFF
--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -10,9 +10,11 @@ import {
   SuperBlockStage,
   superBlockStages
 } from '@freecodecamp/shared/config/curriculum';
+import { catalog } from '@freecodecamp/shared/config/catalog';
 import {
   superblockSchemaValidator,
-  availableSuperBlocksValidator
+  availableSuperBlocksValidator,
+  catalogValidator
 } from './external-data-schema-v2';
 import {
   type Curriculum,
@@ -20,8 +22,10 @@ import {
   type GeneratedBlockBasedCurriculumProps,
   type GeneratedChapterBasedCurriculumProps,
   type ChapterBasedCurriculumIntros,
+  type CatalogCourse,
   orderedSuperBlockInfo,
   OrderedSuperBlocks,
+  catalogCourses,
   readCurriculumIntros,
   getCurriculumLocale,
   CurriculumIntros
@@ -88,6 +92,79 @@ describe('external curriculum data build', () => {
 
     expect(result.error?.details).toBeUndefined();
     expect(result.error).toBeFalsy();
+  });
+
+  test('the catalog file should have the correct structure and data', async () => {
+    const validateCatalog = catalogValidator();
+    const catalogFile = JSON.parse(
+      await fs.promises.readFile(
+        `${clientStaticPath}/curriculum-data/${VERSION}/catalog.json`,
+        'utf-8'
+      )
+    ) as { catalog: CatalogCourse[] };
+
+    const result = validateCatalog(catalogFile);
+
+    expect(result.error?.details).toBeUndefined();
+    expect(result.error).toBeFalsy();
+
+    expect(catalogFile.catalog).toHaveLength(catalog.length);
+
+    catalogFile.catalog.forEach((course, index) => {
+      const { superBlock, level, hours, topic } = catalog[index];
+
+      expect(course).toEqual({
+        dashedName: superBlock,
+        title: intros[superBlock].title,
+        summary: intros[superBlock].summary,
+        level,
+        hours,
+        topic
+      });
+    });
+  });
+
+  test('every catalog course should have its blocks and challenges generated', () => {
+    catalog.forEach(({ superBlock }) => {
+      const superBlockPath = `${clientStaticPath}/curriculum-data/${VERSION}/${superBlock}.json`;
+
+      expect(fs.existsSync(superBlockPath)).toBe(true);
+
+      const fileContent = JSON.parse(
+        fs.readFileSync(superBlockPath, 'utf-8')
+      ) as Curriculum<GeneratedCurriculumProps>;
+      const superBlockData = fileContent[superBlock];
+
+      const blocks = chapterBasedSuperBlocks.includes(superBlock)
+        ? (
+            superBlockData as GeneratedChapterBasedCurriculumProps
+          ).chapters.flatMap(chapter =>
+            chapter.modules.flatMap(module => module.blocks)
+          )
+        : (superBlockData as GeneratedBlockBasedCurriculumProps).blocks;
+
+      blocks.forEach(block => {
+        const challengeOrder = block.meta.challengeOrder as { id: string }[];
+
+        challengeOrder.forEach(({ id }) => {
+          expect(
+            fs.existsSync(
+              `${clientStaticPath}/curriculum-data/${VERSION}/challenges/${superBlock}/${block.meta.dashedName as string}/${id}.json`
+            )
+          ).toBe(true);
+        });
+      });
+    });
+  });
+
+  test('catalogCourses should use intro argument', () => {
+    const courses = catalogCourses(dummyIntro);
+
+    expect(courses[0]).toMatchObject({
+      dashedName: catalog[0].superBlock,
+      title: dummyIntro[catalog[0].superBlock].title,
+      summary: []
+    });
   });
 
   test('the super block files generated should have the correct schema', async () => {

--- a/client/tools/external-curriculum/build-external-curricula-data-v2.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.ts
@@ -8,6 +8,11 @@ import {
   chapterBasedSuperBlocks
 } from '@freecodecamp/shared/config/curriculum';
 import { availableLangs, Languages } from '@freecodecamp/shared/config/i18n';
+import {
+  catalog,
+  type Levels,
+  type Topic
+} from '@freecodecamp/shared/config/catalog';
 import type { Chapter } from '@freecodecamp/shared/config/chapters';
 import { getSuperblockStructure } from '@freecodecamp/curriculum/file-handler';
 import {
@@ -28,6 +33,7 @@ export type CurriculumIntros =
 type BlockBasedCurriculumIntros = {
   [keyValue in SuperBlocks]: {
     title: string;
+    summary?: string[];
     intro: string[];
     blocks: Record<string, { title: string; intro: string[] }>;
   };
@@ -36,6 +42,7 @@ type BlockBasedCurriculumIntros = {
 export type ChapterBasedCurriculumIntros = {
   [keyValue in SuperBlocks]: {
     title: string;
+    summary?: string[];
     intro: string[];
     chapters: Record<string, string>;
     modules: Record<string, string>;
@@ -113,6 +120,15 @@ export type OrderedSuperBlocks = Record<
   string,
   Array<{ dashedName: SuperBlocks; public: boolean; title: string }>
 >;
+
+export interface CatalogCourse {
+  dashedName: SuperBlocks;
+  title: string;
+  summary: string[];
+  level: Levels;
+  hours: number;
+  topic: Topic;
+}
 
 const ver = 'v2';
 
@@ -319,6 +335,20 @@ export function orderedSuperBlockInfo(
   };
 }
 
+export function catalogCourses(
+  intros: CurriculumIntros = readCurriculumIntros(getCurriculumLocale())
+): CatalogCourse[] {
+  return catalog.map(({ superBlock, level, hours, topic }) => ({
+    dashedName: superBlock,
+    title: intros[superBlock].title,
+    // Not every language has translated summaries yet.
+    summary: intros[superBlock].summary ?? [],
+    level,
+    hours,
+    topic
+  }));
+}
+
 export const superBlockDashedNames = (() => {
   const info = orderedSuperBlockInfo();
   return Object.keys(info).reduce((acc, superBlockStage) => {
@@ -331,6 +361,8 @@ export const superBlockDashedNames = (() => {
   }, [] as SuperBlocks[]);
 })();
 
+export const catalogDashedNames = catalog.map(({ superBlock }) => superBlock);
+
 export function buildExtCurriculumDataV2(
   curriculum: Curriculum<CurriculumProps>
 ): void {
@@ -341,13 +373,18 @@ export function buildExtCurriculumDataV2(
   getSceneAssets();
 
   function parseCurriculumData() {
-    const superBlockKeys = Object.values(SuperBlocks).filter(x =>
-      superBlockDashedNames.includes(x)
+    // Catalog super blocks are deliberately absent from
+    // `available-superblocks.json`, but their block and challenge data still
+    // needs to be written so that consumers of `catalog.json` can reach it.
+    const superBlockKeys = Object.values(SuperBlocks).filter(
+      x => superBlockDashedNames.includes(x) || catalogDashedNames.includes(x)
     );
 
     writeToFile('available-superblocks', {
       superblocks: orderedSuperBlockInfo()
     });
+
+    writeToFile('catalog', { catalog: catalogCourses(intros) });
 
     for (const superBlockKey of superBlockKeys) {
       if (chapterBasedSuperBlocks.includes(superBlockKey)) {

--- a/client/tools/external-curriculum/external-data-schema-v2.ts
+++ b/client/tools/external-curriculum/external-data-schema-v2.ts
@@ -129,9 +129,13 @@ const catalogSchema = Joi.object({
       dashedName: Joi.string().regex(slugRE).required(),
       title: Joi.string().required(),
       summary: Joi.array().items(Joi.string()).required(),
-      level: Joi.valid(...Object.values(Levels)).required(),
+      level: Joi.valid(
+        ...Object.values(Levels as Record<string, string>)
+      ).required(),
       hours: Joi.number().required(),
-      topic: Joi.valid(...Object.values(Topic)).required()
+      topic: Joi.valid(
+        ...Object.values(Topic as Record<string, string>)
+      ).required()
     })
   )
 });

--- a/client/tools/external-curriculum/external-data-schema-v2.ts
+++ b/client/tools/external-curriculum/external-data-schema-v2.ts
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 import { chapterBasedSuperBlocks } from '@freecodecamp/shared/config/curriculum';
+import { Levels, Topic } from '@freecodecamp/shared/config/catalog';
 
 const slugRE = new RegExp('^[a-z0-9-]+$');
 
@@ -122,6 +123,19 @@ const availableSuperBlocksSchema = Joi.object({
   )
 });
 
+const catalogSchema = Joi.object({
+  catalog: Joi.array().items(
+    Joi.object({
+      dashedName: Joi.string().regex(slugRE).required(),
+      title: Joi.string().required(),
+      summary: Joi.array().items(Joi.string()).required(),
+      level: Joi.valid(...Object.values(Levels)).required(),
+      hours: Joi.number().required(),
+      topic: Joi.valid(...Object.values(Topic)).required()
+    })
+  )
+});
+
 export const superblockSchemaValidator =
   () => (superBlock: Record<string, unknown>) => {
     const superBlockName = Object.keys(superBlock)[0];
@@ -135,3 +149,6 @@ export const superblockSchemaValidator =
 
 export const availableSuperBlocksValidator = () => (data: unknown) =>
   availableSuperBlocksSchema.validate(data);
+
+export const catalogValidator = () => (data: unknown) =>
+  catalogSchema.validate(data);

--- a/packages/shared/src/config/catalog.ts
+++ b/packages/shared/src/config/catalog.ts
@@ -1,12 +1,12 @@
 import { SuperBlocks } from './curriculum';
 
-enum Levels {
+export enum Levels {
   Beginner = 'beginner',
   Intermediate = 'intermediate',
   Advanced = 'advanced'
 }
 
-enum Topic {
+export enum Topic {
   Html = 'html',
   CSS = 'css',
   Js = 'js',
@@ -27,7 +27,7 @@ enum Topic {
   AI = 'ai'
 }
 
-interface Catalog {
+export interface Catalog {
   superBlock: SuperBlocks;
   level: Levels;
   hours: number;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

This makes the catalog available as static data in the v2 external curriculum output, so consumers outside the client can render it without reimplementing the config.

### What is added

`curriculum-data/v2/catalog.json` lists the 63 catalog courses with `dashedName`, `title`, `summary`, `level`, `hours` and `topic`. Level, hours and topic come from `packages/shared/src/config/catalog.ts`; title and summary come from the curriculum locale's `intro.json`, so the file follows `CURRICULUM_LOCALE` the way the super block files do. Locales without translated summaries fall back to an empty array.

The super block loop in `parseCurriculumData` now also covers the catalog super blocks, so each one gets its usual `v2/<dashed-name>.json` and `v2/challenges/<dashed-name>/<block>/<challenge-id>.json` files through the existing block-based and chapter-based paths. Without that, `catalog.json` would be a dead end: a consumer would have a `dashedName` and no way to reach its blocks or challenges.

So the access path is:

1. `catalog.json` for the course list.
2. `<dashed-name>.json` for the intro and the blocks, including `meta.challengeOrder`.
3. `challenges/<dashed-name>/<block>/<challenge-id>.json` for each challenge.

`available-superblocks.json` is deliberately left alone. Catalog super blocks are treated like upcoming ones in the learn map, so they stay out of the stage-ordered list and are discovered through `catalog.json` instead.

`Levels`, `Topic` and the `Catalog` interface are now exported from the shared config so the joi schema can validate against the enums rather than duplicating the allowed values.
