### PR TITLE
fix: add missing lab-story-fragment-restoration to javascript-fundamentals-review

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2669,6 +2669,13 @@
           "You'll practice conditionals to determine the student's grade based on their score."
         ]
       },
+      "lab-story-fragment-restoration": {
+        "title": "Restore a Coherent Narrative from an Array of Story Fragments",
+        "intro": [
+          "In this lab, you'll restore a coherent narrative from a corrupted array of story fragments.",
+          "You will practice working with loops by implementing fundamental array algorithms from scratch."
+        ]
+      },
       "lecture-the-var-keyword-and-hoisting": {
         "title": "The var Keyword and Hoisting",
         "intro": [

--- a/curriculum/structure/superblocks/javascript-fundamentals-review.json
+++ b/curriculum/structure/superblocks/javascript-fundamentals-review.json
@@ -9,6 +9,7 @@
     "lab-slice-and-splice",
     "lab-pyramid-generator",
     "lab-gradebook-app",
+    "lab-story-fragment-restoration",
     "lecture-the-var-keyword-and-hoisting",
     "lab-title-case-converter",
     "lab-falsy-remover",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69509 

<!-- Feel free to add any additional description of changes below this line -->
The `lab-story-fragment-restoration` block exists in the `javascript-v9` module but was missing from the standalone `javascript-fundamentals-review` superblock.

Added it in module order (after `lab-gradebook-app`) to:
- `curriculum/structure/superblocks/javascript-fundamentals-review.json`
- `client/i18n/locales/english/intro.json` (under the `javascript-fundamentals-review` key)