### PR TITLE
fix(curriculum): update keyboard shortcut text

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
@@ -9,21 +9,21 @@ dashedName: what-are-several-useful-keyboard-shortcuts-for-maximizing-productivi
 
 You're likely already familiar with some of the basic shortcuts, which are inherited from your operating system. Shortcuts like `Ctrl + S` to save, `Ctrl + C` to copy, and `Ctrl + V` to paste all work in VS Code.
 
-But there's a few that are application specific and can still level up your productivity. It's worth noting that some of these shortcuts may differ by operating system.
+But there are a few that are application-specific and can still level up your productivity. It's worth noting that some of these shortcuts may differ by operating system.
 
-For example, `Shift + Alt + F` will run your configured formatter (such as prettier, for a JavaScript project) on the currently opened file.
+For example, `Shift + Alt + F` will run your configured formatter (such as Prettier, for a JavaScript project) on the currently opened file.
 
-Or `Ctrl + Shift + F` (Windows), or `Cmd + Shift + F` (Mac), to search the text contents of all the files in your workspace. Then `Ctrl + Shift + H` (Windows), or `Cmd + Shift + H` (Mac), if you want to run a find-and-replace.
+Use `Ctrl + Shift + F` (Windows/Linux) or `Cmd + Shift + F` (macOS) to search the text contents of all the files in your workspace. Then use `Ctrl + Shift + H` (Windows/Linux) or `Cmd + Shift + H` (macOS) if you want to run a find-and-replace.
 
-If you need to remove a line, `Ctrl + Shift + K` (Windows), or `Cmd + Shift + K` (Mac), will delete it.
+If you need to remove a line, `Ctrl + Shift + K` (Windows/Linux) or `Cmd + Shift + K` (macOS) will delete it.
 
-Need some extra room for all your code? `Ctrl + B` (Windows), or `Cmd + B` (Mac), will hide the sidebar - which has the file list and extensions menu.
+Need some extra room for all your code? `Ctrl + B` (Windows/Linux) or `Cmd + B` (macOS) will hide the sidebar, which has the file list and extensions menu.
 
-Or maybe you just can't see your code? `Ctrl + plus` (Windows), or `Cmd + plus` (Mac), will increase the scaling of the editor, and `Ctrl + minus` (Windows), or `Cmd + minus` (Mac), will decrease it.
+Or maybe you just can't see your code? `Ctrl + plus` (Windows/Linux) or `Cmd + plus` (macOS) will increase the scaling of the editor, and `Ctrl + minus` (Windows/Linux) or `Cmd + minus` (macOS) will decrease it.
 
-Another helpful feature in VS Code is multi-line editing, which allows you to make changes across several lines at once. For example, you can place multiple cursors by using `Ctrl + Alt + down` and `Ctrl + Alt + up` (Windows/Linux), or `Option + Command + down` and `Option + Command + up` (Mac), to extend the cursor to consecutive lines. You can also press and hold `Alt` (Windows/Linux) or `Option` (Mac) and click to add cursors on separate lines wherever you need them. Once the cursors are placed, anything you type or delete will apply to all those locations simultaneously — which can save a lot of time when working with repetitive code.
+Another helpful feature in VS Code is multi-line editing, which allows you to make changes across several lines at once. For example, you can place multiple cursors by using `Ctrl + Alt + down` and `Ctrl + Alt + up` (Windows/Linux) or `Option + Cmd + down` and `Option + Cmd + up` (macOS) to extend the cursor to consecutive lines. You can also press and hold `Alt` (Windows/Linux) or `Option` (macOS) and click to add cursors on separate lines wherever you need them. Once the cursors are placed, anything you type or delete will apply to all those locations simultaneously, which can save a lot of time when working with repetitive code.
 
-Finally, if you forget any of these shortcuts, you always have `Ctrl + Shift + P` (Windows), or `Cmd + Shift + P` (Mac), which opens the command palette for you to select whatever you may need.
+Finally, if you forget any of these shortcuts, you always have `Ctrl + Shift + P` (Windows/Linux) or `Cmd + Shift + P` (macOS), which opens the command palette for you to select whatever you may need.
 
 With this knowledge, and maybe a little practice, you are well on your way to becoming a VS Code power user.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69523

This PR fixes the style issues in the "What Are Several Useful Keyboard Shortcuts for Maximizing Productivity in VS Code?" lecture:

- Fixes the subject-verb agreement and hyphenates the compound modifier (`there are a few ... application-specific`)
- Capitalizes the formatter name (`Prettier`)
- Replaces the sentence fragment opening `Or ...` with `Use ...`
- Replaces the hyphen and em dash with commas
- Standardizes the platform labels to `(Windows/Linux)` and `(macOS)` and uses `Cmd` for the key throughout the description

These are text-only changes to the challenge description; the markdown structure is unchanged.