### PR TITLE
fix(curriculum): use kbd in bash review pages

### DIFF
--- a/curriculum/challenges/english/blocks/review-bash-commands/6724e387ee098d1ef33108ba.md
+++ b/curriculum/challenges/english/blocks/review-bash-commands/6724e387ee098d1ef33108ba.md
@@ -21,11 +21,11 @@ dashedName: review-bash-commands
 
 ## Command Line Shortcuts
 
-- **Up/Down arrows**: Cycle through previous/next commands in history.
-- **Tab**: Autocomplete commands.
-- **`Control+L`** (Linux/macOS) or typing `cls` (Windows): Clear the terminal screen.
-- **`Control+C`**: Interrupt a running command (also used for copying in PowerShell if text is selected).
-- **`Control+Z`** (Linux/macOS only): Suspend a task to the background; use `fg` to resume it.
+- <kbd>Up Arrow</kbd>/<kbd>Down Arrow</kbd>: Cycle through previous/next commands in history.
+- <kbd>Tab</kbd>: Autocomplete commands.
+- <kbd>Control</kbd> + <kbd>L</kbd> (Linux/macOS) or typing `cls` (Windows): Clear the terminal screen.
+- <kbd>Control</kbd> + <kbd>C</kbd>: Interrupt a running command (also used for copying in PowerShell if text is selected).
+- <kbd>Control</kbd> + <kbd>Z</kbd> (Linux/macOS only): Suspend a task to the background; use `fg` to resume it.
 - **`!!`**: Instantly rerun the last executed command.
 
 ## Bash Basics

--- a/curriculum/challenges/english/blocks/review-relational-databases/6724e5e321bce627736ea145.md
+++ b/curriculum/challenges/english/blocks/review-relational-databases/6724e5e321bce627736ea145.md
@@ -20,11 +20,11 @@ dashedName: review-relational-databases
 
 ## Command Line Shortcuts
 
-- **Up/Down arrows**: Cycle through previous/next commands in history.
-- **Tab**: Autocomplete commands.
-- **`Control+L`** (Linux/macOS) or typing `cls` (Windows): Clear the terminal screen.
-- **`Control+C`**: Interrupt a running command (also used for copying in PowerShell if text is selected).
-- **`Control+Z`** (Linux/macOS only): Suspend a task to the background; use `fg` to resume it.
+- <kbd>Up Arrow</kbd>/<kbd>Down Arrow</kbd>: Cycle through previous/next commands in history.
+- <kbd>Tab</kbd>: Autocomplete commands.
+- <kbd>Control</kbd> + <kbd>L</kbd> (Linux/macOS) or typing `cls` (Windows): Clear the terminal screen.
+- <kbd>Control</kbd> + <kbd>C</kbd>: Interrupt a running command (also used for copying in PowerShell if text is selected).
+- <kbd>Control</kbd> + <kbd>Z</kbd> (Linux/macOS only): Suspend a task to the background; use `fg` to resume it.
 - **`!!`**: Instantly rerun the last executed command.
 
 ## Bash Basics


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69695

<!-- Feel free to add any additional description of changes below this line -->

Replaces bold and inline-code formatting of physical keys with `<kbd>` elements in the Command Line Shortcuts section of both affected review pages:

- `curriculum/challenges/english/blocks/review-bash-commands/6724e387ee098d1ef33108ba.md`
- `curriculum/challenges/english/blocks/review-relational-databases/6724e5e321bce627736ea145.md`

The two sections were identical, so both received the same change.

Each physical key gets its own element, with `+` left as plain text between them (`<kbd>Control</kbd> + <kbd>L</kbd>`). The `cls`, `fg`, and `!!` shell inputs keep their existing code formatting, since they are typed input rather than physical keys. The list structure is unchanged.