### PR TITLE
fix(curriculum): correct spelling of symbol in Spanish contact information task

### DIFF
--- a/curriculum/challenges/english/blocks/es-a1-learn-contact-information-and-spelling/693a5b879c8089c10050ab0d.md
+++ b/curriculum/challenges/english/blocks/es-a1-learn-contact-information-and-spelling/693a5b879c8089c10050ab0d.md
@@ -44,7 +44,7 @@ This word refers to "email". Remember it often appears as `correo electrónico`.
 
 ### --feedback--
 
-This is the simbol for the word `arroba`.
+This is the symbol for the word `arroba`.
 
 ---
 


### PR DESCRIPTION
…ation task

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69688 

<!-- Feel free to add any additional description of changes below this line -->

Fixes a typo in the feedback for the `@` blank: "simbol" → "symbol".

This was the only occurrence in the English curriculum. The correct spelling is already used elsewhere in the same file. The Spanish term `arroba` is unchanged.