### PR TITLE
fix(curriculum): use semantic keyboard markup

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-python-installation/69fd6b21fcaa14b089c27182.md
+++ b/curriculum/challenges/english/blocks/lecture-python-installation/69fd6b21fcaa14b089c27182.md
@@ -20,7 +20,7 @@ Other common choices for Python development include the following:
 
 Once you have downloaded your editor, you will need to open it. Once it is opened, you will need to open a folder. You can click on the `File` menu option in the upper left hand corner and click on `Open Folder`. From there, you can choose or create a folder for your project. For extra practice outside of the lesson, you might want a folder named `python-projects`.
 
-Once you have your folder set up, you can open the explorer which is the left sidebar in VS Code. Click on the `New File` icon which looks like a piece of paper with a plus icon over it. Then create a file called `main.py` and press enter. The `.py` is a file extension signalling this is a Python file.
+Once you have your folder set up, you can open the explorer which is the left sidebar in VS Code. Click on the `New File` icon which looks like a piece of paper with a plus icon over it. Then create a file called `main.py` and press <kbd>Enter</kbd>. The `.py` is a file extension signalling this is a Python file.
 
 Open up your `main.py` file and type the following code:
 

--- a/curriculum/challenges/english/blocks/lecture-python-installation/69fd75321df075656f836fff.md
+++ b/curriculum/challenges/english/blocks/lecture-python-installation/69fd75321df075656f836fff.md
@@ -13,7 +13,7 @@ But first, let's review what a terminal is.
 
 A terminal is a text-based interface that lets you interact with your computer by typing commands. Each operating system comes with a default terminal app. On macOS, you can use the Terminal app. On Windows, you can use Command Prompt or PowerShell. On Linux, each desktop environment has its own default terminal app, like GNOME Terminal or Konsole.
 
-Open up a terminal app and type in `python` and press `Enter`. This will start a Python interactive shell. An interactive shell is a program that lets you type commands one at a time and see the results.
+Open up a terminal app and type in `python` and press <kbd>Enter</kbd>. This will start a Python interactive shell. An interactive shell is a program that lets you type commands one at a time and see the results.
 
 When you start a new session, you might see this type of output initially:
 

--- a/curriculum/challenges/english/blocks/quiz-python-installation/69fd84e01123960e15bb8455.md
+++ b/curriculum/challenges/english/blocks/quiz-python-installation/69fd84e01123960e15bb8455.md
@@ -153,19 +153,19 @@ How do you start the Python interactive shell from the terminal?
 
 #### --distractors--
 
-Type `node python` and press `Enter`.
+Type `node python` and press <kbd>Enter</kbd>.
 
 ---
 
-Type `run python` and press `Enter`.
+Type `run python` and press <kbd>Enter</kbd>.
 
 ---
 
-Type `start python shell` and press `Enter`.
+Type `start python shell` and press <kbd>Enter</kbd>.
 
 #### --answer--
 
-Type `python` and press `Enter`.
+Type `python` and press <kbd>Enter</kbd>.
 
 ### --question--
 

--- a/curriculum/challenges/english/blocks/review-python-installation/69fd80a1798f22441459a70f.md
+++ b/curriculum/challenges/english/blocks/review-python-installation/69fd80a1798f22441459a70f.md
@@ -35,7 +35,7 @@ python main.py
 
 ## Using the Python Interactive Shell
 
-- **Definition**: An interactive shell is a program that lets you type commands one at a time and see the results. Open up a terminal app and type in `python` and press `Enter`. This will start a Python interactive shell. The `>>>` symbol means Python is waiting for you to type a command. Try printing `"Hello, world!"` to the terminal:
+- **Definition**: An interactive shell is a program that lets you type commands one at a time and see the results. Open up a terminal app and type in `python` and press <kbd>Enter</kbd>. This will start a Python interactive shell. The `>>>` symbol means Python is waiting for you to type a command. Try printing `"Hello, world!"` to the terminal:
 
 ```bash
 print("Hello, world!")

--- a/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
+++ b/curriculum/challenges/english/blocks/review-python/67f39e391c9b373069def02c.md
@@ -40,7 +40,7 @@ python main.py
 
 ## Using the Python Interactive Shell
 
-- **Definition**: An interactive shell is a program that lets you type commands one at a time and see the results. Open up a terminal app and type in `python` and press `Enter`. This will start a Python interactive shell. The `>>>` symbol means Python is waiting for you to type a command. Try printing `"Hello, world!"` to the terminal:
+- **Definition**: An interactive shell is a program that lets you type commands one at a time and see the results. Open up a terminal app and type in `python` and press <kbd>Enter</kbd>. This will start a Python interactive shell. The `>>>` symbol means Python is waiting for you to type a command. Try printing `"Hello, world!"` to the terminal:
 
 ```bash
 print("Hello, world!")


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your contribution into consideration. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69722

<!-- Feel free to add any additional description of changes below this line -->

This PR updates the keyboard shortcut markup in the Python V9 curriculum.

The `Enter` key is now represented using the semantic `<kbd>` element in the affected Python installation lectures, reviews, and quiz.

The changes are limited to the keyboard shortcut markup requested in the issue.
