### PR TITLE
fix(curriculum): add file-management keyboard shortcut summary table

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac3c5d0e9fd31835ff772.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672ac3c5d0e9fd31835ff772.md
@@ -15,9 +15,9 @@ When you click on "New" and select the file type, you will see a new text file i
 
 The process of creating folders is exactly the same. Click the "New" button at the top left and then select the "Folder" option or right-click on an empty spot and go to "New." Then, select the "Folder" option. You'll see a new empty folder in your current location.
 
-You can rename files and folders by selecting them and clicking on the "Rename" option at the top. When current name of the file is highlighted, you can start writing the new name of the file. Press Enter to confirm the changes.
+You can rename files and folders by selecting them and clicking on the "Rename" option at the top. When current name of the file is highlighted, you can start writing the new name of the file. Press <kbd>Enter</kbd> to confirm the changes.
 
-Alternatively, you can right-click on the file or folder and select the "Rename" option or use the F2 keyboard shortcut. Write the new name and press Enter to confirm the changes. 
+Alternatively, you can right-click on the file or folder and select the "Rename" option or use the <kbd>F2</kbd> keyboard shortcut. Write the new name and press <kbd>Enter</kbd> to confirm the changes. 
 
 You can move a file or folder to another folder by dragging and dropping it into the destination folder, if you have it opened it as a tab. 
 
@@ -43,7 +43,7 @@ Once you are inside the app, you should see an option to save your file in the F
 
 In one of the App menu options, you should see a command to save the file. This is usually under the File menu.
 
-Next to it, you will see the keyboard shortcut for saving your file. This is usually `Command + S` on macOS.
+Next to it, you will see the keyboard shortcut for saving your file. This is usually <kbd>Command</kbd> + <kbd>S</kbd> on macOS.
 
 When you are saving the file for the first time, you should see a dialog window, where you can write the name of the file and choose a location.
 
@@ -53,7 +53,7 @@ After saving the file, you can open Finder by clicking on the Finder icon in the
 
 To create a new folder, you should go to the location where you want to create that new folder and right-click on an empty spot. You will see a list of options. The first option is "New Folder."
 
-If you click on it, you can assign a name to your new folder. Write the name and press Enter to confirm.
+If you click on it, you can assign a name to your new folder. Write the name and press <kbd>Enter</kbd> to confirm.
 
 There are multiple ways to move files and folders in Finder. If you need to move them to a folder listed in your Finder "Favorites" section, you can just drag and drop it.
 
@@ -61,13 +61,41 @@ If you need to move it to a different folder, you have two options.
 
 You can either open the destination folder as a tab and drag and drop the file or folder into the tab.
 
-Or you can use keyboard shortcuts. First, copy the file with `Command + C`, go to the new folder, and then use `Command + Option + V` to paste the file or folder in that location. This will also remove it from the original folder.
+Or you can use keyboard shortcuts. First, copy the file with <kbd>Command</kbd> + <kbd>C</kbd>, go to the new folder, and then use <kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>V</kbd> to paste the file or folder in that location. This will also remove it from the original folder.
 
 To delete a file or folder, you can right-click on it and select "Move to trash."
 
 You can also drag and drop them into the trash icon on the Dock. This is equivalent.
 
 When the file or folder is in the trash can, you can right-click on it to delete it immediately or you can empty the trash to remove all the deleted files and folders permanently.
+
+<table>
+  <caption>File-management keyboard shortcuts</caption>
+  <thead>
+    <tr>
+      <th scope="col">Action</th>
+      <th scope="col">Platform</th>
+      <th scope="col">Shortcut</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Rename a file or folder</th>
+      <td>Windows</td>
+      <td><kbd>F2</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Save a file</th>
+      <td>macOS</td>
+      <td><kbd>Command</kbd> + <kbd>S</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Move a file or folder</th>
+      <td>macOS</td>
+      <td><kbd>Command</kbd> + <kbd>C</kbd>, then <kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>V</kbd></td>
+    </tr>
+  </tbody>
+</table>
 
 Knowing how to create, move, and delete files and folders on Windows and macOS is very important. By mastering these skills, you can organize your files, locate them quickly, and free up storage on your computer by deleting unnecessary files.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69631

<!-- Feel free to add any additional description of changes below this line -->

Marks the physical keys in the prose with `kbd` elements and adds the summary table after the file-management instructions, before the concluding paragraph.

- Prose: `F2`, `Enter`, `Command + S`, and `Command + C` / `Command + Option + V` now use a separate `kbd` element per key, with the `+` characters as plain text outside the elements.
- Table: a `caption`, `Action` / `Platform` / `Shortcut` column headers as `th` with `scope="col"`, and each action as a `th` with `scope="row"`. One row each for renaming a file or folder on Windows, saving a file on macOS, and moving a file or folder on macOS.
- The existing wording, instruction order, and code formatting are unchanged, and the table summarizes the shortcuts rather than repeating the instructional prose.

This lesson is shared by the Computer Basics and Responsive Web Design (v9) certifications, so the single file covers both affected pages.

Validated locally against the repo's `curriculum/challenges/.markdownlint.yaml` (clean) and by rendering the description through `markdown-it` with `html: true` to confirm the table is emitted as a raw HTML block.
