### PR TITLE
fix(curriculum): correct ISP lesson wording

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab83c4297910eade53c2e.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab83c4297910eade53c2e.md
@@ -7,17 +7,17 @@ dashedName: what-are-the-different-types-of-internet-service-providers
 
 # --description--
 
-First, what is an internet service provider, or ISP? It’s a company that sells access to the global internet network, essentially. And they come in three different tiers.
+First, what is an internet service provider, or ISP? It's essentially a company that sells access to the global internet network. And they come in three different tiers.
 
-The first tier are the giant conglomerate companies, which have the infrastructure to handle most (if not all) of their network traffic independently.
+The first tier is the giant conglomerate companies, which have the infrastructure to handle most (if not all) of their network traffic independently.
 
-The second tier are the country-wide providers, which sometimes rent access to tier 1 networks but can stand fairly well on their own.
+The second tier is the country-wide providers, which sometimes rent access to tier 1 networks but can stand fairly well on their own.
 
-The third tier are the small companies that primarily focus on providing internet to local markets, and rely on larger ISPs to provide their infrastructure.
+The third tier is the small companies that primarily focus on providing internet to local markets, and rely on larger ISPs to provide their infrastructure.
 
 These providers will offer different types of connections as well.
 
-Fibre optic connections rely on glass or plastic fibres to transmit data via light, resulting in very high connection speeds and data exchange.
+Fiber optic connections rely on glass or plastic fibers to transmit data via light, resulting in very high connection speeds and data exchange.
 
 Cable connections use the same infrastructure as a cable television provider, which often makes them readily available in many regions.
 
@@ -25,7 +25,7 @@ DSL connections use the infrastructure that landline phone services use. Because
 
 Dial-up also uses the phone lines, but requires exclusive connection (disabling the use of the line for phone purposes when connected to the internet). This is a much older technology that has fallen into disuse.
 
-Satellite connections use an array of satellites orbiting the earth to connect various devices across the world. And finally, similar to that, a 5G home internet provider uses the cell tower infrastructure to keep you online.
+Satellite connections use an array of satellites orbiting Earth to connect various devices across the world. And finally, similar to that, a 5G home internet provider uses the cell tower infrastructure to keep you online.
 
 And that should give you a basic rundown of what types of internet service providers and internet connections are out there!
 
@@ -33,7 +33,7 @@ And that should give you a basic rundown of what types of internet service provi
 
 ## --text--
 
-Which of the following is NOT a tier of Internet Service Provider (ISP)?
+Which of the following is NOT a tier of internet service provider (ISP)?
 
 ## --answers--
 
@@ -69,7 +69,7 @@ International organizations overseeing global internet access.
 
 ## --text--
 
-Which type of internet connection uses glass or plastic fibres to transmit data via light?
+Which type of internet connection uses glass or plastic fibers to transmit data via light?
 
 ## --answers--
 
@@ -89,7 +89,7 @@ This connection type is known for its very high speeds due to its unique transmi
 
 ---
 
-Fibre optic connection.
+Fiber optic connection.
 
 ---
 
@@ -121,7 +121,7 @@ They require exclusive use of the phone line when connected.
 
 ---
 
-They use an array of satellites orbiting the earth.
+They use an array of satellites orbiting Earth.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

Closes #69458

This updates the Internet Service Providers lesson to fix the wording and consistency issues listed in the issue:

- move "essentially" to a clearer position and use a straight apostrophe
- fix subject-verb agreement in the three tier descriptions
- use American spelling for "fiber"
- capitalize "Earth" when referring to the planet
- use lowercase for "internet service provider" in the question

Checks run:

- `git diff --check`
- Prettier
- Markdownlint
- `CURRICULUM_LOCALE=english pnpm test-curriculum-content` — 1,017 test files and 56,012 tests passed
- `CURRICULUM_LOCALE=english pnpm build:curriculum` — passed