### PR TITLE
fix(client): make right-click Paste work in the challenge editor

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -711,6 +711,32 @@ const Editor = (props: EditorProps): JSX.Element => {
         }
       }
     });
+    // Monaco's built-in context menu "Paste" action relies on
+    // document.execCommand('paste'), which most modern browsers silently
+    // block. Overriding it with the same id swaps in the async Clipboard
+    // API, which browsers do allow from a genuine user gesture such as a
+    // context menu click. Ctrl+V is unaffected, since it's handled natively
+    // by the browser rather than through this action.
+    editor.addAction({
+      id: 'editor.action.clipboardPasteAction',
+      label: 'Paste',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 2,
+      run: () => {
+        navigator.clipboard
+          .readText()
+          .then(text => {
+            const selection = editor.getSelection();
+            if (selection) {
+              editor.executeEdits('paste-from-clipboard', [
+                { range: selection, text, forceMoveMarkers: true }
+              ]);
+              editor.pushUndoStop();
+            }
+          })
+          .catch(err => console.error(err));
+      }
+    });
     editor.onDidFocusEditorWidget(() => props.setEditorFocusability(true));
 
     // aria-roledescription is on (true) by default, check if it needs


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69663

## Description

Right-clicking in the challenge code editor and choosing **Paste** from the context menu silently did nothing. `Ctrl+V` worked as a workaround, which pointed to the context-menu action itself being broken rather than clipboard permissions in general.

### Root cause

Monaco's built-in context-menu `Paste` action (`editor.action.clipboardPasteAction`) falls back to `document.execCommand('paste')`. Modern browsers (Chrome, Firefox, Edge) block this call for security reasons, so the command fails silently — the menu item appears and is clickable, but nothing happens. `Ctrl+V` is unaffected because it's handled natively by the browser rather than going through this Monaco action.

### Fix

Override the built-in action (same id, so it replaces rather than duplicates the menu entry) and read from the clipboard with the async Clipboard API (`navigator.clipboard.readText()`), which browsers do permit when triggered by a genuine user gesture such as a context-menu click. The retrieved text replaces the current editor selection via `executeEdits`.

This mirrors the existing `select-all-and-copy` action just above it in the same file, which already works around the equivalent copy-side limitation using `navigator.clipboard.writeText()`.

`Ctrl+V` behavior is untouched, since it never went through this action to begin with.

## Test plan

- [x] Open a challenge with the classic editor.
- [x] Copy text to the OS clipboard.
- [x] Right-click inside the editor and click **Paste** — text is now inserted at the cursor / replaces the selection, instead of doing nothing.
- [x] Confirm `Ctrl+V` still works exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)