### PR TITLE
fix(tools): address shellcheck SC2206 and SC2044 warnings in helper scripts

### DIFF
--- a/tools/scripts/move-bf.sh
+++ b/tools/scripts/move-bf.sh
@@ -7,7 +7,7 @@ source_file="curriculum/challenges/english/22-rosetta-code/rosetta-code-challeng
 destination_dir="curriculum/challenges"
 
 # Loop through all directories except _meta and english
-for dir in $(find "$destination_dir" -mindepth 1 -maxdepth 1 -type d ! -name '_meta' ! -name 'english'); do
+find "$destination_dir" -mindepth 1 -maxdepth 1 -type d ! -name '_meta' ! -name 'english' -print0 | while IFS= read -r -d '' dir; do
     # Copy the file to each directory
     cp "./$source_file" "./$dir/22-rosetta-code/rosetta-code-challenges/"
 done

--- a/tools/scripts/test_challenges.sh
+++ b/tools/scripts/test_challenges.sh
@@ -5,10 +5,10 @@ echo "Enter the ids of the challenges you wish to test (separated by commas) and
 read -r input
 
 
-IFS=',' challengeIDS=($input)
+IFS=',' read -ra challengeIDS <<< "$input"
 
 for challengeID in "${challengeIDS[@]}";
 do
   challengeID="$(tr -d ' ' <<< "$challengeID")"
-  FCC_CHALLENGE_ID=$challengeID pnpm turbo -F=@freecodecamp/curriculum test
+  FCC_CHALLENGE_ID="$challengeID" pnpm turbo -F=@freecodecamp/curriculum test
 done


### PR DESCRIPTION
### Summary
- In `tools/scripts/test_challenges.sh`: use `IFS=',' read -ra challengeIDS <<< "$input"` to split user input robustly, eliminating shellcheck warning `SC2206`.
- In `tools/scripts/move-bf.sh`: replace fragile `for dir in $(find ...)` with `find ... -print0 | while IFS= read -r -d '' dir`, eliminating shellcheck warning `SC2044`.