### PR TITLE
fix(a11y): use semantic keyboard markup

### DIFF
--- a/curriculum/challenges/english/blocks/lab-technical-documentation-page/587d78b0367417b2b2512b05.md
+++ b/curriculum/challenges/english/blocks/lab-technical-documentation-page/587d78b0367417b2b2512b05.md
@@ -416,7 +416,7 @@ assert.isTrue(cssCheck.length > 0 || htmlSourceAttr.length > 0);
             greetMe("World");
           </code>
 
-          Select the code in the pad and hit <kbd>Ctrl</kbd>+<kbd>R</kbd> to watch it unfold in your browser!
+          Select the code in the pad and hit <kbd>Ctrl</kbd> + <kbd>R</kbd> to watch it unfold in your browser!
         </article>
       </section>
       <section class="main-section" id="Variables">

--- a/curriculum/challenges/english/blocks/lab-technical-documentation-page/587d78b0367417b2b2512b05.md
+++ b/curriculum/challenges/english/blocks/lab-technical-documentation-page/587d78b0367417b2b2512b05.md
@@ -416,8 +416,7 @@ assert.isTrue(cssCheck.length > 0 || htmlSourceAttr.length > 0);
             greetMe("World");
           </code>
 
-          Select the code in the pad and hit Ctrl+R to watch it unfold in your
-          browser!
+          Select the code in the pad and hit <kbd>Ctrl</kbd>+<kbd>R</kbd> to watch it unfold in your browser!
         </article>
       </section>
       <section class="main-section" id="Variables">

--- a/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3cade9fa77275d9f4efe62.md
+++ b/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3cade9fa77275d9f4efe62.md
@@ -9,7 +9,7 @@ dashedName: step-40
 
 That worked, but there is still a little space on the right of the price.
 
-You could keep trying various percentages for the widths. Instead, use the backspace key to move the `p` element with the class `price` next to the `p` element with the class `flavor` so that they are on the same line in the editor. Make sure there is no space between the two elements.
+You could keep trying various percentages for the widths. Instead, use the <kbd>Backspace</kbd> key to move the `p` element with the class `price` next to the `p` element with the class `flavor` so that they are on the same line in the editor. Make sure there is no space between the two elements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3cade9fa77275d9f4efe62.md
+++ b/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3cade9fa77275d9f4efe62.md
@@ -9,7 +9,7 @@ dashedName: step-40
 
 That worked, but there is still a little space on the right of the price.
 
-You could keep trying various percentages for the widths. Instead, use the <kbd>Backspace</kbd> key to move the `p` element with the class `price` next to the `p` element with the class `flavor` so that they are on the same line in the editor. Make sure there is no space between the two elements.
+You could keep trying various percentages for the widths. Instead, use the backspace key to move the `p` element with the class `price` next to the `p` element with the class `flavor` so that they are on the same line in the editor. Make sure there is no space between the two elements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55fbc2d95a9453151caf.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-media-elements/672a55fbc2d95a9453151caf.md
@@ -124,7 +124,7 @@ Think about how you control the sequence of focusable elements.
 
 ---
 
-It allows you to control the order in which elements are focused when using the tab key.
+It allows you to control the order in which elements are focused when using the <kbd>Tab</kbd> key.
 
 ---
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
@@ -77,7 +77,7 @@ Right-click the folder and select "Pin to Start".
 
 ---
 
-Press "Ctrl + Pin".
+Press <kbd>Ctrl</kbd> + <kbd>Pin</kbd>.
 
 ### --feedback--
 
@@ -113,7 +113,7 @@ Click on the Finder icon in the Dock.
 
 ---
 
-Press "Command + Find".
+Press <kbd>Command</kbd> + <kbd>Find</kbd>.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
@@ -77,7 +77,7 @@ Right-click the folder and select "Pin to Start".
 
 ---
 
-Press <kbd>Ctrl</kbd> + <kbd>Pin</kbd>.
+Press <kbd>Ctrl</kbd> + Pin.
 
 ### --feedback--
 
