### PR TITLE
fix(curriculum): pass a string to fetch in advanced node and express tests

### DIFF
--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f700f9fc0f352b528e63.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f700f9fc0f352b528e63.md
@@ -37,7 +37,7 @@ Pug should be a dependency.
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json();
   assert.property(
     packJson.dependencies,
@@ -50,7 +50,7 @@ View engine should be Pug.
 
 ```js
   const url = new URL("/_api/app", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const app = await res.json();
   assert.equal(app?.settings?.['view engine'], "pug");
 ```
@@ -59,7 +59,7 @@ You should set the `views` property of the application to `./views/pug`.
 
 ```js
   const url = new URL("/_api/app", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const app = await res.json();
   assert.equal(app?.settings?.views, "./views/pug");
 ```
@@ -68,7 +68,7 @@ Use the correct ExpressJS method to render the index page from the response.
 
 ```js
   const url = new URL("/", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
       assert.match(
         data,
@@ -81,7 +81,7 @@ Pug should be working.
 
 ```js
   const url = new URL("/", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
       assert.match(
         data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70bf9fc0f352b528e64.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70bf9fc0f352b528e64.md
@@ -60,7 +60,7 @@ Pug should correctly render variables.
 
 ```js
   const url = new URL("/", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70cf9fc0f352b528e65.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70cf9fc0f352b528e65.md
@@ -37,7 +37,7 @@ Passport and Express-session should be dependencies.
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json();
   assert.property(
     packJson.dependencies,
@@ -55,7 +55,7 @@ Dependencies should be correctly required.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -73,7 +73,7 @@ Express app should use new dependencies.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(data, /passport\.initialize/, 'Your express app should use "passport.initialize()"');
   assert.match(data, /passport\.session/, 'Your express app should use "passport.session()"');
@@ -83,7 +83,7 @@ Session and session secret should be correctly set up.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70cf9fc0f352b528e66.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70cf9fc0f352b528e66.md
@@ -54,7 +54,7 @@ You should serialize the user object correctly.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -72,7 +72,7 @@ You should deserialize the user object correctly.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -90,7 +90,7 @@ MongoDB should be a dependency.
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json();
   assert.property(
     packJson.dependencies,
@@ -103,7 +103,7 @@ Mongodb should be properly required including the ObjectId.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70cf9fc0f352b528e67.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70cf9fc0f352b528e67.md
@@ -48,7 +48,7 @@ Database connection should be present.
 
 ```js
   const url = new URL("/", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -61,7 +61,7 @@ Deserialization should now be correctly using the DB and `done(null, null)` shou
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70df9fc0f352b528e68.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70df9fc0f352b528e68.md
@@ -44,7 +44,7 @@ Passport-local should be a dependency.
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json();
   assert.property(
     packJson.dependencies,
@@ -57,7 +57,7 @@ Passport-local should be correctly required and set up.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70df9fc0f352b528e69.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70df9fc0f352b528e69.md
@@ -28,7 +28,7 @@ All steps should be correctly implemented in `server.js`.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -51,7 +51,7 @@ A POST request to `/login` should correctly redirect to `/`.
 
 ```js
   const url = new URL("/login", code);
-  const res = await fetch(url, { method: 'POST' });
+  const res = await fetch(url.href, { method: 'POST' });
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70df9fc0f352b528e6a.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70df9fc0f352b528e6a.md
@@ -41,7 +41,7 @@ The middleware `ensureAuthenticated` should be implemented and attached to the `
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -59,7 +59,7 @@ An unauthenticated GET request to `/profile` should correctly redirect to `/`.
 
 ```js
   const url = new URL("/profile", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70ef9fc0f352b528e6b.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/5895f70ef9fc0f352b528e6b.md
@@ -34,7 +34,7 @@ You should correctly add a Pug render variable to `/profile`.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/58965611f9fc0f352b528e6c.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/58965611f9fc0f352b528e6c.md
@@ -38,7 +38,7 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -51,7 +51,7 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```js
   const url = new URL("/logout", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/58966a17f9fc0f352b528e6d.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/58966a17f9fc0f352b528e6d.md
@@ -66,7 +66,7 @@ You should have a `/register` route and display a registration form on the home 
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589690e6f9fc0f352b528e6e.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589690e6f9fc0f352b528e6e.md
@@ -34,7 +34,7 @@ Modules should be present.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589a69f5f9fc0f352b528e71.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589a69f5f9fc0f352b528e71.md
@@ -39,7 +39,7 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json();
   assert.property(
     packJson.dependencies,
@@ -52,7 +52,7 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```js
   const url = new URL("/_api/auth.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -65,7 +65,7 @@ GitHub strategy should be setup correctly thus far.
 
 ```js
   const url = new URL("/_api/auth.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589a8eb3f9fc0f352b528e72.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589a8eb3f9fc0f352b528e72.md
@@ -51,7 +51,7 @@ GitHub strategy setup should be complete.
 
 ```js
   const url = new URL("/_api/auth.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589fc830f9fc0f352b528e74.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589fc830f9fc0f352b528e74.md
@@ -50,7 +50,7 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json();
   assert.property(
     packJson.dependencies,
@@ -63,7 +63,7 @@ You should correctly require and instantiate `http` as `http`.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -76,7 +76,7 @@ You should correctly require and instantiate `socket.io` as `io`.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -89,7 +89,7 @@ Socket.IO should be listening for connections.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -102,7 +102,7 @@ Your client should connect to your server.
 
 ```js
   const url = new URL("/public/client.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589fc831f9fc0f352b528e75.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589fc831f9fc0f352b528e75.md
@@ -46,7 +46,7 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -59,7 +59,7 @@ Server should emit the current user count at each new connection.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -72,7 +72,7 @@ Your client should be listening for `'user count'` event.
 
 ```js
   const url = new URL("/public/client.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589fc831f9fc0f352b528e76.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589fc831f9fc0f352b528e76.md
@@ -30,7 +30,7 @@ Server should handle the event disconnect from a socket.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(data, /socket.on.*('|")disconnect('|")/s, '');
 ```
@@ -39,7 +39,7 @@ Your client should be listening for `'user count'` event.
 
 ```js
   const url = new URL("/public/client.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589fc831f9fc0f352b528e77.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589fc831f9fc0f352b528e77.md
@@ -73,7 +73,7 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json();
   assert.property(
     packJson.dependencies,
@@ -86,7 +86,7 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json();
   assert.property(
     packJson.dependencies,
@@ -99,7 +99,7 @@ passportSocketIo should be properly required.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -112,7 +112,7 @@ passportSocketIo should be properly setup.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589fc832f9fc0f352b528e78.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589fc832f9fc0f352b528e78.md
@@ -42,7 +42,7 @@ Event `'user'` should be emitted with `username`, `currentUsers`, and `connected
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   // Regex is lenient to match both `username` and `name` as the key on purpose.
   assert.match(
@@ -56,7 +56,7 @@ Client should properly handle and display the new data from event `'user'`.
 
 ```js
   const url = new URL("/public/client.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/589fc832f9fc0f352b528e79.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/589fc832f9fc0f352b528e79.md
@@ -36,7 +36,7 @@ Server should listen for `'chat message'` and then emit it properly.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,
@@ -49,7 +49,7 @@ Client should properly handle and display the new data from event `'chat message
 
 ```js
   const url = new URL("/public/client.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,

--- a/curriculum/challenges/english/blocks/advanced-node-and-express/58a25c98f9fc0f352b528e7f.md
+++ b/curriculum/challenges/english/blocks/advanced-node-and-express/58a25c98f9fc0f352b528e7f.md
@@ -32,7 +32,7 @@ BCrypt should be a dependency.
 
 ```js
   const url = new URL("/_api/package.json", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const packJson = await res.json()
   assert.property(
     packJson.dependencies,
@@ -45,7 +45,7 @@ BCrypt should be correctly required and implemented.
 
 ```js
   const url = new URL("/_api/server.js", code);
-  const res = await fetch(url);
+  const res = await fetch(url.href);
   const data = await res.text();
   assert.match(
     data,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

Every test in this block builds its target the same way:

```js
const url = new URL("/_api/package.json", code);
const res = await fetch(url);
```

`fetch` inside the DOM test evaluator is a proxy that forwards the request to the parent window over `postMessage`, and a `URL` object is not serializable. The call throws before anything is sent:

```
DataCloneError: Failed to execute 'postMessage' on 'Window': The URL object could not be cloned.
```

No request reaches the camper's project, so every challenge in Advanced Node and Express fails identically regardless of what they wrote. That is 21 of the block's 22 files, 51 call sites in total.

Passing `url.href` sends a string, which clones.

This is the same failure and the same shape of fix as #66132, which resolved it for the Basic Node and Express POST challenge, where the unserializable value was a `URLSearchParams` body.

Reported in #66938 and repeatedly on the forum, in English and Spanish:

- https://forum.freecodecamp.org/t/780953
- https://forum.freecodecamp.org/t/792556
- https://forum.freecodecamp.org/t/792558
- https://forum.freecodecamp.org/t/793801
- https://forum.freecodecamp.org/t/795017

The change is mechanical. `new URL(...)` is always assigned to `const url`, `url` is never used for anything other than the `fetch` call, and there are no `url.pathname`-style reads anywhere in the block.
