### PR TITLE
fix(curriculum): check test_settings existence in user configuration manager lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
+++ b/curriculum/challenges/english/blocks/lab-user-configuration-manager/684aaf9ec670c68d20efd0d0.md
@@ -66,6 +66,7 @@ You should create a dictionary named `test_settings` and add some values to it.
 ```js
 ({
     test: () => runPython(`
+        assert _Node(_code).has_variable("test_settings")
         is_dict = isinstance(test_settings, dict)
         length = len(test_settings)
         assert is_dict and length > 0


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69596 

<!-- Feel free to add any additional description of changes below this line -->

### Description

Added AST check for test_settings in the first test of the User Configuration Manager lab so it fails with the hint instead of throwing a NameError when the variable isn't created yet.