@@ -113,7 +113,7 @@ Click on the Finder icon in the Dock.
 
 ---
 
-Press <kbd>Command</kbd> + <kbd>Find</kbd>.
+Press <kbd>Command</kbd> + Find.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-file-systems/672aa58c389eb9565978495d.md
@@ -77,7 +77,7 @@ Right-click the folder and select "Pin to Start".
 
 ---
 
-Press <kbd>Ctrl</kbd> + <kbd>Pin</kbd>.
+Press "Ctrl + Pin".
 
 ### --feedback--
 
@@ -113,7 +113,7 @@ Click on the Finder icon in the Dock.
 
 ---
 
-Press <kbd>Command</kbd> + <kbd>Find</kbd>.
+Press "Command + Find".
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-forms/672a4cf959443073a6774908.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-forms/672a4cf959443073a6774908.md
@@ -19,9 +19,9 @@ The first state would be considered the `default` state. The default state of an
 
 :::
 
-When the user clicks on a form control or selects it with the keyboard's tab key, then that means it is in the `focused` state. When an input is in the `focused` state, most browsers will show a blue highlighted border around the input. But you can choose to add additional styles in CSS.
+When the user clicks on a form control or selects it with the keyboard's <kbd>Tab</kbd> key, then that means it is in the `focused` state. When an input is in the `focused` state, most browsers will show a blue highlighted border around the input. But you can choose to add additional styles in CSS.
 
-Click on any part of the whitespace in the preview window and then press the `tab` key to see the focus state. To see the previews, you will need to enable the interactive editor.
+Click on any part of the whitespace in the preview window and then press the <kbd>Tab</kbd> key to see the focus state. To see the previews, you will need to enable the interactive editor.
 
 :::interactive_editor
 
@@ -163,7 +163,7 @@ Refer back to the beginning of the lesson where the focused state was discussed.
 
 ---
 
-When the user clicks on an input or selects it using the tab key to focus it.
+When the user clicks on an input or selects it using the <kbd>Tab</kbd> key to focus it.
 
 ---
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
@@ -35,7 +35,7 @@ To see what the issue might be, you can use the developer tools.
 
 To open the developer tools in your browser, you can right-click on the page and select `Inspect`.
 
-You can also use `Control Shift I` on your PC keyboard or `Command Option I` on your Mac.
+You can also use <kbd>Control</kbd> <kbd>Shift</kbd> <kbd>I</kbd> on your PC keyboard or <kbd>Command</kbd> <kbd>Option</kbd> <kbd>I</kbd> on your Mac.
 
 When you open developer tools in Google Chrome, you'll see a number of tabs. The first tab is called the `Elements` tab. This tab shows you the HTML structure of the page you are on.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
@@ -35,7 +35,8 @@ To see what the issue might be, you can use the developer tools.
 
 To open the developer tools in your browser, you can right-click on the page and select `Inspect`.
 
-You can also use <kbd>Control</kbd> <kbd>Shift</kbd> <kbd>I</kbd> on your PC keyboard or <kbd>Command</kbd> <kbd>Option</kbd> <kbd>I</kbd> on your Mac.
+You can also use <kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> on your PC keyboard or
+<kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>I</kbd> on your Mac.
 
 When you open developer tools in Google Chrome, you'll see a number of tabs. The first tab is called the `Elements` tab. This tab shows you the HTML structure of the page you are on.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-html-tools/672a511bb408ec81c592eb68.md
@@ -35,8 +35,7 @@ To see what the issue might be, you can use the developer tools.
 
 To open the developer tools in your browser, you can right-click on the page and select `Inspect`.
 
-You can also use <kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> on your PC keyboard or
-<kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>I</kbd> on your Mac.
+You can also use <kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> on your PC keyboard or <kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>I</kbd> on your Mac.
 
 When you open developer tools in Google Chrome, you'll see a number of tabs. The first tab is called the `Elements` tab. This tab shows you the HTML structure of the page you are on.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
