### PR TITLE
fix(client): fix daily coding challenge sign-in button width

### DIFF
--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -287,9 +287,7 @@ function DailyCodingChallengeCalendar({
       {!isSignedIn && (
         <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
           <Spacer size='m' />
-          <div className='completion-modal-login-btn'>
-            <Login block={true}>{t('buttons.logged-out-cta-btn')}</Login>
-          </div>
+          <Login block={true}>{t('buttons.logged-out-cta-btn')}</Login>
         </Col>
       )}
     </>


### PR DESCRIPTION
## Description

The sign-in button on the Daily Coding Challenge archive can appear excessively wide.

The button was wrapped in `completion-modal-login-btn`, a class intended for the challenge completion modal. That class applies a `max-width: 100%` override to the sign-in button.

This change removes that unrelated wrapper so the Daily Coding Challenge sign-in button uses its normal width constraints.

## Testing

- Reproduced the issue locally.
- Confirmed that removing the conflicting `completion-modal-login-btn` styling makes the button render at the expected width.
- I was unable to fully verify the source change through the local development server because Gatsby hangs during page-data generation in my environment.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.


Closes #69665
