### PR TITLE
fix(curriculum): resolve rpg creature search fetch stub from a timer

### DIFF
--- a/curriculum/challenges/english/blocks/build-an-rpg-creature-search-app-project/6555c1d3e11a1574434cf8b5.md
+++ b/curriculum/challenges/english/blocks/build-an-rpg-creature-search-app-project/6555c1d3e11a1574434cf8b5.md
@@ -68,18 +68,30 @@ const creatures = [
   { id: 20, name: "Faegis", weight: 55, height: 30, special: { name: "Enchanted Shield", description: "Blocks the first super-effective attack in battle." }, stats: [{ base_stat: 85, name: "hp" }, { base_stat: 50, name: "attack" }, { base_stat: 120, name: "defense" }, { base_stat: 100, name: "special-attack" }, { base_stat: 115, name: "special-defense" }, { base_stat: 55, name: "speed" }], types: [{ name: "fairy" }, { name: "steel" }] },
 ];
 
+// a real response arrives in a later task, never in a microtask, so the stub
+// resolves from a timer to keep that ordering
+const _respondWith = (body) =>
+  new Promise((resolve) =>
+    setTimeout(
+      () =>
+        resolve({
+          ok: body !== undefined,
+          status: body !== undefined ? 200 : 404,
+          statusText: body !== undefined ? "OK" : "Not Found",
+          json: () => Promise.resolve(body),
+          text: () => Promise.resolve(JSON.stringify(body)),
+        }),
+      0
+    )
+  );
+
 window.fetch = (url) => {
   const path = String(url).split("?")[0].replace(/\/+$/, "");
   const lastSegment = decodeURIComponent(path.split("/").pop());
 
   // GET /api/creatures -> list of every creature's id and name
   if (lastSegment.toLowerCase() === "creatures") {
-    return Promise.resolve({
-      ok: true,
-      status: 200,
-      json: () =>
-        Promise.resolve(creatures.map(({ id, name }) => ({ id, name }))),
-    });
+    return _respondWith(creatures.map(({ id, name }) => ({ id, name })));
   }
 
   // GET /api/creature/<name-or-id> -> a single creature
@@ -88,11 +100,7 @@ window.fetch = (url) => {
     (c) => c.name.toLowerCase() === key || String(c.id) === key
   );
 
-  return Promise.resolve({
-    ok: Boolean(creature),
-    status: creature ? 200 : 404,
-    json: () => Promise.resolve(creature),
-  });
+  return _respondWith(creature);
 };
 ```
 

--- a/curriculum/challenges/english/blocks/build-an-rpg-creature-search-app-project/6555c1d3e11a1574434cf8b5.md
+++ b/curriculum/challenges/english/blocks/build-an-rpg-creature-search-app-project/6555c1d3e11a1574434cf8b5.md
@@ -73,14 +73,19 @@ const creatures = [
 const _respondWith = (body) =>
   new Promise((resolve) =>
     setTimeout(
-      () =>
+      () => {
+        const found = body !== undefined;
+        const responseText = found
+          ? JSON.stringify(body)
+          : "Invalid creature name or ID";
         resolve({
-          ok: body !== undefined,
-          status: body !== undefined ? 200 : 404,
-          statusText: body !== undefined ? "OK" : "Not Found",
-          json: () => Promise.resolve(body),
-          text: () => Promise.resolve(JSON.stringify(body)),
-        }),
+          ok: found,
+          status: found ? 200 : 404,
+          statusText: found ? "OK" : "Not Found",
+          json: () => Promise.resolve().then(() => JSON.parse(responseText)),
+          text: () => Promise.resolve(responseText),
+        });
+      },
       0
     )
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

Follow up to #69574, for the one certification project that stubs network calls.

The response shape here was already right, with `ok` and `status` set per branch, so the only problem is timing. The `--before-all--` script is injected into the test frame ahead of the camper's code, and the stub settled in a microtask, so the promise resolved before `DOMContentLoaded` fired. A real network response never wins that race. An app that starts loading the creature list at the top level of the file and assigns its DOM references in a `DOMContentLoaded` handler therefore ran its `.then` callback against undefined variables and threw inside a swallowed rejection, passing on production and failing only under test.

Both branches of the stub now resolve from a `setTimeout` through a shared helper, which also adds `statusText` and `text`. No fake timers are installed in this project, so the timer fires normally.

Verified locally with `FCC_BLOCK=build-an-rpg-creature-search-app-project pnpm run test-curriculum-content`.
