### PR TITLE
fix(curriculum): add nano keyboard shortcut summary table

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-nano/688170ebc58d8d3b1ae493a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-nano/688170ebc58d8d3b1ae493a2.md
@@ -30,9 +30,9 @@ Then, at the bottom, you will see a list of available keyboard shortcuts, that l
 ^X Exit   ^R Read File    ^\ Replace    ^U Paste    ^J Justify  ^/ Go To Line   M-E Redo    M-6 Copy        ^B Where Was      M-F Next
 ```
 
-Shortcuts which start with the caret (`^`) symbol indicate you need to hold the Ctrl key and press the indicated letter. Shortcuts which start with `M-` require you to hold the "meta key", which in most setups should be the Alt key, and press the letter.
+Shortcuts which start with the caret (`^`) symbol indicate you need to hold the <kbd>Ctrl</kbd> key and press the indicated letter. Shortcuts which start with `M-` require you to hold the "meta key", which in most setups should be the <kbd>Alt</kbd> key, and press the letter.
 
-To edit a file in Nano, you only need to know a few of the shortcut commands. After making changes to a file, you can press `Ctrl + O` to "Write Out", or save, the file. After entering the command, you will see the menu at the bottom change to this:
+To edit a file in Nano, you only need to know a few of the shortcut commands. After making changes to a file, you can press <kbd>Ctrl</kbd> + <kbd>O</kbd> to "Write Out", or save, the file. After entering the command, you will see the menu at the bottom change to this:
 
 ```bash
 File Name to write : <filename>
@@ -40,9 +40,9 @@ File Name to write : <filename>
 ^C Cancel                   TAB Complete
 ```
 
-Press enter to save the file and go back to editing the file, or `Ctrl + C` to cancel and go back to editing the file.
+Press <kbd>Enter</kbd> to save the file and go back to editing the file, or <kbd>Ctrl</kbd> + <kbd>C</kbd> to cancel and go back to editing the file.
 
-While in the editor, you can press `Ctrl + X` to exit Nano and go back to the terminal. If you have unsaved changes when trying to exit, you will see this in the bottom menu:
+While in the editor, you can press <kbd>Ctrl</kbd> + <kbd>X</kbd> to exit Nano and go back to the terminal. If you have unsaved changes when trying to exit, you will see this in the bottom menu:
 
 ```bash
 Save modified buffer (ANSWERING "No" WILL DESTROY CHANGES) ?
@@ -50,7 +50,31 @@ Save modified buffer (ANSWERING "No" WILL DESTROY CHANGES) ?
 ^C Cancel                   N No
 ```
 
-Press `Y` to save your unsaved changes, or `N` to discard them.
+Press <kbd>Y</kbd> to save your unsaved changes, or <kbd>N</kbd> to discard them.
+
+<table>
+  <caption>Nano keyboard shortcuts</caption>
+  <thead>
+    <tr>
+      <th scope="col">Action</th>
+      <th scope="col">Shortcut</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Save the file</th>
+      <td><kbd>Ctrl</kbd> + <kbd>O</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Cancel the current prompt</th>
+      <td><kbd>Ctrl</kbd> + <kbd>C</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Exit Nano</th>
+      <td><kbd>Ctrl</kbd> + <kbd>X</kbd></td>
+    </tr>
+  </tbody>
+</table>
 
 With this knowledge, you should be better prepared the next time you need to quickly edit a file on a remote server, where you might not have access to a full graphical environment.
 
@@ -98,7 +122,7 @@ In Nano's interface, what does the caret (`^`) symbol before a key indicate?
 
 ## --answers--
 
-Press the `Shift` key and the indicated letter.
+Press the <kbd>Shift</kbd> key and the indicated letter.
 
 ### --feedback--
 
@@ -106,11 +130,11 @@ The lesson explains how to interpret the keyboard shortcuts shown at the bottom 
 
 ---
 
-Press the Control (`Ctrl`) key and the indicated letter.
+Press the Control (<kbd>Ctrl</kbd>) key and the indicated letter.
 
 ---
 
-Press the `Alt` key and the indicated letter.
+Press the <kbd>Alt</kbd> key and the indicated letter.
 
 ### --feedback--
 
@@ -134,7 +158,7 @@ What keyboard shortcut is used to save changes to a file in Nano?
 
 ## --answers--
 
-`Ctrl + Q`
+<kbd>Ctrl</kbd> + <kbd>Q</kbd>
 
 ### --feedback--
 
@@ -142,7 +166,7 @@ Find where the lesson mentions how to save the file.
 
 ---
 
-`Ctrl + X`
+<kbd>Ctrl</kbd> + <kbd>X</kbd>
 
 ### --feedback--
 
@@ -150,7 +174,7 @@ Find where the lesson mentions how to save the file.
 
 ---
 
-`Ctrl + G`
+<kbd>Ctrl</kbd> + <kbd>G</kbd>
 
 ### --feedback--
 
@@ -158,7 +182,7 @@ Find where the lesson mentions how to save the file.
 
 ---
 
-`Ctrl + O`
+<kbd>Ctrl</kbd> + <kbd>O</kbd>
 
 ## --video-solution--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69630

<!-- Feel free to add any additional description of changes below this line -->

Marks the physical keys with `kbd` elements and adds the summary table after the shortcut workflows, before the concluding paragraph.

- Prose: `Ctrl`, `Alt`, `Enter`, `Y`, `N`, and the `Ctrl + O` / `Ctrl + C` / `Ctrl + X` combinations now use a separate `kbd` element per key, with the `+` characters as plain text outside the elements.
- Questions and answers: the `Shift`, `Ctrl`, and `Alt` key references and the four `Ctrl + <key>` answers use the same `kbd` semantics.
- Table: a `caption`, `Action` / `Shortcut` column headers as `th` with `scope="col"`, and each action as a `th` with `scope="row"`. One row each for saving the file, canceling the current prompt, and exiting Nano.
- The caret notation, `M-` prefix, `nano <filename>`, and the fenced terminal-output examples keep their existing code formatting, and the explanations are unchanged.

This lesson is shared by the Introduction to Nano and Relational Databases (v9) certifications, so the single file covers both affected pages.

Validated locally against the repo's `curriculum/challenges/.markdownlint.yaml` (clean) and by rendering the description and answers through `markdown-it` with `html: true`.
