### PR TITLE
fix: use semantic kbd markup in JavaScript V9 lessons

### DIFF
--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/63e9eb5b2328eed3d194b28a.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/63e9eb5b2328eed3d194b28a.md
@@ -9,11 +9,11 @@ dashedName: step-7
 
 If you open your browser's console and type in the number input, you'll see event objects logged to the browser. And if you take a closer look at one of those event objects, you'll see helpful properties like `type` and `target`.
 
-Since you want to perform an action when the `Enter` key is pressed, the most helpful property is `key`, which tells you the string value of the key that was pressed.
+Since you want to perform an action when the <kbd>Enter</kbd> key is pressed, the most helpful property is `key`, which tells you the string value of the key that was pressed.
 
 Remove the `console.log()` statement from the callback function and add an `if` statement that checks if `e.key` is equal to the string `"Enter"`. Leave the body of your `if` statement empty for now.
 
-Note: Since the `Enter` and `Return` keys have similar functions, they both have the same string value of `"Enter"`.
+Note: Since the <kbd>Enter</kbd> and <kbd>Return</kbd> keys have similar functions, they both have the same string value of `"Enter"`.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/64005ab13a78eb062547c12d.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/64005ab13a78eb062547c12d.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-Next, within the body of the `if` statement, call the `checkUserInput()` function. After this, if you enter numbers into the number input and press the `Enter` / `Return` key, you should see numbers logged to the console.
+Next, within the body of the `if` statement, call the `checkUserInput()` function. After this, if you enter numbers into the number input and press the <kbd>Enter</kbd> / <kbd>Return</kbd> key, you should see numbers logged to the console.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/6448d62ce222044458b75931.md
+++ b/curriculum/challenges/english/blocks/learn-recursion-by-building-a-decimal-to-binary-converter/6448d62ce222044458b75931.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Your `Convert` button should be working now. But it could get tiring for users to enter in a number, then click that button each time they want to convert from decimal to binary. It would be much more convenient to perform the conversion when the `Enter` or `Return` key is pressed.
+Your `Convert` button should be working now. But it could get tiring for users to enter in a number, then click that button each time they want to convert from decimal to binary. It would be much more convenient to perform the conversion when the <kbd>Enter</kbd> or <kbd>Return</kbd> key is pressed.
 
 The `keydown` event fires every time a user presses a key on their keyboard, and is a good way to add more interactivity to `input` elements.
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733d3a33abdd27cd562bdf2.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733d3a33abdd27cd562bdf2.md
@@ -9,7 +9,7 @@ dashedName: what-is-the-purpose-of-e-preventdefault
 
 Let's learn about the purpose of the `preventDefault()` method on events.
 
-Every event that triggers in the DOM has some sort of default behavior. The `click` event on a checkbox toggles the state of that checkbox, by default. Pressing the space bar on a focused button activates the button. The `preventDefault()` method on these event objects stops that behavior from happening.
+Every event that triggers in the DOM has some sort of default behavior. The `click` event on a checkbox toggles the state of that checkbox, by default. Pressing the <kbd>space bar</kbd> on a focused button activates the button. The `preventDefault()` method on these event objects stops that behavior from happening.
 
 Let's take a look at an example. Let's define an `input` element for a user to type in:
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733d3ab69e94b7df7ee91b0.md
@@ -11,7 +11,7 @@ Let's learn about how the `submit` event works with HTML forms. First, we need t
 
 The first is when the user clicks a button in the form which has the `type` attribute set to `submit`.
 
-The second is when the user presses the Enter key on any editable input field in the form.
+The second is when the user presses the <kbd>Enter</kbd> key on any  in the form.
 
 The third is through a JavaScript call to the `requestSubmit()` or `submit()` methods of the form element.
 
@@ -88,7 +88,7 @@ The lesson mentions three specific ways to submit a form.
 
 ---
 
