### PR TITLE
fix(curriculum): correct style issues in the safe sign-in lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab849aa1ef70eefd29364.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-computer-internet-and-tooling-basics/672ab849aa1ef70eefd29364.md
@@ -9,29 +9,29 @@ dashedName: what-are-safe-ways-to-sign-into-your-computer
 
 Many of you have been using computers for a while. But you might not have thought about the safest or most secure ways to sign into your computer.
 
-Whether you are using a Mac or PC, there are many ways to safely sign into your computer.
+Whether you are using a Mac or a PC, there are many ways to safely sign into your computer.
 
-The first thing you should do is to make sure that your computer is password protected.
+The first thing you should do is to make sure that your computer is password-protected.
 
 For Windows users, start by opening the Start menu and selecting Settings. From there, go to Accounts and then Sign-in options. You can then set up a password for your computer.
 
 *Note: If you encounter any difficulties or are using a different version of Windows, refer to the official Microsoft documentation or support resources for detailed instructions tailored to your specific version.*
 
-When creating your password, make sure it is a long and complex password. You can use a combination of letters, numbers and special characters to make it more secure.
+When creating your password, make sure it is a long and complex password. You can use a combination of letters, numbers, and special characters to make it more secure.
 
 Choosing an easy password like `12345` or `password` is not a good idea. These are easy to guess and can be easily hacked.
 
 Also, do not use passwords based on personal information like your name, birthday, or address. Those are also easy for hackers to guess.
 
-When you create your password, it is also a good idea to setup two-factor authentication (2FA). 2FA serves as an extra layer of security and requires a second form of verification to ensure that the person trying to access the account is indeed the authorized user.
+When you create your password, it is also a good idea to set up two-factor authentication (2FA). 2FA serves as an extra layer of security and requires a second form of verification to ensure that the person trying to access the account is indeed the authorized user.
 
-If you are a Mac user, you can click on the Apple menu and then go to system settings. From there you can go to Users & Groups and set up a password for your computer.
+If you are a Mac user, you can click on the Apple menu and then go to System Settings. From there you can go to Users & Groups and set up a password for your computer.
 
-Some Mac computers come with a touch ID feature, which is often considered more secure than regular passwords. This feature allows you to sign into your computer using your fingerprint.
+Some Mac computers come with a Touch ID feature, which is often considered more secure than regular passwords. This feature allows you to sign into your computer using your fingerprint.
 
 For Windows users, the Windows Hello feature offers a more secure way to sign in. It uses biometric methods such as facial recognition or fingerprints for authentication, providing an alternative to traditional passwords.
 
-After you finish this lesson, I urge you to look into these additional security features and set them up on your computer so that you can keep your computer safe and secure.
+After you finish this lesson, look into these additional security features and set them up so that your computer stays secure.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69561

Fixes the six style issues called out in the "safe ways to sign into your computer" lecture: "Mac or PC" → "Mac or a PC", "password protected" → hyphenated, missing serial comma in the letters/numbers/special-characters list, "setup" → "set up" (verb form), inconsistent capitalization of System Settings/Touch ID, and rewrote the closing sentence from first person to second person to match the rest of the lecture's voice.

Tested by running the project's markdown/content linter (`challenge-linter`) against the changed challenge file only — no errors.