### PR TITLE
feat(curriculum): add REST API and Web Services review

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -7410,6 +7410,12 @@
           "You will learn route parameters and modular routing with <code>express.Router</code> by building a weather service API."
         ]
       },
+      "review-rest-api-and-web-services": {
+        "title": "REST API and Web Services Review",
+        "intro": [
+          "Review web services, the REST architecture, HTTP status codes, and microservices."
+        ]
+      },
       "lab-timestamp-microservice": {
         "title": "Build a Timestamp Microservice",
         "intro": [
@@ -7444,7 +7450,7 @@
       "review-introduction-to-express": {
         "title": "Introduction to Express Review",
         "intro": [
-          "Review web services, REST, microservices, and Express.js routing before you take the quiz."
+          "Review Express.js, routing, response methods, and serving static files before you take the quiz."
         ]
       },
       "quiz-introduction-to-express": {

--- a/curriculum/challenges/english/blocks/review-introduction-to-express/6a0354d43d4c00eca38561f7.md
+++ b/curriculum/challenges/english/blocks/review-introduction-to-express/6a0354d43d4c00eca38561f7.md
@@ -7,53 +7,6 @@ dashedName: review-introduction-to-express
 
 # --description--
 
-## Web Services and APIs
-
-- **API (Application Programming Interface)**: A general way for software to communicate with other software.
-- **Web service**: A specific type of API that uses web technologies like HTTP to exchange data over a network. Every web service is an API, but not every API is a web service.
-- **Key characteristics of a web service**: runs on a server, enables machine-to-machine communication, is language-agnostic, is platform-agnostic, and uses standard web protocols (HTTP/HTTPS, FTP, SMTP).
-- **REST (Representational State Transfer)**: The most widely used type of web service today. Exposes resources identified by URL paths like `/users` or `/users/20`. Responses are usually in JSON, but can also be XML or plain text.
-- **SOAP (Simple Object Access Protocol)**: Uses only XML. Common in enterprise systems that need stricter standards and security.
-- **XML-RPC**: Uses XML to encode requests and responses. Lightweight but less flexible than REST.
-- **`Accept` header**: Used by a client to tell the server which response format it wants, for example `Accept: application/json`.
-
-## The REST Architecture
-
-- **Statelessness**: Every request must include all the information the server needs to process it. The server does not remember previous requests.
-- **Resource**: A piece of data that can be accessed or modified, identified by a URL (for example, `/products/1`).
-- **HTTP methods in REST**:
-  - `GET` — retrieve a resource
-  - `POST` — create a new resource
-  - `PUT` / `PATCH` — update an existing resource
-  - `DELETE` — remove a resource
-
-## HTTP Status Codes
-
-After processing a request, the server responds with a **status code** that indicates the result:
-
-- `200` **(OK)**: The request was successful
-- `201` **(Created)**: A new resource was created
-- `400` **(Bad Request)**: The client sent invalid data
-- `404` **(Not Found)**: The requested resource does not exist
-- `500` **(Internal Server Error)**: An error occurred on the server
-
-### How a REST request works
-
-1. The client sends a request with a method, URL, optional headers, and optional body.
-2. The server validates the request and identifies the resource.
-3. The server performs the action (get, create, update, or delete).
-4. The server builds a response with a status code and optional body (usually JSON).
-5. The server sends the response — no client state is stored.
-6. The client checks the status code and processes the returned data.
-
-## Monoliths vs. Microservices
-
-- **Monolith**: A single, large codebase where the UI, database, and API all live together. Works well for small apps but gets harder to maintain and scale as it grows.
-- **Microservices**: An architecture where a large app is broken into smaller, independent services. Each service handles one business capability (for example, products, orders, payments) and can have its own codebase, database, and team.
-- **How microservices communicate**: Through APIs or message-based systems.
-- **Advantages of microservices**: Faster development, better fault isolation, and the freedom to use different languages or frameworks per service.
-- **Challenges of microservices**: More complex debugging, harder infrastructure management, and more network overhead between services.
-
 ## What Is Express.js?
 
 - **Express**: A minimal and flexible web framework built on top of Node.js that makes it easier to build web servers and APIs.

--- a/curriculum/challenges/english/blocks/review-rest-api-and-web-services/6a7c78ad958a597ee788ad2a.md
+++ b/curriculum/challenges/english/blocks/review-rest-api-and-web-services/6a7c78ad958a597ee788ad2a.md
@@ -1,0 +1,59 @@
+---
+id: 6a7c78ad958a597ee788ad2a
+title: REST API and Web Services Review
+challengeType: 31
+dashedName: review-rest-api-and-web-services
+---
+
+# --description--
+
+## Web Services and APIs
+
+- **API (Application Programming Interface)**: A general way for software to communicate with other software.
+- **Web service**: A specific type of API that uses web technologies like HTTP to exchange data over a network. Every web service is an API, but not every API is a web service.
+- **Key characteristics of a web service**: runs on a server, enables machine-to-machine communication, is language-agnostic, is platform-agnostic, and uses standard web protocols (HTTP/HTTPS, FTP, SMTP).
+- **REST (Representational State Transfer)**: The most widely used type of web service today. Exposes resources identified by URL paths like `/users` or `/users/20`. Responses are usually in JSON, but can also be XML or plain text.
+- **SOAP (Simple Object Access Protocol)**: Uses only XML. Common in enterprise systems that need stricter standards and security.
+- **XML-RPC**: Uses XML to encode requests and responses. Lightweight but less flexible than REST.
+- **`Accept` header**: Used by a client to tell the server which response format it wants, for example `Accept: application/json`.
+
+## The REST Architecture
+
+- **Statelessness**: Every request must include all the information the server needs to process it. The server does not remember previous requests.
+- **Resource**: A piece of data that can be accessed or modified, identified by a URL (for example, `/products/1`).
+- **HTTP methods in REST**:
+  - `GET` — retrieve a resource
+  - `POST` — create a new resource
+  - `PUT` / `PATCH` — update an existing resource
+  - `DELETE` — remove a resource
+
+## HTTP Status Codes
+
+After processing a request, the server responds with a **status code** that indicates the result:
+
+- `200` **(OK)**: The request was successful
+- `201` **(Created)**: A new resource was created
+- `400` **(Bad Request)**: The client sent invalid data
+- `404` **(Not Found)**: The requested resource does not exist
+- `500` **(Internal Server Error)**: An error occurred on the server
+
+### How a REST request works
+
+1. The client sends a request with a method, URL, optional headers, and optional body.
+2. The server validates the request and identifies the resource.
+3. The server performs the action (get, create, update, or delete).
+4. The server builds a response with a status code and optional body (usually JSON).
+5. The server sends the response — no client state is stored.
+6. The client checks the status code and processes the returned data.
+
+## Monoliths vs. Microservices
+
+- **Monolith**: A single, large codebase where the UI, database, and API all live together. Works well for small apps but gets harder to maintain and scale as it grows.
+- **Microservices**: An architecture where a large app is broken into smaller, independent services. Each service handles one business capability (for example, products, orders, payments) and can have its own codebase, database, and team.
+- **How microservices communicate**: Through APIs or message-based systems.
+- **Advantages of microservices**: Faster development, better fault isolation, and the freedom to use different languages or frameworks per service.
+- **Challenges of microservices**: More complex debugging, harder infrastructure management, and more network overhead between services.
+
+# --assignment--
+
+Review the REST API and Web Services topics and concepts.

--- a/curriculum/structure/blocks/review-rest-api-and-web-services.json
+++ b/curriculum/structure/blocks/review-rest-api-and-web-services.json
@@ -1,0 +1,13 @@
+{
+  "isUpcomingChange": false,
+  "dashedName": "review-rest-api-and-web-services",
+  "helpCategory": "Backend Development",
+  "blockLayout": "link",
+  "challengeOrder": [
+    {
+      "id": "6a7c78ad958a597ee788ad2a",
+      "title": "REST API and Web Services Review"
+    }
+  ],
+  "blockLabel": "review"
+}

--- a/curriculum/structure/superblocks/back-end-development-and-apis-v9.json
+++ b/curriculum/structure/superblocks/back-end-development-and-apis-v9.json
@@ -51,7 +51,8 @@
           "dashedName": "rest-api-and-web-services",
           "blocks": [
             "lecture-understanding-rest-api-and-web-services",
-            "workshop-build-a-weather-service-api"
+            "workshop-build-a-weather-service-api",
+            "review-rest-api-and-web-services"
           ]
         },
         {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The `rest-api-and-web-services` module had no review block, and its content was living in the Introduction to Express review instead. Every other non-`cert-project` module in the superblock ends with a review and a quiz.

This adds a `review-rest-api-and-web-services` block and moves the four sections that belong to it out of `review-introduction-to-express`:

- Web Services and APIs
- The REST Architecture
- HTTP Status Codes
- Monoliths vs. Microservices

The sections are moved unchanged. They summarize the three `lecture-understanding-rest-api-and-web-services` lessons: `How Do Web Services Work?`, `What Is The REST Architecture and How Does It Work?`, and `What Are Microservices?`.

The Introduction to Express review now starts at `What Is Express.js?` and covers only the `introduction-to-express` lectures. Both `intro.json` intros were updated to match what each page now contains.

The module still has no quiz, tracked in #69504, and `quiz-introduction-to-express` still holds six questions on these REST topics, tracked in #69505.
