### PR TITLE
fix(curriculum): wrapped the link with backticks to stop overflowing

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac403a9ba7732b31c6480.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac403a9ba7732b31c6480.md
@@ -51,7 +51,7 @@ And finally, let's talk about documentation. In web applications, you will usual
 
 They are usually written in a file format called Markdown. With Markdown, you can create structured documents with headings, subheadings, links, images, lists, and more. Markdown files have a `.md` or `.markdown` extension.
 
-Here you can find the `README` file of freeCodeCamp's GitHub repository: https://github.com/freeCodeCamp/freeCodeCamp/blob/main/README.md
+Here you can find the `README` file of freeCodeCamp's GitHub repository: `https://github.com/freeCodeCamp/freeCodeCamp/blob/main/README.md`
 
 You can create this detailed structure and format using Markdown.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69448


### here's the before-after
before:
<img width="350" height="620" alt="Screenshot 2026-08-15 at 11 59 31 AM" src="https://github.com/user-attachments/assets/21b2ec5f-887d-4e1d-ac94-78b24fdd348b" />


after:
<img width="350" height="617" alt="Screenshot 2026-08-15 at 12 00 55 PM" src="https://github.com/user-attachments/assets/6c7183e2-ddd3-4504-832e-d1b18f342e7f" />
