### PR TITLE
fix(curriculum): add section headers to margins-padding lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
@@ -25,6 +25,8 @@ Here is an HTML example of three paragraph elements on the page:
 
 :::
 
+## The margin Property
+
 To apply spacing to the top of each paragraph element, you can use the `margin-top` property like this:
 
 :::interactive_editor
@@ -77,6 +79,8 @@ p {
 :::
 
 In this example, we are assigning spacing values on all four sides of the paragraph element. A solid black border has also been added so you can see the margins better.
+
+## Margin Shorthand
 
 Another way to use the `margin` property is with shorthand notation. You can specify one, two, three, or four values at once. Let's explore these options together.
 
@@ -178,6 +182,8 @@ p {
 
 This sets the margin to `10px` for the `top`, `20px` for the `right`, `30px` for the `bottom`, and `40px` for the `left`.
 
+## The padding Property
+
 The `padding` property is used to apply space inside the element, between the content and its border.
 
 Like the `margin` property, the four `padding` properties are `padding-top`, `padding-right`, `padding-bottom` and `padding-left`.
@@ -209,6 +215,8 @@ p {
 This sets the padding to `10px` for the `top`, `20px` for the `right`, `30px` for the `bottom`, and `40px` for the `left`.
 
 As you can see, `padding` is applied to the content which is inside the border, unlike `margin` which applies to outside the border.
+
+## Padding Shorthand
 
 Just like the `margin` property, you can also choose to use the shorthand for the `padding` property.
 

--- a/curriculum/challenges/english/blocks/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
+++ b/curriculum/challenges/english/blocks/lecture-what-is-css/672acc538e6ef24e9dd3c94f.md
@@ -25,7 +25,7 @@ Here is an HTML example of three paragraph elements on the page:
 
 :::
 
-## The margin Property
+## The `margin` Property
 
 To apply spacing to the top of each paragraph element, you can use the `margin-top` property like this:
 
@@ -80,7 +80,7 @@ p {
 
 In this example, we are assigning spacing values on all four sides of the paragraph element. A solid black border has also been added so you can see the margins better.
 
-## Margin Shorthand
+## `margin` Shorthand
 
 Another way to use the `margin` property is with shorthand notation. You can specify one, two, three, or four values at once. Let's explore these options together.
 
@@ -182,7 +182,7 @@ p {
 
 This sets the margin to `10px` for the `top`, `20px` for the `right`, `30px` for the `bottom`, and `40px` for the `left`.
 
-## The padding Property
+## The `padding` Property
 
 The `padding` property is used to apply space inside the element, between the content and its border.
 
@@ -216,7 +216,7 @@ This sets the padding to `10px` for the `top`, `20px` for the `right`, `30px` fo
 
 As you can see, `padding` is applied to the content which is inside the border, unlike `margin` which applies to outside the border.
 
-## Padding Shorthand
+## `padding` Shorthand
 
 Just like the `margin` property, you can also choose to use the shorthand for the `padding` property.
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the contribution guidelines.
- [x] I have read and followed the how to open a pull request guide.
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #69306

## Description
Adds `##` section headers to the lecture body of "What Are Margins and Padding, and How Do They Work?" to break the ~634-word unbroken block into scannable sections.

Headers added:
- The margin Property
- Margin Shorthand
- The padding Property
- Padding Shorthand

No prose was rewritten - only headers were inserted. Front matter, code blocks, interactive editor blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below:
<img width="700" height="105" alt="Screenshot 2026-08-24 at 5 47 06 PM" src="https://github.com/user-attachments/assets/ee2d5955-b98f-42a8-b58e-a354495993d2" />
<img width="701" height="285" alt="Screenshot 2026-08-24 at 5 47 57 PM" src="https://github.com/user-attachments/assets/b7ccafc5-329e-49da-8335-3be50c64e8a4" />
<img width="701" height="289" alt="Screenshot 2026-08-24 at 5 48 22 PM" src="https://github.com/user-attachments/assets/5f8cda0f-bec1-4d50-b61e-cc4d84884e60" />
<img width="700" height="354" alt="Screenshot 2026-08-24 at 5 48 46 PM" src="https://github.com/user-attachments/assets/17d3e8f3-5e33-4f4b-a15a-b1122f976720" />

