### PR TITLE
fix(curriculum): use kbd markup in live certifications

### DIFF
--- a/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244d9.md
+++ b/curriculum/challenges/english/blocks/basic-javascript/56533eb9ac21ba0edf2244d9.md
@@ -10,7 +10,7 @@ dashedName: comparisons-with-the-logical-or-operator
 
 The <dfn>logical or</dfn> operator (`||`) returns `true` if either of the <dfn>operands</dfn> is `true`. Otherwise, it returns `false`.
 
-The <dfn>logical or</dfn> operator is composed of two pipe symbols: (`||`). This can typically be found between your Backspace and Enter keys.
+The <dfn>logical or</dfn> operator is composed of two pipe symbols: (`||`). This can typically be found between your <kbd>Backspace</kbd> and <kbd>Enter</kbd> keys.
 
 The pattern below should look familiar from prior waypoints.
 

--- a/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bed.md
+++ b/curriculum/challenges/english/blocks/basic-node-and-express/587d7fb0367417b2b2512bed.md
@@ -21,7 +21,7 @@ We recommend to keep the terminal open while working at these challenges. By rea
 
 The server must be restarted after making changes to its files.
 
-You can stop the server from the terminal using `Ctrl + C` and start it using Node directly (`node mainEntryFile.js`) or using a run script in the `package.json` file with `npm run`.
+You can stop the server from the terminal using <kbd>Ctrl</kbd> + <kbd>C</kbd> and start it using Node directly (`node mainEntryFile.js`) or using a run script in the `package.json` file with `npm run`.
 
 For example, the `"start": "node server.js"` script would be run from the terminal using `npm run start`.
 

--- a/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3cade9fa77275d9f4efe62.md
+++ b/curriculum/challenges/english/blocks/learn-basic-css-by-building-a-cafe-menu/5f3cade9fa77275d9f4efe62.md
@@ -9,7 +9,7 @@ dashedName: step-40
 
 That worked, but there is still a little space on the right of the price.
 
-You could keep trying various percentages for the widths. Instead, use the backspace key to move the `p` element with the class `price` next to the `p` element with the class `flavor` so that they are on the same line in the editor. Make sure there is no space between the two elements.
+You could keep trying various percentages for the widths. Instead, use the <kbd>Backspace</kbd> key to move the `p` element with the class `price` next to the `p` element with the class `flavor` so that they are on the same line in the editor. Make sure there is no space between the two elements.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-basic-javascript-by-building-a-role-playing-game/62a255dae245b52317da824a.md
+++ b/curriculum/challenges/english/blocks/learn-basic-javascript-by-building-a-role-playing-game/62a255dae245b52317da824a.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-One of the most powerful tools is your developer console. Depending on your browser, this might be opened by pressing `F12` or `Ctrl+Shift+I`. On Mac, you can press `Option + ⌘ + C` and select "Console". You can also click the "Console" button above the preview window to see our built-in console. 
+One of the most powerful tools is your developer console. Depending on your browser, this might be opened by pressing <kbd>F12</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd>. On Mac, you can press <kbd>Option</kbd> + <kbd>⌘</kbd> + <kbd>C</kbd> and select "Console". You can also click the "Console" button above the preview window to see our built-in console. 
 
 The developer console will include errors that are produced by your code, but you can also use it to see values of variables in your code, which is helpful for debugging.
 

--- a/curriculum/challenges/english/blocks/learn-basic-javascript-by-building-a-role-playing-game/62a255dae245b52317da824a.md
+++ b/curriculum/challenges/english/blocks/learn-basic-javascript-by-building-a-role-playing-game/62a255dae245b52317da824a.md
@@ -7,7 +7,7 @@ dashedName: step-3
 
 # --description--
 
-One of the most powerful tools is your developer console. Depending on your browser, this might be opened by pressing <kbd>F12</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd>. On Mac, you can press <kbd>Option</kbd> + <kbd>⌘</kbd> + <kbd>C</kbd> and select "Console". You can also click the "Console" button above the preview window to see our built-in console. 
+One of the most powerful tools is your developer console. Depending on your browser, this might be opened by pressing <kbd>F12</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd>. On Mac, you can press <kbd>Option</kbd> + <kbd>Cmd</kbd> + <kbd>C</kbd> and select "Console". You can also click the "Console" button above the preview window to see our built-in console. 
 
 The developer console will include errors that are produced by your code, but you can also use it to see values of variables in your code, which is helpful for debugging.
 

--- a/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5dc23991f86c76b9248c6eb8.md
+++ b/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5dc23991f86c76b9248c6eb8.md
@@ -18,7 +18,7 @@ Here is an example of nesting and indentation:
 </main>
 ```
 
-The `h1` element, `h2` element and the comment are indented two spaces more than the `main` element in the code below. Use the space bar on your keyboard to add two more spaces in front of the `p` element so that it is indented properly as well.
+The `h1` element, `h2` element and the comment are indented two spaces more than the `main` element in the code below. Use the <kbd>Space</kbd> bar on your keyboard to add two more spaces in front of the `p` element so that it is indented properly as well.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5dc23991f86c76b9248c6eb8.md
+++ b/curriculum/challenges/english/blocks/learn-html-by-building-a-cat-photo-app/5dc23991f86c76b9248c6eb8.md
@@ -18,7 +18,7 @@ Here is an example of nesting and indentation:
 </main>
 ```
 
