### PR TITLE
fix(curriculum): allow arrow functions in factorial calculator lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -56,7 +56,7 @@ assert.isFunction(factorialCalculator);
 The `factorialCalculator` function should take a number as an argument.
 
 ```js
-assert.match(factorialCalculator.toString(), /\s*factorialCalculator\(\s*\w+\s*\)/);
+assert.strictEqual(factorialCalculator.length, 1);
 ```
 
 The factorial of `5` should return `120`.

--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
@@ -7,9 +7,9 @@ dashedName: what-is-a-code-editor-and-ide
 
 # --description--
 
-You might think these are the same thing, but not quite. A code editor is any application that allows you to edit code files. An IDE, or Integrated Development Environment, is a full application that allows you to compile, run, and debug your code while you edit it.
+You might think these are the same thing, but not quite. A code editor is any application that allows you to edit code files. An IDE, or integrated development environment, is a full application that allows you to compile, run, and debug your code while you edit it.
 
-Perhaps some examples might be helpful.
+Some examples will help.
 
 First, let's consider a few popular IDEs. Visual Studio is an integrated development environment by Microsoft that provides a comprehensive suite of tools for building, debugging, and deploying applications across various platforms.
 
@@ -23,9 +23,9 @@ Visual Studio Code is a lightweight, open-source code editor by Microsoft that s
 
 Another popular editor would be Sublime Text. Sublime Text is a fast, versatile text editor known for its sleek interface, powerful features, and support for a wide range of programming languages through customizable syntax highlighting and plugins.
 
-And another one is Notepad++. This is a free, open-source, text and source code editor for Windows that offers syntax highlighting, code folding, and a range of plugins to enhance productivity and customization.
+And another one is Notepad++. This is a free, open-source text and source code editor for Windows that offers syntax highlighting, code folding, and a range of plugins to enhance productivity and customization.
 
-You may have noticed how the code editors focus primarily on the text contents of the file, where the IDEs expose various tools to manage your code.
+You may have noticed how the code editors focus primarily on the text contents of the file, whereas the IDEs expose various tools to manage your code.
 
 These examples are all local programs you can run on your computer, but there are also cloud-based editors that you can use.
 
@@ -35,11 +35,11 @@ Let's take a look at a few cloud-based editors.
 
 Replit is an online platform that provides a collaborative environment for coding, allowing users to write, run, and share code in various programming languages directly from a web browser.
 
-Another popular cloud-based editor is GitHub Codespaces. This is a cloud-based development environment that provides instant access to a fully-configured code editor and development tools directly from GitHub, enabling seamless coding and collaboration.
+Another popular cloud-based editor is GitHub Codespaces. This is a cloud-based development environment that provides instant access to a fully configured code editor and development tools directly from GitHub, enabling seamless coding and collaboration.
 
 And another one is Ona. Ona is a cloud-based development environment that integrates with GitHub and GitLab, offering instant, customizable workspaces for coding, building, and debugging directly from your browser.
 
-And there are many more options. Some options, such as Visual Studio Code, are highly extensible and can work with multiple different project types and languages. Other options might be specifically tailored to a small subset of languages or project types.
+And there are many more options. Some options, such as Visual Studio Code, are highly extensible and can work with many project types and languages. Other options might be specifically tailored to a small subset of languages or project types.
 
 The application you use might be different for specific projects. You should explore the options to see what will work best for your needs.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d457bcdd8b350ec2b6254.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d457bcdd8b350ec2b6254.md
@@ -7,25 +7,25 @@ dashedName: what-are-some-good-vs-code-extensions-you-can-use-in-your-editor
 
 # --description--
 
-_Better Comments_ is an extension that offers special highlighting for specific code comments. For example, it will call out "TODO" comments, as well as syntax to indicate questions or warnings.
+Better Comments is an extension that offers special highlighting for specific code comments. For example, it will call out "TODO" comments, as well as syntax to indicate questions or warnings.
 
