### PR TITLE
fix: clean up wording in the Vite React setup lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e88cc46e6dc679420040.md
@@ -13,7 +13,7 @@ One of the most popular tools for setting up projects is Vite. Vite, which means
 
 To create a new project with Vite, you will need to use the command line. If you are using a Windows machine, then you can use the Command Prompt or Windows PowerShell. If you are using a Mac, then you can use the Terminal app.
 
-In case you don't have Node.js installed, which is needed for npm to work, here is a link to the official Node.js webpage: https://nodejs.org. Follow the installation instructions then come back here to resume your React installation.
+In case you don't have Node.js installed, which is needed for npm to work, here is a link to the official Node.js webpage: [nodejs.org](https://nodejs.org). Follow the installation instructions, then come back here to resume your React installation.
 
 Once you have the command line open, you can use the following command:
 
@@ -36,7 +36,7 @@ npm install
 
 The `cd my-react-app` command ensures that you change to the correct directory where your project is located.
 
-The `npm install` command is used to install the dependencies needed to properly run your React project. Dependencies are libraries or packages that your React project requires in order to function correctly, such as React itself, ReactDOM, or other third-party packages that provide additional functionality.
+The `npm install` command is used to install the dependencies needed to properly run your React project. Dependencies are libraries or packages that your React project requires in order to function correctly, such as React itself, `react-dom`, or other third-party packages that provide additional functionality.
 
 Running `npm install` will read the `package.json` file in your project directory and install all the dependencies listed there, allowing you to build and run your React app without missing any necessary components.
 
@@ -50,11 +50,11 @@ To run your project, run the `npm run dev` command and open up a new browser tab
 
 You should see the starter template that Vite has provided for you.
 
-If you need to stop the local server, press `CTRL + C` in the command line.
+If you need to stop the local server, press `Ctrl + C` in the command line.
 
-To actually see the code for this starter template, you can go into your project inside the `src` folder and you should see the `App.jsx` file.
+To actually see the code for this starter template, you can go into the `src` folder inside your project, where you should see the `App.jsx` file.
 
-From there you can start to modify the file, save your changes and see the new changes display in the browser.
+From there you can modify the file, save your changes, and watch them appear in the browser.
 
 And with that, you're ready to begin building your React application!
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69526

Cleanup of the What Is Vite lesson text. Changes:

- Bare URL became a markdown link, comma added before "then"
- `ReactDOM` -> `react-dom`, `CTRL + C` -> `Ctrl + C`
- Flipped the "project inside src folder" sentence so the folder sits in the project
- Last sentence got its serial comma and a clearer ending ("watch them appear in the browser")