### PR TITLE
fix(curriculum): correct wording and capitalization in code editor and IDE lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
@@ -7,9 +7,9 @@ dashedName: what-is-a-code-editor-and-ide
 
 # --description--
 
-You might think these are the same thing, but not quite. A code editor is any application that allows you to edit code files. An IDE, or Integrated Development Environment, is a full application that allows you to compile, run, and debug your code while you edit it.
+You might think these are the same thing, but not quite. A code editor is any application that allows you to edit code files. An IDE, or integrated development environment, is a full application that allows you to compile, run, and debug your code while you edit it.
 
-Perhaps some examples might be helpful.
+Some examples will help.
 
 First, let's consider a few popular IDEs. Visual Studio is an integrated development environment by Microsoft that provides a comprehensive suite of tools for building, debugging, and deploying applications across various platforms.
 
@@ -23,9 +23,9 @@ Visual Studio Code is a lightweight, open-source code editor by Microsoft that s
 
 Another popular editor would be Sublime Text. Sublime Text is a fast, versatile text editor known for its sleek interface, powerful features, and support for a wide range of programming languages through customizable syntax highlighting and plugins.
 
-And another one is Notepad++. This is a free, open-source, text and source code editor for Windows that offers syntax highlighting, code folding, and a range of plugins to enhance productivity and customization.
+And another one is Notepad++. This is a free, open-source text and source code editor for Windows that offers syntax highlighting, code folding, and a range of plugins to enhance productivity and customization.
 
-You may have noticed how the code editors focus primarily on the text contents of the file, where the IDEs expose various tools to manage your code.
+You may have noticed how the code editors focus primarily on the text contents of the file, whereas the IDEs expose various tools to manage your code.
 
 These examples are all local programs you can run on your computer, but there are also cloud-based editors that you can use.
 
@@ -35,11 +35,11 @@ Let's take a look at a few cloud-based editors.
 
 Replit is an online platform that provides a collaborative environment for coding, allowing users to write, run, and share code in various programming languages directly from a web browser.
 
-Another popular cloud-based editor is GitHub Codespaces. This is a cloud-based development environment that provides instant access to a fully-configured code editor and development tools directly from GitHub, enabling seamless coding and collaboration.
+Another popular cloud-based editor is GitHub Codespaces. This is a cloud-based development environment that provides instant access to a fully configured code editor and development tools directly from GitHub, enabling seamless coding and collaboration.
 
 And another one is Ona. Ona is a cloud-based development environment that integrates with GitHub and GitLab, offering instant, customizable workspaces for coding, building, and debugging directly from your browser.
 
-And there are many more options. Some options, such as Visual Studio Code, are highly extensible and can work with multiple different project types and languages. Other options might be specifically tailored to a small subset of languages or project types.
+And there are many more options. Some options, such as Visual Studio Code, are highly extensible and can work with many project types and languages. Other options might be specifically tailored to a small subset of languages or project types.
 
 The application you use might be different for specific projects. You should explore the options to see what will work best for your needs.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69469

This applies the six corrections described in the issue to `what-is-a-code-editor-and-ide`, using the exact replacement text from the issue's Expected behavior section.

1. **Inconsistent capitalization.** `Integrated Development Environment` was capitalized where the term is defined but lowercase in all three examples that follow (Visual Studio, Xcode, Android Studio). Now lowercase throughout.

2. **Stacked hedges.** `Perhaps some examples might be helpful.` hedges twice in one short sentence. Now reads `Some examples will help.`

3. **Stray comma.** The comma after `open-source` separated the adjective list from the noun it modifies. Now reads `a free, open-source text and source code editor`.

4. **`where` used for contrast.** The sentence contrasts code editors with IDEs, so it needs a contrastive conjunction rather than a relative pronoun of place. Now reads `whereas the IDEs expose various tools`.

5. **Hyphenated `-ly` adverb.** Adverbs ending in `-ly` are not hyphenated to the adjective they modify. Now reads `a fully configured code editor`.

6. **Redundancy.** `multiple different` says the same thing twice. Now reads `can work with many project types and languages`.

Prose-only changes to a single lesson file. No frontmatter or markdown structure was touched.
