### PR TITLE
fix(curriculum): removed first person plural pronoun

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -31,7 +31,7 @@ function Button({ buttonText }) {
 }
 ```
 
-In this example, we define a style object called `defaultStyles`. We then apply these styles to a button element using the `style` attribute. React takes care of applying these styles to the element when it renders.
+In this example, you define a style object called `defaultStyles`. You then apply these styles to a button element using the `style` attribute. React takes care of applying these styles to the element when it renders.
 
 You can also choose to pass in an object directly to the `style` attribute. Here is what a revised example would look like:
 
@@ -54,7 +54,7 @@ Notice the double curly braces `{{}}` in the `style` attribute. The outer braces
 
 Sometimes you might want to pass in an object directly if there are only a few properties like shown here. Otherwise, passing in a name to an object would be better like in the first example.
 
-It's important to note that while CSS property names are typically written in kebab case, like `font-size`, in React's inline styles, we use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.
+It's important to note that while CSS property names are typically written in kebab case, like `font-size`, in React's inline styles, you use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.
 
 A great advantage of inline styles in React is that they support dynamic styling based on a component state or props. For example:
 
@@ -88,7 +88,7 @@ In React inline styles, how should the CSS property `background-color` be writte
 
 ### --feedback--
 
-Remember what we said about the naming convention for CSS properties in React inline styles.
+Remember the naming convention for CSS properties in React inline styles.
 
 ---
 
@@ -100,7 +100,7 @@ Remember what we said about the naming convention for CSS properties in React in
 
 ### --feedback--
 
-Remember what we said about the naming convention for CSS properties in React inline styles.
+Remember the naming convention for CSS properties in React inline styles.
 
 ---
 
@@ -108,7 +108,7 @@ Remember what we said about the naming convention for CSS properties in React in
 
 ### --feedback--
 
-Remember what we said about the naming convention for CSS properties in React inline styles.
+Remember the naming convention for CSS properties in React inline styles.
 
 ## --video-solution--
 
@@ -124,7 +124,7 @@ They support all CSS features including media queries.
 
 ### --feedback--
 
-Think about what we discussed regarding dynamic styling in React components.
+Think about the dynamic styling in React components.
 
 ---
 
@@ -132,7 +132,7 @@ They are always more performant than external CSS.
 
 ### --feedback--
 
-Think about what we discussed regarding dynamic styling in React components.
+Think about the dynamic styling in React components.
 
 ---
 
@@ -144,7 +144,7 @@ They are the only way to style React components.
 
 ### --feedback--
 
-Think about what we discussed regarding dynamic styling in React components.
+Think about the dynamic styling in React components.
 
 ## --video-solution--
 
@@ -160,7 +160,7 @@ Using the `class` attribute.
 
 ### --feedback--
 
-Recall the syntax we used in our examples for applying styles to React elements.
+Recall the syntax used in the examples for applying styles to React elements.
 
 ---
 
@@ -172,7 +172,7 @@ Using a separate CSS file
 
 ### --feedback--
 
-Recall the syntax we used in our examples for applying styles to React elements.
+Recall the syntax used in the examples for applying styles to React elements.
 
 ---
 
@@ -180,7 +180,7 @@ Using the `css` attribute
 
 ### --feedback--
 
-Recall the syntax we used in our examples for applying styles to React elements.
+Recall the syntax used in the examples for applying styles to React elements.
 
 ## --video-solution--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -31,7 +31,7 @@ function Button({ buttonText }) {
 }
 ```
 
-In this example, a style object called `defaultStyles`. You then apply these styles to a button element using the `style` attribute. React takes care of applying these styles to the element when it renders.
+In this example, a style object called `defaultStyles` is defined. You then apply these styles to a button element using the `style` attribute. React takes care of applying these styles to the element when it renders.
 
 You can also choose to pass in an object directly to the `style` attribute. Here is what a revised example would look like:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -31,7 +31,7 @@ function Button({ buttonText }) {
 }
 ```
 
-In this example, you define a style object called `defaultStyles`. You then apply these styles to a button element using the `style` attribute. React takes care of applying these styles to the element when it renders.
+In this example, a style object called `defaultStyles`. You then apply these styles to a button element using the `style` attribute. React takes care of applying these styles to the element when it renders.
 
 You can also choose to pass in an object directly to the `style` attribute. Here is what a revised example would look like:
 
@@ -54,7 +54,7 @@ Notice the double curly braces `{{}}` in the `style` attribute. The outer braces
 
 Sometimes you might want to pass in an object directly if there are only a few properties like shown here. Otherwise, passing in a name to an object would be better like in the first example.
 
-It's important to note that while CSS property names are typically written in kebab case, like `font-size`, in React's inline styles, you use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.
+It's important to note that while CSS property names are typically written in kebab case, like `font-size`, in React's inline styles use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.
 
 A great advantage of inline styles in React is that they support dynamic styling based on a component state or props. For example:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-data-in-react/673500bfe1f41601c1ddb1a2.md
@@ -54,7 +54,7 @@ Notice the double curly braces `{{}}` in the `style` attribute. The outer braces
 
 Sometimes you might want to pass in an object directly if there are only a few properties like shown here. Otherwise, passing in a name to an object would be better like in the first example.
 
-It's important to note that while CSS property names are typically written in kebab case, like `font-size`, in React's inline styles use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.
+It's important to note that while CSS property names are typically written in kebab case, like `font-size`, React's inline styles use camel case, like `fontSize`. This is because the style object is a JavaScript object, and kebab case names are not valid as object keys in JavaScript without using quotes.
 
 A great advantage of inline styles in React is that they support dynamic styling based on a component state or props. For example:
 


### PR DESCRIPTION
## Summary
Removes first-person plural pronoun "we" from the "How Do Inline Styles Work in React?" lesson, replacing it with second-person "you" per the curriculum style guide.

## Changes
- Removed "we" pronoun from the lesson description

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69686