### PR TITLE
fix(curriculum): add section headers to css-flexbox lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672aa7f7284b235f46f7d4e9.md
@@ -9,6 +9,8 @@ dashedName: what-is-css-flexbox
 
 CSS flexbox is a one-dimensional layout model that allows you to arrange elements in rows or columns within a container. You can also control their order and orientation. Web developers use it to create responsive websites and web applications that adapt to different screen sizes and orientations. We refer to flexbox as a one-dimensional layout model because it focuses on arranging elements along a single axis at a time. The axis can be either horizontal or vertical. 
 
+## Flex Containers and Flex Items
+
 There are two key concepts that you should know about before you start working with flexbox: flex container and flex item.
 
 A flex container is an HTML element with a flex layout. You can arrange and align elements in various ways within a flex container. To make an HTML element a flex container, you need to add `display: flex` to its CSS styles.
@@ -99,7 +101,11 @@ div {
 
 By default, a flex container will be a block-level element, so the container itself will be on its own row relative to other elements and containers.
 
+## Flex Properties
+
 Now that you know more about flex containers and flex items, you should also know about flex properties. These properties determine how flex items will be arranged, resized, and distributed within the flex container. Some of the most commonly used ones are `flex-direction`, `justify-content`, `align-items`, and `flex-wrap`.
+
+## The Flex Model
 
 Great. Now let's talk a little bit about the flex model. This model defines how flex items are arranged within a flex container. Every flex container has two axes:
 
@@ -107,6 +113,8 @@ Great. Now let's talk a little bit about the flex model. This model defines how 
 - The cross axis.
 
 The orientation of these axes determines how different properties will affect the layout and distribution of the flex items. By default, the main axis of a flex container is horizontal and the cross axis is vertical. Flex items are arranged in the direction of the main axis. The cross axis is perpendicular to the main axis.
+
+## The `flex-direction` Property
 
 The `flex-direction` property sets the direction of the main axis. The default value of `flex-direction` is `row`, which places all the flex items on the same row, in the direction of your browser's default language (left to right or right to left):
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the main branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #69314

## Description

Adds `##` section headers to the lecture body of "What Is CSS Flexbox, and When Should You Use It?" to break the ~606-word unbroken block into scannable sections.

Headers added:
- Flex Containers and Flex Items
- Flex Properties
- The Flex Model
- The `flex-direction` Property

No prose was rewritten - only headers were inserted. Front matter, code blocks, interactive editor blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below:

<img width="580" height="272" alt="Screenshot 2026-08-20 at 2 56 33 PM" src="https://github.com/user-attachments/assets/90a12957-f01c-40b3-bd24-d549fdf21836" />
<img width="580" height="477" alt="Screenshot 2026-08-20 at 2 57 05 PM" src="https://github.com/user-attachments/assets/c4ac8c0c-d86d-4a2d-84fc-69a88b80fd74" />