-The `h1` element, `h2` element and the comment are indented two spaces more than the `main` element in the code below. Use the <kbd>Space</kbd> bar on your keyboard to add two more spaces in front of the `p` element so that it is indented properly as well.
+The `h1` element, `h2` element and the comment are indented two spaces more than the `main` element in the code below. Use the <kbd>Spacebar</kbd> on your keyboard to add two more spaces in front of the `p` element so that it is indented properly as well.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-introductory-javascript-by-building-a-pyramid-generator/660f23b53db70af0f2620e78.md
+++ b/curriculum/challenges/english/blocks/learn-introductory-javascript-by-building-a-pyramid-generator/660f23b53db70af0f2620e78.md
@@ -9,7 +9,7 @@ dashedName: step-43
 
 Now all of your numbers are appearing on the same line. This will not work for creating a pyramid.
 
-You will need to add a new line to each row. However, pressing the return key to insert a line break between quotes in JavaScript will result in a parsing error. Instead, you need to use the special <dfn>escape sequence</dfn> `\n`, which is interpreted as a new line when the string is logged. For example:
+You will need to add a new line to each row. However, pressing the <kbd>Return</kbd> key to insert a line break between quotes in JavaScript will result in a parsing error. Instead, you need to use the special <dfn>escape sequence</dfn> `\n`, which is interpreted as a new line when the string is logged. For example:
 
 ```js
 lineOne = lineOne + "\n" + lineTwo;

--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/63e9eb5b2328eed3d194b28a.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/63e9eb5b2328eed3d194b28a.md
@@ -9,11 +9,11 @@ dashedName: step-7
 
 If you open your browser's console and type in the number input, you'll see event objects logged to the browser. And if you take a closer look at one of those event objects, you'll see helpful properties like `type` and `target`.
 
-Since you want to perform an action when the `Enter` key is pressed, the most helpful property is `key`, which tells you the string value of the key that was pressed.
+Since you want to perform an action when the <kbd>Enter</kbd> key is pressed, the most helpful property is `key`, which tells you the string value of the key that was pressed.
 
 Remove the `console.log()` statement from the callback function and add an `if` statement that checks if `e.key` is equal to the string `"Enter"`. Leave the body of your `if` statement empty for now.
 
-Note: Since the `Enter` and `Return` keys have similar functions, they both have the same string value of `"Enter"`.
+Note: Since the <kbd>Enter</kbd> and <kbd>Return</kbd> keys have similar functions, they both have the same string value of `"Enter"`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/64005ab13a78eb062547c12d.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/64005ab13a78eb062547c12d.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-Next, within the body of the `if` statement, call the `checkUserInput()` function. After this, if you enter numbers into the number input and press the `Enter` / `Return` key, you should see numbers logged to the console.
+Next, within the body of the `if` statement, call the `checkUserInput()` function. After this, if you enter numbers into the number input and press the <kbd>Enter</kbd> / <kbd>Return</kbd> key, you should see numbers logged to the console.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/6448d62ce222044458b75931.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/6448d62ce222044458b75931.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Your `Convert` button should be working now. But it could get tiring for users to enter in a number, then click that button each time they want to convert from decimal to binary. It would be much more convenient to perform the conversion when the `Enter` or `Return` key is pressed.
+Your `Convert` button should be working now. But it could get tiring for users to enter in a number, then click that button each time they want to convert from decimal to binary. It would be much more convenient to perform the conversion when the <kbd>Enter</kbd> or <kbd>Return</kbd> key is pressed.
 
 The `keydown` event fires every time a user presses a key on their keyboard, and is a good way to add more interactivity to `input` elements.
 

--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/644905b34f614973a8252a26.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/644905b34f614973a8252a26.md
@@ -7,7 +7,7 @@ dashedName: step-9
 
 # --description--
 
-Now that your `Convert` button and number input are listening for clicks and `Enter` key presses, it's time to complete the `checkUserInput()` function.
+Now that your `Convert` button and number input are listening for clicks and <kbd>Enter</kbd> key presses, it's time to complete the `checkUserInput()` function.
 
 It would be helpful to alert users if they don't enter a value into the number input, or the number they enter is invalid. While the `input type="number"` element makes validation easier by only allowing numbers and some special characters, remember that all values you get from HTML elements are actually strings. Also, if the number input is empty, the `value` property will be an empty string.
 

--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036179.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d4036179.md
@@ -18,7 +18,7 @@ We've added a button which submits the form. You can see it has the `type` set t
 
 **Note:** You also must call `event.preventDefault()` in the submit handler, to prevent the default form submit behavior which will refresh the web page. For camper convenience, the default behavior has been disabled here to prevent refreshes from resetting challenge code.
 
-Finally, create an `h1` tag after the `form` which renders the `submit` value from the component's `state`. You can then type in the form and click the button (or press enter), and you should see your input rendered to the page.
+Finally, create an `h1` tag after the `form` which renders the `submit` value from the component's `state`. You can then type in the form and click the button (or press <kbd>Enter</kbd>), and you should see your input rendered to the page.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/react/5a24c314108439a4d403617e.md
+++ b/curriculum/challenges/english/blocks/react/5a24c314108439a4d403617e.md
@@ -63,7 +63,7 @@ assert(
 );
 ```
 
