### PR TITLE
fix(curriculum): add keyboard shortcut summary table to vs code lesson

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
@@ -58,7 +58,7 @@ Finally, if you forget any of these shortcuts, you always have <kbd>Ctrl</kbd> +
       <th scope="row">Format file</th>
       <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd></td>
       <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd></td>
-      <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd></td>
+      <td><kbd>Shift</kbd> + <kbd>Option</kbd> + <kbd>F</kbd></td>
     </tr>
     <tr>
       <th scope="row">Search all files</th>

--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
@@ -57,7 +57,7 @@ Finally, if you forget any of these shortcuts, you always have <kbd>Ctrl</kbd> +
     <tr>
       <th scope="row">Format file</th>
       <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd></td>
-      <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd></td>
       <td><kbd>Shift</kbd> + <kbd>Option</kbd> + <kbd>F</kbd></td>
     </tr>
     <tr>

--- a/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-code-editors-and-ides/672d456f4ac35950b300e93f.md
@@ -7,23 +7,115 @@ dashedName: what-are-several-useful-keyboard-shortcuts-for-maximizing-productivi
 
 # --description--
 
-You're likely already familiar with some of the basic shortcuts, which are inherited from your operating system. Shortcuts like `Ctrl + S` (Windows/Linux) or `Cmd + S` (macOS) to save, `Ctrl + C` or `Cmd + C` to copy, and `Ctrl + V` or `Cmd + V` to paste all work in VS Code.
+You're likely already familiar with some of the basic shortcuts, which are inherited from your operating system. Shortcuts like <kbd>Ctrl</kbd> + <kbd>S</kbd> (Windows/Linux) or <kbd>Cmd</kbd> + <kbd>S</kbd> (macOS) to save, <kbd>Ctrl</kbd> + <kbd>C</kbd> or <kbd>Cmd</kbd> + <kbd>C</kbd> to copy, and <kbd>Ctrl</kbd> + <kbd>V</kbd> or <kbd>Cmd</kbd> + <kbd>V</kbd> to paste all work in VS Code.
 
 But there are a few that are application-specific and can still level up your productivity. It's worth noting that some of these shortcuts may differ by operating system.
 
-For example, `Shift + Alt + F` will run your configured formatter (such as Prettier, for a JavaScript project) on the currently opened file.
+For example, <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd> will run your configured formatter (such as Prettier, for a JavaScript project) on the currently opened file.
 
-Use `Ctrl + Shift + F` (Windows/Linux) or `Cmd + Shift + F` (macOS) to search the text contents of all the files in your workspace. Then use `Ctrl + Shift + H` (Windows/Linux) or `Cmd + Shift + H` (macOS) if you want to run a find-and-replace.
+Use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd> (Windows/Linux) or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd> (macOS) to search the text contents of all the files in your workspace. Then use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd> (Windows/Linux) or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd> (macOS) if you want to run a find-and-replace.
 
-If you need to remove a line, `Ctrl + Shift + K` (Windows/Linux) or `Cmd + Shift + K` (macOS) will delete it.
+If you need to remove a line, <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd> (Windows/Linux) or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd> (macOS) will delete it.
 
-Need some extra room for all your code? `Ctrl + B` (Windows/Linux), or `Cmd + B` (macOS), will hide the sidebar, which has the file list and extensions menu.
+Need some extra room for all your code? <kbd>Ctrl</kbd> + <kbd>B</kbd> (Windows/Linux), or <kbd>Cmd</kbd> + <kbd>B</kbd> (macOS), will hide the sidebar, which has the file list and extensions menu.
 
