### PR TITLE
ci: reuse client build for e2e tests

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,116 +1,14 @@
 name: CI - E2E - Playwright
 on:
-  workflow_dispatch:
-  # workflow_run:
-  #   workflows: ['CI - Node.js']
-  #   types:
-  #     - completed
-  # TODO: refactor with a workflow_call
-  pull_request:
-    branches:
-      - 'main'
-      - 'temp-**' # Temporary branches allowed on Upstream
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main') && !contains(github.ref, 'prod-') }}
+  workflow_call:
 
 permissions:
   contents: read
 
 jobs:
-  build-client:
-    name: Build Client
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        node-version: [24]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          persist-credentials: false
-          submodules: 'recursive'
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Setup Turbo Cache
-        uses: ./.github/actions/setup-turbo-cache
-        with:
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
-          turbo-signature-key: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-
-      - name: Checkout client-config
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          repository: freeCodeCamp/client-config
-          path: client-config
-          persist-credentials: false
-
-      - name: Set freeCodeCamp Environment Variables
-        run: |
-          sed '/^[[:space:]]*#/d; /^$/d' sample.env >> $GITHUB_ENV
-
-      - name: Install and Build
-        run: |
-          pnpm install
-          pnpm run build
-
-      - name: Move serve.json to Public Folder
-        run: cp client-config/serve.json client/public/serve.json
-
-      - name: Upload Client Artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: client-artifact
-          path: client/public
-
-      - name: Upload Webpack Stats
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: webpack-stats
-          path: client/public/stats.json
-
-  build-api:
-    name: Build API (Container)
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout Source Files
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          persist-credentials: false
-          submodules: 'recursive'
-
-      - name: Create Image
-        run: |
-          docker build \
-            -t fcc-api \
-            -f docker/api/Dockerfile .
-
-      - name: Save Image
-        run: docker save fcc-api > api-artifact.tar
-
-      - name: Upload API Artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: api-artifact
-          path: api-artifact.tar
-
   playwright-run:
     name: Run Playwright Tests
     runs-on: ubuntu-24.04
-    needs: [build-client, build-api]
     strategy:
       fail-fast: false
       matrix:
@@ -133,6 +31,16 @@ jobs:
         with:
           name: client-artifact
           path: client/public
+
+      - name: Checkout client-config
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: freeCodeCamp/client-config
+          path: client-config
+          persist-credentials: false
+
+      - name: Move serve.json to Public Folder
+        run: cp client-config/serve.json client/public/serve.json
 
       - name: Download Api Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -93,10 +93,8 @@ jobs:
           pnpm lint
 
   # DONT REMOVE THIS JOB.
-  # TODO: Refactor and use re-usable workflow and shared artifacts
   build:
     name: Build
-    needs: lint
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -134,6 +132,49 @@ jobs:
         run: |
           pnpm install
           pnpm run build
+
+      - name: Upload Client Artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: client-artifact
+          path: client/public
+          retention-days: 1
+
+  build-e2e-api:
+    name: Build E2E API (Container)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          submodules: 'recursive'
+
+      - name: Create Image
+        run: |
+          docker build \
+            -t fcc-api \
+            -f docker/api/Dockerfile .
+
+      - name: Save Image
+        run: docker save fcc-api > api-artifact.tar
+
+      - name: Upload API Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: api-artifact
+          path: api-artifact.tar
+          retention-days: 1
+
+  e2e:
+    name: E2E
+    if: github.event_name == 'pull_request'
+    needs: [build, build-e2e-api]
+    uses: ./.github/workflows/e2e-playwright.yml
+    secrets: inherit
 
   test:
     name: Test


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Closes #XXXXX -->

<!-- Feel free to add any additional description of changes below this line -->

## Summary

- upload the full `client/public` artifact from the existing Node.js build job
- build the E2E API image alongside the client build
- call the Playwright workflow as a reusable workflow after both artifacts are ready
- remove the duplicate E2E client build and webpack stats upload
- retain build artifacts for one day

The Node build no longer waits for lint. This preserves the existing CI critical path: lint, the normal full build, and the E2E API image build run concurrently, just as the separate Node and E2E workflows did previously.

This replaces and closes #69717. It uses the normal client artifact rather than maintaining a selective E2E-only build.

## Testing

- Prettier check for both workflow files
- YAML parsing with `js-yaml`
- `actionlint` v1.7.12 for both workflow files