### PR TITLE
fix(client): remove tool-panel from side-panel tests

### DIFF
--- a/client/src/templates/Challenges/components/side-panel.test.tsx
+++ b/client/src/templates/Challenges/components/side-panel.test.tsx
@@ -39,8 +39,6 @@ const tests: Test[] = [
   }
 ];
 
-const toolPanelText = 'Tool panel placeholder';
-
 function renderSidePanel({
   hasDemo = false,
   showSidePanelTests = true,
@@ -69,7 +67,6 @@ function renderSidePanel({
         }
         instructionsPanelRef={React.createRef()}
         hasDemo={hasDemo}
-        toolPanel={<div>{toolPanelText}</div>}
         tests={tests}
         openModal={openModal}
         showSidePanelTests={showSidePanelTests}
@@ -79,7 +76,7 @@ function renderSidePanel({
 }
 
 describe('<SidePanel />', () => {
-  it('renders the challenge title, description, tool panel, and test results', () => {
+  it('renders the challenge title, description, and test results', () => {
     renderSidePanel();
 
     expect(
@@ -88,7 +85,6 @@ describe('<SidePanel />', () => {
     expect(screen.getByText(description)).toBeInTheDocument();
     expect(screen.getByText(instructions)).toBeInTheDocument();
 
-    expect(screen.getByText(toolPanelText)).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: t('learn.editor-tabs.tests') })
     ).toBeInTheDocument();
@@ -97,7 +93,7 @@ describe('<SidePanel />', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('hides the tool panel and test results when side panel tests are disabled', () => {
+  it('hides the test results when side panel tests are disabled', () => {
     renderSidePanel({ showSidePanelTests: false });
 
     expect(
@@ -105,7 +101,6 @@ describe('<SidePanel />', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(description)).toBeInTheDocument();
 
-    expect(screen.queryByText(toolPanelText)).not.toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: t('learn.editor-tabs.tests') })
     ).not.toBeInTheDocument();


### PR DESCRIPTION
[This PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/68916/changes#diff-efaec2a361837c8116dd8c8a527c645e4c898ac4b94eb6548babc99857aedddb) - removed the tool panel from the side panel.

[This PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/68511/changes#diff-f079f908099b85509cbb09a1ea1a7478c3e7bae739c8139b554330ec3532e06eR72) - that changed the side panel tests, was created before the above one went in and was just merged - it assumed the tool panel was still there.

This PR removes the tool panel from the new tests - which should fix the failing tests on main.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
