### PR TITLE
fix(curriculum): allow arrow functions in factorial calculator lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -56,7 +56,9 @@ assert.isFunction(factorialCalculator);
 The `factorialCalculator` function should take a number as an argument.
 
 ```js
-assert.match(factorialCalculator.toString(), /\s*factorialCalculator\(\s*\w+\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.allFunctions.factorialCalculator);
+assert.lengthOf(explorer.allFunctions.factorialCalculator.parameters, 1);
 ```
 
 The factorial of `5` should return `120`.

--- a/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
+++ b/curriculum/challenges/english/blocks/lab-factorial-calculator/66c07238b01053abaf812065.md
@@ -57,8 +57,8 @@ The `factorialCalculator` function should take a number as an argument.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.allFunctions.factorialCalculator);
-assert.lengthOf(explorer.allFunctions.factorialCalculator.parameters, 1);
+const { factorialCalculator } = explorer.allFunctions;
+assert.lengthOf(factorialCalculator?.parameters, 1);
 ```
 
 The factorial of `5` should return `120`.


### PR DESCRIPTION
Replaced the factorialCalculator.toString() regex assertion (which only matched named function declarations) with the allFunctions/parameters AST helpers, so the arg-count hint passes for function declarations, function expressions, and arrow function solutions alike.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69484

<!-- Feel free to add any additional description of changes below this line -->
