### PR TITLE
fix(curriculum): make digital pet game fetch stub response-like

### DIFF
--- a/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
+++ b/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
@@ -60,7 +60,15 @@ The second view:
 ```js
 globalThis._PET_NAME = 'Fitzgerald';
 globalThis._clock = __FakeTimers.install();
-window.fetch = () => Promise.resolve({ json: () => Promise.resolve('Cats sleep for around 13 to 16 hours a day.') });
+const _testCatFact = 'Cats sleep for around 13 to 16 hours a day.';
+window.fetch = () =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(_testCatFact),
+    text: () => Promise.resolve(JSON.stringify(_testCatFact))
+  });
 ```
 
 # --after-all--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

Same class of problem as #69574. The `fetch` stub in this lab fails camper code that passes against the live endpoint on production.

The object it resolved to only had a `json` method:

```js
window.fetch = () => Promise.resolve({ json: () => Promise.resolve('Cats sleep for around 13 to 16 hours a day.') });
```

So a solution guarding the response, which is what campers are normally taught to write, always takes the error path because `response.ok` is `undefined`. The stub now resolves to something closer to a `Response`, with `ok`, `status`, `statusText` and `text` alongside `json`, and the fact itself moved to a variable so `json` and `text` cannot drift apart.

Unlike #69574, the resolution stays in a microtask here on purpose: `__FakeTimers.install()` runs in the same `--before-all--` block, before the camper's code, so a stub resolving from a `setTimeout` would never settle unless a hint advanced the clock.

Verified locally with `FCC_BLOCK=lab-digital-pet-game pnpm run test-curriculum-content`.
