### PR TITLE
fix(curriculum): unordered log assertions

### DIFF
--- a/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
+++ b/curriculum/challenges/english/blocks/lab-javascript-trivia-bot/66ed41f912d0bb1dc62da5dd.md
@@ -35,7 +35,7 @@ const getLogs = () => spy.calls.map(call => call?.[0]);
 You should log `"Hello! I'm your coding fun fact guide!"` to the console.
 
 ```js
-assert.equal(getLogs()[0], "Hello! I'm your coding fun fact guide!")
+assert.include(getLogs(), "Hello! I'm your coding fun fact guide!")
 ```
 
 You should declare a `botName` variable. Double check for any spelling or casing errors.
@@ -77,13 +77,13 @@ assert.isString(favoriteLanguage);
 You should log to the console `"My name is (botName) and I live on (botLocation)."` and add the variables to the string.
 
 ```js
-assert.equal(getLogs()[1], `My name is ${botName} and I live on ${botLocation}.`)
+assert.include(getLogs(), `My name is ${botName} and I live on ${botLocation}.`)
 ```
 
 You should log to the console `"My favorite programming language is (favoriteLanguage)."` and add the variable to the string.
 
 ```js
-assert.equal(getLogs()[2], `My favorite programming language is ${favoriteLanguage}.`)
+assert.include(getLogs(), `My favorite programming language is ${favoriteLanguage}.`)
 ```
 
 You should use `let` to declare a new variable `codingFact`.
@@ -107,7 +107,13 @@ You should log `codingFact` to the console.
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
-assert.include(getLogs()[3], favoriteLanguage);
+const factLogs = getLogs().filter(log =>
+  typeof log === 'string' &&
+  log.includes(favoriteLanguage) &&
+  log !== favoriteLanguage &&
+  log !== `My favorite programming language is ${favoriteLanguage}.`
+);
+assert.isNotEmpty(factLogs);
 assert.isAtLeast(loggingCodingFacts.length, 1);
 ```
 
@@ -116,10 +122,15 @@ You should assign a new value to `codingFact` that also contains `favoriteLangua
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
+const factLogs = getLogs().filter(log =>
+  typeof log === 'string' &&
+  log.includes(favoriteLanguage) &&
+  log !== favoriteLanguage &&
+  log !== `My favorite programming language is ${favoriteLanguage}.`
+);
 assert.exists(loggingCodingFacts);
 assert.isAtLeast(loggingCodingFacts.length, 2);
-assert.include(getLogs()[4], favoriteLanguage);
-assert.notEqual(getLogs()[4], getLogs()[3]);
+assert.isAtLeast(new Set(factLogs).size, 2);
 ```
 
 You should assign a value to `codingFact` for the third time that also contains `favoriteLanguage`, and log it to the console.
@@ -127,15 +138,21 @@ You should assign a value to `codingFact` for the third time that also contains 
 ```js
 const codeWithoutComments = __helpers.removeJSComments(code);
 const loggingCodingFacts = codeWithoutComments.match(/console\.log\(\s*codingFact\s*\)/g)
+const factLogs = getLogs().filter(log =>
+  typeof log === 'string' &&
+  log.includes(favoriteLanguage) &&
+  log !== favoriteLanguage &&
+  log !== `My favorite programming language is ${favoriteLanguage}.`
+);
 assert.lengthOf(loggingCodingFacts, 3);
-assert.notEqual(getLogs()[5], getLogs()[4]);
+assert.isAtLeast(new Set(factLogs).size, 3);
 assert.isNotEmpty(codingFact);
 ```
 
 You should log to the console `"It was fun sharing these facts with you. Goodbye! - (botName) from (botLocation)."` and add the values of the variables.
 
 ```js
-assert.equal(getLogs()[6], `It was fun sharing these facts with you. Goodbye! - ${botName} from ${botLocation}.`);
+assert.include(getLogs(), `It was fun sharing these facts with you. Goodbye! - ${botName} from ${botLocation}.`);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69421

<!-- Feel free to add any additional description of changes below this line -->

The hints checked console logs by position, so any extra `console.log` a camper added while debugging shifted the positions and failed hints even though the required output was there.

**What changed:**

- Four hints now just check that the required text was logged at some point, instead of checking a fixed position.
- The three `codingFact` hints need three *different* facts, so they can't use a simple "was this logged" check. They now count the distinct fact logs instead. The count skips a plain `console.log(favoriteLanguage)` and the "My favorite programming language is…" line, since both contain the language name but aren't facts.

The reference solution and user stories are unchanged.

**Testing:**

- Ran `pnpm test-gen && npx vitest run --project test lab-javascript-trivia-bot` — passes with the normal solution, and with the extra debug logs from the issue.
- Put the old hints back with that same code to confirm it fails first: `expected 'JsBot' to equal 'My name is JsBot and I live on planet…'`
- Also checked it in the dev client at `/learn/javascript-v9/lab-javascript-trivia-bot/lab-javascript-trivia-bot`.