### PR TITLE
fix(curriculum): restore list sub-headings in backend lessons

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-the-web-standards-model/69fc757399f4066e674a5160.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-web-standards-model/69fc757399f4066e674a5160.md
@@ -14,16 +14,16 @@ However, underneath those differences, the process of turning an idea into a web
 1. ## Identifying a need
     Standards start with friction, like developers hitting a brick wall, browsers implementing the same behavior in incompatible ways, or a new capability the platform simply doesn't support yet. Someone, somewhere, gets frustrated enough to write it down. That someone can be anyone; a developer, a large company with a product need, or an engineer inside a browser team. What matters at this stage is not authority, but evidence and questions on whether the problem is real, and whether enough people are running into it to justify the web platform's attention.
 
-1. **Proposal and early discussion**
+1. ## Proposal and early discussion
     The idea gets written up informally through a GitHub issue, a short document, or an explainer that describes the problem and sketches a possible solution. At this stage, the goal is not to produce a finished specification but to find out whether the problem resonates. Do other developers recognize it? Are browser vendors interested? Is there an obvious solution, or several competing ones? In TC39, this early phase corresponds to Stage 0 and Stage 1. In the W3C, it often happens informally in a Community Group before a formal Working Group is chartered. The WHATWG handles it through open GitHub discussions on its core repositories. The venue differs, but the function is the same.
 
-1. **Writing the specification**
+1. ## Writing the specification
     If the proposal gains traction, someone or a small team has to write the actual specification, or spec. A spec is not a blog post or a tutorial, but a precise, formal document describing exactly how a feature must behave in every possible situation. Edge cases, error conditions, interactions with existing features, and security implications all have to be thought through and written down.
 
-1. **Review, objection, and iteration**
+1. ## Review, objection, and iteration
     The draft is published and reviewed publicly, and by the other browser vendors. This is where most of the real work happens. Objections are raised, and the spec is revised. A feature that one major browser engine refuses to implement will rarely become a standard, regardless of its technical merits. Consensus-building at this stage can take a long time. Some proposals stall for years while vendors negotiate over design details. Others die entirely when it becomes clear that no agreement is reachable.
 
-1. **Implementation and testing**
+1. ## Implementation and testing
     Once a spec is stable enough, browser vendors begin implementing it. This usually starts with a feature flag first, so it can be tested without affecting existing users. Implementation often reveals problems that the spec didn't anticipate, which then get sent back to the editors for clarification. A shared test suite verifies that every implementation actually behaves the same way. If Chrome, Firefox, and Safari all pass the same tests, the spec is working. If they diverge, either the spec is unclear, or one of the implementations has a bug.
 
 1. ## Finalization

--- a/curriculum/challenges/english/blocks/lecture-understanding-the-web-standards-model/69fc757399f4066e674a5161.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-web-standards-model/69fc757399f4066e674a5161.md
@@ -13,22 +13,22 @@ The lifecycle of a web standard feature is related, but on a more granular scale
 
 Think of the process as the rulebook, and the lifecycle as what actually happens when you play the game.
 
-1. **Proposal**
+1. ## Proposal
     Every feature starts with a problem someone cared enough to write down. A developer, a browser engineer, or a company files a GitHub issue or explainer describing what the web can't currently do and why it should. At this stage, the idea is loose, with more questions than answers. The goal is simply to find out whether anyone else recognizes the same pain.
 
-1. **Incubation**
+1. ## Incubation
     If the proposal resonates, it enters a period of open discussion and early design. Competing approaches get sketched out, use cases are gathered, and the community stress-tests the idea. Many proposals die here, possibly because the problem turns out to be too niche, or no solution can satisfy everyone. The ones that survive emerge with a clearer shape and at least some browser vendor interest behind them.
 
-1. **Specification**
+1. ## Specification
     A surviving proposal gets written up as a formal spec. Every edge case, error condition, and interaction with existing features has to be defined clearly. This is the point where a good idea meets hard reality. Vague concepts have to become exact rules that two independent engineers could read and implement identically.
 
-1. **Interoperability testing**
+1. ## Interoperability testing
     Before a feature can be considered stable, it has to behave the same way in every browser. The W3C Web Platform Tests suite is the main tool for verifying this. It is a shared battery of tests that Chrome, Firefox, Safari, and others all run against their implementations. Diverging results mean either the spec is ambiguous, or someone has a bug. Either must be resolved before the feature moves forward.
 
