### PR TITLE
ci: skip the client build in the Node.js test workflow on PRs

### DIFF
--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -131,9 +131,16 @@ jobs:
           sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
 
       - name: Install and Build
+        # No test task depends on the client (Gatsby) build: `turbo test` only
+        # pulls in `setup` and the builds of each package's dependencies, and
+        # nothing depends on @freecodecamp/client. On pull requests it is
+        # skipped here because CI - E2E - Playwright already builds the client.
+        # E2E does not run on push, so those events keep the full build.
+        env:
+          BUILD_FILTER: ${{ github.event_name == 'pull_request' && '--filter=!@freecodecamp/client' || '' }}
         run: |
           pnpm install
-          pnpm run build
+          pnpm turbo build $BUILD_FILTER
 
   test:
     name: Test


### PR DESCRIPTION
## Summary

The `Build` job in `CI - Node.js` runs the full `pnpm run build`, which includes the Gatsby client build. No test task depends on it.

`turbo test` pulls in each package's `setup` task plus the builds of that package's dependencies (`setup` dependsOn `^build`). Nothing in the workspace depends on `@freecodecamp/client`, so `@freecodecamp/client#build` never appears in the test task graph. Verified with `turbo test --dry=json`: the graph contains `@freecodecamp/client#setup` and `@freecodecamp/client#test`, but no `@freecodecamp/client#build`.

This changes the build step to `pnpm turbo build --filter=!@freecodecamp/client`.

### Cost of the client build

From the last `main` run of the workflow (run 30821043077):

```
Install and Build   12m27s
  turbo build       11m09s  (9 tasks, 7 cached; the 2 uncached ones are client#setup and client#build)
  gatsby build      10m53s
```

So the Gatsby build accounts for roughly 11 of the ~12.5 minutes.

### Coverage

The full production client build still runs on every pull request in the `Build Client` job of `CI - E2E - Playwright`, so a change that breaks the Gatsby build is still caught.

One thing worth flagging for reviewers: `CI - Node.js` also runs on pushes to `main`, `prod-**`, `renovate/**`, `hotfix-**`, and `temp-**`, while `CI - E2E - Playwright` only runs on `pull_request` and `workflow_dispatch`. After this change, those push events no longer build the client. Since every change reaching those branches goes through a pull request first, the build is validated before the merge rather than after it. If you would rather keep post-merge validation, I am happy to gate the filter on `github.event_name == 'pull_request'` instead.

### Context

This is point 3 of #68950, split out on its own so it can be reviewed and merged independently.

## Test plan

- [x] `turbo test --dry=json` confirms `@freecodecamp/client#build` is absent from the test graph
- [x] `turbo build --filter=!@freecodecamp/client --dry=json` confirms the client is excluded and all other packages still build
- [x] `prettier --check` passes on the workflow file
- [ ] CI passes on this PR

## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
