### PR TITLE
fix(curriculum): use kbd for Windows key

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
@@ -11,7 +11,7 @@ A file management application is a way to easily store, organize, and edit your 
 
 If you have a Windows computer, the default file manager is the File Explorer. This is used to browse, search, and manage files and folders, as well as perform file operations like copying, moving, and deleting.
 
-To find the File Explorer, you can go to the Start menu or press the Windows logo key on your keyboard.
+To find the File Explorer, you can go to the Start menu or press the <kbd>Windows logo key</kbd> on your keyboard.
 
 To pin a folder, you can right click with your mouse and select "Pin". To move a file or folder, you first need to select it, then select "Cut" and then navigate to the new location to paste it.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69697

This wraps the Windows logo key in semantic `<kbd>` markup in the canonical lecture source used by both affected curriculum routes.
