### PR TITLE
fix(curriculum): disambiguate CSS grid quiz answers

### DIFF
--- a/curriculum/challenges/english/blocks/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
+++ b/curriculum/challenges/english/blocks/quiz-css-grid/66ed8fedf45ce3ece4053eb3.md
@@ -773,11 +773,11 @@ How would you create a grid with 3 equal columns and a `20px` gap between them?
 
 #### --text--
 
-What does `repeat(3, minmax(100px, 1fr))` create?
+What does `grid-template-columns: repeat(3, minmax(100px, 1fr))` create?
 
 #### --distractors--
 
-Three columns that can't shrink below `100px`.
+Three columns that can't grow beyond `100px`.
 
 ---
 
@@ -901,7 +901,7 @@ Offsets it by 2 pixels.
 
 ---
 
-Positions it starting at the second vertical grid line.
+Positions it starting at the second row line.
 
 #### --answer--
 


### PR DESCRIPTION
## 🧢 Changes

- Adds `grid-template-columns` to the `repeat()` question so its track direction is explicit.
- Replaces two distractors that duplicated correct behavior.

## ☕️ Reasoning

The two questions each had more than one technically correct choice. Making the property context explicit and changing the duplicate distractors leaves one correct answer per question without changing the concepts being tested.

## 🎫 Affected issues

Fixes: #69456

## 🧪 Validation

- `CURRICULUM_LOCALE=english FCC_CHALLENGE_ID=66ed8fedf45ce3ece4053eb3 pnpm test-curriculum-content` (3 tests passed)
- `CURRICULUM_LOCALE=english pnpm test-curriculum-content` (56,005 tests passed)

## ⚠️ Risk

Low. The change only updates quiz wording and does not affect application code.