### PR TITLE
fix(curriculum): report the payload when message board tests are unavailable

### DIFF
--- a/curriculum/challenges/english/blocks/information-security-projects/587d824a367417b2b2512c45.md
+++ b/curriculum/challenges/english/blocks/information-security-projects/587d824a367417b2b2512c45.md
@@ -345,8 +345,12 @@ All 10 functional tests are complete and passing.
 
 ```js
   const tests = await fetch(code + '/_api/get-tests');
+  if (!tests.ok) {
+    throw Error(await tests.text());
+  }
   const parsed = await tests.json();
-  assert.isTrue(parsed.length >= 10);
+  assert.isArray(parsed);
+  assert.isAtLeast(parsed.length, 10);
   parsed.forEach((test) => {
     assert.equal(test.state, 'passed');
     assert.isAtLeast(test.assertions.length, 1);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

`/_api/get-tests` is gated on `NODE_ENV` in the boilerplate. When the camper's app is not running in test mode the endpoint answers:

```json
{"status":"unavailable"}
```

The hint read `length` straight off that object, so `undefined >= 10` evaluated to `false` and the camper saw:

```
expected false to be true
```

That names neither the endpoint nor the payload, so there is nothing to act on. The five Quality Assurance projects already check the response and assert the shape first, which produces `expected { status: 'unavailable' } to be an array` and points straight at the cause. This brings Anonymous Message Board in line with them.

The instructions already tell campers to set `NODE_ENV`, so this changes only what the failure says, not what is required to pass.

Live confirmation of the payload:

```
GET https://anonymous-message-board.freecodecamp.rocks/_api/get-tests  →  {"status":"unavailable"}
```

`assert.isTrue(parsed.length >= 10)` also becomes `assert.isAtLeast(parsed.length, 10)`, which reports the actual count when a camper is short on tests, matching how Issue Tracker already asserts.

Companion to the same fix for Stock Price Checker.
