### PR TITLE
fix(curriculum): add section headers to pseudo-elements lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbed37c6f51aa3a15e78c.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-pseudo-classes-and-pseudo-elements-in-css/672bbed37c6f51aa3a15e78c.md
@@ -9,6 +9,8 @@ dashedName: what-are-pseudo-elements
 
 One of the most interesting aspects of CSS is the use of pseudo-elements. In this context, "pseudo" means "not real", so pseudo-elements are virtual or synthetic elements that don't directly match any actual HTML elements. They allow you to style specific parts of an element or insert content without adding extra HTML.
 
+## Pseudo-element Syntax
+
 To apply a pseudo-element, attach it to the original element's selector using a double colon (`::`). Note that the selector can be any type, such as a class or ID selector. Here's what the basic syntax of pseudo-elements looks like:
 
 ```css
@@ -20,6 +22,8 @@ selector::pseudo-element {
 This double colon is what distinguishes pseudo-elements from pseudo-classes, which use a single colon.
 
 Pseudo-elements allow you to style specific parts of an element's content or insert content before or after it, but they cannot exist independently. The element to which a pseudo-element is attached is called its originating element.
+
+## The `::before` and `::after` Pseudo-elements
 
 Let's start by looking at examples for the `::before` and `::after` pseudo-elements. As their names suggest, `::before` lets you insert content just before the element's content while `::after` lets you insert content after it.
 
@@ -123,6 +127,8 @@ With `transform: translateX(2px)` in the hover state, the content gets pushed to
 
 That's what the `transform` property does – it allows you to rotate, skew, scale, or translate an element in a particular direction. You will learn more about that in future lessons.
 
+## The `::first-letter` Pseudo-element
+
 In the next example, we will look at the `::first-letter` pseudo-element. The `::first-letter` pseudo-element targets the first letter of an element's content, allowing you to style it. Here's an example of some paragraph text. If we want to style the first letter, we can use the `::first-letter` pseudo-element like this:
 
 :::interactive_editor
@@ -139,6 +145,8 @@ p::first-letter {
 ```
 
 :::
+
+## The `::marker` Pseudo-element
 
 In the last example, we will look at the `::marker` pseudo-element, which lets you select the marker, bullet or numbering of list items for styling. The `::marker` pseudo-element offers a way to enhance your website's brand identity by customizing list markers to match your color scheme.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #69328

### Description
Adds `##` section headers to the lecture body of "What Are Pseudo-elements, and How Do They Work?" to break the ~558-word unbroken block into scannable sections.

Headers added:
- Pseudo-element Syntax
- The `::before` and `::after` Pseudo-elements
- The `::first-letter` Pseudo-element
- The `::marker` Pseudo-element

No prose was rewritten - only headers were inserted. Front matter, code blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below:

<img width="520" height="89" alt="Screenshot 2026-08-17 at 6 57 12 PM" src="https://github.com/user-attachments/assets/d5a4c4a8-300e-46e3-8f35-66e54180e89e" />
<img width="520" height="164" alt="Screenshot 2026-08-17 at 6 57 33 PM" src="https://github.com/user-attachments/assets/ba93eb3f-3140-4413-86a3-0b4b02992499" />
<img width="520" height="117" alt="Screenshot 2026-08-17 at 6 57 57 PM" src="https://github.com/user-attachments/assets/0b817bb6-089a-42f4-be6f-29e987dce132" />
<img width="520" height="161" alt="Screenshot 2026-08-17 at 6 58 25 PM" src="https://github.com/user-attachments/assets/2f8d7958-c23a-482a-8bac-e86c918825a0" />
