### PR TITLE
ci: reduce e2e curriculum build

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -96,6 +96,7 @@ jobs:
             learn-greetings-in-your-first-day-at-the-office,
             learn-html-by-building-a-cat-photo-app,
             learn-introductory-javascript-by-building-a-pyramid-generator,
+            lecture-introduction-to-common-searching-and-sorting-algorithms,
             lecture-understanding-html-attributes,
             lecture-what-is-css,
             lecture-working-with-code-editors-and-ides,
@@ -116,7 +117,6 @@ jobs:
             workshop-cafe-menu,
             workshop-cat-photo-app,
             workshop-curriculum-outline,
-            workshop-greeting-bot,
             write-your-first-code-using-c-sharp
         run: |
           pnpm install

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -62,6 +62,62 @@ jobs:
           sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
 
       - name: Install and Build
+        # Keep this in sync with the blocks referenced by the E2E suite.
+        # The full production build is still exercised by CI - Node.js.
+        env:
+          FCC_BLOCK: >-
+            applied-visual-design,
+            back-end-development-and-apis-projects,
+            basic-html-and-html5,
+            basic-javascript,
+            bootstrap,
+            build-a-cash-register-project,
+            build-a-data-graph-explorer-project,
+            build-a-palindrome-checker-project,
+            build-a-personal-portfolio-webpage-project,
+            build-a-survey-form-project,
+            build-a-tribute-page-project,
+            data-analysis-with-python-projects,
+            foundational-c-sharp-with-microsoft-certification-exam,
+            front-end-development-libraries-projects,
+            javascript-algorithms-and-data-structures-projects,
+            jquery,
+            lab-debug-camperbots-profile-page,
+            lab-drum-machine,
+            lab-event-flyer-page,
+            lab-markdown-to-html-converter,
+            lab-palindrome-checker,
+            lab-survey-form,
+            learn-about-adverbial-phrases,
+            learn-bash-by-building-a-boilerplate,
+            learn-basic-css-by-building-a-cafe-menu,
+            learn-basic-javascript-by-building-a-role-playing-game,
+            learn-css-transforms-by-building-a-penguin,
+            learn-greetings-in-your-first-day-at-the-office,
+            learn-html-by-building-a-cat-photo-app,
+            learn-introductory-javascript-by-building-a-pyramid-generator,
+            lecture-understanding-html-attributes,
+            lecture-what-is-css,
+            lecture-working-with-code-editors-and-ides,
+            machine-learning-with-python-projects,
+            managing-packages-with-npm,
+            project-euler-problems-1-to-100,
+            project-euler-problems-401-to-480,
+            python-for-everybody,
+            quiz-basic-html,
+            responsive-web-design-principles,
+            review-basic-html,
+            review-html,
+            review-semantic-html,
+            rosetta-code-challenges,
+            sass,
+            workshop-blog-page,
+            workshop-caesar-cipher,
+            workshop-cafe-menu,
+            workshop-cat-photo-app,
+            workshop-curriculum-outline,
+            workshop-greeting-bot,
+            write-your-first-code-using-c-sharp
         run: |
           pnpm install
           pnpm run build

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -121,6 +121,7 @@ jobs:
         run: |
           pnpm install
           pnpm run build
+          node e2e/verify-build.mjs
 
       - name: Move serve.json to Public Folder
         run: cp client-config/serve.json client/public/serve.json

--- a/curriculum/src/filter.test.js
+++ b/curriculum/src/filter.test.js
@@ -149,6 +149,32 @@ describe('filters', () => {
       ]);
     });
 
