### PR TITLE
refactor(curriculum): Replace regex-based test cases in Bug Emoji Picker Workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/690fe8b8e39ebd4a4d217d6b.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/690fe8b8e39ebd4a4d217d6b.md
@@ -21,14 +21,18 @@ Create an abstract class named `Bug` with a generic type parameter `T`.
 You should have an abstract class named `Bug`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /abstract\s+class\s+Bug/);
+const explorer = await __helpers.Explorer(code);
+const { Bug } = explorer.classes;
+assert.isTrue(Bug?.toString().startsWith("abstract"));
 ```
 
 Your `Bug` class should have a generic type parameter `T`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bug.typeParameters[0].matches("T"));
+const { Bug } = explorer.classes;
+assert.lengthOf(Bug?.typeParameters, 1);
+assert.isTrue(Bug?.typeParameters[0].matches("T"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/690ffbe80b0429c0d448050c.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/690ffbe80b0429c0d448050c.md
@@ -17,20 +17,23 @@ Your `Bug` class should have a property named `emoji`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bug.classProps.emoji);
+assert.exists(explorer.classes.Bug?.classProps.emoji);
 ```
 
 Your `emoji` property should have the type `T`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bug.classProps.emoji.annotation.matches("T"));
+assert.isTrue(explorer.classes.Bug?.classProps.emoji?.annotation.matches("T"));
 ```
 
 Your `emoji` property should use the definite assignment assertion operator (`!`).
 
 ```js
-assert.match(__helpers.removeJSComments(code), /emoji\s*!/);
+const explorer = await __helpers.Explorer(code);
+const emoji = explorer.classes.Bug?.classProps.emoji;
+const strippedCode = __helpers.removeJSComments(emoji?.toString() ?? "");
+assert.match(strippedCode, /!\s*:/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/690ffbe80b0429c0d448050c.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/690ffbe80b0429c0d448050c.md
@@ -17,21 +17,26 @@ Your `Bug` class should have a property named `emoji`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bug?.classProps.emoji);
+const { Bug } = explorer.classes;
+const { emoji } = Bug?.classProps ?? {};
+assert.exists(emoji);
 ```
 
 Your `emoji` property should have the type `T`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bug?.classProps.emoji?.annotation.matches("T"));
+const { Bug } = explorer.classes;
+const { emoji } = Bug?.classProps ?? {};
+assert.isTrue(emoji?.annotation.matches("T"));
 ```
 
 Your `emoji` property should use the definite assignment assertion operator (`!`).
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const emoji = explorer.classes.Bug?.classProps.emoji;
+const { Bug } = explorer.classes;
+const { emoji } = Bug?.classProps ?? {};
 const strippedCode = __helpers.removeJSComments(emoji?.toString() ?? "");
 assert.match(strippedCode, /!\s*:/);
 ```

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/690ffbe80b0429c0d448050c.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/690ffbe80b0429c0d448050c.md
@@ -37,8 +37,7 @@ Your `emoji` property should use the definite assignment assertion operator (`!`
 const explorer = await __helpers.Explorer(code);
 const { Bug } = explorer.classes;
 const { emoji } = Bug?.classProps ?? {};
-const strippedCode = __helpers.removeJSComments(emoji?.toString() ?? "");
-assert.match(strippedCode, /!\s*:/);
+assert.isTrue(emoji?.matches("emoji!: T"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/6927b1bf0ec0410912d6f738.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/6927b1bf0ec0410912d6f738.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-Still inside the `Bug` class, declare a property named `emojiElement` with the type `HTMLParagraphElement`. This property will hold a reference to the HTML paragraph element where the bug emoji will be displayed.
+Still inside the `Bug` class, declare a property named `emojiElement` with the type `HTMLParagraphElement`, again using the definite assignment assertion operator (`!`). This property will hold a reference to the HTML paragraph element where the bug emoji will be displayed.
 
 # --hints--
 
@@ -15,20 +15,23 @@ Your `Bug` class should have a property named `emojiElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bug.classProps.emojiElement);
+assert.exists(explorer.classes.Bug?.classProps.emojiElement);
 ```
 
 Your `emojiElement` property should have the type `HTMLParagraphElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bug.classProps.emojiElement.annotation.matches("HTMLParagraphElement"));
+assert.isTrue(explorer.classes.Bug?.classProps.emojiElement?.annotation.matches("HTMLParagraphElement"));
 ```
 
 Your `emojiElement` property should use the definite assignment assertion operator (`!`).
 
 ```js
