### PR TITLE
fix(curriculum): reword otp button text

### DIFF
--- a/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -8,7 +8,7 @@ demoType: onClick
 
 # --description--
 
-In this lab, you will generate a 6-digit OTP (One-Time Password) and display it to the user. The OTP will expire after 5 seconds, and a new OTP will be generated when the user clicks the `"Generate New OTP"` button.
+In this lab, you will generate a 6-digit OTP (One-Time Password) and display it to the user. The OTP will expire after 5 seconds, and a new OTP will be generated when the user clicks the `"Generate OTP"` button.
 
 **Objective:** Fulfill the user stories below and get all the tests to pass to complete the lab. 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

https://www.freecodecamp.org/learn/front-end-development-libraries-v9/lab-one-time-password-generator/build-a-one-time-password-generator

Sample project:
<img width="496" height="289" alt="image" src="https://github.com/user-attachments/assets/414cadee-0850-4ee9-9f49-6542340835b3" />

Affected text:
> In this lab, you will generate a 6-digit OTP (One-Time Password) and display it to the user. The OTP will expire after 5 seconds, and a new OTP will be generated when the user clicks the `"Generate New OTP"` button.

Instruction for creating `button` element:
> A button element with the ID generate-otp-button labeled `"Generate OTP"`. When clicked, it should generate a new OTP and start a 5-second countdown.
