### PR TITLE
fix(curriculum): fix typos and formatting in challenge descriptions

### DIFF
--- a/curriculum/challenges/english/blocks/applied-visual-design/587d781c367417b2b2512ac0.md
+++ b/curriculum/challenges/english/blocks/applied-visual-design/587d781c367417b2b2512ac0.md
@@ -11,7 +11,7 @@ dashedName: use-the-text-transform-property-to-make-text-uppercase
 
 The `text-transform` property in CSS is used to change the appearance of text. It's a convenient way to make sure text on a webpage appears consistently, without having to change the text content of the actual HTML elements.
 
-The following table shows how the different `text-transform`values change the example text "Transform me".
+The following table shows how the different `text-transform` values change the example text "Transform me".
 
 <table><thead><tr><th>Value</th><th>Result</th></tr></thead><tbody><tr><td><code>lowercase</code></td><td>"transform me"</td></tr><tr><td><code>uppercase</code></td><td>"TRANSFORM ME"</td></tr><tr><td><code>capitalize</code></td><td>"Transform Me"</td></tr><tr><td><code>initial</code></td><td>Use the default value</td></tr><tr><td><code>inherit</code></td><td>Use the <code>text-transform</code> value from the parent element</td></tr><tr><td><code>none</code></td><td><strong>Default:</strong> Use the original text</td></tr></tbody></table>
 

--- a/curriculum/challenges/english/blocks/workshop-binary-search/683ec95f2f8781355556ff81.md
+++ b/curriculum/challenges/english/blocks/workshop-binary-search/683ec95f2f8781355556ff81.md
@@ -11,7 +11,7 @@ You need to test out things so you will understand the flow of the algorithm at 
 
 To do that, you need to first break out of the loop. That's because the current implementation will only allow one iteration, so if the condition is not met, there will be an infinite loop.
 
-Just after the `if`statement, use the `break` keyword to break out of the `while` loop. Then, after the `while` loop, return an empty list to signify that the value was not found.
+Just after the `if` statement, use the `break` keyword to break out of the `while` loop. Then, after the `while` loop, return an empty list to signify that the value was not found.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69ea02adff0fd528639ee23b.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69ea02adff0fd528639ee23b.md
@@ -7,7 +7,7 @@ dashedName: step-64
 
 # --description--
 
-Next, create a `loadPlayer` function with `PlayerData` has the return type. Inside it, add a `try...catch` syntax with `error` as the parameter of the `catch` block. Leave every other thing empty for now.
+Next, create a `loadPlayer` function with `PlayerData` as the return type. Inside it, add a `try...catch` syntax with `error` as the parameter of the `catch` block. Leave every other thing empty for now.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69eb216380522cfc11aa408c.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69eb216380522cfc11aa408c.md
@@ -13,7 +13,7 @@ The `span` elements in the three rows should have these values:
 - `98` and `SHO`
 - `83` and `PAS`
 
-`PAC` stands for pace, `SHO` represents shot, and `PAS`represents passing.
+`PAC` stands for pace, `SHO` represents shot, and `PAS` represents passing.
 
 The number goes in the `stat-value` spans and the attributes in the `stat-label` spans.
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69eb23665c115447405343ac.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69eb23665c115447405343ac.md
@@ -9,7 +9,7 @@ dashedName: step-18
 
 Each `stat-row` should contain two `span` elements with the `className` of `stat-value` and `stat-label` respectively.
 
-In the `spans` elements inside the `div` elements, you should have the following:
+In the `span` elements inside the `div` elements, you should have the following:
 
 - `99` and `DRI`
 - `41` and `DEF`

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69f1b1fb36c6c0c80907e8e1.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69f1b1fb36c6c0c80907e8e1.md
@@ -7,7 +7,7 @@ dashedName: step-37
 
 # --description--
 
-Inside the `preview-panel` element, add a `p` element of `className` of `preview-label` and text `Live Preview`, another `p` element of  `className` of `preview-hint` and the text `Updates as you type`, and a `div` with the `className` of set to the template literal `preview-box tier-${getPlayerTier(player.overallRating)}`.
+Inside the `preview-panel` element, add a `p` element with a `className` of `preview-label` and text `Live Preview`, another `p` element with a `className` of `preview-hint` and the text `Updates as you type`, and a `div` with the `className` set to the template literal `preview-box tier-${getPlayerTier(player.overallRating)}`.
 
 Inside the last `div`, move in the `PlayerCard` component and its prop.
 

--- a/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69f1b591221851200c734eb4.md
+++ b/curriculum/challenges/english/blocks/workshop-build-a-football-player-card-builder/69f1b591221851200c734eb4.md
@@ -7,7 +7,7 @@ dashedName: step-41
 
 # --description--
 
-Moving to the second `div` element, add a `label` of `className` of `label`, an `htmlFor` of `overallRating` a text of `Overall`, and an `input` with an `id` set to `overallRating`, a `className` of  of `input` and a type of `number`.
+Moving to the second `div` element, add a `label` with a `className` of `label`, an `htmlFor` of `overallRating`, text of `Overall`, and an `input` with an `id` set to `overallRating`, a `className` of `input`, and a type of `number`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

### Description of changes:
This PR fixes minor grammatical typos, duplicated words, and missing spaces adjacent to inline code blocks across steps in:
- Applied Visual Design (`text-transform` description)
- Binary Search Workshop (Step 9)
- Football Player Card Builder Workshop (Steps 15, 18, 37, 41, 64)