### PR TITLE
fix(curriculum): make forum leaderboard fetch stub response-like

### DIFF
--- a/curriculum/challenges/english/blocks/lab-fcc-forum-leaderboard/673c91f0b934834bc4a3ecc2.md
+++ b/curriculum/challenges/english/blocks/lab-fcc-forum-leaderboard/673c91f0b934834bc4a3ecc2.md
@@ -152,7 +152,19 @@ const _testData = {
 };
 
 window.fetch = () =>
-  Promise.resolve({ json: () => Promise.resolve(_testData) });
+  new Promise(resolve =>
+    setTimeout(
+      () =>
+        resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve(_testData),
+          text: () => Promise.resolve(JSON.stringify(_testData))
+        }),
+      0
+    )
+  );
 ```
 
 # --hints--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

Same class of problem as #69574. The `fetch` stub in this lab fails camper code that passes against the live endpoint on production.

The object it resolved to only had a `json` method:

```js
window.fetch = () =>
  Promise.resolve({ json: () => Promise.resolve(_testData) });
```

So a solution guarding the response, which is what campers are normally taught to write, always takes the error path because `response.ok` is `undefined`:

```js
const res = await fetch(forumLatest);
if (!res.ok) throw new Error('Failed to fetch');
```

The stub now resolves to something closer to a `Response`, with `ok`, `status`, `statusText` and `text` alongside `json`.

It also settled in a microtask. The `--before-all--` script is injected into the test frame ahead of the camper's code, so the promise resolved before `DOMContentLoaded` fired, which a real network response never does. Code that starts loading at the top level of the file and assigns its DOM references in a `DOMContentLoaded` handler therefore ran its `.then` callback against undefined variables and threw inside a swallowed rejection. The stub now resolves from a `setTimeout`, so the ordering matches production. No fake timers are installed in this lab, so the timer fires normally.

Verified locally with `FCC_BLOCK=lab-fcc-forum-leaderboard pnpm run test-curriculum-content`.
