### PR TITLE
fix(curriculum): restore event target examples

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-the-event-object-and-event-delegation/67338e93b75977a344cf6d40.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-event-object-and-event-delegation/67338e93b75977a344cf6d40.md
@@ -31,8 +31,8 @@ But what does this actually mean? Well, you could attach an event listener to th
 ```
 
 ```js
-const p = document.querySelector("p");
-p.addEventListener("click", (event) => {
+const paragraph = document.querySelector("p");
+paragraph.addEventListener("click", (event) => {
   console.log(event.target);
 });
 ```
@@ -57,9 +57,9 @@ Just to be sure how things are working, let's expand our code:
 ```
 
 ```js
-const p = document.querySelector("p");
+const paragraph = document.querySelector("p");
 const span = document.querySelector("span");
-p.addEventListener("click", (event) => {
+paragraph.addEventListener("click", (event) => {
   console.log("P listener: ");
   console.log(event.target);
 });
@@ -92,9 +92,9 @@ Now let's see what happens when you prevent the propagation of an event with `st
 ```
 
 ```js
-const p = document.querySelector("p");
+const paragraph = document.querySelector("p");
 const span = document.querySelector("span");
-p.addEventListener("click", (event) => {
+paragraph.addEventListener("click", (event) => {
   console.log("P listener: ");
   console.log(event.target);
 });
@@ -130,9 +130,9 @@ Going back to our code, let's update it so clicking on a `span` element changes 
 ```
 
 ```js
-const p = document.querySelector("p");
+const paragraph = document.querySelector("p");
 const span = document.querySelector("span");
-p.addEventListener("click", (event) => {});
+paragraph.addEventListener("click", (event) => {});
 span.addEventListener("click", (event) => {
   event.target.style.color = "red";
 });
@@ -147,8 +147,8 @@ Rather than having to attach an event listener to every single `span` element, y
 Our code might now look something like this:
 
 ```js
-const p = document.querySelector("p");
-p.addEventListener("click", (event) => {
+const paragraph = document.querySelector("p");
+paragraph.addEventListener("click", (event) => {
   event.target.style.color = "red";
 });
 ```
@@ -170,8 +170,8 @@ Let's generate a few extra `span` elements and see:
 ```
 
 ```js
-const p = document.querySelector("p");
-p.addEventListener("click", (event) => {
+const paragraph = document.querySelector("p");
+paragraph.addEventListener("click", (event) => {
   event.target.style.color = "red";
 });
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69690

The interactive editor already uses the short `p` identifier, preventing the lesson examples from binding their paragraph element. This renames that binding to `paragraph` consistently across all examples on the page so the event listeners run and log their targets.

Tests:

- 103 targeted curriculum tests
- Prettier check for the changed lesson
- `git diff --check`
