### PR TITLE
fix(curriculum): correct SPA navigation and performance explanations

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript-libraries-and-frameworks/6734e867bbf41cc5b11648c4.md
@@ -11,17 +11,17 @@ Unlike traditional multi-page websites, single page applications (SPAs) load onl
 
 SPAs heavily use JavaScript to manage the application's state and render content. Instead of requesting new HTML pages from the server, SPAs use JavaScript to manipulate the DOM and fetch data asynchronously. This is often done using libraries and frameworks like React, Vue, or Angular, which provide great tools for building complex user interfaces.
 
-SPAs have some common issues. One significant issue is that screen readers may struggle with dynamically updated content. When content changes without a page reload/refresh, screen readers might not notify these changes, which makes our users unaware of updates on our web app.
+SPAs have some common issues. One significant issue is that screen readers may struggle with dynamically updated content. When content changes without a page reload, screen readers might not announce these changes, which leaves users unaware of updates to the web app.
 
-Another challenge with SPAs is with navigation and browser history. Users expect the back and forward buttons to work as they do on traditional websites. This might not work properly in SPAs because technically, the URL of the web app doesn't change. Since the URL of the web app doesn't change, they can't bookmark any specific page. Refreshing the page might reset the application to its initial state, rather than maintaining the current view.
+Another challenge with SPAs is navigation and browser history. Users expect the back and forward buttons to work as they do on traditional websites. This only works if the app updates the browser history as the view changes. An SPA that renders new views without updating the URL leaves the back and forward buttons doing nothing, and gives the user no address to bookmark. Refreshing the page might reset the application to its initial state, rather than maintaining the current view.
 
 SPAs can pose challenges for SEO. Search engines like Google can have difficulty indexing dynamically loaded content because they may not execute JavaScript properly or may miss content that isn't included in the initial HTML page. This can lead to pages not being indexed correctly.
 
 However, modern search engines have improved their ability to crawl SPAs, and there are techniques such as server-side rendering (SSR), pre-rendering, and the use of SEO-friendly URLs that can help mitigate these issues and improve SEO for SPAs.
 
-Performance is another consideration. SPAs load the entire application in one go, which means that if the loading time increases, users will be seeing a blank screen for a longer period of time. Now consider the scenario of users with slower internet speeds. Overall, the user experience will not be very pleasant.
+Performance is another consideration. An SPA has to load its JavaScript before it can render anything, so a large bundle leaves the user looking at a blank screen for a longer period of time. Now consider the scenario of users with slower internet speeds. Overall, the user experience will not be very pleasant.
 
-In conclusion, while Single Page Applications offer many benefits, they also present unique challenges. Developers need to be careful of accessibility, usability, SEO, and performance considerations when building SPAs. By addressing these issues, it's possible to create SPAs that are fast, responsive, and accessible to all users.
+In conclusion, while single page applications offer many benefits, they also present unique challenges. Developers need to be mindful of accessibility, usability, SEO, and performance considerations when building SPAs. By addressing these issues, it's possible to create SPAs that are fast, responsive, and accessible to all users.
 
 # --questions--
 
@@ -51,7 +51,7 @@ Think about how SPAs differ from traditional multi-page websites in terms of pag
 
 ---
 
-It always requires a server-side rendering.
+It always requires server-side rendering.
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69566

Corrects several inaccuracies in the SPA navigation and performance lecture: the screen-reader sentence used the wrong verb and phrasing, a duplicate "with," the claim that "the URL doesn't change" in an SPA (it does — the app manages it via `pushState`/back-forward), the claim that SPAs load the "entire app" upfront (code-splitting means they usually don't), inconsistent capitalization of "single page applications" in the conclusion, "careful of" → "mindful of," and a stray article before "server-side rendering."

Tested by running the project's markdown/content linter (`challenge-linter`) against the changed challenge file only — no errors.