### PR TITLE
fix(curriculum): correct wording and tool-name casing in developer tools lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab8573f32480f192aaae1.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab8573f32480f192aaae1.md
@@ -9,7 +9,7 @@ dashedName: what-are-the-different-types-of-tools-professional-developers-use
 
 Professional developers rely on a variety of tools to increase productivity and code quality. Let's learn about those tools, including the ones that seem very obvious.
 
-The first among the tools is computers. A computer is the primary development environment. It could be a heavy desktop or a portable laptop with either Windows, macOS, or Linux as the operating system.
+The first tool is the computer itself. A computer is the primary development environment. It could be a heavy desktop or a portable laptop with Windows, macOS, or Linux as the operating system.
 
 Professional developers often go for computers with fast processing power and plenty of RAM to handle resource-intensive tasks.
 
@@ -21,7 +21,7 @@ Visual Studio Code (VS Code) is essentially a code editor, but it also provides 
 
 Other code editors are Sublime Text, Atom, Notepad++, and Brackets.
 
-When you write code with code editors and IDEs, you need to track the changes you make to them. The tool that lets you track those changes is a version control system.
+When you write code with code editors and IDEs, you need to track the changes you make to that code. The tool that lets you track those changes is a version control system.
 
 Git is the most widely used version control system in the development community.
 
@@ -31,8 +31,8 @@ Package managers are another critical tool. They help developers simplify the pr
 
 Examples of popular package managers are:
 
-* NPM, Yarn, and PNPM for JavaScript
-* PIP for Python
+* npm, Yarn, and pnpm for JavaScript
+* pip for Python
 * Composer for PHP
 * Maven for Java
 
@@ -147,7 +147,7 @@ Think about tools that run automated checks on the code.
 
 ---
 
-Version control systems
+Version control systems.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69457

This applies the four corrections described in the issue to `what-are-the-different-types-of-tools-professional-developers-use`, using the exact replacement text from the issue's Expected behavior section.

1. **Subject-verb agreement and `either` before a three-item list.** `The first among the tools is computers.` pairs a singular verb with a plural complement, and `either` covers two alternatives while three operating systems follow it. Now reads `The first tool is the computer itself.` and `a portable laptop with Windows, macOS, or Linux`.

2. **Ambiguous `them`.** The nearest plural noun was `code editors and IDEs`, so the sentence read as tracking changes made to the editor. Now reads `the changes you make to that code`.

3. **Package manager casing.** The projects style themselves `npm`, `pnpm`, and `pip`. The testing framework list further down the same lesson already uses the lowercase `pytest`, so this makes the two lists consistent.

4. **Missing period.** The `Version control systems` answer now ends with a period, matching the other three answers in the same question.

Prose-only changes to a single lesson file. No frontmatter, markdown structure, or quiz logic was touched.