-Or maybe you just can't see your code? `Ctrl + Plus` (Windows/Linux), or `Cmd + Plus` (macOS), will increase the scaling of the editor, and `Ctrl + Minus` (Windows/Linux), or `Cmd + Minus` (macOS), will decrease it.
+Or maybe you just can't see your code? <kbd>Ctrl</kbd> + <kbd>Plus</kbd> (Windows/Linux), or <kbd>Cmd</kbd> + <kbd>Plus</kbd> (macOS), will increase the scaling of the editor, and <kbd>Ctrl</kbd> + <kbd>Minus</kbd> (Windows/Linux), or <kbd>Cmd</kbd> + <kbd>Minus</kbd> (macOS), will decrease it.
 
-Another helpful feature in VS Code is multi-line editing, which allows you to make changes across several lines at once. For example, you can place multiple cursors by using `Ctrl + Alt + Down` and `Ctrl + Alt + Up` (Windows), `Shift + Alt + Down` and `Shift + Alt + Up` (Linux), or `Option + Cmd + Down` and `Option + Cmd + Up` (macOS), to extend the cursor to consecutive lines. You can also press and hold `Alt` (Windows/Linux) or `Option` (macOS) and click to add cursors on separate lines wherever you need them. Once the cursors are placed, anything you type or delete will apply to all those locations simultaneously, which can save a lot of time when working with repetitive code.
+Another helpful feature in VS Code is multi-line editing, which allows you to make changes across several lines at once. For example, you can place multiple cursors by using <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Down</kbd> and <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Up</kbd> (Windows), <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>Down</kbd> and <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>Up</kbd> (Linux), or <kbd>Option</kbd> + <kbd>Cmd</kbd> + <kbd>Down</kbd> and <kbd>Option</kbd> + <kbd>Cmd</kbd> + <kbd>Up</kbd> (macOS), to extend the cursor to consecutive lines. You can also press and hold <kbd>Alt</kbd> (Windows/Linux) or <kbd>Option</kbd> (macOS) and click to add cursors on separate lines wherever you need them. Once the cursors are placed, anything you type or delete will apply to all those locations simultaneously, which can save a lot of time when working with repetitive code.
 
-Finally, if you forget any of these shortcuts, you always have `Ctrl + Shift + P` (Windows/Linux) or `Cmd + Shift + P` (macOS), which opens the command palette for you to select whatever you may need.
+Finally, if you forget any of these shortcuts, you always have <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> (Windows/Linux) or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> (macOS), which opens the command palette for you to select whatever you may need.
+
+<table>
+  <caption>VS Code keyboard shortcuts</caption>
+  <thead>
+    <tr>
+      <th scope="col">Action</th>
+      <th scope="col">Windows</th>
+      <th scope="col">Linux</th>
+      <th scope="col">macOS</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Save</th>
+      <td><kbd>Ctrl</kbd> + <kbd>S</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>S</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>S</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Copy</th>
+      <td><kbd>Ctrl</kbd> + <kbd>C</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>C</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>C</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Paste</th>
+      <td><kbd>Ctrl</kbd> + <kbd>V</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>V</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>V</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Format file</th>
+      <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd></td>
+      <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd></td>
+      <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Search all files</th>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Find and replace</th>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Delete line</th>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Hide sidebar</th>
+      <td><kbd>Ctrl</kbd> + <kbd>B</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>B</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>B</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Increase editor zoom</th>
+      <td><kbd>Ctrl</kbd> + <kbd>Plus</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>Plus</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>Plus</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Decrease editor zoom</th>
+      <td><kbd>Ctrl</kbd> + <kbd>Minus</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>Minus</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>Minus</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Add cursor above/below line</th>
+      <td><kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Down</kbd> / <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Up</kbd></td>
+      <td><kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>Down</kbd> / <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>Up</kbd></td>
+      <td><kbd>Option</kbd> + <kbd>Cmd</kbd> + <kbd>Down</kbd> / <kbd>Option</kbd> + <kbd>Cmd</kbd> + <kbd>Up</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Add cursor on click</th>
+      <td><kbd>Alt</kbd> + click</td>
+      <td><kbd>Alt</kbd> + click</td>
+      <td><kbd>Option</kbd> + click</td>
+    </tr>
+    <tr>
+      <th scope="row">Open command palette</th>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd></td>
+      <td><kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd></td>
+    </tr>
+  </tbody>
+</table>
 
 With this knowledge, and maybe a little practice, you are well on your way to becoming a VS Code power user.
 
