### PR TITLE
fix(curriculum): fix style issues in JS libraries lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e3a9cc78faaf4248d335.md
@@ -7,7 +7,7 @@ dashedName: what-is-the-role-of-js-libraries-and-frameworks-and-why-are-they-use
 
 # --description--
 
-JavaScript libraries and frameworks provide pre-built code that streamlines the development process.  While both libraries and frameworks serve to improve productivity and standardize coding practices, they differ in their approach and level of control they provide to developers.
+JavaScript libraries and frameworks provide pre-built code that streamlines the development process. While both libraries and frameworks serve to improve productivity and standardize coding practices, they differ in their approach and in the level of control they provide to developers.
 
 Libraries are generally more focused on providing solutions to specific tasks, such as manipulating the DOM, handling events, or managing AJAX requests.
 
@@ -29,11 +29,11 @@ Although libraries and frameworks are used across projects of all sizes, the cho
 
 In the industry, libraries and frameworks are widely used for several reasons. They significantly speed up development by providing quick solutions for common problems.
 
-One common problem in JavaScript is working with dates and timezones. But there are libraries out there with built-in solutions to help you with date manipulation, time zones, parsing and formatting of dates.
+One common problem in JavaScript is working with dates and time zones. But there are libraries out there with built-in solutions to help you with date manipulation, time zones, and parsing and formatting of dates.
 
 A lot of popular libraries and frameworks are well-tested and maintained by large communities. This means they're often more practical than building the same thing from scratch.
 
-Libraries and frameworks follow best practices and patterns that have been proven effective in real life scenarios. This can lead to more robust and scalable applications.
+Libraries and frameworks follow best practices and patterns that have been proven effective in real-life scenarios. This can lead to more robust and scalable applications.
 
 In conclusion, libraries and frameworks offer quick solutions to common problems, speed up development, and promote best practices. Understanding the differences between libraries and frameworks, and knowing when to use them is a valuable skill for any JavaScript developer.
 
@@ -45,7 +45,7 @@ Why was jQuery a popular library of choice in the early 2010s?
 
 ## --answers--
 
-jQuery was used to simplify things like DOM manipulation, event handling, animations and effects.
+jQuery was used to simplify things like DOM manipulation, event handling, animations, and effects.
 
 ---
 
@@ -65,7 +65,7 @@ Think about how this library helped to simplify the development process.
 
 ---
 
-jQuery allowed you to write 100% bug free code.
+jQuery allowed you to write 100% bug-free code.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69565

Fixes the six style issues in the "Introduction to JavaScript Libraries and Frameworks" lecture: a double space after "development process," a missing "in" before "the level of control," "timezones" → "time zones" (both occurrences, plus a missing serial comma), "real life scenarios" → "real-life scenarios," a missing serial comma in the DOM-manipulation list, and "bug free code" → "bug-free code."

Tested by running the project's markdown/content linter (`challenge-linter`) against the changed challenge file only — no errors.