### PR TITLE
fix(curriculum): add accessible nano shortcut summary table

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-nano/688170ebc58d8d3b1ae493a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-nano/688170ebc58d8d3b1ae493a2.md
@@ -32,7 +32,7 @@ Then, at the bottom, you will see a list of available keyboard shortcuts, that l
 
 Shortcuts which start with the caret (`^`) symbol indicate you need to hold the Ctrl key and press the indicated letter. Shortcuts which start with `M-` require you to hold the "meta key", which in most setups should be the Alt key, and press the letter.
 
-To edit a file in Nano, you only need to know a few of the shortcut commands. After making changes to a file, you can press `Ctrl + O` to "Write Out", or save, the file. After entering the command, you will see the menu at the bottom change to this:
+To edit a file in Nano, you only need to know a few of the shortcut commands. After making changes to a file, you can press <kbd>Ctrl</kbd> + <kbd>O</kbd> to "Write Out", or save, the file. After entering the command, you will see the menu at the bottom change to this:
 
 ```bash
 File Name to write : <filename>
@@ -40,9 +40,9 @@ File Name to write : <filename>
 ^C Cancel                   TAB Complete
 ```
 
-Press enter to save the file and go back to editing the file, or `Ctrl + C` to cancel and go back to editing the file.
+Press enter to save the file and go back to editing the file, or <kbd>Ctrl</kbd> + <kbd>C</kbd> to cancel and go back to editing the file.
 
-While in the editor, you can press `Ctrl + X` to exit Nano and go back to the terminal. If you have unsaved changes when trying to exit, you will see this in the bottom menu:
+While in the editor, you can press <kbd>Ctrl</kbd> + <kbd>X</kbd> to exit Nano and go back to the terminal. If you have unsaved changes when trying to exit, you will see this in the bottom menu:
 
 ```bash
 Save modified buffer (ANSWERING "No" WILL DESTROY CHANGES) ?
@@ -50,7 +50,31 @@ Save modified buffer (ANSWERING "No" WILL DESTROY CHANGES) ?
 ^C Cancel                   N No
 ```
 
-Press `Y` to save your unsaved changes, or `N` to discard them.
+Press <kbd>Y</kbd> to save your unsaved changes, or <kbd>N</kbd> to discard them.
+
+<table>
+  <caption>Nano keyboard shortcuts</caption>
+  <thead>
+    <tr>
+      <th scope="col">Action</th>
+      <th scope="col">Shortcut</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Save the file</th>
+      <td><kbd>Ctrl</kbd> + <kbd>O</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Cancel the current prompt</th>
+      <td><kbd>Ctrl</kbd> + <kbd>C</kbd></td>
+    </tr>
+    <tr>
+      <th scope="row">Exit Nano</th>
+      <td><kbd>Ctrl</kbd> + <kbd>X</kbd></td>
+    </tr>
+  </tbody>
+</table>
 
 With this knowledge, you should be better prepared the next time you need to quickly edit a file on a remote server, where you might not have access to a full graphical environment.
 
@@ -98,7 +122,7 @@ In Nano's interface, what does the caret (`^`) symbol before a key indicate?
 
 ## --answers--
 
-Press the `Shift` key and the indicated letter.
+Press the <kbd>Shift</kbd> key and the indicated letter.
 
 ### --feedback--
 
@@ -106,11 +130,11 @@ The lesson explains how to interpret the keyboard shortcuts shown at the bottom 
 
 ---
 
-Press the Control (`Ctrl`) key and the indicated letter.
+Press the Control (<kbd>Ctrl</kbd>) key and the indicated letter.
 
 ---
 
-Press the `Alt` key and the indicated letter.
+Press the <kbd>Alt</kbd> key and the indicated letter.
 
 ### --feedback--
 
@@ -134,7 +158,7 @@ What keyboard shortcut is used to save changes to a file in Nano?
 
 ## --answers--
 
