### PR TITLE
fix(curriculum): use kbd markup for spotlight shortcut

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac3f129efbf327742eb33.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac3f129efbf327742eb33.md
@@ -29,7 +29,7 @@ This is how you can search for files and folders on Windows. Now let's see how y
 
 First, you can use Spotlight, a tool that helps you find files on your Mac. To open Spotlight, go to your menu bar at the top right and find the magnifying glass icon. If you don't see this icon on the menu bar, you can add it in the Control Center settings.
 
-Go to your settings, filter by "Control Center", click on this option and then scroll down until you find the "Spotlight" option. You can also use a keyboard shortcut to open Spotlight: `Command + Spacebar`.
+Go to your settings, filter by "Control Center", click on this option and then scroll down until you find the "Spotlight" option. You can also use a keyboard shortcut to open Spotlight: <kbd>Command</kbd> + <kbd>Spacebar</kbd>.
 
 When you open Spotlight, you'll see the Spotlight Search, where you can search for any file or folder by typing its name. When you start typing, you'll see the results grouped by category, including suggestions, folders, presentations, photos, documents, and related searches.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69626

The "How Can You Search for Files and Folders on Your Computer?" lesson presented the Spotlight keyboard shortcut as a single inline-code span: `` `Command + Spacebar` ``. The keys represent input the learner should press, so they should use the `<kbd>` element to be identified as keyboard input rather than generic code, per [MDN's `<kbd>` guidance](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd).

This PR wraps each physical key in its own `<kbd>` element, leaving the `+` as plain text outside the tags: `<kbd>Command</kbd> + <kbd>Spacebar</kbd>`.

Tested locally with `pnpm test-curriculum-content` scoped to the `lecture-working-with-file-systems` block (13/13 tests passed).