-1. **Finalization**
+1. ## Finalization
     Once multiple independent implementations pass the tests, the feature is finalized. For W3C, it is a recommendation, for TC39, it is stage 4, and it is a stable entry in the WHATWG living standard. The flags come down and the feature ships to users. At this point, it becomes part of the baseline web platform, something every developer can rely on indefinitely.
 
-1. **Deprecation**
+1. ## Deprecation
     Not every standard ages well. Some features get superseded by better ones, others turn out to have security or privacy implications that weren't apparent at the time. When a feature needs to go, it gets formally deprecated. That is, supported but marked as something developers should stop using. Eventually, it is removed from the spec. Removal from browsers is slow and cautious, because the core promise of the web is that old pages keep working. Some deprecated features linger in browsers for decades solely for the backwards-compatibility obligation.
 
 # --questions--

--- a/curriculum/challenges/english/blocks/lecture-understanding-the-web-standards-model/69fc757399f4066e674a5162.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-web-standards-model/69fc757399f4066e674a5162.md
@@ -9,25 +9,25 @@ dashedName: what-are-the-key-principles-that-web-standards-are-built-on
 
 Web standards aren't just technical documents, they reflect a set of values about what the web should be and who it should serve. Understanding these principles helps you see not just how the web works, but why it was built the way it was. Let's discuss those principles.
 
-1. **Openness**
+1. ## Openness
     Web standards are developed in the open and implemented royalty-free. Anyone can read the specs, anyone can build a browser, and no company can charge licensing fees for implementing a standard. This openness is what distinguishes the web from proprietary platforms and what allows small teams to build tools that reach billions of people without asking permission from a gatekeeper.
 
-1.  **Accessibility**
+1.  ## Accessibility
     The web was designed to be usable by everyone, regardless of ability. Accessibility isn't an add-on to web standards, it is baked into the design of HTML, CSS, and browser behavior. The W3C's WCAG guidelines set the formal bar for what accessible means in practice. A feature that creates barriers for people using screen readers, keyboard navigation, or assistive technology is considered deficient by design, not just by ethics.
 
-1.  **Interoperability**
+1.  ## Interoperability
     The most foundational principle is that the web should work the same everywhere. A page built to standard should behave identically in Chrome, Firefox, and Safari, and on Windows, macOS, Linux, Android, and iOS. Without interoperability, the web breaks into a collection of browser-specific experiences, and developers are forced to write the same thing multiple times. Every standard exists, at its core, to prevent that.
 
-1.  **Backwards compatibility**
+1.  ## Backwards compatibility
     The web has a near-absolute commitment to not breaking old things. A page written in 1999 should still render in a modern browser, and standards bodies take this obligation seriously when designing new features. This is why new capabilities are layered on top rather than replacing what came before. It's a constraint that sometimes frustrates designers, but it's also what makes the web uniquely durable as a platform.
 
-1.  **Privacy and security**
+1.  ## Privacy and security
     Modern standards are reviewed for privacy and security implications before they ship. New APIs that could expose user data or enable tracking face significant scrutiny in the standards process. The principle is that the platform should protect users by default, and that convenience for developers should never come at the cost of user safety.
 
-1.  **Layering**
+1.  ## Layering
     The web is built in distinct, composable layers: HTML for structure, CSS for presentation, and JavaScript for behavior. Standards are designed to respect these boundaries rather than collapse them. A well-layered feature can be adopted incrementally. A page that doesn't use JavaScript still works, and a browser that doesn't support a new CSS property still renders something reasonable. This separation of concerns is what gives the web its resilience.
 
-1.  **Progressive enhancement**
+1.  ## Progressive enhancement
     Closely related to layering is the idea that the web should work for everyone, then get better for those with more capable browsers or devices. A standard feature should degrade gracefully when unsupported, not break entirely. This principle shapes how new CSS properties are specified, how JavaScript APIs handle missing capabilities, and how standards bodies think about the gap between modern browsers and the older ones still in wide use across the world.
 
 # --questions--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Current layout is on the left and updated is on the right
<img width="1372" height="535" alt="image" src="https://github.com/user-attachments/assets/fe765e87-6b78-4c46-b1aa-7841a39a6f0b" />