@@ -83,8 +83,7 @@ a:hover {
 
 Then we have `:focus`. This state applies when we focus on a link.
 
- Click on any portion of the whitespace in the preview window and then press <kbd>Tab</kbd> on your keyboard. You should see the link change to green. To see the previews, you will need to enable the interactive editor.
-
+Click on any portion of the whitespace in the preview window and then press <kbd>Tab</kbd> on your keyboard. You should see the link change to green. To see the previews, you will need to enable the interactive editor.
 :::interactive_editor
 
 ```html

--- a/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
@@ -83,7 +83,7 @@ a:hover {
 
 Then we have `:focus`. This state applies when we focus on a link.
 
-Click on any portion of the whitespace in the preview window and then press `tab` on your keyboard. You should see the link change to green. To see the previews, you will need to enable the interactive editor.
+ Click on any portion of the whitespace in the preview window and then press <kbd>Tab</kbd> on your keyboard. You should see the link change to green. To see the previews, you will need to enable the interactive editor.
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-links/67168323932391a9ee0d3a9e.md
@@ -84,6 +84,7 @@ a:hover {
 Then we have `:focus`. This state applies when we focus on a link.
 
 Click on any portion of the whitespace in the preview window and then press <kbd>Tab</kbd> on your keyboard. You should see the link change to green. To see the previews, you will need to enable the interactive editor.
+
 :::interactive_editor
 
 ```html

--- a/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3cade9fa77275d9f4efe62.md
+++ b/curriculum/challenges/english/blocks/workshop-cafe-menu/5f3cade9fa77275d9f4efe62.md
@@ -9,7 +9,7 @@ dashedName: step-36
 
 That worked, but there is still a little space on the right of the price.
 
-You could keep trying various percentages for the widths. Instead, use the backspace key to move the `p` element with the class `price` next to the `p` element with the class `flavor` so that they are on the same line in the editor. Make sure there is no space between the two elements.
+You could keep trying various percentages for the widths. Instead, use the <kbd>Backspace</kbd> key to move the `p` element with the class `price` next to the `p` element with the class `flavor` so that they are on the same line in the editor. Make sure there is no space between the two elements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc23991f86c76b9248c6eb8.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc23991f86c76b9248c6eb8.md
@@ -18,7 +18,7 @@ Here is an example of nesting and indentation:
 </main>
 ```
 
-The `h1` element, `h2` element and the comment are indented two spaces more than the `main` element in the code below. Use the space bar on your keyboard to add two more spaces in front of the `p` element so that it is indented properly as well.
+The `h1` element, `h2` element and the comment are indented two spaces more than the `main` element in the code below. Use the <kbd>Space</kbd> bar on your keyboard to add two more spaces in front of the `p` element so that it is indented properly as well.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc23991f86c76b9248c6eb8.md
+++ b/curriculum/challenges/english/blocks/workshop-cat-photo-app/5dc23991f86c76b9248c6eb8.md
@@ -18,7 +18,7 @@ Here is an example of nesting and indentation:
 </main>
 ```
 
-The `h1` element, `h2` element and the comment are indented two spaces more than the `main` element in the code below. Use the <kbd>Space</kbd> bar on your keyboard to add two more spaces in front of the `p` element so that it is indented properly as well.
+The `h1` element, `h2` element and the comment are indented two spaces more than the `main` element in the code below. Use the <kbd>Spacebar</kbd> on your keyboard to add two more spaces in front of the `p` element so that it is indented properly as well.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69724

## Summary

- Replaced plain-text keyboard keys with semantic `<kbd>` elements across the affected Responsive Web Design V9 lessons.
- Each key in keyboard shortcuts is represented by its own `<kbd>` element.
- Preserved code formatting for HTML elements, class names, and other code identifiers.
- Updated all 8 affected curriculum files identified in issue #69724.