### PR TITLE
fix(curriculum): add section headers to link states lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
@@ -9,7 +9,9 @@ dashedName: what-are-the-different-link-states
 
 You may have seen a link on a web page become purple after you click it. This is because the state of the link has changed, so different styling gets applied. There are five different states a link can be in.
 
-## The `:link` State
+## Link States
+
+### The `:link` State
 
 The first is the default state, which is `:link`. This state represents a link which the user has not visited, clicked, or interacted with yet. You can think of this state as providing the base styles for all links on your page. The other states build on top of it.
 
@@ -23,7 +25,7 @@ Enable the interactive editor and take a look at the link in the preview window.
 
 :::
 
-## The `:visited` State
+### The `:visited` State
 
 The second state is `:visited`, which applies when a user has already visited the page being linked to. By default, this turns the link purple - but you can leverage CSS to provide a different visual indication to the user. This is helpful to let someone know they have already read a portion of your documentation. Or, that the site is one they can trust because they have used it before.
 
@@ -51,7 +53,7 @@ a:visited {
 
 :::
 
-## The `:hover` State
+### The `:hover` State
 
 The third state is `:hover`. This state applies when a user is hovering their cursor over a link. This state is helpful for providing extra attention to a link, to ensure a user actually intends to click it.
 
@@ -77,7 +79,7 @@ a:hover {
 
 :::
 
-## The `:focus` State
+### The `:focus` State
 
 Then we have `:focus`. This state applies when we focus on a link.
 
@@ -103,7 +105,7 @@ a:focus {
 
 :::
 
-## The `:active` State
+### The `:active` State
 
 And finally, we have `:active`. This state applies to links that are being activated by the user. This typically means clicking on the link with the primary mouse button by left clicking, in most cases. This state can be helpful for showing a user that the element they clicked on is interactive.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
@@ -9,6 +9,8 @@ dashedName: what-are-the-different-link-states
 
 You may have seen a link on a web page become purple after you click it. This is because the state of the link has changed, so different styling gets applied. There are five different states a link can be in.
 
+## The `:link` State
+
 The first is the default state, which is `:link`. This state represents a link which the user has not visited, clicked, or interacted with yet. You can think of this state as providing the base styles for all links on your page. The other states build on top of it.
 
 Enable the interactive editor and take a look at the link in the preview window. It should be the default color of blue which represents the default state. If you click on it, then it will turn purple. 
@@ -20,6 +22,8 @@ Enable the interactive editor and take a look at the link in the preview window.
 ```
 
 :::
+
+## The `:visited` State
 
 The second state is `:visited`, which applies when a user has already visited the page being linked to. By default, this turns the link purple - but you can leverage CSS to provide a different visual indication to the user. This is helpful to let someone know they have already read a portion of your documentation. Or, that the site is one they can trust because they have used it before.
 
@@ -47,6 +51,8 @@ a:visited {
 
 :::
 
+## The `:hover` State
+
 The third state is `:hover`. This state applies when a user is hovering their cursor over a link. This state is helpful for providing extra attention to a link, to ensure a user actually intends to click it.
 
 Enable the interactive editor and try hovering your mouse over the link. You will see the color change to red. 
@@ -70,6 +76,8 @@ a:hover {
 ```
 
 :::
+
+## The `:focus` State
 
 Then we have `:focus`. This state applies when we focus on a link.
 
@@ -95,6 +103,8 @@ a:focus {
 
 :::
 
+## The `:active` State
+
 And finally, we have `:active`. This state applies to links that are being activated by the user. This typically means clicking on the link with the primary mouse button by left clicking, in most cases. This state can be helpful for showing a user that the element they clicked on is interactive.
 
 Enable the interactive editor and click on the link. You should see the link turn to black. This happens pretty quickly so you might need to click on it a few times to see the color change. 
@@ -118,6 +128,8 @@ a:active {
 ```
 
 :::
+
+## Styling Order
 
 When you use these states to style your links, there is a specific order you need to write your CSS in: `link`, `visited`, `hover`, `focus`, then `active`.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #69340

### Description
Adds `##` section headers to the lecture body of "What Are the Different Link States, and Why Are They Important?" to break the ~528-word unbroken block into scannable sections.

Headers added:
- The `:link` State
- The `:visited` State
- The `:hover` State
- The `:focus` State
- The `:active` State
- Styling Order

No prose was rewritten - only headers were inserted. Front matter, code blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below:

<img width="520" height="144" alt="Screenshot 2026-08-16 at 7 53 14 PM" src="https://github.com/user-attachments/assets/a7dd941e-3336-45d9-9b65-db8cf742c8d2" />
<img width="521" height="228" alt="Screenshot 2026-08-16 at 7 53 46 PM" src="https://github.com/user-attachments/assets/3c199285-c519-4d8c-91cd-7945e82374b3" />
<img width="519" height="141" alt="Screenshot 2026-08-16 at 7 54 00 PM" src="https://github.com/user-attachments/assets/a46c85ac-664b-47da-8b64-0ae064db22d4" />
<img width="521" height="125" alt="Screenshot 2026-08-16 at 7 54 12 PM" src="https://github.com/user-attachments/assets/c127f9c5-7464-4078-bc9e-41a5fe85c338" />
<img width="520" height="145" alt="Screenshot 2026-08-16 at 7 54 24 PM" src="https://github.com/user-attachments/assets/4cdd7117-5fd5-4412-8c2d-edf245c30ae9" />
<img width="521" height="135" alt="Screenshot 2026-08-16 at 7 54 41 PM" src="https://github.com/user-attachments/assets/de422239-5231-4a24-834a-19be6c3ba0df" />
