### PR TITLE
fix(curriculum): allow arrow functions in factorial calculator

### DIFF
--- a/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -57,8 +57,8 @@ The `factorialCalculator` function should take a number as an argument.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const parameters = explorer.allFunctions.factorialCalculator.parameters;
-assert.lengthOf(parameters, 1);
+const { factorialCalculator } = explorer.allFunctions;
+assert.lengthOf(factorialCalculator?.parameters, 1);
 ```
 
 The factorial of `5` should return `120`.

--- a/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -56,7 +56,9 @@ assert.isFunction(factorialCalculator);
 The `factorialCalculator` function should take a number as an argument.
 
 ```js
-assert.match(factorialCalculator.toString(), /\s*factorialCalculator\(\s*\w+\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const parameters = explorer.allFunctions.factorialCalculator.parameters;
+assert.lengthOf(parameters, 1);
 ```
 
 The factorial of `5` should return `120`.


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69484

## Summary

- replace the `Function.prototype.toString()` regex with the curriculum `Explorer` AST helper
- validate the `factorialCalculator` parameter count independently of function syntax

## Why

The previous regex only matched a named function declaration, so valid function expressions and arrow functions failed the parameter hint. Inspecting the parsed function node makes the test accept all three forms while still requiring exactly one parameter.

## Validation

- `pnpm exec vitest run --project test` with `FCC_CHALLENGE_ID=66c07238b01053abaf812065` (`6 passed`)
- `pnpm -F @freecodecamp/curriculum lint-challenges`
- `pnpm exec prettier --check curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md`