### PR TITLE
fix(client): parse both session-user response shapes

### DIFF
--- a/client/src/utils/ajax.test.ts
+++ b/client/src/utils/ajax.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { postDeleteAccount } from './ajax';
+import { getSessionUser, postDeleteAccount } from './ajax';
 
 vi.mock('../../config/env.json', () => ({
   default: {
@@ -41,5 +41,52 @@ describe('ajax utils', () => {
 
     expect(result.data).toBeUndefined();
     expect(result.response.status).toBe(200);
+  });
+
+  describe('getSessionUser', () => {
+    // TODO(Post-MVP): drop this once /user/session-user always returns the
+    // flat shape and the dynamic-key fallback is removed from ajax.ts.
+    it('parses the legacy dynamic-key response shape', async () => {
+      const fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            user: { foobar: { username: 'foobar' } },
+            result: 'foobar'
+          }),
+          { status: 200 }
+        )
+      );
+      vi.stubGlobal('fetch', fetch);
+
+      const result = await getSessionUser();
+
+      expect(result.data).toMatchObject({ username: 'foobar' });
+    });
+
+    it('parses the flat response shape', async () => {
+      const fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ user: { username: 'foobar' } }), {
+          status: 200
+        })
+      );
+      vi.stubGlobal('fetch', fetch);
+
+      const result = await getSessionUser();
+
+      expect(result.data).toMatchObject({ username: 'foobar' });
+    });
+
+    it('returns null for an unauthenticated user in either shape', async () => {
+      const fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ user: {}, result: '' }), {
+          status: 200
+        })
+      );
+      vi.stubGlobal('fetch', fetch);
+
+      const result = await getSessionUser();
+
+      expect(result.data).toBeNull();
+    });
   });
 });

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -142,6 +142,33 @@ function parseApiResponseToClientUser(data: ApiUserResponse): User | null {
     : null;
 }
 
+type SessionUserResponse = {
+  user: ApiUser | { [username: string]: ApiUser } | Record<string, never>;
+  result?: string;
+};
+
+function isApiUser(user: SessionUserResponse['user']): user is ApiUser {
+  return 'username' in user;
+}
+
+// TODO(Post-MVP): once /user/session-user always returns the user object
+// directly (i.e. `{ user }`, not `{ user: { [username]: user }, result }`),
+// drop the `isApiUser` check and the fallback to `parseApiResponseToClientUser`.
+function parseSessionUserResponse(data: SessionUserResponse): User | null {
+  const { user } = data;
+  if (isApiUser(user)) {
+    return {
+      ...user,
+      completedChallenges: mapFilesToChallengeFiles(user.completedChallenges),
+      savedChallenges: mapFilesToChallengeFiles(user.savedChallenges)
+    };
+  }
+  return parseApiResponseToClientUser({
+    user,
+    result: data.result
+  });
+}
+
 // TODO: this at least needs a few aliases so it's human readable
 export function mapFilesToChallengeFiles<File, Rest>(
   fileContainer: ({ files: (File & { key: string })[] } & Rest)[] = []
@@ -161,13 +188,13 @@ function mapKeyToFileKey<K>(
 export function getSessionUser(
   signal?: AbortSignal
 ): Promise<ResponseWithData<User | null>> {
-  const responseWithData: Promise<ResponseWithData<ApiUserResponse>> = get(
+  const responseWithData: Promise<ResponseWithData<SessionUserResponse>> = get(
     '/user/session-user',
     signal
   );
   // TODO: Once DB is migrated, no longer need to parse `files` -> `challengeFiles` etc.
   return responseWithData.then(({ response, data }) => {
-    const user = parseApiResponseToClientUser(data);
+    const user = parseSessionUserResponse(data);
     return {
       response,
       data: user


### PR DESCRIPTION
## Summary

Prepares the client's `/user/session-user` parsing to accept a future flat response shape (`{ user: {...} }`) in addition to the current dynamic-key shape (`{ user: { [username]: {...} }, result }`), so the client and API can be deployed independently without breaking sign-in state.

Refs #50484

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.