### PR TITLE
fix(client): set content direction on scene dialogue captions

### DIFF
--- a/client/src/templates/Challenges/components/scene/scene.tsx
+++ b/client/src/templates/Challenges/components/scene/scene.tsx
@@ -14,6 +14,7 @@ import { FullScene } from '../../../../redux/prop-types';
 import { Loader } from '../../../../components/helpers';
 import ClosedCaptionsIcon from '../../../../assets/icons/closedcaptions';
 import ChallengeTranscript from '../challenge-transcript';
+import { getChallengeContentLangProps } from '../../../../utils/challenge-content-lang';
 import { sounds, backgrounds, characterAssets } from './scene-assets';
 import Character from './character';
 import { SceneSubject } from './scene-subject';
@@ -398,6 +399,7 @@ export function Scene({
                 <div
                   className='scene-dialogue-text'
                   dangerouslySetInnerHTML={{ __html: dialogue.text }}
+                  {...getChallengeContentLangProps(superBlock)}
                 />
               </div>
             )}


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Follow-up to #69460, which missed the scene's on-screen dialogue caption. It renders through `dangerouslySetInnerHTML` without a `dir`, so in an RTL locale an English line shows as `?Hey Lisa, do you have a minute`. It now uses the same `dir="auto"` treatment as the rest of the challenge content.
