### PR TITLE
fix(curriculum): correct React import/export lecture inaccuracies

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/674ba6876f7ada867135bb95.md
@@ -13,9 +13,9 @@ An export makes a component available to other files. An import allows a file to
 
 In this lesson, you will learn how to export React components using default exports and named exports, and how to import them where they are needed.
 
-In this example, we have a `Cat` component that belongs in a file called `Cat.jsx`. For the file extension, we are using the `.jsx` file extension because this file is mainly working with JSX.
+In this example, we have a `Cat` component that belongs in a file called `Cat.jsx`. We are using the `.jsx` extension because this file is mainly working with JSX.
 
-This `Cat` component returns a JSX markup with a title and image for a cat called Mr. Whiskers:
+This `Cat` component returns JSX markup with a title and image for a cat called Mr. Whiskers:
 
 ```jsx
 function Cat() {
@@ -24,7 +24,7 @@ function Cat() {
       <h2>Mr. Whiskers</h2>
       <img
         src="https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg"
-        alt="Tuxedo cats running on dirt ground."
+        alt="Cats walking on dirt ground near a bundle of straw."
       />
     </div>
   );
@@ -40,7 +40,7 @@ function Cat() {
       <h2>Mr. Whiskers</h2>
       <img
         src="https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg"
-        alt="Tuxedo cats running on dirt ground."
+        alt="Cats walking on dirt ground near a bundle of straw."
       />
     </div>
   );
@@ -58,7 +58,7 @@ export default function Cat() {
       <h2>Mr. Whiskers</h2>
       <img
         src="https://cdn.freecodecamp.org/curriculum/cat-photo-app/running-cats.jpg"
-        alt="Tuxedo cats running on dirt ground."
+        alt="Cats walking on dirt ground near a bundle of straw."
       />
     </div>
   );
@@ -67,13 +67,11 @@ export default function Cat() {
 
 You can choose to import child components in other parent component files, or import them in the root component file. For this example, we will import the `Cat` component inside the root component file.
 
-Every React project will have a top-level component, typically called `App.jsx`:
+Every React project will have a top-level component, typically called `App`, defined in a file named `App.jsx`:
 
 ```jsx
 export default function App() {
-  return (
-    // return component here
-  );
+  return null; // return your component here
 }
 ```
 
@@ -85,9 +83,7 @@ To use the `Cat` component inside the root `App` component, you will need to imp
 import Cat from "./Cat";
 
 export default function App() {
-  return (
-    // return component here
-  );
+  return null; // return your component here
 }
 ```
 
@@ -105,10 +101,9 @@ export default function App() {
 
 This approach works well when a file is responsible for exporting a single main component, keeping the import syntax simple and easy to read. Remember, a file can only have one default export, which makes it ideal for a file that primarily contains a single component.
 
-
 Now that you know how to use default exports, let's look at named exports. Named exports allow a file to share multiple components or functions. Unlike default exports, these must be imported using the exact name they were exported with (unless you rename them using the `as` keyword).
 
-This is useful when a file serves as a library of components. For example, here is a file containing two components, Cat and Dog:
+This is useful when a file serves as a library of components. For example, here is a file containing two components, `Cat` and `Dog`:
 
 ```jsx
 // Animals.jsx
@@ -121,8 +116,7 @@ export function Dog() {
 }
 ```
 
-We use the export keyword individually on each component. To use these in another file, we import them using curly braces:
-
+We use the `export` keyword individually on each component. To use these in another file, we import them using curly braces:
 
 ```jsx
 import { Cat, Dog } from "./Animals";


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69563

Fixes the issues called out in the default/named exports lecture: duplicated "file extension" wording, an uncountable-noun article on "markup," alt text on three code-block screenshots that wrongly described a photo of tuxedo cats, a component/file-name conflation around `App.jsx`, two double-blank-line breaks, missing backticks around `Cat`, `Dog`, and `export`, and two code blocks with `return (\n  // comment\n);` which is actually a syntax error — replaced with `return null; // return your component here` so the example is valid JS.

Tested by running the project's markdown/content linter (`challenge-linter`) against the changed challenge file only — no errors.