@@ -35,7 +127,7 @@ Which Windows keyboard shortcut is used to run the configured formatter on the c
 
 ## --answers--
 
-`Ctrl + F`
+<kbd>Ctrl</kbd> + <kbd>F</kbd>
 
 ### --feedback--
 
@@ -43,11 +135,11 @@ The lesson mentions a specific shortcut for formatting the current file.
 
 ---
 
-`Shift + Alt + F`
+<kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>F</kbd>
 
 ---
 
-`Ctrl + Shift + F`
+<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd>
 
 ### --feedback--
 
@@ -55,7 +147,7 @@ The lesson mentions a specific shortcut for formatting the current file.
 
 ---
 
-`Alt + F4`
+<kbd>Alt</kbd> + <kbd>F4</kbd>
 
 ### --feedback--
 
@@ -67,7 +159,7 @@ The lesson mentions a specific shortcut for formatting the current file.
 
 ## --text--
 
-What function does the keyboard shortcut `Ctrl + Shift + K` (Windows/Linux) or `Cmd + Shift + K` (macOS) perform in VS Code?
+What function does the keyboard shortcut <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd> (Windows/Linux) or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd> (macOS) perform in VS Code?
 
 ## --answers--
 
@@ -107,7 +199,7 @@ Which Windows keyboard shortcut opens the command palette in VS Code?
 
 ## --answers--
 
-`Ctrl + P`
+<kbd>Ctrl</kbd> + <kbd>P</kbd>
 
 ### --feedback--
 
@@ -115,11 +207,11 @@ The lesson mentions this shortcut last as a way to access any command you might 
 
 ---
 
-`Ctrl + Shift + P`
+<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>
 
 ---
 
-`Alt + F4`
+<kbd>Alt</kbd> + <kbd>F4</kbd>
 
 ### --feedback--
 
@@ -127,7 +219,7 @@ The lesson mentions this shortcut last as a way to access any command you might 
 
 ---
 
-`Ctrl + Space`
+<kbd>Ctrl</kbd> + <kbd>Space</kbd>
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69627

## What changed

In the "What Are Several Useful Keyboard Shortcuts for Maximizing Productivity in VS Code?" lesson:

- Converted every physical key mentioned in the description prose from inline code (`` `Ctrl + S` ``) to individual `<kbd>` elements (`<kbd>Ctrl</kbd> + <kbd>S</kbd>`), leaving the `+` as plain text between keys. Wording and paragraph order are unchanged.
- Added a new raw HTML summary table (action × Windows/Linux/macOS) after the shortcut-explanation paragraphs and before the closing paragraph, covering every action already described in the prose (save, copy, paste, format file, search all files, find-and-replace, delete line, hide sidebar, increase/decrease editor zoom, add cursor above/below line, add cursor on click, open command palette).
- Applied the same `<kbd>` treatment to the shortcut references in the `--questions--` section (quiz answers), without moving them into the table.

## Why

Using `<kbd>` is the semantic-correct way to mark up keyboard input, and the new table gives a scannable action/OS matrix instead of requiring readers to parse the shortcuts out of prose.

Addresses the pattern requested in #69619 for this specific lesson (that issue may cover other lessons too, so I'm not force-closing it — leaving that to maintainer judgment).

## Testing

- Ran `pnpm test-curriculum-content` (`turbo -F=@freecodecamp/curriculum test-content`), which regenerates block tests and runs the content validation suite against the changed file — passed (11/11 tests).
- Manually reviewed the diff to confirm every `<kbd>` pairs with a real physical key, the table content matches the prose, and no explanatory wording changed.