### PR TITLE
fix(curriculum): correct hardware and dev tool explanations

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672aa578a2129554d4675049.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672aa578a2129554d4675049.md
@@ -19,7 +19,7 @@ The CPU is a small square chip that goes into the motherboard's CPU socket. The 
 
 The next critical component of a computer is the system's short-term memory. This is known as RAM, or Random Access Memory. RAM is a temporary storage location for the computer's CPU. Anytime the computer needs to access data quickly, it will use RAM.
 
-The more RAM you have on your computer, the faster it will run and the more programs you can run at the same time. If you are running low on RAM, your computer will run slower and you will notice the difference in performance.
+Having enough RAM lets your computer run more programs at the same time without slowing down. If you are running low on RAM, your computer will run slower and you will notice the difference in performance. Adding RAM beyond what your programs need will not make your computer any faster.
 
 It is important to note that RAM is volatile memory. This means that it is lost when the computer is turned off. This is why it is important to save your work on your computer.
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab8573f32480f192aaae1.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab8573f32480f192aaae1.md
@@ -15,11 +15,11 @@ Professional developers often go for computers with fast processing power and pl
 
 After the computer is a program for writing and editing code right on that computer. That's a code editor or integrated development environment (IDE).
 
-IDEs like Visual Studio, IntelliJ IDEA, JetBrains, and PyCharm provide powerful features like code completion, debugging, and integrated terminal support.
+IDEs like Visual Studio, IntelliJ IDEA, and PyCharm provide powerful features like code completion, debugging, and integrated terminal support.
 
 Visual Studio Code (VS Code) is essentially a code editor, but it also provides these functionalities with its rich extension library.
 
-Other code editors are Sublime Text, Atom, Notepad++, and Brackets.
+Other code editors are Sublime Text and Notepad++.
 
 When you write code with code editors and IDEs, you need to track the changes you make to that code. The tool that lets you track those changes is a version control system.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69567

Corrects three inaccuracies in the "Understanding Computer, Internet, and Tooling Basics" lecture block (RWD v9):

1. The computer-parts lesson said more RAM always makes a computer run faster. It now distinguishes insufficient RAM (which does slow a computer down) from adding RAM beyond what a workload needs (which doesn't speed anything up further).
2. The dev-tools lesson listed JetBrains alongside Visual Studio, IntelliJ IDEA, and PyCharm as if it were its own IDE. JetBrains is the company that makes IntelliJ IDEA and PyCharm, not a separate product, so it's removed from the list.
3. The same lesson recommended Atom and Brackets as current code editors. GitHub archived Atom in December 2022 and Adobe ended Brackets support in September 2021, so both are removed, leaving the still-maintained Sublime Text and Notepad++.

### Local testing
- `FCC_BLOCK='lecture-understanding-computer-internet-and-tooling-basics' pnpm run test-curriculum-content` — 11/11 tests passed
- `pnpm run lint-challenges` — no violations
- Pre-commit `challenge-linter` markdown lint — passed on both changed files