### PR TITLE
fix(curriculum): use kbd elements for screen reader shortcuts

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
+++ b/curriculum/challenges/english/blocks/lecture-importance-of-accessibility-and-good-html-structure/672a5310d7e46b8a34d48dfd.md
@@ -21,9 +21,9 @@ Apart from text-to-speech and braille output, other notable features of screen r
 
 Screen reader programs are also not only made for the blind and visually impaired. Dyslexic individuals and people with cognitive disabilities also use screen readers. All the popular operating systems out there have screen readers built into them.
 
-macOS and iOS both have VoiceOver built-in. You can enable it on your computer by pressing `CMD + F5`. You can access it on iPhones through Settings.
+macOS and iOS both have VoiceOver built-in. You can enable it on your computer by pressing <kbd>CMD</kbd> + <kbd>F5</kbd>. You can access it on iPhones through Settings.
 
-Windows computers have Narrator built-in. You can turn it on by pressing `WIN + CTRL + ENTER`. NonVisual Desktop Access (NVDA) and Job Access With Speech (JAWS) are also available for Windows computers. NVDA is free and open-source, while JAWS is paid.
+Windows computers have Narrator built-in. You can turn it on by pressing <kbd>WIN</kbd> + <kbd>CTRL</kbd> + <kbd>ENTER</kbd>. NonVisual Desktop Access (NVDA) and Job Access With Speech (JAWS) are also available for Windows computers. NVDA is free and open-source, while JAWS is paid.
 
 Linux has _Orca_ for the desktop environment and _Speakup_ for the Linux terminal.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69639

The "What Are Screen Readers, and Who Uses Them?" lesson presented the VoiceOver and Narrator shortcuts as single inline-code spans, so the individual keys weren't identified as keyboard input.

- VoiceOver shortcut: split into `<kbd>CMD</kbd> + <kbd>F5</kbd>`.
- Narrator shortcut: split into `<kbd>WIN</kbd> + <kbd>CTRL</kbd> + <kbd>ENTER</kbd>`.
- Kept the `+` characters as plain text outside the `kbd` elements and left the shortcuts inline in the surrounding prose.

### Local testing
Ran `pnpm run lint-challenges` (clean) and `pnpm run test-content` (1018 test files / 56005 tests passing) in `curriculum/` with `CURRICULUM_LOCALE=english`.