-_Code Spell Checker_ offers indication when you have spelled something incorrectly in your code. Because it is designed for code files, it will account for things like camel case.
+Code Spell Checker flags words that are spelled incorrectly in your code. Because it is designed for code files, it will account for things like camel case.
 
-_Error Lens_ will help you catch any highlighted errors in your code. Rather than having to rely on the underline that VS Code shows by default, this extension highlights the entire line and displays the error message.
+Error Lens makes the errors in your code harder to miss. Rather than having to rely on the underline that VS Code shows by default, this extension highlights the entire line and displays the error message.
 
-_Indent Rainbow_ adds color to your different levels of indentation. In combination with VS Code's native bracket pair colorization, this can dramatically help identify what scope your code is in.
+Indent Rainbow adds color to your different levels of indentation. In combination with VS Code's native bracket pair colorization, this can dramatically help identify what scope your code is in.
 
-Or maybe you're looking for something a bit more practical? Consider an AI assistant, like _GitHub Copilot_ or _Tabnine_, to offer you inline suggestions as you are writing your code.
+Or maybe you're looking for something a bit more practical? Consider an AI assistant, like GitHub Copilot or Tabnine, to offer you inline suggestions as you are writing your code.
 
-An icon pack, such as _VS Code Great Icons_, can help make your file tree cleaner and easier to parse at a glance. And an extension like _Colorize_ can help you understand the values in your CSS properties.
+An icon pack, such as VS Code Great Icons, can help make your file tree cleaner and easier to parse at a glance. And an extension like Colorize can help you understand the values in your CSS properties.
 
-You'll also want language-specific extensions for your projects. If you are using JavaScript, you will likely want _ESLint_ and _Prettier_ to lint and format your code. If you are using TypeScript, you might want _Pretty TypeScript Errors_ for easier to read messages.
+You'll also want language-specific extensions for your projects. If you are using JavaScript, you will likely want ESLint and Prettier to lint and format your code. If you are using TypeScript, you might want Pretty TypeScript Errors for easier-to-read messages.
 
-Finally, you can also have a bit of fun with your editor. _VS Code Pets_ offers configurable virtual pets to keep you company while you squash some bugs.
+Finally, you can also have a bit of fun with your editor. VS Code Pets offers configurable virtual pets to keep you company while you squash some bugs.
 
-_Power Mode_ will create flashy effects when you achieve a high enough "combo" by writing more code.
+Power Mode will create flashy effects when you achieve a high enough "combo" by writing more code.
 
-_Discord Presence_ will let you show off what you're working on to all of your friends.
+Discord Presence will let you show off what you're working on to all of your friends.
 
 And there are so many more extensions out there. Feel free to explore the extension marketplace and see what works best for you.
 
@@ -33,7 +33,7 @@ And there are so many more extensions out there. Feel free to explore the extens
 
 ## --text--
 
-What feature does the "Better Comments" extension provide in VS Code?
+What feature does the Better Comments extension provide in VS Code?
 
 ## --answers--
 
@@ -69,7 +69,7 @@ The lesson mentions how this extension affects certain types of comments.
 
 ## --text--
 
-Which VS Code extension is described as helping to catch highlighted errors in your code by displaying the error message on the entire line?
+Which VS Code extension highlights the whole line and displays the error message inline, instead of relying on the default underline?
 
 ## --answers--
 
@@ -105,7 +105,7 @@ The lesson mentions an extension that enhances error visibility beyond VS Code's
 
 ## --text--
 
-What unique feature does the "VS Code Pets" extension offer?
+What unique feature does the VS Code Pets extension offer?
 
 ## --answers--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69484

<!-- Feel free to add any additional description of changes below this line -->
Replaced the factorialCalculator.toString() regex assertion (which only matched named function declarations) with assert.strictEqual(factorialCalculator.length, 1), so the arg-count hint passes for both function declarations and arrow function solutions.