### PR TITLE
fix(curriculum): mark Ctrl+C as keyboard input

### DIFF
--- a/curriculum/challenges/english/blocks/review-error-handling-in-express/6a0442dde4dae604852951bb.md
+++ b/curriculum/challenges/english/blocks/review-error-handling-in-express/6a0442dde4dae604852951bb.md
@@ -149,7 +149,7 @@ process.on('SIGTERM', () => {
 });
 ```
 
-- Listen for the `SIGINT` signal (sent when the developer presses Ctrl+C during local development) and call the same shutdown logic as `SIGTERM`.
+- Listen for the `SIGINT` signal (sent when the developer presses <kbd>Ctrl</kbd> + <kbd>C</kbd> during local development) and call the same shutdown logic as `SIGTERM`.
 
 ### Marking the App Unhealthy Before Shutdown
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69672

The Express error-handling review now marks the `Ctrl` and `C` keys with semantic `<kbd>` elements. This gives the shortcut a programmatic keyboard-input meaning while preserving the existing code formatting for `SIGINT` and `SIGTERM`.

Tests:

- `CURRICULUM_LOCALE=english FCC_CHALLENGE_ID=6a0442dde4dae604852951bb PUPPETEER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" pnpm test-content` (3 passed)
- `pnpm exec prettier --check curriculum/challenges/english/blocks/review-error-handling-in-express/6a0442dde4dae604852951bb.md`
