### PR TITLE
fix(curriculum): clarify the React introduction lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e86f590727c5e7e9ec5e.md
@@ -7,9 +7,9 @@ dashedName: what-is-react-and-what-is-it-commonly-used-for
 
 # --description--
 
-React is one of the most popular JavaScript libraries for building user interfaces and web applications. Originally developed and maintained by Facebook, React has gained huge popularity in web development due to its efficiency, flexibility, and features.
+React is one of the most popular JavaScript libraries for building user interfaces and web applications. Originally developed at Facebook, now Meta, React has gained huge popularity in web development due to its efficiency, flexibility, and features.
 
-A fundamental concept in React is the creation of reusable UI components. These components, such as buttons, cards, and avatar components, can be easily reused throughout your application. You can nest these components inside each other to build more complex, dynamic interfaces.
+A fundamental concept in React is the creation of reusable UI components. These components, such as buttons, cards, and avatars, can be easily reused throughout your application. You can nest these components inside each other to build more complex, dynamic interfaces.
 
 One of the key advantages of React is that these custom components can update and render independently as data changes.
 
@@ -19,9 +19,9 @@ In addition to reusable components, React also provides a powerful way to manage
 
 With React, you can easily track and update the state of components, ensuring that the UI reflects the most current data. You will learn more about working with state in future lessons.
 
-While there are many libraries within the JavaScript ecosystem, freeCodeCamp will mainly be focused on teaching React because of its widespread use and demand in the industry.
+While there are many libraries within the JavaScript ecosystem, freeCodeCamp mainly teaches React because of its widespread use and demand in the industry.
 
-Our next few lessons will dive deeper into building custom components, managing state, and more.
+In the next few lessons, you will go deeper into building custom components, managing state, and more.
 
 # --questions--
 
@@ -71,7 +71,7 @@ State determines the styling of UI components.
 
 ### --feedback--
 
-Review the beginning section where this was discussed. 
+Review the section on managing state in your application.
 
 ---
 
@@ -83,7 +83,7 @@ State is used to manage the DOM directly.
 
 ### --feedback--
 
-Review the beginning section where this was discussed. 
+Review the section on managing state in your application.
 
 ---
 
@@ -91,7 +91,7 @@ State is only used in functional components.
 
 ### --feedback--
 
-Review the beginning section where this was discussed. 
+Review the section on managing state in your application.
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69564

Cleans up the React introduction lecture: credits Facebook/Meta correctly, gives concrete examples of reusable UI pieces (buttons, cards, avatars), clarifies why freeCodeCamp teaches React specifically, and rewords the closing paragraph. Also aligned the three feedback strings on question 2 so they're consistent with each other and with the corrected lesson text.

Tested by running the project's markdown/content linter (`challenge-linter`) against the changed challenge file only — no errors.