### PR TITLE
fix(curriculum): add section headers to calc() function lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
@@ -11,6 +11,8 @@ With the `calc()` function, you can perform calculations directly within your st
 
 `calc()` is a CSS function. You'll learn more about functions when you start learning about JavaScript, but in this lesson, you're going to learn the basics that you need to know to understand how `calc()` works.
 
+## What Is a Function?
+
 A function is a block of code that performs a specific task. Some functions are already defined in CSS, so you can use them directly and pass any necessary values to them to customize how their tasks will be performed.
 
 In the world of programming, when we run the task performed by a function, we say that we "call" the function. The values that we pass into the function are known as arguments. 
@@ -20,6 +22,8 @@ Like you can see in the code below, to call a function, you write its name follo
 ```css
 function(argument1, argument2, argument3)
 ```
+
+## Calling the `calc()` Function
 
 A function may only need one value to know what to do. In that case, it will only take one argument. That's what happens with the `calc()` function. It takes one argument because it needs to know what to calculate.
 
@@ -33,6 +37,8 @@ calc(expression)
 
 The expression is evaluated to calculate the final result. "Evaluated" just means that the values and operators are converted into a single value behind the scenes. The result is assigned to the CSS property where the calculation is being made.
 
+## Supported Units and Operators
+
 You can perform calculations on values that represent length, angle, time, percentages, and numbers. You can also combine different units like pixels, percentages, and ems.
 
 For addition and subtraction, all the values in the expression, also called the operands, must have their corresponding units, like `px`, `em`, and percentage (`%`). Depending on the operator, different operands may have different units.
@@ -40,6 +46,8 @@ For addition and subtraction, all the values in the expression, also called the 
 You can use the addition (`+`), subtraction (`-`), multiplication (`*`), and division (`/`) operators in the expression.
 
 If there are multiple operands and operators, `calc()` will follow the standard operator precedence rule. You can also add parentheses to establish the order of the operations if needed.
+
+## Calculating a Width with `calc()`
 
 In the example below, you can see a `div` with the text `Hello, World!`.
 
@@ -71,6 +79,8 @@ The width of the `div` is approximately half the total width of its container, a
 That's the key advantage of using `calc()`. You can determine the value of a CSS property dynamically based on different aspects of the application or viewport.
 
 The expression can also contain CSS functions and variables if you need to use them in your calculations. You'll learn more about CSS variables in the next lessons.
+
+## Best Practices for Using `calc()`
 
 Great. Now that you know about the basics of the `calc()` function, let's cover some of its best practices.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69290

Added five `##` section headers to the `# --interactive--` section of the calc() function lecture so the ~900 word body can be scanned:

- What Is a Function?
- Calling the `calc()` Function
- Supported Units and Operators
- Calculating a Width with `calc()`
- Best Practices for Using `calc()`

The headers follow the convention in `lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md` — short Title Case headers before each major sub-topic, with code identifiers in backticks, and the opening paragraphs left as the lead-in.

No prose was rewritten; the diff is additions only. The front matter, code blocks, and `# --questions--` section are untouched.