### PR TITLE
fix(curriculum): add section headers to text-shadow lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd853c985cdfdeb32f4f9.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd853c985cdfdeb32f4f9.md
@@ -13,6 +13,8 @@ CSS doesn't apply any shadows to the text by default. This is an example of a pa
 text-shadow: /* Values */
 ```
 
+## The X and Y Offset Values
+
 In CSS, you can describe a shadow through a combination of its `X` offset, `Y` offset, blur radius, and color. First, you need to specify the `X` and `Y` offset, which represent the horizontal and vertical distance of the shadow from the text, respectively. These values are required.
 
 Here's an example of how to apply an `X` and `Y` offset on a shadow. We apply the `text-shadow` property with an x-offset of `3px` and a y-offset of `2px`:
@@ -31,6 +33,8 @@ p {
 ```
 
 :::
+
+## Adding a Color to the Shadow
 
 In the browser, the text and the shadow will look similar but we can also customize the color of the shadow by specifying the value before or after the offset. Let's set the shadow color. We will use a hexadecimal color here but you can use any valid color format. 
 
@@ -66,6 +70,8 @@ p {
 
 :::
 
+## Positive and Negative Offset Values
+
 In the browser, the shadow will have a specific color, so we can distinguish it very easily from the text. Now that we can differentiate the shadow from the text, it's also important to see how positive and negative values affect the shadow offset. Positive values of the `X` offset and `Y` offset will move the shadow right and down, respectively, while negative values will move the shadow left and up. Here's an example that uses negative values instead:
 
 :::interactive_editor
@@ -82,6 +88,8 @@ p {
 ```
 
 :::
+
+## The Blur Radius
 
 Now the shadow will move left and up in relation to the text. Great. But the shadow is not looking very nice, because it looks exactly like the original text but placed behind it. To make it look nicer, we need to add a third value, the blur radius. This value is optional but makes the shadow look a lot smoother and more subtle. The default value of the radius blur is zero. The higher the value, the bigger the blur, which means that the shadow becomes lighter.
 
@@ -103,6 +111,8 @@ p {
 :::
 
 Now it's starting to look like a shadow. It's more blurry and subtle, so we can focus on the main text while the shadow adds some style in the background. From here, we can tweak the values a little bit until we find a combination of offset, color, and blur radius that fits our needs.
+
+## Adding Multiple Shadows
 
 It's also helpful to know that the text can have more than one shadow. You just need to write them in the same `text-shadow` property separated by commas. They will be applied in layers, from front to back, with the first shadow at the top.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd853c985cdfdeb32f4f9.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-fonts/672bd853c985cdfdeb32f4f9.md
@@ -13,7 +13,7 @@ CSS doesn't apply any shadows to the text by default. This is an example of a pa
 text-shadow: /* Values */
 ```
 
-## The X and Y Offset Values
+## The `X` and `Y` Offset Values
 
 In CSS, you can describe a shadow through a combination of its `X` offset, `Y` offset, blur radius, and color. First, you need to specify the `X` and `Y` offset, which represent the horizontal and vertical distance of the shadow from the text, respectively. These values are required.
 
@@ -34,9 +34,11 @@ p {
 
 :::
 
+In the browser, the text and the shadow will look similar.
+
 ## Adding a Color to the Shadow
 
-In the browser, the text and the shadow will look similar but we can also customize the color of the shadow by specifying the value before or after the offset. Let's set the shadow color. We will use a hexadecimal color here but you can use any valid color format. 
+We can also customize the color of the shadow by specifying the value before or after the offset. Let's set the shadow color. We will use a hexadecimal color here but you can use any valid color format.
 
 :::interactive_editor
 
@@ -70,9 +72,11 @@ p {
 
 :::
 
+In the browser, the shadow will have a specific color, so we can distinguish it very easily from the text.
+
 ## Positive and Negative Offset Values
 
-In the browser, the shadow will have a specific color, so we can distinguish it very easily from the text. Now that we can differentiate the shadow from the text, it's also important to see how positive and negative values affect the shadow offset. Positive values of the `X` offset and `Y` offset will move the shadow right and down, respectively, while negative values will move the shadow left and up. Here's an example that uses negative values instead:
+Now that we can differentiate the shadow from the text, it's also important to see how positive and negative values affect the shadow offset. Positive values of the `X` offset and `Y` offset will move the shadow right and down, respectively, while negative values will move the shadow left and up. Here's an example that uses negative values instead:
 
 :::interactive_editor
 
@@ -89,9 +93,11 @@ p {
 
 :::
 
+Now the shadow will move left and up in relation to the text. Great.
+
 ## The Blur Radius
 
-Now the shadow will move left and up in relation to the text. Great. But the shadow is not looking very nice, because it looks exactly like the original text but placed behind it. To make it look nicer, we need to add a third value, the blur radius. This value is optional but makes the shadow look a lot smoother and more subtle. The default value of the radius blur is zero. The higher the value, the bigger the blur, which means that the shadow becomes lighter.
+But the shadow is not looking very nice, because it looks exactly like the original text but placed behind it. To make it look nicer, we need to add a third value, the blur radius. This value is optional but makes the shadow look a lot smoother and more subtle. The default value of the radius blur is zero. The higher the value, the bigger the blur, which means that the shadow becomes lighter.
 
 Here, we are setting the blur radius to `3px` and we're back to positive values for the offset:
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #69336

### Description

Adds `##` section headers to the lecture body of "What Is the text-shadow Property, and How Does It Work?" to break the ~537-word unbroken block into scannable sections.

Headers added:

- The X and Y Offset Values
- Adding a Color to the Shadow
- Positive and Negative Offset Values
- The Blur Radius
- Adding Multiple Shadows

No prose was rewritten - only headers were inserted. Front matter, code blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below:
<img width="520" height="140" alt="Screenshot 2026-08-12 at 9 03 10 PM" src="https://github.com/user-attachments/assets/86176e55-eb09-4dc7-bc29-5ca90284b7e3" />
<img width="520" height="90" alt="Screenshot 2026-08-12 at 9 04 36 PM" src="https://github.com/user-attachments/assets/4017b952-224b-4993-a2de-29d24f3cc608" />
<img width="520" height="125" alt="Screenshot 2026-08-12 at 9 08 35 PM" src="https://github.com/user-attachments/assets/27418a4f-ee77-4330-bb95-99aecc6fa975" />
<img width="520" height="129" alt="Screenshot 2026-08-12 at 9 09 39 PM" src="https://github.com/user-attachments/assets/a825cd8a-aaf0-48b0-82b6-b60089f4873d" />
<img width="520" height="104" alt="Screenshot 2026-08-12 at 9 10 03 PM" src="https://github.com/user-attachments/assets/00b8c5c8-34ea-491d-b9a6-d3dde4afd02d" />
