### PR TITLE
fix(client): expand computer basics catalog intro

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -9641,7 +9641,7 @@
       "lecture-understanding-computer-internet-and-tooling-basics": {
         "title": "Understanding Computer, Internet, and Tooling Basics",
         "intro": [
-          "In these lessons, you will learn about the computer, its different parts, internet service providers (ISPs), and the tools professional developers use."
+          "In these lessons, you will learn about computers and their different parts, how to work safely with a keyboard and mouse, how to sign into your computer securely, internet service providers (ISPs), and the tools professional developers use."
         ]
       },
       "lecture-working-with-file-systems": {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69560

The catalog intro for the `computer-basics` entry covered only three of the block's five lessons, omitting the keyboard/mouse ergonomics lesson and the safe sign-in lesson. Updated the string in `client/i18n/locales/english/intro.json` to the wording requested in the issue so all five lessons are represented.

Verified the file still parses as JSON and passes `prettier --check`.