### PR TITLE
fix(curriculum): stop file metadata test from using Response.blob()

### DIFF
--- a/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/bd7158d8c443edefaeb5bd0f.md
+++ b/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/bd7158d8c443edefaeb5bd0f.md
@@ -50,15 +50,18 @@ The form file input field has the `name` attribute set to `upfile`.
 When you submit a file, you receive the file `name`, `type`, and `size` in bytes within the JSON response.
 
 ```js
-  const formData = new FormData();
-  const fileData = await fetch(
-    'https://cdn.freecodecamp.org/weather-icons/01d.png'
-  );
-  const file = await fileData.blob();
-  formData.append('upfile', file, 'icon');
+  const boundary = 'fccBoundary1234567890';
+  const head =
+    `--${boundary}\r\n` +
+    'Content-Disposition: form-data; name="upfile"; filename="icon"\r\n' +
+    'Content-Type: image/png\r\n\r\n';
+  const body = new Blob([head, new Uint8Array(70), `\r\n--${boundary}--\r\n`]);
   const data = await fetch(code + '/api/fileanalyse', {
     method: 'POST',
-    body: formData
+    headers: {
+      'Content-Type': `multipart/form-data; boundary=${boundary}`
+    },
+    body
   });
   const parsed = await data.json();
   assert.property(parsed, 'size');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

The last test of File Metadata Microservice cannot pass, for anyone. It starts by pulling a PNG off the CDN and calling `Response.blob()` on it:

```js
const fileData = await fetch('https://cdn.freecodecamp.org/weather-icons/01d.png');
const file = await fileData.blob();
```

`fetch` inside the DOM test evaluator is a proxy that forwards the request to the parent window over `postMessage`. The parent reads every response with `await res.text()` and sends back four keys, so the reconstructed `Response` only implements `status`, `statusText`, `url`, `text`, `ok` and `json`. Everything else is a stub that throws `<name> is not implemented yet`, `blob` included. The throw happens on the second line of the test, so `/api/fileanalyse` is never contacted and the result is identical regardless of what the camper wrote.

File Metadata is the fifth of the five projects `back-end-development-and-apis.yml` requires, so this blocks the certification rather than a single test.

The fix builds the upload inside the evaluator and drops the CDN round trip. `FormData` cannot be used for the body: it is not serializable, so it fails to cross the same `postMessage` boundary with `DataCloneError`. The multipart envelope is assembled by hand instead and sent as a `Blob`, which is serializable. `multer` reads `name` from `filename`, `type` from the part's `Content-Type` and `size` from the byte count, so the bytes never need to decode as a real image.

Tested locally against `https://file-metadata-microservice.freecodecamp.rocks/`, with the example-URL guard in the first hint temporarily disabled to allow that submission. All four tests pass. The guard is untouched in this diff.
