### PR TITLE
fix: use semantic keyboard markup for F12

### DIFF
--- a/curriculum/challenges/english/blocks/top-the-box-model/64a5529c02815a7d323aab88.md
+++ b/curriculum/challenges/english/blocks/top-the-box-model/64a5529c02815a7d323aab88.md
@@ -8,7 +8,7 @@ dashedName: the-box-model-lesson-a
 
 Being able to inspect and debug your HTML and CSS is critical to front-end development. This lesson will take us through the Chrome Dev Tools, which allow you to see detailed information about your elements and CSS rules, as well as assist you in finding and fixing problems in your code.
 
-To open up the inspector, you can right-click on any element of a webpage and click “Inspect” or press F12. Go ahead and do that right now to see the HTML and CSS used on this page.
+To open up the inspector, you can right-click on any element of a webpage and click “Inspect” or press <kbd>F12</kbd>. Go ahead and do that right now to see the HTML and CSS used on this page.
 
 Don’t get overwhelmed with all the tools you’re now seeing! For this lesson, we want to focus on the Elements and Styles panes.
 


### PR DESCRIPTION
## Description

Use semantic keyboard markup for the F12 keyboard shortcut in The Box Model Lesson A.

## Related Issue

Fixes #69675

## How Has This Been Tested?

Verified the lesson file change and confirmed that `F12` is now wrapped in `<kbd>` markup.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69675