### PR TITLE
perf(client): externalize global stylesheet

### DIFF
--- a/client/gatsby-ssr.tsx
+++ b/client/gatsby-ssr.tsx
@@ -15,6 +15,7 @@ import {
   getPreBodyThemeScript
 } from './utils/tags';
 import GrowthBookProvider from './src/components/growth-book/growth-book-wrapper';
+import { externalizeGlobalCss } from './utils/gatsby/externalize-global-css';
 
 const store = createStore();
 
@@ -50,7 +51,7 @@ export const onPreRenderHTML: GatsbySSR['onPreRenderHTML'] = ({
   const isBootstrapScript = (key: React.Key | null) =>
     key === 'bootstrap-min-preload' || key === 'bootstrap-min';
 
-  const headComponents = getHeadComponents();
+  const headComponents = externalizeGlobalCss(getHeadComponents());
   headComponents.sort((x, y) => {
     const xKey = React.isValidElement(x) ? x.key : null;
     const yKey = React.isValidElement(y) ? y.key : null;

--- a/client/utils/gatsby/externalize-global-css.test.tsx
+++ b/client/utils/gatsby/externalize-global-css.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { describe, expect, test } from 'vitest';
+
+import { externalizeGlobalCss } from './externalize-global-css';
+
+describe('externalizeGlobalCss', () => {
+  test('replaces Gatsby global styles with a stylesheet link', () => {
+    const globalStyle = (
+      <style
+        data-href='/styles.css'
+        data-identity='gatsby-global-css'
+        dangerouslySetInnerHTML={{ __html: '.foo { color: red; }' }}
+        key='global-css'
+      />
+    );
+    const meta = <meta content='freeCodeCamp' key='description' />;
+
+    const [stylesheet, unchangedMeta] = externalizeGlobalCss([
+      globalStyle,
+      meta
+    ]);
+
+    expect(stylesheet).toMatchObject({
+      key: 'global-css',
+      props: {
+        href: '/styles.css',
+        rel: 'stylesheet'
+      },
+      type: 'link'
+    });
+    expect(unchangedMeta).toBe(meta);
+  });
+
+  test('does not replace unrelated style elements', () => {
+    const style = <style data-href='/styles.css' key='other-css' />;
+
+    const [unchangedStyle] = externalizeGlobalCss([style]);
+
+    expect(unchangedStyle).toBe(style);
+  });
+});

--- a/client/utils/gatsby/externalize-global-css.tsx
+++ b/client/utils/gatsby/externalize-global-css.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface GatsbyGlobalStyleProps {
+  'data-href'?: unknown;
+  'data-identity'?: unknown;
+}
+
+export const externalizeGlobalCss = (
+  headComponents: React.ReactNode[]
+): React.ReactNode[] =>
+  headComponents.map(component => {
+    if (!React.isValidElement<GatsbyGlobalStyleProps>(component)) {
+      return component;
+    }
+
+    const href = component.props['data-href'];
+    const identity = component.props['data-identity'];
+
+    if (identity !== 'gatsby-global-css' || typeof href !== 'string') {
+      return component;
+    }
+
+    // Gatsby inlines the complete global stylesheet into every generated page.
+    // Linking it avoids duplicating the same CSS across thousands of pages.
+    return <link href={href} key={component.key} rel='stylesheet' />;
+  });


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

## Summary

This reduces the amount of duplicated data generated and cached by the Gatsby client build:

- Replaces Gatsby's inline global stylesheet with a link to the generated stylesheet.
- Filters superblock introduction page queries to the current superblock instead of serializing every curriculum challenge and structure on every page.
- Applies the same superblock filtering to downloadable exam pages.
- Limits CI webpack stats to the fields consumed by `webpack-bundle-analyzer`.

No curriculum pages or challenges are removed. The generated client has the same functionality, but its HTML, page data, webpack stats, and Turbo cache archive are smaller.

## Why

The complete approximately 493 KB global stylesheet was embedded in each of 19,228 generated HTML pages. Superblock introduction pages also contained approximately 8 MB of curriculum data each, while downloadable exam pages contained approximately 4.18 MB each, because their queries returned challenges from every superblock.

Besides increasing browser downloads, this duplicated output increased Gatsby rendering, artifact upload, and cache finalization time. The Turbo client archive also exceeded the remote cache's 100 MB request limit and returned `413 Payload Too Large`.

The external stylesheet adds one render-blocking CSS request on the first page load. Unlike the inline copy, the browser can cache and reuse it across pages.

## Local results

| Measurement | Before | After |
| --- | ---: | ---: |
| Full Gatsby build | 158.8 s | 81.1 s |
| Average challenge HTML | approximately 500 KB | 8.2 KB |
| Generated `page-data.json` for `/learn/javascript-algorithms-and-data-structures-v8/` | 8.0 MB | 594 KB |
| Generated `page-data.json` for a Responsive Web Design downloadable exam | 4.18 MB | 319 KB |
| Total Gatsby page data | approximately 1.1 GB | 276 MB |
| CI webpack stats | 576 MB | 31 MB |
| Turbo client cache archive | approximately 150 MB | 93.9 MB |

The final Turbo archive is below the current remote-cache upload limit. A subsequent local build restored all eight Turbo tasks from cache in 397 ms.

## Testing

- Added focused unit coverage for externalizing Gatsby global styles while preserving unrelated styles.
- Ran the affected superblock and downloadable-exam suites: 33 tests passed.
- Ran the full client suite during development: 1,100 tests passed.
- Ran client formatting, linting, and type-checking.
- Completed a CI-mode full build of all 19,228 pages after the final changes.
- Generated a webpack-bundle-analyzer report from the minimized stats file; it contained 178 JavaScript assets.
- Served and visually verified a generated challenge page in Chromium, including a successful stylesheet response.
