### PR TITLE
fix(curriculum): numbered list in backend lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-express-middleware/69f42d414b7626e21a922795.md
+++ b/curriculum/challenges/english/blocks/lecture-express-middleware/69f42d414b7626e21a922795.md
@@ -13,45 +13,45 @@ Express provides a range of built-in middleware functions that help perform comm
 
 1. `express.json()`: A built-in middleware that parses incoming JSON payloads.
 
-```js
-app.use(express.json())
-```
+    ```js
+    app.use(express.json())
+    ```
 
 1. `express.static()`: A middleware for serving static files like images, CSS, and JavaScript files.
 
-```js
-app.use(express.static('public'))
-```
+   ```js
+   app.use(express.static('public'))
+   ```
 
 1. `express.urlencoded()`: A middleware that parses incoming requests with URL-encoded payloads, the format typically sent by HTML forms. It makes the parsed data available on `req.body`.
 
-```js
-app.use(express.urlencoded({ extended: true }))
-```
+    ```js
+    app.use(express.urlencoded({ extended: true }))
+    ```
 
 **Now, here are some examples of third-party middleware:**
 
 1. `cors`: A popular third-party middleware to enable Cross-Origin Resource Sharing.
 
-```bash
-npm install cors
-```
+    ```bash
+    npm install cors
+    ```
 
-```js
-const cors = require('cors')
-app.use(cors())
-```
+    ```js
+    const cors = require('cors')
+    app.use(cors())
+    ```
 
 1. `morgan`: A logging middleware for HTTP requests.
 
-```bash
-npm install morgan
-```
+    ```bash
+    npm install morgan
+    ```
 
-```js
-const morgan = require('morgan')
-app.use(morgan('tiny'))
-```
+    ```js
+    const morgan = require('morgan')
+    app.use(morgan('tiny'))
+    ```
 
 Now, let's look at an example of using both built-in and third-party middleware:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The numbers are not rendered properly since the blocks are not indented:
<img width="600" height="633" alt="image" src="https://github.com/user-attachments/assets/de1b5640-9282-469e-8817-a919f26f5f29" />
After the fix:
<img width="600" height="633" alt="image" src="https://github.com/user-attachments/assets/41f6ee48-7151-4372-8202-6957b54cf13a" />
