### PR TITLE
fix(curriculum): make motorcycle shop fetch stub response-like

### DIFF
--- a/curriculum/challenges/english/blocks/lab-motorcycle-shop/694175528a794a090ea0ba74.md
+++ b/curriculum/challenges/english/blocks/lab-motorcycle-shop/694175528a794a090ea0ba74.md
@@ -317,7 +317,19 @@ const _testMotorcycles = [
 ];
 
 window.fetch = () =>
-  Promise.resolve({ json: () => Promise.resolve(_testMotorcycles) });
+  new Promise(resolve =>
+    setTimeout(
+      () =>
+        resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve(_testMotorcycles),
+          text: () => Promise.resolve(JSON.stringify(_testMotorcycles))
+        }),
+      0
+    )
+  );
 ```
 
 # --hints--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

Follow up to #69243, which stubbed `fetch` in this lab. The stub as written fails two kinds of valid camper code that pass against the live endpoint on production.

The object it resolved to only had a `json` method:

```js
window.fetch = () =>
  Promise.resolve({ json: () => Promise.resolve(_testMotorcycles) });
```

So a solution guarding the response, which is what campers are normally taught to write, always takes the error path because `response.ok` is `undefined`:

```ts
const response = await fetch(url);
if (!response.ok) throw new Error('Failed to fetch');
```

The stub now resolves to something closer to a `Response`, with `ok`, `status`, `statusText` and `text` alongside `json`.

The second problem is timing. The `--before-all--` script is injected into the test frame ahead of the camper's code, and the stub settled in a microtask, so the promise resolved before `DOMContentLoaded` fired. A real network response never wins that race. Code that starts loading at the top level of the file and assigns its DOM references in a `DOMContentLoaded` handler therefore ran its `.then` callback against undefined elements and threw inside a swallowed rejection, leaving the grid empty and failing the eight `renderMotorcycles` hints. The stub now resolves from a `setTimeout`, so the ordering matches production.

The reference solution is not affected by either case, which is why CI stayed green: it creates the app inside `DOMContentLoaded` and does not check `response.ok`. Verified locally with `FCC_BLOCK=lab-motorcycle-shop pnpm run test-curriculum-content`.

https://github.com/freeCodeCamp/freeCodeCamp/issues/69141 does not get closed by this, which covers the wider audit of the lab.
