### PR TITLE
fix(curriculum): wrap README link in backticks in file-systems lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac403a9ba7732b31c6480.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac403a9ba7732b31c6480.md
@@ -51,7 +51,7 @@ And finally, let's talk about documentation. In web applications, you will usual
 
 They are usually written in a file format called Markdown. With Markdown, you can create structured documents with headings, subheadings, links, images, lists, and more. Markdown files have a `.md` or `.markdown` extension.
 
-Here you can find the `README` file of freeCodeCamp's GitHub repository: https://github.com/freeCodeCamp/freeCodeCamp/blob/main/README.md
+Here you can find the `README` file of freeCodeCamp's GitHub repository: `https://github.com/freeCodeCamp/freeCodeCamp/blob/main/README.md`
 
 You can create this detailed structure and format using Markdown.
 


### PR DESCRIPTION
## Checklist:
- [x] I have read the [contributing guidelines](https://contribute.freecodecamp.org/#/).
- [x] This PR targets the `main` branch of freeCodeCamp.

### Description

Wraps the plain README URL in backticks in the "What Are Some Common File Types You Will Work With in Web Applications?" lecture so it renders as inline code instead of overflowing the page on mobile.

### Issue

Fixes #69448

Fix suggested by @majestic-owl448 in the issue thread.