+    it('returns multiple specified blocks', () => {
+      const superblocks = [
+        {
+          name: 'superblock-1',
+          blocks: [{ dashedName: 'block-1' }, { dashedName: 'block-2' }]
+        },
+        {
+          name: 'superblock-2',
+          blocks: [{ dashedName: 'block-2' }, { dashedName: 'block-3' }]
+        }
+      ];
+      const filtered = filterByBlock(superblocks, {
+        block: 'block-1, block-3'
+      });
+      expect(filtered).toEqual([
+        {
+          name: 'superblock-1',
+          blocks: [{ dashedName: 'block-1' }]
+        },
+        {
+          name: 'superblock-2',
+          blocks: [{ dashedName: 'block-3' }]
+        }
+      ]);
+    });
+
     it('returns an empty array if no blocks match the specified block', () => {
       const superblocks = [
         {
@@ -269,6 +295,21 @@ describe('filters', () => {
       expect(closestFilters(superblocks, { block: 'basic-javascr' })).toEqual({
         block: 'basic-javascript'
       });
+    });
+
+    it('does not alter a multiple block filter', () => {
+      const superblocks = [
+        {
+          name: 'responsive-web-design',
+          blocks: [
+            { dashedName: 'basic-html-and-html5', challengeOrder: [] },
+            { dashedName: 'css-flexbox', challengeOrder: [] }
+          ]
+        }
+      ];
+      const target = { block: 'basic-html-and-html5,css-flexbox' };
+
+      expect(closestFilters(superblocks, target)).toEqual(target);
     });
 
     it('should throw if the closest match has Dice-Sørensen score below the threshold', () => {

--- a/curriculum/src/filter.ts
+++ b/curriculum/src/filter.ts
@@ -1,11 +1,12 @@
 /**
- * Filters the superblocks array to include any superblocks with the specified block.
+ * Filters the superblocks array to include any superblocks with the specified block(s).
  * If no block is provided, returns the original superblocks array.
+ * Supports comma-separated block names for filtering multiple blocks.
  *
  * @param {Array<Object>} superblocks - Array of superblock objects, each containing a blocks array.
  * @param {Object} [options] - Options object
- * @param {string} [options.block] - The dashedName of the block to filter for (in kebab case).
- * @returns {Array<Object>} Array with one superblock containing the specified block, or the original array if block is not provided.
+ * @param {string} [options.block] - The dashedName(s) of the block(s) to filter for (comma-separated for multiple).
+ * @returns {Array<Object>} Filtered superblocks containing the specified block(s), or the original array if block is not provided.
  */
 export function filterByBlock<T extends { blocks: { dashedName: string }[] }>(
   superblocks: T[],
@@ -13,10 +14,17 @@ export function filterByBlock<T extends { blocks: { dashedName: string }[] }>(
 ): T[] {
   if (!block) return superblocks;
 
+  const blockList = block
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+
   const remainingSuperblocks = superblocks
     .map(superblock => ({
       ...superblock,
-      blocks: superblock.blocks.filter(({ dashedName }) => dashedName === block)
+      blocks: superblock.blocks.filter(({ dashedName }) =>
+        blockList.includes(dashedName)
+      )
     }))
     .filter(superblock => superblock.blocks.length > 0);
 
@@ -229,6 +237,11 @@ export function closestFilters(
     const blocks = superblocks.flatMap(({ blocks }) =>
       blocks.map(({ dashedName }) => dashedName)
     );
+
+    // If there are multiple blocks, do not attempt to find a closest match.
+    if (target.block.includes(',')) {
+      return target;
+    }
 
     const { closest, score } = closestMatch(target.block, blocks);
 

--- a/e2e/block-navigation.spec.ts
+++ b/e2e/block-navigation.spec.ts
@@ -55,19 +55,30 @@ test.describe('Block Navigation - Hash Updates', () => {
   }) => {
     await page.goto('/learn/javascript-v9');
 
-    await page.getByRole('button', { name: /^Build a Greeting Bot/ }).click();
+    await page.getByRole('button', { name: 'Algorithms', exact: true }).click();
 
-    // Click on step 1 in the accordion
-    const step1Link = page.getByRole('link', { name: 'Step 1 Not Passed' });
-    await expect(step1Link).toBeVisible();
-    await step1Link.click();
+    await page
+      .getByRole('button', {
+        name: /^Introduction to Common Searching and Sorting Algorithms/
+      })
+      .click();
+
+    const challengeLink = page.getByRole('link', {
+      name: /What Is Binary Search and How Does It Differ From Linear Search\?/
+    });
+    await expect(challengeLink).toBeVisible();
+    await challengeLink.click();
 
     // Wait for navigation
-    await page.waitForURL(/step-1$/);
+    await page.waitForURL(
+      /what-is-binary-search-and-how-does-it-differ-from-linear-search$/
+    );
 
     // Go back to verify the hash persists in history
     await page.goBack();
-    await expect(page).toHaveURL(/#workshop-greeting-bot$/);
+    await expect(page).toHaveURL(
+      /#lecture-introduction-to-common-searching-and-sorting-algorithms$/
+    );
   });
 
   test('should update URL hash when clicking on a certification project in accordion layout (v9)', async ({

--- a/e2e/completed-project-preview.spec.ts
+++ b/e2e/completed-project-preview.spec.ts
@@ -22,13 +22,14 @@ const unlockedProfile = {
 
 async function expectPreviewToBeShown(page: Page) {
   await page
-    .getByRole('button', { name: 'View Solution for Build a Tribute Page' })
+    .getByRole('button', {
+      name: /View Solution for .*Build a Tribute Page$/
+    })
     .first()
     .click();
   await page.getByRole('menuitem', { name: 'View Project' }).click();
   const modalHeading = page.getByRole('heading', {
-    name: 'Build a Tribute Page',
-    exact: true
+    name: /Build a Tribute Page$/
   });
   await expect(modalHeading).toBeVisible();
 

--- a/e2e/super-block-page.spec.ts
+++ b/e2e/super-block-page.spec.ts
@@ -316,7 +316,7 @@ test.describe('Super Block Page - Search Lessons', () => {
   test('should filter blocks and auto-expand matching modules on a chapter-based superblock', async ({
     page
   }) => {
-    const searchTerm = 'Greeting Bot';
+    const searchTerm = 'Binary Search';
 
     await page.goto('/learn/javascript-v9/');
 
@@ -329,7 +329,9 @@ test.describe('Super Block Page - Search Lessons', () => {
       .fill(searchTerm);
 
     await expect(
-      page.getByRole('heading', { name: 'Build a Greeting Bot' })
+      page.getByRole('heading', {
+        name: 'Introduction to Common Searching and Sorting Algorithms'
+      })
     ).toBeVisible();
     await expect(
       page.getByRole('button', { name: /^Booleans and Numbers$/ })

--- a/e2e/verify-build.mjs
+++ b/e2e/verify-build.mjs
@@ -1,0 +1,134 @@
+import console from 'node:console';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const e2eDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(e2eDirectory, '..');
+const curriculumPath = path.join(
+  repositoryRoot,
+  'curriculum/generated/curriculum.json'
+);
+const publicDirectory = path.join(repositoryRoot, 'client/public');
+
+// These blocks are exercised through superblock search or navigation, so their
+// challenge URLs do not appear literally in the specs.
+const indirectlyReferencedBlocks = [
+  'lecture-introduction-to-common-searching-and-sorting-algorithms',
+  'lecture-understanding-html-attributes',
+  'project-euler-problems-401-to-480',
+  'workshop-curriculum-outline'
+];
+
+function fail(message) {
+  console.error(`\nE2E build verification failed:\n\n${message}\n`);
+  process.exitCode = 1;
+}
+
+if (!process.env.FCC_BLOCK) {
+  fail('FCC_BLOCK is not set. This verification is only for selective builds.');
+} else if (!fs.existsSync(curriculumPath)) {
+  fail(`Curriculum data was not generated at ${curriculumPath}.`);
+} else {
+  const curriculum = JSON.parse(fs.readFileSync(curriculumPath, 'utf8'));
+  const blockRoutes = new Map();
+
+  for (const certification of Object.values(curriculum)) {
+    for (const [blockName, block] of Object.entries(
+      certification.blocks ?? {}
+    )) {
+      const routes = blockRoutes.get(blockName) ?? [];
+
+      for (const challenge of block.challenges) {
+        if (!challenge.superBlock || !challenge.dashedName) continue;
+
+        routes.push(
+          `/learn/${challenge.superBlock}/${challenge.block}/${challenge.dashedName}`
+        );
+      }
+
+      blockRoutes.set(blockName, routes);
+    }
+  }
+
+  const specSource = fs
+    .readdirSync(e2eDirectory)
+    .filter(fileName => fileName.endsWith('.spec.ts'))
+    .map(fileName => fs.readFileSync(path.join(e2eDirectory, fileName), 'utf8'))
+    .join('\n');
+
+  const requiredBlocks = new Set(indirectlyReferencedBlocks);
+
+  for (const [blockName, routes] of blockRoutes) {
+    const referencesBlockDirectly =
+      specSource.includes(`#${blockName}`) ||
+      specSource.includes(`block: '${blockName}'`) ||
+      specSource.includes(`block: "${blockName}"`);
+    const referencesChallenge = routes.some(
+      route => specSource.includes(route) || specSource.includes(route.slice(1))
+    );
+
+    if (referencesBlockDirectly || referencesChallenge) {
+      requiredBlocks.add(blockName);
+    }
+  }
+
+  const selectedBlocks = new Set(
+    process.env.FCC_BLOCK.split(',')
+      .map(block => block.trim())
+      .filter(Boolean)
+  );
+  const unknownBlocks = [...selectedBlocks].filter(
+    block => !blockRoutes.has(block)
+  );
+  const missingBlocks = [...requiredBlocks].filter(
+    block => !selectedBlocks.has(block)
+  );
+  const blocksWithoutPages = [...requiredBlocks].filter(block => {
+    const routes = blockRoutes.get(block) ?? [];
+
+    return !routes.some(route =>
+      fs.existsSync(path.join(publicDirectory, route, 'index.html'))
+    );
+  });
+
+  const errors = [];
+
+  if (unknownBlocks.length > 0) {
+    errors.push(
+      `FCC_BLOCK contains unknown blocks:\n${unknownBlocks
+        .sort()
+        .map(block => `  - ${block}`)
+        .join('\n')}`
+    );
+  }
+
+  if (missingBlocks.length > 0) {
+    errors.push(
+      `The E2E specs reference blocks that are missing from FCC_BLOCK:\n${missingBlocks
+        .sort()
+        .map(block => `  - ${block}`)
+        .join(
+          '\n'
+        )}\n\nAdd them to FCC_BLOCK in .github/workflows/e2e-playwright.yml.`
+    );
+  }
+
+  if (blocksWithoutPages.length > 0) {
+    errors.push(
+      `No built challenge page was found for these required blocks:\n${blocksWithoutPages
+        .sort()
+        .map(block => `  - ${block}`)
+        .join('\n')}`
+    );
+  }
+
+  if (errors.length > 0) {
+    fail(errors.join('\n\n'));
+  } else {
+    console.log(
+      `Verified ${requiredBlocks.size} curriculum blocks required by the E2E suite.`
+    );
+  }
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## Summary

- allow curriculum builds to select multiple comma-separated blocks
- limit the Playwright CI build to the 52 curriculum blocks exercised by the E2E suite
- preserve the full production build in the existing Node.js CI job

## CI results

Compared the [selective-build run](https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/32745267443) with a [full-build run using the unchanged workflow](https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/32729233373).

| Step | Full build | E2E blocks | Reduction |
| --- | ---: | ---: | ---: |
| Build Client job | 20m 20s | 7m 23s | 12m 57s (63.7%) |
| Install and Build | 14m 04s | 5m 49s | 8m 15s (58.6%) |
| Upload Client Artifact | 5m 26s | 37s | 4m 49s (88.7%) |
| Download Client Artifact | 1m 09s | 7s | 1m 02s (89.9%) |
| Workflow start to Playwright tests | 26m 00s | 10m 29s | 15m 31s (59.7%) |

The selective client build completed successfully. The smaller output improves both the build and the artifact transfer, allowing Playwright to start about 15.5 minutes earlier.

## Local results

| Build | Pages | Time |
| --- | ---: | ---: |
| Full curriculum | 19,228 | 158.84s |
| E2E blocks | 2,109 | 73.74s |

This removes 17,119 generated pages and reduced the measured local build time by 85.10 seconds (53.6%).

## Testing

- curriculum filter unit tests: 18 passed
- selective production build: passed locally and in CI
- route-heavy Playwright validation: no missing-page failures
- targeted regression validation for both deterministic CI failures: 5 passed
- isolated legacy redirect validation: 19 passed

