### PR TITLE
fix: Fix/otp generator id wording

### DIFF
--- a/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
+++ b/curriculum/challenges/english/blocks/lab-one-time-password-generator/67c562286b29447da020d407.md
@@ -18,13 +18,13 @@ In this lab, you will generate a 6-digit OTP (One-Time Password) and display it 
 2. Your `OTPGenerator` component should return a `div` element with the class name `container`.
 3. The `div` having the class `container` should include the following elements:
 
-    - An `h1` element with the ID `otp-title` and text `"OTP Generator"`.
-    - An `h2` element with the ID `otp-display` that either displays the message `"Click 'Generate OTP' to get a code"` or shows the generated OTP if one is available.
-    - A `p` element with the ID `otp-timer` and `aria-live` attribute set to a valid value that:
+    - An `h1` element with id `otp-title` and text `"OTP Generator"`.
+    - An `h2` element with id `otp-display` that either displays the message `"Click 'Generate OTP' to get a code"` or shows the generated OTP if one is available.
+    - A `p` element with id `otp-timer` and `aria-live` attribute set to a valid value that:
         - Starts off empty.
         - Displays `"Expires in: X seconds"` after the button is clicked, where `X` represents the remaining time before the OTP expires.
         - Shows the message `"OTP expired. Click the button to generate a new OTP."` once the countdown reaches `0`.
-    - A `button` element with the ID `generate-otp-button` labeled `"Generate OTP"`. When clicked, it should generate a new OTP and start a 5-second countdown.
+    - A `button` element with an id of `generate-otp-button` labeled `"Generate OTP"`. When clicked, it should generate a new OTP and start a 5-second countdown.
     - The `"Generate OTP"` button must be disabled while the countdown is active.
 
 4. You should ensure the countdown timer stops automatically once it reaches `0` seconds to prevent unnecessary updates.
@@ -57,7 +57,7 @@ const containerDiv = document.querySelector('.container');
 assert.exists(containerDiv);
 ```
 
-The `.container` should contain an `h1` element with the ID `otp-title` the text `"OTP Generator"`.
+The `.container` should contain an `h1` element with id `otp-title` the text `"OTP Generator"`.
 
 ```js
 const h1 = document.querySelector(".container h1#otp-title");
@@ -65,7 +65,7 @@ assert.exists(h1);
 assert.equal(h1.textContent, "OTP Generator");
 ```
 
-The `.container` should contain an `h2` element with the ID `otp-display` that displays the OTP when generated. 
+The `.container` should contain an `h2` element with id `otp-display` that displays the OTP when generated. 
 
 ```js
 const h2 = document.querySelector(".container h2#otp-display");
@@ -78,7 +78,7 @@ Initially, the `h2` inside `.container` should display the message `"Click 'Gene
 assert.strictEqual(document.querySelector('.container h2#otp-display').textContent.trim(), "Click 'Generate OTP' to get a code");
 ```
 
-The `.container` element should contain a `p` element with the ID `otp-timer`.
+The `.container` element should contain a `p` element with id `otp-timer`.
 
 ```js
 const container = document.querySelector('.container');
@@ -103,7 +103,7 @@ const pElement = document.querySelector('.container p');
 assert.strictEqual(pElement?.innerText, "", "The `p` element should be empty");
 ```
 
-The `.container` should contain a `button` element with the ID `generate-otp-button` and text `"Generate OTP"`. 
+The `.container` should contain a `button` element with id `generate-otp-button` and text `"Generate OTP"`. 
 
 ```js
 const button = document.querySelector('.container button#generate-otp-button').textContent;

--- a/curriculum/challenges/english/blocks/workshop-library-manager/6827deed7fc01f074c90fc0d.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/6827deed7fc01f074c90fc0d.md
@@ -7,11 +7,11 @@ dashedName: step-16
 
 # --description--
 
-It would be nice to test our your `getBooksByAuthor` function with another author.
+It would be nice to test out your `getBooksByAuthor` function with another author.
 
 Begin by logging the message `"\nList of books by James Clear:\n"` to the console. 
 
-Below that `console.log()`, add another `console.log()`.  Inside that `console.log()`, call the `getBooksByAuthor()` function with `library` and `"James Clear"` for arguments.
+Below that `console.log()`, add another `console.log()`. Inside that `console.log()`, call the `getBooksByAuthor()` function with `library` and `"James Clear"` for arguments.
 
 Now, you should see all of the books for that particular author in the console.
 


### PR DESCRIPTION
Use `id` instead of `ID` when referring to HTML id attributes
in the One-Time Password Generator lab.

Fixes #69606

Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #69606 
