### PR TITLE
fix: stabilize dialog tests

### DIFF
--- a/client/src/templates/Challenges/components/reset-modal.test.tsx
+++ b/client/src/templates/Challenges/components/reset-modal.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { createStore } from '../../../redux/create-store';
@@ -86,7 +87,10 @@ describe('<ResetModal />', () => {
 
     await user.click(screen.getByText('Close'));
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
     expect(reduxStore.getState().challenge.modal.reset).toBe(false);
   });
 
@@ -102,7 +106,10 @@ describe('<ResetModal />', () => {
     expect(state.challenge.challengeFiles[0].contents).toBe(seedContents);
     expect(state.challenge.isResetting).toBe(true);
     expect(state.challenge.modal.reset).toBe(false);
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('renders the saved-code revert content for DB-backed projects', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We got flaky dialog disappearance assertions after a new batch of tests: 

<img width="923" height="260" alt="Screenshot 2026-08-12 at 20 12 27" src="https://github.com/user-attachments/assets/858823e2-16e8-4b66-b3b3-4a8b488ed34c" />

This PR stabilizes the tests, similar to #68851.

Log: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/31592210741/job/94105243537#step:10:1492



<!-- Feel free to add any additional description of changes below this line -->
