### PR TITLE
fix(client): align BEDA v9 intro.json block order with the superblock

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -7347,12 +7347,6 @@
           "You will learn how to initialize, configure, and publish an NPM module by building a case converter."
         ]
       },
-      "lab-prime-number-checker-module": {
-        "title": "Build a Prime Number Checker Module",
-        "intro": [
-          "Practice building and exporting an NPM module by creating a prime number checker."
-        ]
-      },
       "review-npm": {
         "title": "NPM Review",
         "intro": ["Review npm concepts to prepare for the upcoming quiz."]
@@ -7360,6 +7354,12 @@
       "quiz-npm": {
         "title": "NPM Quiz",
         "intro": ["Test what you have learned about npm in this quiz."]
+      },
+      "lab-prime-number-checker-module": {
+        "title": "Build a Prime Number Checker Module",
+        "intro": [
+          "Practice building and exporting an NPM module by creating a prime number checker."
+        ]
       },
       "lecture-understanding-how-http-dns-tcpip-work": {
         "title": "Understanding how HTTP, DNS and TCP/IP work",
@@ -7435,12 +7435,6 @@
           "You will learn basic Express routing and response methods by building a random joke app."
         ]
       },
-      "lab-personal-profile-app": {
-        "title": "Build a Personal Profile App",
-        "intro": [
-          "Practice building an Express server and JSON API by creating a personal profile application."
-        ]
-      },
       "review-introduction-to-express": {
         "title": "Introduction to Express Review",
         "intro": [
@@ -7451,6 +7445,12 @@
         "title": "Introduction to Express Quiz",
         "intro": [
           "Test your knowledge of web services, REST, microservices, Express.js, and routing."
+        ]
+      },
+      "lab-personal-profile-app": {
+        "title": "Build a Personal Profile App",
+        "intro": [
+          "Practice building an Express server and JSON API by creating a personal profile application."
         ]
       },
       "lecture-understanding-error-handling-and-health-checks": {
@@ -7519,12 +7519,6 @@
           "You will learn Node.js WebSockets and real-time data streaming by building a system resource monitor."
         ]
       },
-      "lab-chat-app": {
-        "title": "Build a Chat App",
-        "intro": [
-          "Practice building a real-time multi-client chat server using Node.js WebSockets."
-        ]
-      },
       "review-websockets": {
         "title": "WebSockets Review",
         "intro": [
@@ -7535,6 +7529,12 @@
         "title": "WebSockets Quiz",
         "intro": [
           "Test your knowledge of WebSockets and Pub/Sub with this quiz."
+        ]
+      },
+      "lab-chat-app": {
+        "title": "Build a Chat App",
+        "intro": [
+          "Practice building a real-time multi-client chat server using Node.js WebSockets."
         ]
       },
       "lecture-understanding-security-and-privacy-in-web-applications": {
@@ -7567,12 +7567,6 @@
           "You will learn authentication and role-based authorization by building an Express application with JWT-protected routes."
         ]
       },
-      "lab-family-movie-watchlist-api": {
-        "title": "Build a Family Movie Watchlist API",
-        "intro": [
-          "Practice implementing authentication and authorization in an Express application by building a family movie watchlist API."
-        ]
-      },
       "review-authentication-and-authorization": {
         "title": "Authentication and Authorization Review",
         "intro": [
@@ -7583,6 +7577,12 @@
         "title": "Authentication and Authorization Quiz",
         "intro": [
           "Test your knowledge of authentication and authorization concepts covered in this module."
+        ]
+      },
+      "lab-family-movie-watchlist-api": {
+        "title": "Build a Family Movie Watchlist API",
+        "intro": [
+          "Practice implementing authentication and authorization in an Express application by building a family movie watchlist API."
         ]
       },
       "review-back-end-development-and-apis": {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69489

---

## Summary

Same fix as #69401, applied to the other superblock that had this problem.

Four `cert-project` labs were listed *before* the `review`/`quiz` pair closing their module, while the superblock places the review and quiz first and the lab after. Each was exactly two positions early:

| block moved | now sits after |
|---|---|
| `lab-prime-number-checker-module` | `quiz-npm` |
| `lab-personal-profile-app` | `quiz-introduction-to-express` |
| `lab-chat-app` | `quiz-websockets` |
| `lab-family-movie-watchlist-api` | `quiz-authentication-and-authorization` |

Only key order changed inside `blocks` — no titles, intro copy, `modules` entries, or other superblocks were touched.

## Verification

- before: 53 blocks in each file, same set, first divergence at index 11
- after: 53 blocks in each, **same set and identical order** (`order == intro_order` → `True`)
- the superblock's `modules` object still has its original 18 entries (this file has both a `modules` and a `blocks` dict keyed by the same names, so I scoped the edit to the `blocks` object explicitly — all eight diff hunks land inside its line range)
- `npx prettier --check client/i18n/locales/english/intro.json` → *All matched files use Prettier code style!*

Re-ran the comparison across all 98 superblocks: `back-end-development-and-apis-v9` is now consistent, and no other superblock's status changed.

## Note on `full-stack-open`

While sweeping, `full-stack-open` also shows up as inconsistent, but it's a different problem — its superblock lists 14 blocks (one duplicated) while `intro.json` has a single entry, so it's a structural gap rather than an ordering slip. I've left it alone; happy to open a separate issue if that's useful.