### PR TITLE
fix(curriculum): use semantic kbd markup in 'How Does a Browser Render a Page?'

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-performance-in-web-applications/67d2f6e2836565795d789ab7.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-performance-in-web-applications/67d2f6e2836565795d789ab7.md
@@ -7,7 +7,7 @@ dashedName: how-does-a-browser-render-a-page
 
 # --description--
 
-Have you ever wondered what happens behind the scenes when you enter a URL and press enter? How does the browser transform code into the interactive pages we see?
+Have you ever wondered what happens behind the scenes when you enter a URL and press <kbd>Enter</kbd>? How does the browser transform code into the interactive pages we see?
 
 Understanding how a browser renders a web page is essential for developers aiming to optimize performance and enhance user experience.
 


### PR DESCRIPTION
Closes #69720.

## Description

Changed the plain-text 'press enter' reference to use semantic `<kbd>` markup in the **How Does a Browser Render a Page?** lesson (Front End Libraries V9 certification).

### Before
```html
press enter
```

### After
```html
press <kbd>Enter</kbd>
```

The `<kbd>` element is the semantic way to mark up keyboard input, consistent with freeCodeCamp's accessibility guidelines (see #69619).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)