### PR TITLE
fix(curriculum): correct typos in workshop-library-manager

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-library-manager/6827deed7fc01f074c90fc0d.md
+++ b/curriculum/challenges/english/blocks/workshop-library-manager/6827deed7fc01f074c90fc0d.md
@@ -7,11 +7,11 @@ dashedName: step-16
 
 # --description--
 
-It would be nice to test our your `getBooksByAuthor` function with another author.
+It would be nice to test out your `getBooksByAuthor` function with another author.
 
 Begin by logging the message `"\nList of books by James Clear:\n"` to the console. 
 
-Below that `console.log()`, add another `console.log()`.  Inside that `console.log()`, call the `getBooksByAuthor()` function with `library` and `"James Clear"` for arguments.
+Below that `console.log()`, add another `console.log()`. Inside that `console.log()`, call the `getBooksByAuthor()` function with `library` and `"James Clear"` for arguments.
 
 Now, you should see all of the books for that particular author in the console.
 


### PR DESCRIPTION
Fixes #69602
Fixes two typos in Step 16 of the Library Manager Workshop.

Checklist:

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #69602 

