### PR TITLE
fix(curriculum): include tomorrow in exercise tracker expected dates

### DIFF
--- a/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/5a8b073d06fa14fcfde687aa.md
+++ b/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/5a8b073d06fa14fcfde687aa.md
@@ -500,7 +500,7 @@ The `date` property of any object in the `log` array that is returned from `GET 
         timeZone: "UTC", weekday: "short", month: "short",
         day: "2-digit", year: "numeric"
       }).replaceAll(',', ''),
-      new Date(currentDate.setDate(currentDate.getDate() + 1)).toLocaleDateString("en-US", {
+      new Date(currentDate.setDate(currentDate.getDate() + 2)).toLocaleDateString("en-US", {
         timeZone: "UTC", weekday: "short", month: "short",
         day: "2-digit", year: "numeric"
       }).replaceAll(',', '')

--- a/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/5a8b073d06fa14fcfde687aa.md
+++ b/curriculum/challenges/english/blocks/back-end-development-and-apis-projects/5a8b073d06fa14fcfde687aa.md
@@ -490,20 +490,21 @@ The `date` property of any object in the `log` array that is returned from `GET 
   
   if (res.ok) {
     const { _id, username } = await res.json();
-    const currentDate = new Date();
+    // 24 hours * 60 minutes * 60 seconds * 1000 ms
+    const epochDay = 24 * 60 * 60 * 1000;
+    const today = new Date();
+    const yesterday = new Date(today.getTime() - epochDay);
+    const tomorrow = new Date(today.getTime() + epochDay);
+    const dateAsLocaleUSString = (date) =>
+      date.toLocaleDateString("en-US", {
+        timeZone: "UTC", weekday: "short", month: "short",
+        day: "2-digit", year: "numeric"
+      }).replaceAll(',', '');
+
     const expectedDates = [
-      new Date(currentDate.setDate(currentDate.getDate() - 1)).toLocaleDateString("en-US", {
-        timeZone: "UTC", weekday: "short", month: "short",
-        day: "2-digit", year: "numeric"
-      }).replaceAll(',', ''),
-      new Date().toLocaleDateString("en-US", {
-        timeZone: "UTC", weekday: "short", month: "short",
-        day: "2-digit", year: "numeric"
-      }).replaceAll(',', ''),
-      new Date(currentDate.setDate(currentDate.getDate() + 2)).toLocaleDateString("en-US", {
-        timeZone: "UTC", weekday: "short", month: "short",
-        day: "2-digit", year: "numeric"
-      }).replaceAll(',', '')
+      dateAsLocaleUSString(yesterday),
+      dateAsLocaleUSString(today),
+      dateAsLocaleUSString(tomorrow)
     ];
     const expected = {
       username,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

The hint checking the `date` property of a log entry builds three acceptable dates:

```js
const currentDate = new Date();
const expectedDates = [
  new Date(currentDate.setDate(currentDate.getDate() - 1))...  // yesterday
  new Date()...                                                // today
  new Date(currentDate.setDate(currentDate.getDate() + 1))...  // today again
];
```

`setDate` mutates the `Date` it is called on. The first entry moves `currentDate` back to yesterday, so the third adds a day to *yesterday* and lands on today rather than tomorrow. The array is `[yesterday, today, today]`, and a camper whose local date is a day ahead of the UTC date at the moment they submit sends a date matching none of the three, failing the test on correct code.

Rather than adjust the offset to compensate for the mutation, this drops the mutation:

```js
// 24 hours * 60 minutes * 60 seconds * 1000 ms
const epochDay = 24 * 60 * 60 * 1000;
const today = new Date();
const yesterday = new Date(today.getTime() - epochDay);
const tomorrow = new Date(today.getTime() + epochDay);
const dateAsLocaleUSString = (date) =>
  date.toLocaleDateString("en-US", {
    timeZone: "UTC", weekday: "short", month: "short",
    day: "2-digit", year: "numeric"
  }).replaceAll(',', '');

const expectedDates = [
  dateAsLocaleUSString(yesterday),
  dateAsLocaleUSString(today),
  dateAsLocaleUSString(tomorrow)
];
```

Each date is now derived from the same starting point, and the shared formatter replaces three copies of the same `toLocaleDateString` options.

It is also more accurate at the edges. `setDate` operates in local time while the formatting is pinned to `timeZone: "UTC"`, so the two can disagree near midnight. Offsetting by a fixed number of milliseconds and formatting in UTC always advances the UTC calendar date by exactly one day, and UTC has no DST to complicate it.

This is the version @Orkfaeller proposed in https://github.com/freeCodeCamp/freeCodeCamp/pull/58431#issuecomment-2625072337 during review of #58431. @a2937 asked for it to be applied in https://github.com/freeCodeCamp/freeCodeCamp/pull/58431#issuecomment-3122718013, and it went unanswered. That PR could not be revived: its branch predates the curriculum restructure, still targets `curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/exercise-tracker.md`, and now conflicts, with `maintainer_can_modify` disabled so no one else can rebase it.

Reported in #58430 and on the forum at https://forum.freecodecamp.org/t/731919.