-Once the component has mounted, pressing `enter` should update its state and the rendered `h1` tag.
+Once the component has mounted, pressing <kbd>Enter</kbd> should update its state and the rendered `h1` tag.
 
 ```js
   const waitForIt = (fn) =>


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Related to #69619. **There is no sub-issue for this PR**, and the changes are confined to the legacy curriculum — see "Scope" below.

### Scope

The semantic keyboard markup sweep is scoped to the V9 certifications (#69719 - #69724). I opened this to give the same treatment to the non-V9 lessons, where the same physical keys are still presented as plain text or inline code.

An earlier version of this description called those "the certifications that are live today." That was wrong, and I've corrected it. Per `superBlockStages` in `packages/shared/src/config/curriculum.ts`, `SuperBlockStage.Core` contains only the `*V9` superblocks, and every superblock touched here is in `SuperBlockStage.Legacy`:

| Superblock | Stage | Lessons touched here |
| :--- | :--- | :--- |
| `2022/responsive-web-design` | Legacy | Cat Photo App, Cafe Menu |
| `javascript-algorithms-and-data-structures-v8` | Legacy | Pyramid Generator, Role Playing Game, Decimal to Binary Converter |
| `javascript-algorithms-and-data-structures` | Legacy | Comparisons with the Logical Or Operator |
| `front-end-development-libraries` | Legacy | React |
| `back-end-development-and-apis` | Legacy | Meet the Node Console |

The V9 certifications use a separate block set (`workshop-cat-photo-app` rather than `learn-html-by-building-a-cat-photo-app`), so none of these twelve files is shared with a live certification. This is a legacy-only consistency change, and I'm happy to close it if cosmetic changes to the legacy curriculum are out of scope.

### Changes

| Certification | Lesson | Before | After |
| :--- | :--- | :--- | :--- |
| Responsive Web Design | Cat Photo App, Step 6 | `space bar` (plain text) | `<kbd>Spacebar</kbd>` |
| Responsive Web Design | Cafe Menu, Step 40 | `backspace key` (plain text) | `<kbd>Backspace</kbd>` key |
| JavaScript Algorithms and Data Structures | Comparisons with the Logical Or Operator | `Backspace and Enter keys` (plain text) | `<kbd>Backspace</kbd>` and `<kbd>Enter</kbd>` keys |
| JavaScript Algorithms and Data Structures | Role Playing Game, Step 3 | `` `F12` ``, `` `Ctrl+Shift+I` ``, `` `Option + ⌘ + C` `` (code) | one `<kbd>` per key, separators outside, `⌘` spelled out as `Cmd` |
| JavaScript Algorithms and Data Structures | Pyramid Generator, Step 43 | `return key` (plain text) | `<kbd>Return</kbd>` key |
| JavaScript Algorithms and Data Structures | Decimal to Binary Converter, Steps 5, 7, 8, 9 | `` `Enter` ``, `` `Return` `` (code) | `<kbd>Enter</kbd>`, `<kbd>Return</kbd>` |
| Front End Development Libraries | Create a Controlled Form | `press enter` (plain text) | press `<kbd>Enter</kbd>` |
| Front End Development Libraries | Add Event Listeners | `` pressing `enter` `` (code) | pressing `<kbd>Enter</kbd>` |
| Back End Development and APIs | Meet the Node Console | `` `Ctrl + C` `` (code) | `<kbd>Ctrl</kbd>` + `<kbd>C</kbd>` |

### Values that intentionally keep their code formatting

- The `"Enter"` string that `e.key` is compared against in the Decimal to Binary Converter, and the `key` property itself. Only the physical keys in the surrounding prose changed.
- The `\n` escape sequence in the Pyramid Generator lesson.
- The shell commands and `package.json` script names in the Node console lesson.

### Testing

- `pnpm lint-challenges` passes (the `challenge-linter` also ran over all 12 files via the pre-commit hook).
- `pnpm run build:curriculum` succeeds, and the generated `curriculum.json` contains real `kbd` elements rather than escaped text.
- Rendered the Role Playing Game, Cat Photo App, and Node console lessons on a local `develop:client` server and confirmed the keys render as `kbd` and stay visually distinct from the surrounding `code` values.
