### PR TITLE
fix: grammar and formatting in VS Code install lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45583fd75a504136fbbb.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45583fd75a504136fbbb.md
@@ -11,7 +11,7 @@ To install VS Code, you'll want to visit the VS Code website to get the appropri
 
 For Windows, you can download an EXE installer. Once you've downloaded it, run the file, and the setup wizard will take you through the installation process.
 
-For Mac, you can download a `.zip` argit diffchive, which contains a `.app` that you can run. You can also install VS Code via Homebrew.
+For Mac, you can download a `.zip` archive, which contains a `.app` that you can run. You can also install VS Code via Homebrew.
 
 Open up the Terminal app on your Mac and run the following command:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45583fd75a504136fbbb.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45583fd75a504136fbbb.md
@@ -1,17 +1,17 @@
 ---
 id: 672d45583fd75a504136fbbb
-title: How to Install Visual Studio Code onto Your Computer
+title: How to Install Visual Studio Code on Your Computer
 challengeType: 19
 dashedName: how-to-install-visual-studio-code-onto-your-computer
 ---
 
 # --description--
 
-To install VS Code, you'll want to visit their website to get the appropriate installer for your operating system. Make sure you visit the VS Code website, and not the Visual Studio website.
+To install VS Code, you'll want to visit the VS Code website to get the appropriate installer for your operating system. Make sure you visit the VS Code website, and not the Visual Studio website.
 
-For Windows, you can download an EXE installer. Once you've downloaded it, run the file and the setup wizard will take you through the installation process.
+For Windows, you can download an EXE installer. Once you've downloaded it, run the file, and the setup wizard will take you through the installation process.
 
-For Mac, you can download a zip archive which contains a `.app` that you can run. You can also install VS Code via homebrew.
+For Mac, you can download a `.zip` argit diffchive, which contains a `.app` that you can run. You can also install VS Code via Homebrew.
 
 Open up the Terminal app on your Mac and run the following command:
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69493

Fixes grammar and formatting issues in the "How to Install Visual Studio Code" lecture:
- Corrected title preposition: "onto" → "on"
- Fixed vague pronoun "their website" → "the VS Code website"
- Added missing comma between two independent clauses
- Formatted "zip archive" as `.zip` and added missing comma before non-restrictive clause
- Capitalized "homebrew" → "Homebrew" to match the quiz questions