### PR TITLE
feat(client): center trending guides menu in footer at 500px width or less

### DIFF
--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -18,6 +18,9 @@
   .footer-top {
     grid-template-columns: repeat(auto-fit, minmax(19em, 1fr));
   }
+  .trending-guides-articles {
+    text-align: center;
+  }
 }
 
 .footer-top,


### PR DESCRIPTION
## Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69767

<!-- Feel free to add any additional description of changes below this line -->

## Description

Centers the Trending Guides menu items in the footer when the viewport width is 500px or less.

This improves the footer layout and makes the Trending Guides menu more suitable for smaller screens.

## Testing

- Tested locally.
- Verified that the Trending Guides menu items are centered at 500px width and below.
- Verified that the footer layout remains unchanged above 500px.