### PR TITLE
fix(curriculum): show missing test_settings hint in User Configuration Manager lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
+++ b/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
@@ -66,6 +66,7 @@ You should create a dictionary named `test_settings` and add some values to it.
 ```js
 ({
     test: () => runPython(`
+        assert _Node(_code).has_variable("test_settings")
         is_dict = isinstance(test_settings, dict)
         length = len(test_settings)
         assert is_dict and length > 0


### PR DESCRIPTION
## Summary
- The first test in the User Configuration Manager lab evaluated `test_settings` with `isinstance` before checking that the variable existed.
- If the camper had not created `test_settings`, that raised a `NameError`, which the client treated as a pre-test error and hid the intended hint.
- Assert `_Node(_code).has_variable("test_settings")` first so the existing hint is shown: "You should create a dictionary named `test_settings` and add some values to it."

Fixes #69596

## Checklist
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)
- [x] Related issue: #69596

## Test plan
- [ ] Open the User Configuration Manager lab without defining `test_settings`
- [ ] Confirm the first failing hint is about creating `test_settings` (not the generic "error before any tests could run" message)
- [ ] With a valid non-empty `test_settings` dict, confirm the first test still passes

Made with [Cursor](https://cursor.com)