### PR TITLE
fix(curriculum): use kbd elements for express shutdown shortcut

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-error-handling-and-health-checks/69f3046f4c0e76cbdd248590.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-error-handling-and-health-checks/69f3046f4c0e76cbdd248590.md
@@ -52,9 +52,9 @@ process.on('SIGTERM', () => {
 
 This tells Express to stop accepting new connections and wait for existing ones to finish before exiting.
 
-You should also handle `SIGINT`, which is the signal sent when you press Ctrl+C to stop your app during local development.
+You should also handle `SIGINT`, which is the signal sent when you press <kbd>Ctrl</kbd> + <kbd>C</kbd> to stop your app during local development.
 
-While `SIGTERM` is typically used by orchestrators like Kubernetes in production, `SIGINT` covers the everyday developer workflow. Without handling it, hitting Ctrl+C kills the process immediately, skipping any cleanup you've set up.
+While `SIGTERM` is typically used by orchestrators like Kubernetes in production, `SIGINT` covers the everyday developer workflow. Without handling it, hitting <kbd>Ctrl</kbd> + <kbd>C</kbd> kills the process immediately, skipping any cleanup you've set up.
 
 Since both signals should trigger the same graceful shutdown behavior, developers commonly listen for both.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69637

The "How do Health Checks and Graceful Shutdowns Work in Express?" lesson referenced the `Ctrl+C` shortcut as plain text in two places, so it wasn't identified as keyboard input.

- Converted both occurrences to `<kbd>Ctrl</kbd> + <kbd>C</kbd>`, keeping the `+` as plain text outside the elements.
- Left the `SIGINT`/`SIGTERM` signal names in their existing `code` formatting.

### Local testing
Ran `pnpm run lint-challenges` (clean) and `pnpm run test-content` (1018 test files / 56005 tests passing) in `curriculum/` with `CURRICULUM_LOCALE=english`.
