### PR TITLE
feat(curriculum): add headers to pseudo-classes

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbe9d6ec03ea954d92ff7.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbe9d6ec03ea954d92ff7.md
@@ -11,6 +11,8 @@ The appearance and behavior of input elements matter when building web forms. A 
 
 CSS provides several input pseudo-classes that can make your forms more intuitive and user-friendly. Let's look at these pseudo-classes in detail.
 
+## The `:focus` Pseudo-class
+
 The `:focus` pseudo-class allows you to target an input element when a user selects or clicks on it, drawing attention to the active input field. This helps users easily identify where they're currently typing:
 
 :::interactive_editor
@@ -30,6 +32,8 @@ input:focus {
 ```
 
 :::
+
+## The `:hover` Pseudo-class
 
 As the name implies, the `:hover` pseudo-class is triggered when the user places the cursor over an element. It provides visual feedback before the user interacts with the input, effectively alerting them that the input is ready for action.
 
@@ -51,6 +55,8 @@ input:hover {
 :::
 
 In the example above, the input element background changes to an orange color when the user hovers over it, letting them know that the field is ready for interaction.
+
+## The `:checked` Pseudo-class
 
 The `:checked` pseudo-class lets you style a radio button or checkbox differently when a user selects it. This way, the user can easily see which option they've chosen.
 
@@ -113,6 +119,8 @@ Here is an example with a checkbox to agree to terms on a website.
 
 :::
 
+## The `:required` Pseudo-class
+
 `:required` targets input elements that have the `required` attribute. It signals to the user that they must fill out the field to submit the form.
 
 Here is an example with a form that has some required input fields:
@@ -142,6 +150,8 @@ input:required {
 ```
 
 :::
+
+## The `:valid` and `:invalid` Pseudo-classes
 
 When validating forms, you can use the `:valid` pseudo-class to style the input fields that meet the validation criteria, and `:invalid` to style the input fields that do not meet the criteria. Typically, you will use green for a valid input and red for an invalid input. 
 
@@ -185,6 +195,8 @@ input:invalid {
 
 :::
 
+## The `:disabled` Pseudo-class
+
 The `:disabled` pseudo-class allows you to select and style input elements that are disabled. These elements have the `disabled` attribute, which prevents users from interacting with them. When an input is disabled, it cannot be clicked, focused, or edited.
 
 Here is an example of a label and a disabled input element.
@@ -213,6 +225,8 @@ In the CSS, we are targeting that disabled input and giving it a background colo
 The `cursor: not-allowed;` CSS property value changes the appearance of the cursor to indicate that an action is not permitted. 
 
 When applied to an element, it shows a cursor with a circle-slash symbol (usually a circle with a diagonal line through it) to signal to users that the element is not interactive or cannot be clicked or interacted with.
+
+## Other Input Pseudo-classes
 
 Here are some other examples of input pseudo-classes and what they do:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69335 

<!-- Feel free to add any additional description of changes below this line -->

Adds `##` section headers to the "What Are Examples of Input Pseudo-classes?" lecture to make the ~540-word block easier to scan. Headers were added before each major sub-topic, following the convention used in the "How Does the Sort Method Work?" lecture. No changes were made to the existing prose, code blocks, the `# --questions--` section, or front matter.

This is a text-only markdown change, so testing was verifying the rendered structure locally and running the challenge-linter pre-commit check.