-`Ctrl + Q`
+<kbd>Ctrl</kbd> + <kbd>Q</kbd>
 
 ### --feedback--
 
@@ -142,7 +166,7 @@ Find where the lesson mentions how to save the file.
 
 ---
 
-`Ctrl + X`
+<kbd>Ctrl</kbd> + <kbd>X</kbd>
 
 ### --feedback--
 
@@ -150,7 +174,7 @@ Find where the lesson mentions how to save the file.
 
 ---
 
-`Ctrl + G`
+<kbd>Ctrl</kbd> + <kbd>G</kbd>
 
 ### --feedback--
 
@@ -158,7 +182,7 @@ Find where the lesson mentions how to save the file.
 
 ---
 
-`Ctrl + O`
+<kbd>Ctrl</kbd> + <kbd>O</kbd>
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-nano/688170ebc58d8d3b1ae493a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-nano/688170ebc58d8d3b1ae493a2.md
@@ -30,7 +30,7 @@ Then, at the bottom, you will see a list of available keyboard shortcuts, that l
 ^X Exit   ^R Read File    ^\ Replace    ^U Paste    ^J Justify  ^/ Go To Line   M-E Redo    M-6 Copy        ^B Where Was      M-F Next
 ```
 
-Shortcuts which start with the caret (`^`) symbol indicate you need to hold the Ctrl key and press the indicated letter. Shortcuts which start with `M-` require you to hold the "meta key", which in most setups should be the Alt key, and press the letter.
+Shortcuts which start with the caret (`^`) symbol indicate you need to hold the <kbd>Ctrl</kbd> key and press the indicated letter. Shortcuts which start with `M-` require you to hold the "meta key", which in most setups should be the <kbd>Alt</kbd> key, and press the letter.
 
 To edit a file in Nano, you only need to know a few of the shortcut commands. After making changes to a file, you can press <kbd>Ctrl</kbd> + <kbd>O</kbd> to "Write Out", or save, the file. After entering the command, you will see the menu at the bottom change to this:
 
@@ -40,7 +40,7 @@ File Name to write : <filename>
 ^C Cancel                   TAB Complete
 ```
 
-Press enter to save the file and go back to editing the file, or <kbd>Ctrl</kbd> + <kbd>C</kbd> to cancel and go back to editing the file.
+Press <kbd>Enter</kbd> to save the file and go back to editing the file, or <kbd>Ctrl</kbd> + <kbd>C</kbd> to cancel and go back to editing the file.
 
 While in the editor, you can press <kbd>Ctrl</kbd> + <kbd>X</kbd> to exit Nano and go back to the terminal. If you have unsaved changes when trying to exit, you will see this in the bottom menu:
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69630

Adds the raw HTML summary table the issue specified, with a `caption`, `scope="col"` column headers, a `scope="row"` header per action, and rows for saving, canceling, and exiting. Each physical key is its own `kbd` element with the `+` characters left outside them.

Physical keys in the prose, questions, and answers now use `kbd`. The caret (`^`) symbol, the `M-` notation, shell commands, filenames, and the fenced terminal-output blocks keep their existing code formatting, as the issue requested.

Verification:

- Built the lesson locally with `pnpm run develop:client` and confirmed the table renders as a real table with the caption and headers visible, the `kbd` elements styled as keyboard input, and the `+` separators outside them. I also dumped every table cell's `innerHTML` and scanned the rendered page for stray backticks to be sure no raw markup leaked through.
- `pnpm run test-curriculum-content` — 1018 test files passed, 56005 tests passed, exit code 0.
- Checked the shortcuts against the current GNU nano manual (nano 9.2): `Ctrl + O` Write Out, `Ctrl + X` Exit, and the caret / `M-` meta-key notation the lesson describes are all still the defaults.

One judgement call worth flagging: I left "arrow keys" in the navigation sentence as plain prose rather than wrapping it in `kbd`, since it is a collective reference rather than one named key. Happy to wrap it if you would prefer that.