-assert.match(__helpers.removeJSComments(code), /emojiElement\s*!/);
+const explorer = await __helpers.Explorer(code);
+const emojiElement = explorer.classes.Bug?.classProps.emojiElement;
+const strippedCode = __helpers.removeJSComments(emojiElement?.toString() ?? "");
+assert.match(strippedCode, /!\s*:/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/6927b1bf0ec0410912d6f738.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/6927b1bf0ec0410912d6f738.md
@@ -35,8 +35,9 @@ Your `emojiElement` property should use the definite assignment assertion operat
 const explorer = await __helpers.Explorer(code);
 const { Bug } = explorer.classes;
 const { emojiElement } = Bug?.classProps ?? {};
-const strippedCode = __helpers.removeJSComments(emojiElement?.toString() ?? "");
-assert.match(strippedCode, /!\s*:/);
+assert.isTrue(
+  emojiElement?.matches("emojiElement!: HTMLParagraphElement")
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/6927b1bf0ec0410912d6f738.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/6927b1bf0ec0410912d6f738.md
@@ -15,21 +15,26 @@ Your `Bug` class should have a property named `emojiElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bug?.classProps.emojiElement);
+const { Bug } = explorer.classes;
+const { emojiElement } = Bug?.classProps ?? {};
+assert.exists(emojiElement);
 ```
 
 Your `emojiElement` property should have the type `HTMLParagraphElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bug?.classProps.emojiElement?.annotation.matches("HTMLParagraphElement"));
+const { Bug } = explorer.classes;
+const { emojiElement } = Bug?.classProps ?? {};
+assert.isTrue(emojiElement?.annotation.matches("HTMLParagraphElement"));
 ```
 
 Your `emojiElement` property should use the definite assignment assertion operator (`!`).
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const emojiElement = explorer.classes.Bug?.classProps.emojiElement;
+const { Bug } = explorer.classes;
+const { emojiElement } = Bug?.classProps ?? {};
 const strippedCode = __helpers.removeJSComments(emojiElement?.toString() ?? "");
 assert.match(strippedCode, /!\s*:/);
 ```

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb0d9ee52ab2403d8bfe7.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb0d9ee52ab2403d8bfe7.md
@@ -15,15 +15,20 @@ Your `Bug` class should have a constructor.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bug?.classConstructor);
+const { Bug } = explorer.classes;
+const { classConstructor } = Bug ?? {};
+assert.exists(classConstructor);
 ```
 
 Your `Bug` constructor should have a parameter named `emojiElement` of type `HTMLParagraphElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const constructor = explorer.classes.Bug?.classConstructor;
-const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+const { Bug } = explorer.classes;
+const { classConstructor } = Bug ?? {};
+const strippedCode = __helpers.removeJSComments(
+  classConstructor?.toString() ?? ""
+);
 assert.match(
   strippedCode,
   /^\s*constructor\b\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/
@@ -34,7 +39,8 @@ Your `Bug` constructor should assign `emojiElement` to `this.emojiElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const emojiElement = explorer.classes.Bug?.constructorProps.emojiElement;
+const { Bug } = explorer.classes;
+const { emojiElement } = Bug?.constructorProps ?? {};
 assert.isTrue(emojiElement?.matches("this.emojiElement = emojiElement"));
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb0d9ee52ab2403d8bfe7.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb0d9ee52ab2403d8bfe7.md
@@ -20,21 +20,6 @@ const { classConstructor } = Bug ?? {};
 assert.exists(classConstructor);
 ```
 
-Your `Bug` constructor should have a parameter named `emojiElement` of type `HTMLParagraphElement`.
-
-```js
-const explorer = await __helpers.Explorer(code);
-const { Bug } = explorer.classes;
-const { classConstructor } = Bug ?? {};
-const strippedCode = __helpers.removeJSComments(
-  classConstructor?.toString() ?? ""
-);
-assert.match(
-  strippedCode,
-  /^\s*constructor\b\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/
-);
-```
-
 Your `Bug` constructor should assign `emojiElement` to `this.emojiElement`.
 
 ```js
@@ -42,6 +27,19 @@ const explorer = await __helpers.Explorer(code);
 const { Bug } = explorer.classes;
 const { emojiElement } = Bug?.constructorProps ?? {};
 assert.isTrue(emojiElement?.matches("this.emojiElement = emojiElement"));
+```
+
+Your `Bug` constructor should have a parameter named `emojiElement` of type `HTMLParagraphElement`.
+
+```js
+const explorer = await __helpers.Explorer(code);
+const { Bug } = explorer.classes;
+const { classConstructor } = Bug ?? {};
+assert.isTrue(
+  classConstructor?.matches(
+    "constructor(emojiElement: HTMLParagraphElement) { this.emojiElement = emojiElement; }"
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb0d9ee52ab2403d8bfe7.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb0d9ee52ab2403d8bfe7.md
@@ -15,20 +15,27 @@ Your `Bug` class should have a constructor.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bug.classConstructor);
+assert.exists(explorer.classes.Bug?.classConstructor);
 ```
 
 Your `Bug` constructor should have a parameter named `emojiElement` of type `HTMLParagraphElement`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /constructor\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const constructor = explorer.classes.Bug?.classConstructor;
+const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+assert.match(
+  strippedCode,
+  /^\s*constructor\b\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/
+);
 ```
 
 Your `Bug` constructor should assign `emojiElement` to `this.emojiElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bug.constructorProps.emojiElement);
+const emojiElement = explorer.classes.Bug?.constructorProps.emojiElement;
+assert.isTrue(emojiElement?.matches("this.emojiElement = emojiElement"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb24a233fc22e2923e3f2.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb24a233fc22e2923e3f2.md
@@ -14,14 +14,16 @@ After the constructor, create an abstract `render` method that has a return type
 Your `Bug` class should have an abstract `render` method.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /abstract\s+render\s*\(\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const { render } = explorer.classes.Bug?.methods ?? {};
+assert.isTrue(render?.toString().startsWith("abstract"));
 ```
 
 Your `render` method should have a return type of `void`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bug.methods.render.hasReturnAnnotation("void"));
+assert.isTrue(explorer.classes.Bug?.methods.render?.hasReturnAnnotation("void"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb24a233fc22e2923e3f2.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb24a233fc22e2923e3f2.md
@@ -15,7 +15,8 @@ Your `Bug` class should have an abstract `render` method.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const { render } = explorer.classes.Bug?.methods ?? {};
+const { Bug } = explorer.classes;
+const { render } = Bug?.methods ?? {};
 assert.isTrue(render?.toString().startsWith("abstract"));
 ```
 
@@ -23,7 +24,9 @@ Your `render` method should have a return type of `void`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bug?.methods.render?.hasReturnAnnotation("void"));
+const { Bug } = explorer.classes;
+const { render } = Bug?.methods ?? {};
+assert.isTrue(render?.hasReturnAnnotation("void"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb38f7a5889378e93655f.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb38f7a5889378e93655f.md
@@ -15,22 +15,25 @@ You should have a class named `Bee`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bee);
+const { Bee } = explorer.classes;
+assert.exists(Bee);
 ```
 
 Your `Bee` class should extend `Bug`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bee?.doesExtend("Bug"));
+const { Bee } = explorer.classes;
+assert.isTrue(Bee?.doesExtend("Bug"));
 ```
 
 Your `Bee` class should extend `Bug` with a type argument of `string`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
+const { Bee } = explorer.classes;
 assert.isTrue(
-  explorer.classes.Bee?.matches("class Bee extends Bug<string> {}")
+  Bee?.matches("class Bee extends Bug<string> {}")
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb38f7a5889378e93655f.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb38f7a5889378e93655f.md
@@ -22,13 +22,16 @@ Your `Bee` class should extend `Bug`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bee.doesExtend("Bug"));
+assert.isTrue(explorer.classes.Bee?.doesExtend("Bug"));
 ```
 
 Your `Bee` class should extend `Bug` with a type argument of `string`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /class\s+Bee\s+extends\s+Bug\s*<\s*string\s*>/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.classes.Bee?.matches("class Bee extends Bug<string> {}")
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb4da06eeff4114b47433.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb4da06eeff4114b47433.md
@@ -17,25 +17,39 @@ Your `Bee` class should have a constructor.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bee.classConstructor);
+assert.exists(explorer.classes.Bee?.classConstructor);
 ```
 
 Your `Bee` constructor should have a parameter named `emojiElement` of type `HTMLParagraphElement`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /class\s+Bee[\s\S]*?constructor\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const constructor = explorer.classes.Bee?.classConstructor;
+const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+assert.match(
+  strippedCode,
+  /^\s*constructor\b\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/
+);
 ```
 
 Your `Bee` constructor should call `super` with the `emojiElement` parameter.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /super\s*\(\s*emojiElement\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const constructor = explorer.classes.Bee?.classConstructor;
+const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+assert.match(strippedCode, /\bsuper\b\s*\(\s*emojiElement\s*\)/);
 ```
 
 Your `Bee` constructor should set `this.emoji` to `"🐝"`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /this\.emoji\s*=\s*["']🐝["']/);
+const explorer = await __helpers.Explorer(code);
+const emoji = explorer.classes.Bee?.constructorProps.emoji;
+assert.isTrue(
+  emoji?.matches("this.emoji = \"🐝\"") ||
+  emoji?.matches("this.emoji = '🐝'")
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb4da06eeff4114b47433.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb4da06eeff4114b47433.md
@@ -17,15 +17,20 @@ Your `Bee` class should have a constructor.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Bee?.classConstructor);
+const { Bee } = explorer.classes;
+const { classConstructor } = Bee ?? {};
+assert.exists(classConstructor);
 ```
 
 Your `Bee` constructor should have a parameter named `emojiElement` of type `HTMLParagraphElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const constructor = explorer.classes.Bee?.classConstructor;
-const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+const { Bee } = explorer.classes;
+const { classConstructor } = Bee ?? {};
+const strippedCode = __helpers.removeJSComments(
+  classConstructor?.toString() ?? ""
+);
 assert.match(
   strippedCode,
   /^\s*constructor\b\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/
@@ -36,8 +41,11 @@ Your `Bee` constructor should call `super` with the `emojiElement` parameter.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const constructor = explorer.classes.Bee?.classConstructor;
-const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+const { Bee } = explorer.classes;
+const { classConstructor } = Bee ?? {};
+const strippedCode = __helpers.removeJSComments(
+  classConstructor?.toString() ?? ""
+);
 assert.match(strippedCode, /\bsuper\b\s*\(\s*emojiElement\s*\)/);
 ```
 
@@ -45,7 +53,8 @@ Your `Bee` constructor should set `this.emoji` to `"🐝"`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const emoji = explorer.classes.Bee?.constructorProps.emoji;
+const { Bee } = explorer.classes;
+const { emoji } = Bee?.constructorProps ?? {};
 assert.isTrue(
   emoji?.matches("this.emoji = \"🐝\"") ||
   emoji?.matches("this.emoji = '🐝'")

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb4da06eeff4114b47433.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb4da06eeff4114b47433.md
@@ -55,10 +55,7 @@ Your `Bee` constructor should set `this.emoji` to `"🐝"`.
 const explorer = await __helpers.Explorer(code);
 const { Bee } = explorer.classes;
 const { emoji } = Bee?.constructorProps ?? {};
-assert.isTrue(
-  emoji?.matches("this.emoji = \"🐝\"") ||
-  emoji?.matches("this.emoji = '🐝'")
-);
+assert.isTrue(emoji?.matches("this.emoji = '🐝'"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb5ed756efe49f8531441.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb5ed756efe49f8531441.md
@@ -14,14 +14,19 @@ Inside the `Bee` class, implement the `render` method, prefixed by the `override
 Your `Bee` class should have a `render` method using the `override` keyword.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /override\s+render/);
+const explorer = await __helpers.Explorer(code);
+const render = explorer.classes.Bee?.methods.render;
+assert.isTrue(render?.toString().startsWith("override"));
 ```
 
 You should set `this.emojiElement.innerText` to `this.emoji` inside the `render` method of `Bee`.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Bee.methods.render.matches("override render() { this.emojiElement.innerText = this.emoji; }"));
+const emojiElement = document.createElement("p");
+const bee = new Bee(emojiElement);
+bee.emoji = "test_emoji";
+bee.render();
+assert.equal(emojiElement.innerText, "test_emoji");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb5ed756efe49f8531441.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb5ed756efe49f8531441.md
@@ -15,7 +15,8 @@ Your `Bee` class should have a `render` method using the `override` keyword.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const render = explorer.classes.Bee?.methods.render;
+const { Bee } = explorer.classes;
+const { render } = Bee?.methods ?? {};
 assert.isTrue(render?.toString().startsWith("override"));
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb7ad64801c563e8391b7.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb7ad64801c563e8391b7.md
@@ -15,22 +15,25 @@ You should have a class named `Spider`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Spider);
+const { Spider } = explorer.classes;
+assert.exists(Spider);
 ```
 
 Your `Spider` class should extend `Bug`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Spider?.doesExtend("Bug"));
+const { Spider } = explorer.classes;
+assert.isTrue(Spider?.doesExtend("Bug"));
 ```
 
 Your `Spider` class should extend `Bug` with a type argument of `string`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
+const { Spider } = explorer.classes;
 assert.isTrue(
-  explorer.classes.Spider?.matches("class Spider extends Bug<string> {}")
+  Spider?.matches("class Spider extends Bug<string> {}")
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb7ad64801c563e8391b7.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb7ad64801c563e8391b7.md
@@ -22,13 +22,16 @@ Your `Spider` class should extend `Bug`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Spider.doesExtend("Bug"));
+assert.isTrue(explorer.classes.Spider?.doesExtend("Bug"));
 ```
 
 Your `Spider` class should extend `Bug` with a type argument of `string`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /class\s+Spider\s+extends\s+Bug\s*<\s*string\s*>/);
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(
+  explorer.classes.Spider?.matches("class Spider extends Bug<string> {}")
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb81e768aab5a1a6a0381.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb81e768aab5a1a6a0381.md
@@ -55,10 +55,7 @@ Your `Spider` constructor should set `this.emoji` to `"🕷️"`.
 const explorer = await __helpers.Explorer(code);
 const { Spider } = explorer.classes;
 const { emoji } = Spider?.constructorProps ?? {};
-assert.isTrue(
-  emoji?.matches("this.emoji = \"🕷️\"") ||
-  emoji?.matches("this.emoji = '🕷️'")
-);
+assert.isTrue(emoji?.matches("this.emoji = '🕷️'"));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb81e768aab5a1a6a0381.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb81e768aab5a1a6a0381.md
@@ -17,25 +17,39 @@ Your `Spider` class should have a constructor.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Spider.classConstructor);
+assert.exists(explorer.classes.Spider?.classConstructor);
 ```
 
 Your `Spider` constructor should have a parameter named `emojiElement` of type `HTMLParagraphElement`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /class\s+Spider[\s\S]*?constructor\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const constructor = explorer.classes.Spider?.classConstructor;
+const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+assert.match(
+  strippedCode,
+  /^\s*constructor\b\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/
+);
 ```
 
 Your `Spider` constructor should call `super` with the `emojiElement` parameter.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /class\s+Spider[\s\S]*?super\s*\(\s*emojiElement\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const constructor = explorer.classes.Spider?.classConstructor;
+const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+assert.match(strippedCode, /\bsuper\b\s*\(\s*emojiElement\s*\)/);
 ```
 
 Your `Spider` constructor should set `this.emoji` to `"🕷️"`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /this\.emoji\s*=\s*["']🕷️["']/);
+const explorer = await __helpers.Explorer(code);
+const emoji = explorer.classes.Spider?.constructorProps.emoji;
+assert.isTrue(
+  emoji?.matches("this.emoji = \"🕷️\"") ||
+  emoji?.matches("this.emoji = '🕷️'")
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb81e768aab5a1a6a0381.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb81e768aab5a1a6a0381.md
@@ -17,15 +17,20 @@ Your `Spider` class should have a constructor.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Spider?.classConstructor);
+const { Spider } = explorer.classes;
+const { classConstructor } = Spider ?? {};
+assert.exists(classConstructor);
 ```
 
 Your `Spider` constructor should have a parameter named `emojiElement` of type `HTMLParagraphElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const constructor = explorer.classes.Spider?.classConstructor;
-const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+const { Spider } = explorer.classes;
+const { classConstructor } = Spider ?? {};
+const strippedCode = __helpers.removeJSComments(
+  classConstructor?.toString() ?? ""
+);
 assert.match(
   strippedCode,
   /^\s*constructor\b\s*\(\s*emojiElement\s*:\s*HTMLParagraphElement\s*\)/
@@ -36,8 +41,11 @@ Your `Spider` constructor should call `super` with the `emojiElement` parameter.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const constructor = explorer.classes.Spider?.classConstructor;
-const strippedCode = __helpers.removeJSComments(constructor?.toString() ?? "");
+const { Spider } = explorer.classes;
+const { classConstructor } = Spider ?? {};
+const strippedCode = __helpers.removeJSComments(
+  classConstructor?.toString() ?? ""
+);
 assert.match(strippedCode, /\bsuper\b\s*\(\s*emojiElement\s*\)/);
 ```
 
@@ -45,7 +53,8 @@ Your `Spider` constructor should set `this.emoji` to `"🕷️"`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const emoji = explorer.classes.Spider?.constructorProps.emoji;
+const { Spider } = explorer.classes;
+const { emoji } = Spider?.constructorProps ?? {};
 assert.isTrue(
   emoji?.matches("this.emoji = \"🕷️\"") ||
   emoji?.matches("this.emoji = '🕷️'")

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb94bf8221362ce6f54c5.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb94bf8221362ce6f54c5.md
@@ -11,24 +11,22 @@ Inside the `Spider` class, implement the `render` method, prefixed by the `overr
 
 # --hints--
 
-Your `Spider` class should have a `render` method.
+Your `Spider` class should have a `render` method using the `override` keyword.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.classes.Spider.methods.render);
-```
-
-Your `Spider` `render` method should use the `override` keyword.
-
-```js
-assert.match(__helpers.removeJSComments(code), /class\s+Spider[\s\S]*?override\s+render/);
+const render = explorer.classes.Spider?.methods.render;
+assert.isTrue(render?.toString().startsWith("override"));
 ```
 
 Your `Spider` `render` method should set `this.emojiElement.innerText` to `this.emoji`.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Spider.methods.render.matches("override render() { this.emojiElement.innerText = this.emoji; }"));
+const emojiElement = document.createElement("p");
+const spider = new Spider(emojiElement);
+spider.emoji = "test_emoji";
+spider.render();
+assert.equal(emojiElement.innerText, "test_emoji");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb94bf8221362ce6f54c5.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb94bf8221362ce6f54c5.md
@@ -15,7 +15,8 @@ Your `Spider` class should have a `render` method using the `override` keyword.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-const render = explorer.classes.Spider?.methods.render;
+const { Spider } = explorer.classes;
+const { render } = Spider?.methods ?? {};
 assert.isTrue(render?.toString().startsWith("override"));
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb9f4046f1d677f1f6e4e.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb9f4046f1d677f1f6e4e.md
@@ -7,7 +7,7 @@ dashedName: step-12
 
 # --description--
 
-Create a function named `isSelect` that takes a single parameter `element` of type `EventTarget | null`. This function will check if the selected element is a `<select>` HTML element.
+Create a function named `isSelect` that takes a single parameter `element` of type `EventTarget | null`. The function should have a return type of `element is HTMLSelectElement`. This function will check if the selected element is a `<select>` HTML element.
 
 # --hints--
 
@@ -22,13 +22,26 @@ Your `isSelect` function should have a parameter named `element` of type `EventT
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.isSelect.parameters[0].matches("element: EventTarget | null"));
+const { isSelect } = explorer.allFunctions;
+assert.lengthOf(isSelect?.parameters, 1);
+assert.isTrue(
+  isSelect?.parameters[0].matches("element: EventTarget | null")
+);
 ```
 
 Your `isSelect` function should have a return type of `element is HTMLSelectElement`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /:\s*element\s+is\s+HTMLSelectElement/);
+const explorer = await __helpers.Explorer(code);
+const { isSelect } = explorer.allFunctions;
+assert.isTrue(
+  isSelect?.matches(
+    "function isSelect(element: EventTarget | null): element is HTMLSelectElement {}"
+  ) ||
+  isSelect?.matches(
+    "const isSelect = (element: EventTarget | null): element is HTMLSelectElement => {}"
+  )
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb9f4046f1d677f1f6e4e.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb9f4046f1d677f1f6e4e.md
@@ -34,14 +34,16 @@ Your `isSelect` function should have a return type of `element is HTMLSelectElem
 ```js
 const explorer = await __helpers.Explorer(code);
 const { isSelect } = explorer.allFunctions;
-assert.isTrue(
-  isSelect?.matches(
-    "function isSelect(element: EventTarget | null): element is HTMLSelectElement {}"
-  ) ||
-  isSelect?.matches(
-    "const isSelect = (element: EventTarget | null): element is HTMLSelectElement => {}"
-  )
-);
+const validExpressions = [
+  "function isSelect(element: EventTarget | null): element is HTMLSelectElement {}",
+  "const isSelect = (element: EventTarget | null): element is HTMLSelectElement => {}",
+  "let isSelect = (element: EventTarget | null): element is HTMLSelectElement => {}",
+  "var isSelect = (element: EventTarget | null): element is HTMLSelectElement => {}",
+  "const isSelect = function(element: EventTarget | null): element is HTMLSelectElement {}",
+  "let isSelect = function(element: EventTarget | null): element is HTMLSelectElement {}",
+  "var isSelect = function(element: EventTarget | null): element is HTMLSelectElement {}"
+];
+assert.isTrue(validExpressions.some(expression => isSelect?.matches(expression)));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb9f4046f1d677f1f6e4e.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fb9f4046f1d677f1f6e4e.md
@@ -15,7 +15,8 @@ You should have a function named `isSelect`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.allFunctions.isSelect);
+const { isSelect } = explorer.allFunctions;
+assert.exists(isSelect);
 ```
 
 Your `isSelect` function should have a parameter named `element` of type `EventTarget | null`.

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbce895711f7c574c1e81.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbce895711f7c574c1e81.md
@@ -14,8 +14,12 @@ Now inside the `isSelect` function, return a boolean indicating whether the `ele
 Your `isSelect` function should return `element instanceof HTMLSelectElement`.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.allFunctions.isSelect.hasReturn("element instanceof HTMLSelectElement"));
+const select = document.createElement("select");
+const paragraph = document.createElement("p");
+
+assert.isTrue(isSelect(select));
+assert.isFalse(isSelect(paragraph));
+assert.isFalse(isSelect(null));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbdf423ea7685453dbbf9.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbdf423ea7685453dbbf9.md
@@ -32,7 +32,7 @@ const strippedCode = __helpers.removeJSComments(
 );
 assert.match(
   strippedCode,
-  /^document\s*\.\s*querySelector\s*<\s*HTMLParagraphElement\s*>\s*\(\s*["']#bug-emoji["']\s*\)/
+  /^document\s*\.\s*querySelector\s*<\s*HTMLParagraphElement\s*>\s*\(\s*(["'`])#bug-emoji\1\s*\)/
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbdf423ea7685453dbbf9.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbdf423ea7685453dbbf9.md
@@ -17,20 +17,30 @@ You should have a constant named `bugEmojiElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.variables.bugEmojiElement);
+const { bugEmojiElement } = explorer.variables;
+assert.isTrue(bugEmojiElement?.toString().startsWith("const"));
 ```
 
 Your `bugEmojiElement` should query the element with the ID `bug-emoji` using `document.querySelector` with a type argument of `HTMLParagraphElement`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /querySelector\s*<\s*HTMLParagraphElement\s*>\s*\(\s*['"]#bug-emoji['"]\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const { bugEmojiElement } = explorer.variables;
+const strippedCode = __helpers.removeJSComments(
+  bugEmojiElement?.value?.toString() ?? ""
+);
+assert.match(
+  strippedCode,
+  /^document\s*\.\s*querySelector\s*<\s*HTMLParagraphElement\s*>\s*\(\s*["']#bug-emoji["']\s*\)/
+);
 ```
 
 Your `bugEmojiElement` should use the non-null assertion operator (`!`).
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.variables.bugEmojiElement.value.hasNonNullAssertion());
+const { bugEmojiElement } = explorer.variables;
+assert.isTrue(bugEmojiElement?.value?.hasNonNullAssertion());
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbdf423ea7685453dbbf9.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbdf423ea7685453dbbf9.md
@@ -26,8 +26,9 @@ Your `bugEmojiElement` should query the element with the ID `bug-emoji` using `d
 ```js
 const explorer = await __helpers.Explorer(code);
 const { bugEmojiElement } = explorer.variables;
+const { value } = bugEmojiElement ?? {};
 const strippedCode = __helpers.removeJSComments(
-  bugEmojiElement?.value?.toString() ?? ""
+  value?.toString() ?? ""
 );
 assert.match(
   strippedCode,
@@ -40,7 +41,8 @@ Your `bugEmojiElement` should use the non-null assertion operator (`!`).
 ```js
 const explorer = await __helpers.Explorer(code);
 const { bugEmojiElement } = explorer.variables;
-assert.isTrue(bugEmojiElement?.value?.hasNonNullAssertion());
+const { value } = bugEmojiElement ?? {};
+assert.isTrue(value?.hasNonNullAssertion());
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbf63c8fe56907977f450.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/692fbf63c8fe56907977f450.md
@@ -15,21 +15,23 @@ You should have a constant named `bugMap`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.variables.bugMap);
+const { bugMap } = explorer.variables;
+assert.isTrue(bugMap?.toString().startsWith("const"));
 ```
 
 Your `bugMap` should have a type annotation of `Record<string, Bug<string>>`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.variables.bugMap.hasAnnotation("Record<string, Bug<string>>"));
+const { bugMap } = explorer.variables;
+assert.isTrue(bugMap?.hasAnnotation("Record<string, Bug<string>>"));
 ```
 
 Your `bugMap` should be initialized to an empty object.
 
 ```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.variables.bugMap.value.matches("{}"));
+assert.isObject(bugMap);
+assert.isEmpty(bugMap);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69386f3bce81c60f2b3feeb8.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69386f3bce81c60f2b3feeb8.md
@@ -30,7 +30,7 @@ const strippedCode = __helpers.removeJSComments(
 );
 assert.match(
   strippedCode,
-  /^document\s*\.\s*querySelector\s*<\s*HTMLSelectElement\s*>\s*\(\s*["']#species["']\s*\)/
+  /^document\s*\.\s*querySelector\s*<\s*HTMLSelectElement\s*>\s*\(\s*(["'`])#species\1\s*\)/
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69386f3bce81c60f2b3feeb8.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69386f3bce81c60f2b3feeb8.md
@@ -7,7 +7,7 @@ dashedName: step-17
 
 # --description--
 
-Get the `select` element with ID `species` from the DOM and store it in a constant named `selectElement`. Use the `!` non-null assertion operator to assert that the element is not `null`
+Get the `select` element with ID `species` from the DOM and store it in a constant named `selectElement`. Use the `!` non-null assertion operator to assert that the element is not `null`.
 
 # --hints--
 
@@ -15,20 +15,30 @@ You should have a constant named `selectElement`.
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.exists(explorer.variables.selectElement);
+const { selectElement } = explorer.variables;
+assert.isTrue(selectElement?.toString().startsWith("const"));
 ```
 
 Your `selectElement` should query the element with the ID `species` using `document.querySelector` with a type argument of `HTMLSelectElement`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /querySelector\s*<\s*HTMLSelectElement\s*>\s*\(\s*['"]#species['"]\s*\)/);
+const explorer = await __helpers.Explorer(code);
+const { selectElement } = explorer.variables;
+const strippedCode = __helpers.removeJSComments(
+  selectElement?.value?.toString() ?? ""
+);
+assert.match(
+  strippedCode,
+  /^document\s*\.\s*querySelector\s*<\s*HTMLSelectElement\s*>\s*\(\s*["']#species["']\s*\)/
+);
 ```
 
 Your `selectElement` should use the non-null assertion operator (`!`).
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.variables.selectElement.value.hasNonNullAssertion());
+const { selectElement } = explorer.variables;
+assert.isTrue(selectElement?.value?.hasNonNullAssertion());
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69386f3bce81c60f2b3feeb8.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69386f3bce81c60f2b3feeb8.md
@@ -24,8 +24,9 @@ Your `selectElement` should query the element with the ID `species` using `docum
 ```js
 const explorer = await __helpers.Explorer(code);
 const { selectElement } = explorer.variables;
+const { value } = selectElement ?? {};
 const strippedCode = __helpers.removeJSComments(
-  selectElement?.value?.toString() ?? ""
+  value?.toString() ?? ""
 );
 assert.match(
   strippedCode,
@@ -38,7 +39,8 @@ Your `selectElement` should use the non-null assertion operator (`!`).
 ```js
 const explorer = await __helpers.Explorer(code);
 const { selectElement } = explorer.variables;
-assert.isTrue(selectElement?.value?.hasNonNullAssertion());
+const { value } = selectElement ?? {};
+assert.isTrue(value?.hasNonNullAssertion());
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/693874cf5bf4aa32aded7ce5.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/693874cf5bf4aa32aded7ce5.md
@@ -19,7 +19,7 @@ Your `selectElement` should have a `change` event listener with a callback that 
 const strippedCode = __helpers.removeJSComments(code);
 assert.match(
   strippedCode,
-  /selectElement\s*\.\s*addEventListener\s*\(\s*["']change["']\s*,\s*(?:function\s*\(\s*e\s*\)|\(?\s*e\s*\)?\s*=>)/
+  /selectElement\s*\.\s*addEventListener\s*\(\s*(["'`])change\1\s*,\s*(?:function\s*\(\s*e\s*\)|\(?\s*e\s*\)?\s*=>)/
 );
 ```
 
@@ -29,7 +29,7 @@ Your event listener callback should have an `if` statement with the condition `i
 const strippedCode = __helpers.removeJSComments(code);
 assert.match(
   strippedCode,
-  /selectElement\s*\.\s*addEventListener\s*\(\s*["']change["'][\s\S]*?if\s*\(\s*isSelect\s*\(\s*e\.target\s*\)\s*\)/
+  /selectElement\s*\.\s*addEventListener\s*\(\s*(["'`])change\1[\s\S]*?if\s*\(\s*isSelect\s*\(\s*e\.target\s*\)\s*\)/
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/693874cf5bf4aa32aded7ce5.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/693874cf5bf4aa32aded7ce5.md
@@ -13,13 +13,13 @@ Add a `change` event listener to `selectElement`. In the callback, use `isSelect
 
 # --hints--
 
-Your `selectElement` should have a `change` event listener with a callback that takes an event parameter.
+Your `selectElement` should have a `change` event listener with a callback that takes an event parameter `e`.
 
 ```js
 const strippedCode = __helpers.removeJSComments(code);
 assert.match(
   strippedCode,
-  /selectElement\s*\.\s*addEventListener\s*\(\s*["']change["']\s*,\s*(?:function\s*\(\s*\w+\s*\)|\w+\s*=>|\(\s*\w+\s*\)\s*=>)/
+  /selectElement\s*\.\s*addEventListener\s*\(\s*["']change["']\s*,\s*(?:function\s*\(\s*e\s*\)|\(?\s*e\s*\)?\s*=>)/
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/693874cf5bf4aa32aded7ce5.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/693874cf5bf4aa32aded7ce5.md
@@ -16,13 +16,21 @@ Add a `change` event listener to `selectElement`. In the callback, use `isSelect
 Your `selectElement` should have a `change` event listener with a callback that takes an event parameter.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /selectElement\s*\.\s*addEventListener\s*\(\s*["']change["']\s*,\s*(?:function\s*\(\s*\w+\s*\)|\w+\s*=>|\(\s*\w+\s*\)\s*=>)/);
+const strippedCode = __helpers.removeJSComments(code);
+assert.match(
+  strippedCode,
+  /selectElement\s*\.\s*addEventListener\s*\(\s*["']change["']\s*,\s*(?:function\s*\(\s*\w+\s*\)|\w+\s*=>|\(\s*\w+\s*\)\s*=>)/
+);
 ```
 
 Your event listener callback should have an `if` statement with the condition `isSelect(e.target)`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /addEventListener\s*\(\s*["']change["'][\s\S]*?if\s*\(\s*isSelect\s*\(\s*e\.target\s*\)\s*\)/);
+const strippedCode = __helpers.removeJSComments(code);
+assert.match(
+  strippedCode,
+  /selectElement\s*\.\s*addEventListener\s*\(\s*["']change["'][\s\S]*?if\s*\(\s*isSelect\s*\(\s*e\.target\s*\)\s*\)/
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d902c4f58b8a0d48d19c67.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d902c4f58b8a0d48d19c67.md
@@ -14,13 +14,29 @@ Now populate `bugMap` with two entries. Add `"bee"` as a key mapped to a new `Be
 Your `bugMap` should have a `"bee"` entry set to `new Bee(bugEmojiElement)`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /bugMap\s*[^=]*=\s*\{[^}]*["']bee["']\s*:\s*new\s+Bee\s*\(\s*bugEmojiElement\s*\)/s);
+const explorer = await __helpers.Explorer(code);
+const { bugMap } = explorer.variables;
+const strippedCode = __helpers.removeJSComments(
+  bugMap?.value?.toString() ?? ""
+);
+assert.match(
+  strippedCode,
+  /\{[\s\S]*?["']bee["']\s*:\s*new\s+Bee\s*\(\s*bugEmojiElement\s*\)/
+);
 ```
 
 Your `bugMap` should have a `"spider"` entry set to `new Spider(bugEmojiElement)`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /bugMap\s*[^=]*=\s*\{[^}]*["']spider["']\s*:\s*new\s+Spider\s*\(\s*bugEmojiElement\s*\)/s);
+const explorer = await __helpers.Explorer(code);
+const { bugMap } = explorer.variables;
+const strippedCode = __helpers.removeJSComments(
+  bugMap?.value?.toString() ?? ""
+);
+assert.match(
+  strippedCode,
+  /\{[\s\S]*?["']spider["']\s*:\s*new\s+Spider\s*\(\s*bugEmojiElement\s*\)/
+);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d902c4f58b8a0d48d19c67.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d902c4f58b8a0d48d19c67.md
@@ -22,7 +22,7 @@ const strippedCode = __helpers.removeJSComments(
 );
 assert.match(
   strippedCode,
-  /\{[\s\S]*?["']bee["']\s*:\s*new\s+Bee\s*\(\s*bugEmojiElement\s*\)/
+  /\{[\s\S]*?(["'`])bee\1\s*:\s*new\s+Bee\s*\(\s*bugEmojiElement\s*\)/
 );
 ```
 
@@ -37,7 +37,7 @@ const strippedCode = __helpers.removeJSComments(
 );
 assert.match(
   strippedCode,
-  /\{[\s\S]*?["']spider["']\s*:\s*new\s+Spider\s*\(\s*bugEmojiElement\s*\)/
+  /\{[\s\S]*?(["'`])spider\1\s*:\s*new\s+Spider\s*\(\s*bugEmojiElement\s*\)/
 );
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d902c4f58b8a0d48d19c67.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d902c4f58b8a0d48d19c67.md
@@ -16,8 +16,9 @@ Your `bugMap` should have a `"bee"` entry set to `new Bee(bugEmojiElement)`.
 ```js
 const explorer = await __helpers.Explorer(code);
 const { bugMap } = explorer.variables;
+const { value } = bugMap ?? {};
 const strippedCode = __helpers.removeJSComments(
-  bugMap?.value?.toString() ?? ""
+  value?.toString() ?? ""
 );
 assert.match(
   strippedCode,
@@ -30,8 +31,9 @@ Your `bugMap` should have a `"spider"` entry set to `new Spider(bugEmojiElement)
 ```js
 const explorer = await __helpers.Explorer(code);
 const { bugMap } = explorer.variables;
+const { value } = bugMap ?? {};
 const strippedCode = __helpers.removeJSComments(
-  bugMap?.value?.toString() ?? ""
+  value?.toString() ?? ""
 );
 assert.match(
   strippedCode,

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
@@ -16,7 +16,28 @@ With that, your Bug Emoji Picker workshop is complete!
 You should call the `render` method on the corresponding bug from `bugMap`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /bugMap\s*\[\s*e\.target\.value\s*\]\s*\.\s*render\s*\(\s*\)/);
+for (const bugName of ["bee", "spider"]) {
+  const renderSpy = __helpers.spyOn(bugMap[bugName], "render");
+  try {
+    selectElement.value = bugName;
+    selectElement.dispatchEvent(new Event("change"));
+    assert.lengthOf(renderSpy.calls, 1);
+  } finally {
+    renderSpy.restore();
+  }
+}
+
+const renderSpy = __helpers.spyOn(bugMap.bee, "render");
+const originalIsSelect = isSelect;
+try {
+  isSelect = () => false;
+  selectElement.value = "bee";
+  selectElement.dispatchEvent(new Event("change"));
+  assert.lengthOf(renderSpy.calls, 0);
+} finally {
+  isSelect = originalIsSelect;
+  renderSpy.restore();
+}
 ```
 
 # --seed--

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
@@ -28,14 +28,12 @@ for (const bugName of ["bee", "spider"]) {
 }
 
 const renderSpy = __helpers.spyOn(bugMap.bee, "render");
-const originalIsSelect = isSelect;
 try {
-  isSelect = () => false;
-  selectElement.value = "bee";
-  selectElement.dispatchEvent(new Event("change"));
+  selectElement.options[0].dispatchEvent(
+    new Event("change", { bubbles: true })
+  );
   assert.lengthOf(renderSpy.calls, 0);
 } finally {
-  isSelect = originalIsSelect;
   renderSpy.restore();
 }
 ```

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
@@ -16,7 +16,7 @@ With that, your Bug Emoji Picker workshop is complete!
 You should call the `render` method on the corresponding bug from `bugMap`.
 
 ```js
-for (const [selected, other] of [["bee", "spider"], ["spider", "bee"]]) {
+for (const [ selected, other ] of [["bee", "spider"], ["spider", "bee"]]) {
   const selectedSpy = __helpers.spyOn(bugMap[selected], "render");
   const otherSpy = __helpers.spyOn(bugMap[other], "render");
   try {

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
@@ -27,14 +27,17 @@ for (const bugName of ["bee", "spider"]) {
   }
 }
 
-const renderSpy = __helpers.spyOn(bugMap.bee, "render");
+const beeSpy = __helpers.spyOn(bugMap.bee, "render");
+const spiderSpy = __helpers.spyOn(bugMap.spider, "render");
 try {
   selectElement.options[0].dispatchEvent(
     new Event("change", { bubbles: true })
   );
-  assert.lengthOf(renderSpy.calls, 0);
+  assert.lengthOf(beeSpy.calls, 0);
+  assert.lengthOf(spiderSpy.calls, 0);
 } finally {
-  renderSpy.restore();
+  beeSpy.restore();
+  spiderSpy.restore();
 }
 ```
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
@@ -16,14 +16,17 @@ With that, your Bug Emoji Picker workshop is complete!
 You should call the `render` method on the corresponding bug from `bugMap`.
 
 ```js
-for (const bugName of ["bee", "spider"]) {
-  const renderSpy = __helpers.spyOn(bugMap[bugName], "render");
+for (const [selected, other] of [["bee", "spider"], ["spider", "bee"]]) {
+  const selectedSpy = __helpers.spyOn(bugMap[selected], "render");
+  const otherSpy = __helpers.spyOn(bugMap[other], "render");
   try {
-    selectElement.value = bugName;
+    selectElement.value = selected;
     selectElement.dispatchEvent(new Event("change"));
-    assert.lengthOf(renderSpy.calls, 1);
+    assert.lengthOf(selectedSpy.calls, 1);
+    assert.lengthOf(otherSpy.calls, 0);
   } finally {
-    renderSpy.restore();
+    selectedSpy.restore();
+    otherSpy.restore();
   }
 }
 

--- a/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
+++ b/curriculum/challenges/english/blocks/workshop-bug-emoji-picker/69d909f2946a3fcabed720c6.md
@@ -29,19 +29,6 @@ for (const [ selected, other ] of [["bee", "spider"], ["spider", "bee"]]) {
     otherSpy.restore();
   }
 }
-
-const beeSpy = __helpers.spyOn(bugMap.bee, "render");
-const spiderSpy = __helpers.spyOn(bugMap.spider, "render");
-try {
-  selectElement.options[0].dispatchEvent(
-    new Event("change", { bubbles: true })
-  );
-  assert.lengthOf(beeSpy.calls, 0);
-  assert.lengthOf(spiderSpy.calls, 0);
-} finally {
-  beeSpy.restore();
-  spiderSpy.restore();
-}
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68696

<!-- Feel free to add any additional description of changes below this line -->

Overview:
- Improve tests throughout the workshop to use Explorer AST helper patterns instead of (or to scope) regex tests, where possible.
- In some cases, employed behavior/runtime tests to exercise the camper's code rather than trying to match semantics or typed inputs.
- Clarified hint and step descriptions to improve clarity and consistency.
- Where there were regex tests that could not be replaced with Explore AST matches, some were improved to permit more flexibility in whitespace around keywords or symbols. In other cases, improved scoping of the regexes to target matches within specific blocks or statements.
- I've annotated the changes below with context, what was tried, and limitations of the Explorer AST helpers.