### PR TITLE
test(e2e): isolate user token lifecycle

### DIFF
--- a/api/src/plugins/auth-dev.test.ts
+++ b/api/src/plugins/auth-dev.test.ts
@@ -22,6 +22,8 @@ import growthBook from './growth-book.js';
 
 import { newUser } from './__fixtures__/user.js';
 
+const requestedUserEmail = 'isolated-e2e-user@example.com';
+
 describe('dev login', () => {
   let fastify: FastifyInstance;
 
@@ -41,13 +43,13 @@ describe('dev login', () => {
 
   beforeEach(async () => {
     await fastify.prisma.user.deleteMany({
-      where: { email: defaultUserEmail }
+      where: { email: { in: [defaultUserEmail, requestedUserEmail] } }
     });
   });
 
   afterAll(async () => {
     await fastify.prisma.user.deleteMany({
-      where: { email: defaultUserEmail }
+      where: { email: { in: [defaultUserEmail, requestedUserEmail] } }
     });
     await fastify.prisma.$runCommandRaw({ dropDatabase: 1 });
     await fastify.close();
@@ -79,6 +81,28 @@ describe('dev login', () => {
 
       expect(user).toEqual(newUser(defaultUserEmail));
       expect(user.username).toBe(user.usernameDisplay);
+    });
+
+    test('should sign in with the requested email', async () => {
+      await fastify.inject({
+        method: 'GET',
+        url: `/signin?email=${requestedUserEmail}`
+      });
+
+      const user = await fastify.prisma.user.findFirstOrThrow({
+        where: { email: requestedUserEmail }
+      });
+
+      expect(user).toEqual(newUser(requestedUserEmail));
+    });
+
+    test('should reject an invalid requested email', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/signin?email=not-an-email'
+      });
+
+      expect(response.statusCode).toBe(400);
     });
 
     test('should set the jwt_access_token cookie', async () => {

--- a/api/src/plugins/auth-dev.ts
+++ b/api/src/plugins/auth-dev.ts
@@ -1,4 +1,7 @@
-import type { FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
+import {
+  Type,
+  type FastifyPluginCallbackTypebox
+} from '@fastify/type-provider-typebox';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import {
   getRedirectParams,
@@ -10,6 +13,12 @@ import { createAccessToken } from '../utils/tokens.js';
 
 const trimTrailingSlash = (str: string) =>
   str.endsWith('/') ? str.slice(0, -1) : str;
+
+const signInSchema = {
+  querystring: Type.Object({
+    email: Type.Optional(Type.String({ format: 'email', maxLength: 1024 }))
+  })
+};
 
 async function handleRedirects(req: FastifyRequest, reply: FastifyReply) {
   const params = getRedirectParams(req);
@@ -34,8 +43,8 @@ export const devAuth: FastifyPluginCallbackTypebox = (
   _options,
   done
 ) => {
-  fastify.get('/signin', async (req, reply) => {
-    const email = 'foo@bar.com';
+  fastify.get('/signin', { schema: signInSchema }, async (req, reply) => {
+    const email = req.query.email ?? 'foo@bar.com';
 
     const { id } = await findOrCreateUser(fastify, email);
 

--- a/e2e/fixtures/isolated-user.ts
+++ b/e2e/fixtures/isolated-user.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  test as base,
+  type APIRequestContext,
+  type TestInfo
+} from '@playwright/test';
+
+type UserStorageState = Awaited<ReturnType<APIRequestContext['storageState']>>;
+
+type IsolatedUser = {
+  email: string;
+  storageState: UserStorageState;
+};
+
+type IsolatedUserFixtures = {
+  isolatedUser: IsolatedUser;
+};
+
+const apiLocation = process.env.API_LOCATION ?? 'http://localhost:3000';
+
+const getApiUrl = (path: string) => new URL(path, apiLocation).toString();
+
+const createEmail = (testInfo: TestInfo) =>
+  `e2e-w${testInfo.workerIndex}-${randomUUID()}@example.com`;
+
+const getCsrfToken = async (request: APIRequestContext) =>
+  (await request.storageState()).cookies.find(
+    cookie => cookie.name === 'csrf_token'
+  )?.value;
+
+async function deleteAccount(request: APIRequestContext) {
+  const csrfToken = await getCsrfToken(request);
+  if (!csrfToken) {
+    throw new Error(
+      'Could not clean up the isolated user: CSRF token missing.'
+    );
+  }
+
+  const response = await request.post(getApiUrl('/account/delete'), {
+    data: {},
+    headers: { 'csrf-token': csrfToken }
+  });
+
+  if (response.status() !== 200) {
+    const body = await response.text();
+    throw new Error(
+      `Could not clean up the isolated user: /account/delete returned ${response.status()}: ${body}`
+    );
+  }
+}
+
+export const test = base.extend<IsolatedUserFixtures>({
+  isolatedUser: async ({ playwright }, use, testInfo) => {
+    const email = createEmail(testInfo);
+    const request = await playwright.request.newContext({
+      storageState: { cookies: [], origins: [] }
+    });
+    let signedIn = false;
+    let cleanupError: Error | undefined;
+
+    try {
+      const signInUrl = new URL('/signin', apiLocation);
+      signInUrl.searchParams.set('email', email);
+
+      const response = await request.get(signInUrl.toString(), {
+        maxRedirects: 0
+      });
+      const storageState = await request.storageState();
+      signedIn = storageState.cookies.some(
+        cookie => cookie.name === 'jwt_access_token'
+      );
+
+      if (response.status() !== 302) {
+        throw new Error(
+          `Could not create the isolated user: /signin returned ${response.status()}.`
+        );
+      }
+
+      if (!signedIn) {
+        throw new Error(
+          'Could not create the isolated user: /signin did not set an access token.'
+        );
+      }
+
+      await use({ email, storageState });
+    } finally {
+      try {
+        if (signedIn) await deleteAccount(request);
+      } catch (error) {
+        cleanupError =
+          error instanceof Error ? error : new Error(String(error));
+      }
+
+      try {
+        await request.dispose();
+      } catch (error) {
+        cleanupError ??=
+          error instanceof Error ? error : new Error(String(error));
+      }
+
+      if (cleanupError && testInfo.status !== testInfo.expectedStatus) {
+        await testInfo.attach('isolated-user-cleanup-error', {
+          body: cleanupError.stack ?? cleanupError.message,
+          contentType: 'text/plain'
+        });
+      }
+    }
+
+    if (cleanupError && testInfo.status === testInfo.expectedStatus) {
+      throw cleanupError;
+    }
+  },
+
+  storageState: async ({ isolatedUser }, use) => {
+    await use(isolatedUser.storageState);
+  }
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/fixtures/isolated-user.ts
+++ b/e2e/fixtures/isolated-user.ts
@@ -1,10 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import {
-  test as base,
-  type APIRequestContext,
-  type TestInfo
-} from '@playwright/test';
+import { test as base, type APIRequestContext } from '@playwright/test';
 
 type UserStorageState = Awaited<ReturnType<APIRequestContext['storageState']>>;
 
@@ -21,8 +17,7 @@ const apiLocation = process.env.API_LOCATION ?? 'http://localhost:3000';
 
 const getApiUrl = (path: string) => new URL(path, apiLocation).toString();
 
-const createEmail = (testInfo: TestInfo) =>
-  `e2e-w${testInfo.workerIndex}-${randomUUID()}@example.com`;
+const createEmail = () => `${randomUUID()}@example.com`;
 
 const getCsrfToken = async (request: APIRequestContext) =>
   (await request.storageState()).cookies.find(
@@ -51,13 +46,12 @@ async function deleteAccount(request: APIRequestContext) {
 }
 
 export const test = base.extend<IsolatedUserFixtures>({
-  isolatedUser: async ({ playwright }, use, testInfo) => {
-    const email = createEmail(testInfo);
+  isolatedUser: async ({ playwright }, use) => {
+    const email = createEmail();
     const request = await playwright.request.newContext({
       storageState: { cookies: [], origins: [] }
     });
     let signedIn = false;
-    let cleanupError: Error | undefined;
 
     try {
       const signInUrl = new URL('/signin', apiLocation);
@@ -87,28 +81,9 @@ export const test = base.extend<IsolatedUserFixtures>({
     } finally {
       try {
         if (signedIn) await deleteAccount(request);
-      } catch (error) {
-        cleanupError =
-          error instanceof Error ? error : new Error(String(error));
-      }
-
-      try {
+      } finally {
         await request.dispose();
-      } catch (error) {
-        cleanupError ??=
-          error instanceof Error ? error : new Error(String(error));
       }
-
-      if (cleanupError && testInfo.status !== testInfo.expectedStatus) {
-        await testInfo.attach('isolated-user-cleanup-error', {
-          body: cleanupError.stack ?? cleanupError.message,
-          contentType: 'text/plain'
-        });
-      }
-    }
-
-    if (cleanupError && testInfo.status === testInfo.expectedStatus) {
-      throw cleanupError;
     }
   },
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -22,8 +22,8 @@ setup.describe('developmentuser', () => {
   // As the certified user now has the default storage state.
   setup.use({ storageState: { cookies: [], origins: [] } });
 
-  // We can only sign in as a single user (one with email: 'foo@bar.com'), so
-  // changing users means changing the record with that email in the database.
+  // This legacy auth state still signs in without an email query, so it uses
+  // whichever seeded user currently owns foo@bar.com.
   setup.beforeAll(() => {
     execSync('node ../tools/scripts/seed/seed-demo-user');
   });

--- a/e2e/user-token.spec.ts
+++ b/e2e/user-token.spec.ts
@@ -1,50 +1,31 @@
-import { execSync } from 'child_process';
-import { test, expect } from '@playwright/test';
-
 import translations from '../client/i18n/locales/english/translations.json';
+import { expect, test } from './fixtures/isolated-user';
 import { alertToBeVisible } from './utils/alerts';
 
-test.use({ storageState: 'playwright/.auth/development-user.json' });
+test('can create and delete a user token', async ({ page }) => {
+  const userTokenHeading = page
+    .getByRole('main')
+    .getByText('User Token', { exact: true });
 
-test.beforeEach(() => {
-  execSync('node ../tools/scripts/seed/seed-demo-user');
-});
+  await page.goto('/settings');
+  await expect(userTokenHeading).not.toBeVisible();
 
-test.afterAll(() => {
-  execSync('node ../tools/scripts/seed/seed-demo-user --certified-user');
-});
+  await page.goto(
+    '/learn/relational-database/learn-bash-by-building-a-boilerplate/build-a-boilerplate'
+  );
+  await page.getByText('Generate User Token').first().click();
+  await alertToBeVisible(page, translations.flash['user-token-generated']);
 
-test.describe('Initially', () => {
-  test('should not render', async ({ page }) => {
-    await page.goto('/settings');
-    await expect(
-      page.getByRole('main').getByText('User Token', { exact: true })
-    ).not.toBeVisible();
-  });
-});
+  await page.goto('/settings');
+  await expect(userTokenHeading).toBeVisible();
+  await expect(
+    page.getByText(
+      'Your user token is used to save your progress on curriculum sections that use a virtual machine. If you suspect it has been compromised, you can delete it without losing any progress. A new one will be created automatically the next time you open a project.'
+    )
+  ).toBeVisible();
 
-test.describe('After creating token', () => {
-  test('should allow you to delete your token', async ({ page }) => {
-    await page.goto(
-      '/learn/relational-database/learn-bash-by-building-a-boilerplate/build-a-boilerplate'
-    );
-    await page.getByText('Generate User Token').first().click();
+  await page.getByRole('button', { name: 'Delete my user token' }).click();
 
-    await page.goto('/settings');
-    // Set `exact` to `true` to only match the panel heading
-    await expect(
-      page.getByRole('main').getByText('User Token', { exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByText(
-        'Your user token is used to save your progress on curriculum sections that use a virtual machine. If you suspect it has been compromised, you can delete it without losing any progress. A new one will be created automatically the next time you open a project.'
-      )
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Delete my user token' }).click();
-
-    await alertToBeVisible(page, translations.flash['token-deleted']);
-    await expect(
-      page.getByRole('main').getByText('User Token', { exact: true })
-    ).not.toBeVisible();
-  });
+  await alertToBeVisible(page, translations.flash['token-deleted']);
+  await expect(userTokenHeading).not.toBeVisible();
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

This introduces a reusable isolated-user Playwright fixture and uses it for the user-token E2E test.

- Allow development login to select a validated email while preserving the existing default user.
- Create a unique authenticated user for each opted-in test and delete it during teardown.
- Replace the two shared-state user-token tests with one create/view/delete lifecycle.
- Remove per-test demo-user reseeding from `user-token.spec.ts`.