-Pressing Enter on an editable input field.
+Pressing <kbd>Enter</kbd> on an editable input field.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/lecture-understanding-the-event-object-and-event-delegation/6732a06aed1b095f57b0bb82.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-the-event-object-and-event-delegation/6732a06aed1b095f57b0bb82.md
@@ -17,7 +17,7 @@ The `change` event is a special event which is fired when the user modifies the 
 
 - When an input loses focus (the user tabs to the next field, or clicks out of the form) after the user has changed the value.
 
-- When the user otherwise confirms the value, such as by hitting enter after typing some text.
+- When the user otherwise confirms the value, such as by hitting <kbd>Enter</kbd> after typing some text.
 
 Note that the `change` event does NOT fire when your user types in an input. The `change` event will only fire after they have focused on another element.
 
@@ -79,7 +79,7 @@ When the input loses focus after its value has been modified.
 
 ---
 
-Only when the user presses the `Enter` key.
+Only when the user presses the <kbd>Enter</kbd> key.
 
 ### --feedback--
 

--- a/curriculum/challenges/english/blocks/quiz-form-validation-with-javascript/66edd3403d7077eece6dc4b6.md
+++ b/curriculum/challenges/english/blocks/quiz-form-validation-with-javascript/66edd3403d7077eece6dc4b6.md
@@ -363,7 +363,7 @@ When the form's action is cleared.
 
 #### --answer--
 
-When a form's submit button is clicked or Enter is pressed.
+When a form's submit button is clicked or <kbd>Enter</kbd> is pressed.
 
 ### --question--
 

--- a/curriculum/challenges/english/blocks/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
+++ b/curriculum/challenges/english/blocks/review-form-validation-with-javascript/6723ce555ff2dfc0cc04b69a.md
@@ -101,7 +101,7 @@ dashedName: review-form-validation-with-javascript
 
 ## `preventDefault()` Method
 
-- **Definition**: Every event that triggers in the DOM has some sort of default behavior. The click event on a checkbox toggles the state of that checkbox, by default. Pressing the space bar on a focused button activates the button. The `preventDefault()` method on these `Event` objects stops that behavior from happening.
+- **Definition**: Every event that triggers in the DOM has some sort of default behavior. The click event on a checkbox toggles the state of that checkbox, by default. Pressing the <kbd>space bar</kbd> on a focused button activates the button. The `preventDefault()` method on these `Event` objects stops that behavior from happening.
 
 :::interactive_editor
 
@@ -128,7 +128,7 @@ dashedName: review-form-validation-with-javascript
 
 ## Submitting Forms
 
