### PR TITLE
fix(curriculum): fix text and grammar issues in VS Code lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md
@@ -9,21 +9,21 @@ dashedName: how-to-create-a-project-and-run-your-code-locally-in-vs-code
 
 To get started, you should know that VS Code considers projects to be "workspaces". The workspace is whichever directory you opened in VS Code.
 
-To begin, you will need to use a command line interface to create a new directory for your new project. A directory is another name for the folder.
+To begin, you will need to use a command-line interface to create a new directory for your new project. A directory is another name for a folder.
 
-Command-line interfaces, or CLI for short, allow you to interact with your operating system through text-based commands. You will learn more about these tools in future lessons.
+Command-line interfaces, or CLIs for short, allow you to interact with your operating system through text-based commands. You will learn more about these tools in future lessons.
 
 If you are on Windows, you can use the Command Prompt or PowerShell. If you are on a Mac, you can open up your Terminal app.
 
-Once the command line is open, navigate to the home directory by typing in the `cd ~` command and hitting `enter` on your keyboard. Then type in the `mkdir my-project` command and hit `enter`. `mkdir`, or "make directory" is the command used to create a new directory. You should then open your new directory with VS Code. 
+Once the command line is open, navigate to the home directory by typing in the `cd ~` command and hitting `Enter` on your keyboard. Then type in the `mkdir my-project` command and hit `Enter`. `mkdir`, or "make directory", is the command used to create a new directory. You should then open your new directory with VS Code.
 
-There are also some other graphical ways to create a new directory.
+There are also other ways to open a directory in VS Code.
 
 Depending on your operating system, you might have a context menu (or right-click option) to open VS Code directly from your file explorer. You could also choose to double-click on the VS Code application. If you feel comfortable with the command line you can run the command `code /path/to/folder`.
 
 Once it's open, you should see a new blank workspace.
 
-To create a new file, click on the `File` menu at the top-left corner and select `New File...`. Then name your file `index.html` and click on `Save`.
+To create a new file, click on the `File` menu in the top-left corner and select `New File...`. Then name your file `index.html` and click on `Save`.
 
 Now you should see your new file in the explorer tab. Try adding some HTML to your `index.html` file.
 
@@ -31,15 +31,15 @@ Now you might be tempted to open the HTML file in your browser directly. While t
 
 Instead, you should put your HTML file behind a proper web server. That can sound like an intimidating task if you are new to coding, but there's actually a way to do this right from VS Code.
 
-You'll need to grab the _Live Server_ extension first, which is available for free in the marketplace.
+You'll need to grab the Live Server extension first, which is available for free in the marketplace.
 
-Click on the extensions tab in the left hand corner and type in `Live Server` in the search bar.
+Click on the Extensions tab in the left sidebar and type in `Live Server` in the search bar.
 
-Once you have this installed, you should see a `Go live` button in your status bar. Make sure you have your HTML file open, and then click it.
+Once you have this installed, you should see a `Go Live` button in your status bar. Make sure you have your HTML file open, and then click it.
 
-Your new page should open automatically in a new tab in the browser. If it doesn't then you can go directly to `http://localhost:5500/`
+Your new page should open automatically in a new tab in the browser. If it doesn't, then you can go directly to `http://localhost:5500/`.
 
-Congratulations! You've now set up your very own project in VS Code, and can view your changes with live server.
+Congratulations! You've now set up your very own project in VS Code, and can view your changes with Live Server.
 
 # --questions--
 
@@ -57,7 +57,7 @@ The lesson mentions how VS Code defines a workspace in relation to directories.
 
 ---
 
-The directory you opened VS Code from.
+The directory you opened in VS Code.
 
 ---
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

### Summary of Changes

Fixes multiple grammar, phrasing, capitalization, and consistency issues in the lecture block [`how-to-create-a-project-and-run-your-code-locally-in-vs-code`](file:///home/devcareer/Desktop/freeCodeCamp/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md):

1. **Hyphenation & Article**: Changed `"command line interface"` to `"command-line interface"` and `"the folder."` to `"a folder."`
2. **Plural Abbreviation**: Corrected `"CLI for short"` to `"CLIs for short"`.
3. **Key Capitalization & Appositive**: Capitalized `enter` to `Enter` and closed the appositive clause with a comma (`"make directory", is`).
4. **Transition Phrasing**: Changed `"There are also some other graphical ways to create a new directory."` to `"There are also other ways to open a directory in VS Code."`
5. **Preposition Fix**: Changed `"at the top-left corner"` to `"in the top-left corner"`.
6. **Consistent Extension Styling**: Standardized extension name to title case (`Live Server`) in prose while preserving backticks for the search query string (`Live Server`).
7. **UI Element Location**: Updated `"extensions tab in the left hand corner"` to `"Extensions tab in the left sidebar"`.
8. **Button Capitalization**: Corrected `` `Go live` `` button label to `` `Go Live` ``.
9. **Punctuation**: Added missing comma and period to ``If it doesn't, then you can go directly to `http://localhost:5500/`.``
10. **Quiz Answer Alignment**: Updated the quiz option from `"The directory you opened VS Code from."` to `"The directory you opened in VS Code."` to match the lesson text definition.
