### PR TITLE
fix(curriculum): add command-line shortcut summary table

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-the-command-line-and-working-with-bash/687e9437536d762823fefab3.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-command-line-and-working-with-bash/687e9437536d762823fefab3.md
@@ -53,7 +53,7 @@ And finally, there may be commands you need to run twice in a row. You can press
     <tr>
       <th scope="row">Clear the terminal</th>
       <td><kbd>Control</kbd> + <kbd>L</kbd></td>
-      <td>Linux, macOS, and PowerShell (PowerShell's `cls` command clears the screen the same way)</td>
+      <td>Linux, macOS, and PowerShell (PowerShell's <code>cls</code> command clears the screen the same way)</td>
     </tr>
     <tr>
       <th scope="row">Interrupt a running process</th>

--- a/curriculum/challenges/english/blocks/lecture-understanding-the-command-line-and-working-with-bash/687e9437536d762823fefab3.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-command-line-and-working-with-bash/687e9437536d762823fefab3.md
@@ -15,7 +15,7 @@ The first shortcut is the <kbd>Up Arrow</kbd> key. Pressing this key will allow 
 
 Many shells will also offer an auto-complete feature, proposing commands based on what you have started to type. The <kbd>Tab</kbd> key can be used to fill in the rest of the suggestion, quickly populating your command line with the full syntax. How these suggestions are generated will vary from shell to shell. For example, in zsh these suggestions are based on your most recent command history. But in PowerShell, they are based on commands, variables, and arguments that are available (with less weight on how recently they were used).
 
-Sometimes a command may result in a lot of output on your terminal. This extra noise can get in the way, or become disruptive to your workflow. In *nix based terminals found on Linux and macOS devices, you can press <kbd>Control</kbd> + <kbd>L</kbd> to clear the entire screen and start with a fresh clean prompt. In PowerShell, you would need to run the `cls` command (which you can bind to a key combination like <kbd>Control</kbd> + <kbd>L</kbd>).
+Sometimes a command may result in a lot of output on your terminal. This extra noise can get in the way, or become disruptive to your workflow. In *nix based terminals found on Linux and macOS devices, you can press <kbd>Control</kbd> + <kbd>L</kbd> to clear the entire screen and start with a fresh clean prompt. In PowerShell, <kbd>Control</kbd> + <kbd>L</kbd> also clears the screen by default, and you can run the `cls` command for the same result.
 
 If you need to interrupt a command to stop its execution, you can use <kbd>Control</kbd> + <kbd>C</kbd> to kill the process. This will terminate the command and create a new prompt, allowing you to continue with whatever else you may need to work on. For PowerShell users, <kbd>Control</kbd> + <kbd>C</kbd> is also used to copy text - and will only work to terminate a process when the context is not ambiguous (such as when there is no text selected to copy).
 
@@ -23,7 +23,7 @@ The next couple of shortcuts are only available in *nix based terminals, and do 
 
 There may be times when you need to multitask, allowing a process or command to run in the background while you work on another. Pressing <kbd>Control</kbd> + <kbd>Z</kbd> places the current process in a background task and returns you to the command line, where you can continue your work. When you need to shift focus back to the background task, you can use `fg` to restore it.
 
-And finally, there may be commands you need to run twice in a row. You can press the <kbd>Up Arrow</kbd> key to cycle backwards to the previously run command, but you can also type two exclamation points (`!!`) into the command line and hit enter - this will automatically run the last executed command.
+And finally, there may be commands you need to run twice in a row. You can press the <kbd>Up Arrow</kbd> key to cycle backwards to the previously run command, but you can also type two exclamation points (`!!`) into the command line and hit <kbd>Enter</kbd> - this will automatically run the last executed command.
 
 <table>
   <caption>Command-line shortcuts and inputs</caption>
@@ -53,7 +53,7 @@ And finally, there may be commands you need to run twice in a row. You can press
     <tr>
       <th scope="row">Clear the terminal</th>
       <td><kbd>Control</kbd> + <kbd>L</kbd></td>
-      <td>Linux and macOS (PowerShell uses the `cls` command instead, which can be bound to this same key combination)</td>
+      <td>Linux, macOS, and PowerShell (PowerShell's `cls` command clears the screen the same way)</td>
     </tr>
     <tr>
       <th scope="row">Interrupt a running process</th>

--- a/curriculum/challenges/english/blocks/lecture-understanding-the-command-line-and-working-with-bash/687e9437536d762823fefab3.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-command-line-and-working-with-bash/687e9437536d762823fefab3.md
@@ -11,19 +11,67 @@ Let's learn about command line shortcuts you can use to speed up productivity.
 
 Terminal and command line shortcuts can help you streamline your workflows and maximize your productivity. For Linux and macOS, which can both trace their roots to Unix, many of these shortcuts will be the same. But for Windows, there will be some differences.
 
-The first shortcut is the up arrow key. Pressing this key will allow you to cycle backwards through your command history, one command at a time. The down arrow key, then, can be used to cycle forwards through your command history. These two keys allow you to quickly cycle through the commands you have previously run to find one you need to run again.
+The first shortcut is the <kbd>Up Arrow</kbd> key. Pressing this key will allow you to cycle backwards through your command history, one command at a time. The <kbd>Down Arrow</kbd> key, then, can be used to cycle forwards through your command history. These two keys allow you to quickly cycle through the commands you have previously run to find one you need to run again.
 
-Many shells will also offer an auto-complete feature, proposing commands based on what you have started to type. The tab key can be used to fill in the rest of the suggestion, quickly populating your command line with the full syntax. How these suggestions are generated will vary from shell to shell. For example, in zsh these suggestions are based on your most recent command history. But in PowerShell, they are based on commands, variables, and arguments that are available (with less weight on how recently they were used).
+Many shells will also offer an auto-complete feature, proposing commands based on what you have started to type. The <kbd>Tab</kbd> key can be used to fill in the rest of the suggestion, quickly populating your command line with the full syntax. How these suggestions are generated will vary from shell to shell. For example, in zsh these suggestions are based on your most recent command history. But in PowerShell, they are based on commands, variables, and arguments that are available (with less weight on how recently they were used).
 
-Sometimes a command may result in a lot of output on your terminal. This extra noise can get in the way, or become disruptive to your workflow. In *nix based terminals found on Linux and macOS devices, you can press Control + L to clear the entire screen and start with a fresh clean prompt. In PowerShell, you would need to run the `cls` command (which you can bind to a key combination like Control + L).
+Sometimes a command may result in a lot of output on your terminal. This extra noise can get in the way, or become disruptive to your workflow. In *nix based terminals found on Linux and macOS devices, you can press <kbd>Control</kbd> + <kbd>L</kbd> to clear the entire screen and start with a fresh clean prompt. In PowerShell, you would need to run the `cls` command (which you can bind to a key combination like <kbd>Control</kbd> + <kbd>L</kbd>).
 
-If you need to interrupt a command to stop its execution, you can use Control + C to kill the process. This will terminate the command and create a new prompt, allowing you to continue with whatever else you may need to work on. For PowerShell users, Control + C is also used to copy text - and will only work to terminate a process when the context is not ambiguous (such as when there is no text selected to copy).
+If you need to interrupt a command to stop its execution, you can use <kbd>Control</kbd> + <kbd>C</kbd> to kill the process. This will terminate the command and create a new prompt, allowing you to continue with whatever else you may need to work on. For PowerShell users, <kbd>Control</kbd> + <kbd>C</kbd> is also used to copy text - and will only work to terminate a process when the context is not ambiguous (such as when there is no text selected to copy).
 
 The next couple of shortcuts are only available in *nix based terminals, and do not have a PowerShell alternative.
 
-There may be times when you need to multitask, allowing a process or command to run in the background while you work on another. Pressing Control + Z places the current process in a background task and returns you to the command line, where you can continue your work. When you need to shift focus back to the background task, you can use `fg` to restore it.
+There may be times when you need to multitask, allowing a process or command to run in the background while you work on another. Pressing <kbd>Control</kbd> + <kbd>Z</kbd> places the current process in a background task and returns you to the command line, where you can continue your work. When you need to shift focus back to the background task, you can use `fg` to restore it.
 
-And finally, there may be commands you need to run twice in a row. You can press the up arrow key to cycle backwards to the previously run command, but you can also type two exclamation points (`!!`) into the command line and hit enter - this will automatically run the last executed command.
+And finally, there may be commands you need to run twice in a row. You can press the <kbd>Up Arrow</kbd> key to cycle backwards to the previously run command, but you can also type two exclamation points (`!!`) into the command line and hit enter - this will automatically run the last executed command.
+
+<table>
+  <caption>Command-line shortcuts and inputs</caption>
+  <thead>
+    <tr>
+      <th scope="col">Action</th>
+      <th scope="col">Input</th>
+      <th scope="col">Availability or context</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Move backward through command history</th>
+      <td><kbd>Up Arrow</kbd></td>
+      <td>Linux, macOS, and PowerShell</td>
+    </tr>
+    <tr>
+      <th scope="row">Move forward through command history</th>
+      <td><kbd>Down Arrow</kbd></td>
+      <td>Linux, macOS, and PowerShell</td>
+    </tr>
+    <tr>
+      <th scope="row">Complete a suggestion (tab completion)</th>
+      <td><kbd>Tab</kbd></td>
+      <td>Linux, macOS, and PowerShell (suggestion source varies by shell - for example, zsh uses recent command history, while PowerShell uses available commands, variables, and arguments)</td>
+    </tr>
+    <tr>
+      <th scope="row">Clear the terminal</th>
+      <td><kbd>Control</kbd> + <kbd>L</kbd></td>
+      <td>Linux and macOS (PowerShell uses the `cls` command instead, which can be bound to this same key combination)</td>
+    </tr>
+    <tr>
+      <th scope="row">Interrupt a running process</th>
+      <td><kbd>Control</kbd> + <kbd>C</kbd></td>
+      <td>Linux, macOS, and PowerShell (in PowerShell this also copies text, and only terminates a process when nothing is selected to copy)</td>
+    </tr>
+    <tr>
+      <th scope="row">Move a process to the background</th>
+      <td><kbd>Control</kbd> + <kbd>Z</kbd></td>
+      <td>Linux and macOS only, no PowerShell alternative</td>
+    </tr>
+    <tr>
+      <th scope="row">Rerun the previous command</th>
+      <td><code>!!</code></td>
+      <td>Linux and macOS only, no PowerShell alternative</td>
+    </tr>
+  </tbody>
+</table>
 
 Many terminals offer even more shortcuts, and I encourage you to read the documentation for your particular setup to find the shortcuts that work best for you. But these basic universal shortcuts should serve as a great starting point for maximizing your productivity and becoming a terminal wizard.
 
@@ -35,7 +83,7 @@ Which key combination is used to clear the screen in *nix based terminals?
 
 ## --answers--
 
-Control + C
+<kbd>Control</kbd> + <kbd>C</kbd>
 
 ### --feedback--
 
@@ -43,11 +91,11 @@ Think about which shortcut creates a fresh, clean prompt.
 
 ---
 
-Control + L
+<kbd>Control</kbd> + <kbd>L</kbd>
 
 ---
 
-Control + Z
+<kbd>Control</kbd> + <kbd>Z</kbd>
 
 ### --feedback--
 
@@ -55,7 +103,7 @@ Think about which shortcut creates a fresh, clean prompt.
 
 ---
 
-The tab key
+The <kbd>Tab</kbd> key
 
 ### --feedback--
 
@@ -67,7 +115,7 @@ Think about which shortcut creates a fresh, clean prompt.
 
 ## --text--
 
-What happens when you press Control + Z in a *nix based terminal?
+What happens when you press <kbd>Control</kbd> + <kbd>Z</kbd> in a *nix based terminal?
 
 ## --answers--
 
@@ -107,7 +155,7 @@ Which of the following can be used to quickly run the last executed command in a
 
 ## --answers--
 
-Control + L
+<kbd>Control</kbd> + <kbd>L</kbd>
 
 ### --feedback--
 
@@ -115,7 +163,7 @@ This involves typing a specific character twice.
 
 ---
 
-The tab key
+The <kbd>Tab</kbd> key
 
 ### --feedback--
 
@@ -127,7 +175,7 @@ This involves typing a specific character twice.
 
 ---
 
-Control + C
+<kbd>Control</kbd> + <kbd>C</kbd>
 
 ### --feedback--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69636

The "What Are Some Shortcuts You Can Use in the Command Line to Speed Up Productivity?" lesson explained keyboard and shell inputs across several paragraphs, but had no compact reference relating each action to its input and availability. Physical keys were also written as plain text instead of semantic keyboard markup.

- Added a summary table after the existing shortcut explanations and before the concluding paragraph, with a `caption`, a `thead` of scoped column headers (`Action`, `Input`, `Availability or context`), and a `tbody` with one scoped-row action per line covering command-history navigation, tab completion, clearing the terminal, interrupting a process, backgrounding a process, and rerunning the previous command.
- Converted physical keys throughout the lesson's prose and quiz to individual `kbd` elements, with `+` kept as plain text between them.
- Kept existing `code` formatting for shell syntax (`cls`, `fg`, `!!`) and preserved every platform-specific caveat already stated in the lesson (e.g. PowerShell differences) instead of treating any shortcut as universal.

### Local testing
Ran `pnpm run lint-challenges` (clean) and `pnpm run test-content` (1018 test files / 56005 tests passing) in `curriculum/` with `CURRICULUM_LOCALE=english`.