-- **Definition**: There are three ways a form can be submitted. The first is when the user clicks a button in the form which has the `type` attribute set to `submit`. The second is when the user presses the `Enter` key on any editable `input` field in the form. The third is through a JavaScript call to the `requestSubmit()` or `submit()` methods of the `form` element.
+- **Definition**: There are three ways a form can be submitted. The first is when the user clicks a button in the form which has the `type` attribute set to `submit`. The second is when the user presses the  key on any editable `input` field in the form. The third is through a JavaScript call to the `requestSubmit()` or `submit()` methods of the `form` element.
 - **`action` Attribute**: The `action` attribute should contain either a URL or a relative path for the current domain. This value determines where the form attempts to send data - if you do not set an `action` attribute, the form will send data to the current page's URL. 
 
 ```html

--- a/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
+++ b/curriculum/challenges/english/blocks/review-javascript/6723d3cfdd0717d3f1bf27e3.md
@@ -3027,7 +3027,7 @@ console.log("freecoooooooodecamp".replace(regex, "paid$1world"));
 
 ## `preventDefault()` Method
 
-- **Definition**: Every event that triggers in the DOM has some sort of default behavior. The click event on a checkbox toggles the state of that checkbox, by default. Pressing the space bar on a focused button activates the button. The `preventDefault()` method on these `Event` objects stops that behavior from happening.
+- **Definition**: Every event that triggers in the DOM has some sort of default behavior. The click event on a checkbox toggles the state of that checkbox, by default. Pressing the <kbd>space bar</kbd> on a focused button activates the button. The `preventDefault()` method on these `Event` objects stops that behavior from happening.
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/63e9eb5b2328eed3d194b28a.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/63e9eb5b2328eed3d194b28a.md
@@ -9,7 +9,7 @@ dashedName: step-7
 
 If you open your browser's console and type in the number input, you'll see event objects logged to the browser. And if you take a closer look at one of those event objects, you'll see helpful properties like `type` and `target`.
 
-Since you want to perform an action when the `Enter` key is pressed, the most helpful property is `key`, which tells you the string value of the key that was pressed.
+Since you want to perform an action when the <kbd>Enter</kbd> key is pressed, the most helpful property is `key`, which tells you the string value of the key that was pressed.
 
 Remove the `console.log()` statement from the callback function and add an `if` statement that checks if `e.key` is equal to the string `"Enter"`. Leave the body of your `if` statement empty for now.
 

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64005ab13a78eb062547c12d.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/64005ab13a78eb062547c12d.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-Next, within the body of the `if` statement, call the `checkUserInput()` function. After this, if you enter numbers into the number input and press the `Enter` / `Return` key, you should see numbers logged to the console.
+Next, within the body of the `if` statement, call the `checkUserInput()` function. After this, if you enter numbers into the number input and press the <kbd>Enter</kbd> / <kbd>Return</kbd> key, you should see numbers logged to the console.
 
 # --hints--
 

--- a/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6448d62ce222044458b75931.md
+++ b/curriculum/challenges/english/blocks/workshop-decimal-to-binary-converter/6448d62ce222044458b75931.md
@@ -7,7 +7,7 @@ dashedName: step-5
 
 # --description--
 
-Your `Convert` button should be working now. But it could get tiring for users to enter in a number, then click that button each time they want to convert from decimal to binary. It would be much more convenient to perform the conversion when the `Enter` or `Return` key is pressed.
+Your `Convert` button should be working now. But it could get tiring for users to enter in a number, then click that button each time they want to convert from decimal to binary. It would be much more convenient to perform the conversion when the <kbd>Enter</kbd> or <kbd>Return</kbd> key is pressed.
 
 The `keydown` event fires every time a user presses a key on their keyboard, and is a good way to add more interactivity to `input` elements.
 

--- a/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e3.md
+++ b/curriculum/challenges/english/blocks/workshop-todo-app/64fb29348a60361ccd45c1e3.md
@@ -9,8 +9,8 @@ dashedName: step-53
 
 To view what's stored in `localStorage`, open the browser's developer tools and navigate to the local storage section:
 
-- **Chrome/Edge:** Open DevTools (F12), navigate to `Application` > `Storage` and expand `Local Storage`. Click a domain to view its key-value pairs.
-- **Firefox:** Open DevTools (F12), navigate to `Storage` and expand `Local Storage`. Click a domain to view its key-value pairs.
+- **Chrome/Edge:** Open DevTools (<kbd>F12</kbd>), navigate to `Application` > `Storage` and expand `Local Storage`. Click a domain to view its key-value pairs.
+- **Firefox:** Open DevTools (<kbd>F12</kbd>), navigate to `Storage` and expand `Local Storage`. Click a domain to view its key-value pairs.
 - **Safari:** Choose `Safari` > `Settings`, and click `Advanced`. At the bottom of the pane, select the `Show Develop menu in menu bar` checkbox. Once the developer tools are enabled, right-click on the page within browser, select `Inspect element`, go to the `Storage` tab, then select `Local Storage`. Click a domain to view its key-value pairs.
 
 The data stored with the key `data` should be visible. Examine it and note what the values look like.


### PR DESCRIPTION
## Description
This PR updates several JavaScript V9 curriculum files and quizzes to use semantic `<kbd>` markup instead of plain text or code backticks for physical keyboard keys (such as `Enter`, `Return`, `space bar`, and `F12`), improving accessibility and consistency across lessons.

## Changes Made
- Updated physical keyboard key references in:
  - Submit event lesson
  - preventDefault() lesson
  - Form Validation with JavaScript Review & Quiz
  - Change event lesson
  - Decimal to Binary Converter workshop 
  - Todo App workshop 
