### PR TITLE
fix(curriculum): use keyboard markup

### DIFF
--- a/curriculum/challenges/english/blocks/review-relational-databases/6724e5e321bce627736ea145.md
+++ b/curriculum/challenges/english/blocks/review-relational-databases/6724e5e321bce627736ea145.md
@@ -20,11 +20,11 @@ dashedName: review-relational-databases
 
 ## Command Line Shortcuts
 
-- **Up/Down arrows**: Cycle through previous/next commands in history.
-- **Tab**: Autocomplete commands.
-- **`Control+L`** (Linux/macOS) or typing `cls` (Windows): Clear the terminal screen.
-- **`Control+C`**: Interrupt a running command (also used for copying in PowerShell if text is selected).
-- **`Control+Z`** (Linux/macOS only): Suspend a task to the background; use `fg` to resume it.
+- <kbd>Up Arrow</kbd>/<kbd>Down Arrow</kbd>: Cycle through previous/next commands in history.
+- <kbd>Tab</kbd>: Autocomplete commands.
+- <kbd>Control</kbd> + <kbd>L</kbd> (Linux/macOS) or typing `cls` (Windows): Clear the terminal screen.
+- <kbd>Control</kbd> + <kbd>C</kbd>: Interrupt a running command (also used for copying in PowerShell if text is selected).
+- <kbd>Control</kbd> + <kbd>Z</kbd> (Linux/macOS only): Suspend a task to the background; use `fg` to resume it.
 - **`!!`**: Instantly rerun the last executed command.
 
 ## Bash Basics


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69696

This updates the relational databases review to use semantic `<kbd>` markup for physical keyboard keys and key combinations. Command text such as `cls`, `fg`, and `!!` remains formatted as code.
