### PR TITLE
fix(curriculum): use semantic keyboard markup

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
@@ -21,9 +21,9 @@ Apart from text-to-speech and braille output, other notable features of screen r
 
 Screen reader programs are also not only made for the blind and visually impaired. Dyslexic individuals and people with cognitive disabilities also use screen readers. All the popular operating systems out there have screen readers built into them.
 
-macOS and iOS both have VoiceOver built-in. You can enable it on your computer by pressing `CMD + F5`. You can access it on iPhones through Settings.
+macOS and iOS both have VoiceOver built-in. You can enable it on your computer by pressing <kbd>CMD</kbd> + <kbd>F5</kbd>. You can access it on iPhones through Settings.
 
-Windows computers have Narrator built-in. You can turn it on by pressing `WIN + CTRL + ENTER`. NonVisual Desktop Access (NVDA) and Job Access With Speech (JAWS) are also available for Windows computers. NVDA is free and open-source, while JAWS is paid.
+Windows computers have Narrator built-in. You can turn it on by pressing <kbd>WIN</kbd> + <kbd>CTRL</kbd> + <kbd>ENTER</kbd>. NonVisual Desktop Access (NVDA) and Job Access With Speech (JAWS) are also available for Windows computers. NVDA is free and open-source, while JAWS is paid.
 
 Linux has _Orca_ for the desktop environment and _Speakup_ for the Linux terminal.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your contribution into consideration. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. -->

Closes #69639

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the keyboard shortcut markup in the "What Are Screen Readers, and Who Uses Them?" lesson.

The `CMD + F5` and `WIN + CTRL + ENTER` shortcuts were previously wrapped in inline code. This change uses semantic `<kbd>` elements for each individual key while keeping the `+` characters as plain text.

The changes are limited to the keyboard shortcut markup in the lesson.