### PR TITLE
fix(lecture): content issues in code editors lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d26269456511aa3db614d.md
@@ -15,15 +15,15 @@ First, let's consider a few popular IDEs. Visual Studio is an integrated develop
 
 Another IDE is Xcode. Xcode is an integrated development environment by Apple designed for creating, coding, and debugging applications for macOS, iOS, watchOS, and tvOS.
 
-And another IDE would be Android Studio. Android Studio is an integrated development environment by Google specifically designed for building, debugging, and testing Android applications.
+Android Studio is another IDE. Android Studio is an integrated development environment by Google specifically designed for building, debugging, and testing Android applications.
 
 Those are just a few examples of IDEs. Now, let's take a look at a few popular code editors.
 
 Visual Studio Code is a lightweight, open-source code editor by Microsoft that supports a wide range of programming languages and provides features like debugging, syntax highlighting, and version control through extensions.
 
-Another popular editor would be Sublime Text. Sublime Text is a fast, versatile text editor known for its sleek interface, powerful features, and support for a wide range of programming languages through customizable syntax highlighting and plugins.
+Sublime Text is another popular editor. Sublime Text is a fast, versatile text editor known for its sleek interface, powerful features, and support for a wide range of programming languages through customizable syntax highlighting and plugins.
 
-And another one is Notepad++. This is a free, open-source text and source code editor for Windows that offers syntax highlighting, code folding, and a range of plugins to enhance productivity and customization.
+Notepad++ is another popular editor. This is a free, open-source text and source code editor for Windows that offers syntax highlighting, code folding, and a range of plugins to enhance productivity and customization.
 
 You may have noticed how the code editors focus primarily on the text contents of the file, whereas the IDEs expose various tools to manage your code.
 
@@ -37,7 +37,7 @@ Replit is an online platform that provides a collaborative environment for codin
 
 Another popular cloud-based editor is GitHub Codespaces. This is a cloud-based development environment that provides instant access to a fully configured code editor and development tools directly from GitHub, enabling seamless coding and collaboration.
 
-And another one is Ona. Ona is a cloud-based development environment that integrates with GitHub and GitLab, offering instant, customizable workspaces for coding, building, and debugging directly from your browser.
+Ona is another cloud-based editor. Ona is a cloud-based development environment that integrates with GitHub and GitLab, offering instant, customizable workspaces for coding, building, and debugging directly from your browser.
 
 And there are many more options. Some options, such as Visual Studio Code, are highly extensible and can work with many project types and languages. Other options might be specifically tailored to a small subset of languages or project types.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d45651d83b450801efb3a.md
@@ -15,7 +15,7 @@ Command-line interfaces, or CLIs for short, allow you to interact with your oper
 
 If you are on Windows, you can use the Command Prompt or PowerShell. If you are on a Mac, you can open up your Terminal app.
 
-Once the command line is open, navigate to the home directory by typing in the `cd ~` command and hitting `Enter` on your keyboard. Then type in the `mkdir my-project` command and hit `Enter`. `mkdir`, or "make directory", is the command used to create a new directory. You should then open your new directory with VS Code. 
+Once the command line is open, navigate to the home directory by typing in the `cd ~` command and hitting `Enter` on your keyboard. Note that `cd ~` works in PowerShell and the macOS Terminal, but not in the Command Prompt; if you are using the Command Prompt, type `cd %USERPROFILE%` instead. Then type in the `mkdir my-project` command and hit `Enter`. `mkdir`, or "make directory", is the command used to create a new directory. You should then open your new directory with VS Code. 
 
 There are also other ways to open a directory in VS code.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
@@ -19,9 +19,9 @@ If you need to remove a line, `Ctrl + Shift + K` (Windows), or `Cmd + Shift + K`
 
 Need some extra room for all your code? `Ctrl + B` (Windows), or `Cmd + B` (Mac), will hide the sidebar - which has the file list and extensions menu.
 
-Or maybe you just can't see your code? `Ctrl + plus` (Windows), or `Cmd + plus` (Mac), will increase the scaling of the editor, and `Ctrl + minus` (Windows), or `Cmd + minus` (Mac), will decrease it.
+Or maybe you just can't see your code? `Ctrl + Plus` (Windows), or `Cmd + Plus` (Mac), will increase the scaling of the editor, and `Ctrl + Minus` (Windows), or `Cmd + Minus` (Mac), will decrease it.
 
-Another helpful feature in VS Code is multi-line editing, which allows you to make changes across several lines at once. For example, you can place multiple cursors by using `Ctrl + Alt + down` and `Ctrl + Alt + up` (Windows/Linux), or `Option + Command + down` and `Option + Command + up` (Mac), to extend the cursor to consecutive lines. You can also press and hold `Alt` (Windows/Linux) or `Option` (Mac) and click to add cursors on separate lines wherever you need them. Once the cursors are placed, anything you type or delete will apply to all those locations simultaneously — which can save a lot of time when working with repetitive code.
+Another helpful feature in VS Code is multi-line editing, which allows you to make changes across several lines at once. For example, you can place multiple cursors by using `Ctrl + Alt + Down` and `Ctrl + Alt + Up` (Windows/Linux), or `Option + Command + Down` and `Option + Command + Up` (Mac), to extend the cursor to consecutive lines. You can also press and hold `Alt` (Windows/Linux) or `Option` (Mac) and click to add cursors on separate lines wherever you need them. Once the cursors are placed, anything you type or delete will apply to all those locations simultaneously — which can save a lot of time when working with repetitive code.
 
 Finally, if you forget any of these shortcuts, you always have `Ctrl + Shift + P` (Windows), or `Cmd + Shift + P` (Mac), which opens the command palette for you to select whatever you may need.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69524

Addresses the content issues in the Working with Code Editors and IDEs lecture:

1. **What Is a Code Editor and IDE?** — Varies the repetitive sentence openers ("And another IDE would be..." / "And another one is..." x4) and removes the "would be" hedging, keeping the plain statements of fact.
2. **How to Create a Project and Run Your Code Locally in VS Code** — Adds a note that `cd ~` works in PowerShell and the macOS Terminal but not the Command Prompt, with a Command Prompt equivalent (`cd %USERPROFILE%`).
3. **What Are Several Useful Keyboard Shortcuts...** — Capitalizes key names for consistency (`Ctrl + Plus`, `Ctrl + Minus`, `Ctrl + Alt + Down`, `Option + Command + Down`, etc.) so they match the already-capitalized `Ctrl`/`Alt`/`Cmd`/`Option`/`Command`.