### PR TITLE
fix(client): update JSON module imports

### DIFF
--- a/client/src/client-only-routes/show-daily-coding-challenge.tsx
+++ b/client/src/client-only-routes/show-daily-coding-challenge.tsx
@@ -8,7 +8,7 @@ import {
   DailyCodingChallengePageContext
 } from '../redux/prop-types';
 import DailyCodingChallengeNotFound from '../components/daily-coding-challenge/not-found';
-import { apiLocation } from '../../config/env.json';
+import envData from '../../config/env.json';
 import {
   isValidDateOrMonthDayString,
   toMonthDay
@@ -17,6 +17,8 @@ import {
   validateDailyCodingChallengeSchema,
   type DailyCodingChallengeFromDb
 } from '../utils/daily-coding-challenge-validator';
+
+const { apiLocation } = envData;
 
 interface DailyCodingChallengeLanguageData {
   data: {

--- a/client/src/components/Header/components/language-list.tsx
+++ b/client/src/components/Header/components/language-list.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import type { TFunction } from 'i18next';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import { clientLocale } from '../../../../config/env.json';
+import envData from '../../../../config/env.json';
 import {
   availableLangs,
   LangNames,
@@ -12,6 +12,8 @@ import {
 import { hardGoTo as navigate } from '../../../redux/actions';
 import createLanguageRedirect from '../../create-language-redirect';
 import LanguageGlobe from '../../../assets/icons/language-globe';
+
+const { clientLocale } = envData;
 
 const locales = availableLangs.client.filter(
   lang => !hiddenLangs.includes(lang)

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -8,12 +8,14 @@ import React from 'react';
 import { useTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { radioLocation } from '../../../../config/env.json';
+import envData from '../../../../config/env.json';
 import { openSignoutModal, toggleTheme } from '../../../redux/actions';
 import { Link } from '../../helpers';
 import { LocalStorageThemes } from '../../../redux/types';
 import { themeSelector } from '../../../redux/selectors';
 import SupporterBadge from '../../../assets/icons/supporter-badge';
+
+const { radioLocation } = envData;
 
 export interface NavLinksProps {
   displayMenu: boolean;

--- a/client/src/components/Map/index.test.tsx
+++ b/client/src/components/Map/index.test.tsx
@@ -11,9 +11,11 @@ import { describe, expect, it, vi } from 'vitest';
 import introTranslations from '../../../i18n/locales/english/intro.json';
 import i18nTestConfig from '../../../i18n/config-for-tests';
 import translations from '../../../i18n/locales/english/translations.json';
-import { showUpcomingChanges } from '../../../config/env.json';
+import envData from '../../../config/env.json';
 import { getMonthDayUsCentral } from '../daily-coding-challenge/helpers';
 import Map from './index';
+
+const { showUpcomingChanges } = envData;
 
 vi.unmock('react-i18next');
 

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -13,10 +13,13 @@ import {
 import { SuperBlockIcon } from '../../assets/superblock-icon';
 import LinkButton from '../../assets/icons/link-button';
 import { ButtonLink, Link } from '../helpers';
-import { showUpcomingChanges } from '../../../config/env.json';
+import envData from '../../../config/env.json';
 import DailyCodingChallengeWidget from '../daily-coding-challenge/widget';
 
 import './map.css';
+
+const { showUpcomingChanges } = envData;
+
 interface MapProps {
   forLanding?: boolean;
 }

--- a/client/src/components/email-options.tsx
+++ b/client/src/components/email-options.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Col, Row, Button, Spacer } from '@freecodecamp/ui';
-import { apiLocation } from '../../config/env.json';
+import envData from '../../config/env.json';
+
+const { apiLocation } = envData;
 
 interface EmailListOptInProps {
   isSignedIn: boolean;

--- a/client/src/components/landing/components/landing-top.tsx
+++ b/client/src/components/landing/components/landing-top.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useFeature } from '@growthbook/growthbook-react';
 import { Container, Col, Row, Spacer } from '@freecodecamp/ui';
-import { clientLocale } from '../../../../config/env.json';
+import envData from '../../../../config/env.json';
 import {
   AmazonLogo,
   AppleLogo,
@@ -15,6 +15,8 @@ import {
 import BigCallToAction from './big-call-to-action';
 import TwoButtonCTA from './two-button-cta';
 import CampersImage from './campers-image';
+
+const { clientLocale } = envData;
 
 function LandingTop(): JSX.Element {
   const { t } = useTranslation();

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 import { Spacer } from '@freecodecamp/ui';
-import envData, { clientLocale } from '../../../config/env.json';
+import envData from '../../../config/env.json';
 
 import latoBoldURL from '../../../static/fonts/lato/Lato-Bold.woff';
 import latoLightURL from '../../../static/fonts/lato/Lato-Light.woff';
@@ -60,6 +60,8 @@ import './variables.css';
 import './rtl-layout.css';
 import { LocalStorageThemes } from '../../redux/types';
 import DailyChallengeBreadCrumb from '../../templates/Challenges/components/daily-challenge-bread-crumb';
+
+const { clientLocale } = envData;
 
 const mapStateToProps = createSelector(
   isSignedInSelector,

--- a/client/src/components/search/with-instant-search.tsx
+++ b/client/src/components/search/with-instant-search.tsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { useMediaQuery } from 'react-responsive';
 import { createSelector } from 'reselect';
 import { Configure, InstantSearch } from 'react-instantsearch';
-import { algoliaAppId, algoliaAPIKey } from '../../../config/env.json';
+import envData from '../../../config/env.json';
 import { newsIndex } from '../../utils/algolia-locale-setup';
 
 import {
@@ -17,6 +17,8 @@ import {
   toggleSearchDropdown,
   updateSearchQuery
 } from './redux';
+
+const { algoliaAppId, algoliaAPIKey } = envData;
 
 const mockSearchClient = {
   // When Algolia is not configured, the client will still render,

--- a/client/src/components/settings/account.tsx
+++ b/client/src/components/settings/account.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeature } from '@growthbook/growthbook-react';
-import { clientLocale } from '../../../config/env.json';
+import envData from '../../../config/env.json';
 import { Button, Spacer } from '@freecodecamp/ui';
 import { FullWidthRow } from '../helpers';
 
@@ -10,6 +10,8 @@ import KeyboardShortcutsSettings from './keyboard-shortcuts';
 import ScrollbarWidthSettings from './scrollbar-width';
 import SectionHeader from './section-header';
 import SocratesSettings from './socrates';
+
+const { clientLocale } = envData;
 
 type MiscSettingsProps = {
   keyboardShortcuts: boolean;

--- a/client/src/components/signout-modal/index.tsx
+++ b/client/src/components/signout-modal/index.tsx
@@ -7,9 +7,11 @@ import { Button, Modal, Spacer } from '@freecodecamp/ui';
 
 import { closeSignoutModal } from '../../redux/actions';
 import { isSignoutModalOpenSelector } from '../../redux/selectors';
-import { apiLocation } from '../../../config/env.json';
+import envData from '../../../config/env.json';
 import callGA from '../../analytics/call-ga';
 import { pathAfterSignout } from './path-after-signout';
+
+const { apiLocation } = envData;
 
 const mapStateToProps = createSelector(
   isSignoutModalOpenSelector,

--- a/client/src/html.tsx
+++ b/client/src/html.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { clientLocale } from '../config/env.json';
+import envData from '../config/env.json';
 import { rtlLangs } from '@freecodecamp/shared/config/i18n';
+
+const { clientLocale } = envData;
 
 interface HTMLProps {
   body: string;

--- a/client/src/templates/Challenges/components/independent-lower-jaw.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.tsx
@@ -41,7 +41,7 @@ import './independent-lower-jaw.css';
 import Socrates from '../../../assets/icons/socrates';
 import OutlineLightbulb from '../../../assets/icons/outline-lightbulb';
 
-const { apiLocation } = envData;
+const { apiLocation, clientLocale } = envData;
 
 const SOCRATES_DISCOVERED_KEY = 'fcc-socrates-discovered';
 
@@ -168,7 +168,7 @@ export function IndependentLowerJaw({
 }: IndependentLowerJawProps): JSX.Element {
   const { t } = useTranslation();
   const showSocratesFlag =
-    useFeature('show-socrates').on && envData.clientLocale === 'english';
+    useFeature('show-socrates').on && clientLocale === 'english';
   const submitChallenge = useSubmit();
   const firstFailedTest = tests.find(test => !!test.err);
   const hint = firstFailedTest?.message;

--- a/client/src/templates/Challenges/components/independent-lower-jaw.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.tsx
@@ -41,8 +41,6 @@ import './independent-lower-jaw.css';
 import Socrates from '../../../assets/icons/socrates';
 import OutlineLightbulb from '../../../assets/icons/outline-lightbulb';
 
-const { apiLocation, clientLocale } = envData;
-
 const SOCRATES_DISCOVERED_KEY = 'fcc-socrates-discovered';
 
 type SocratesHintState = {
@@ -167,6 +165,7 @@ export function IndependentLowerJaw({
   hasSocratesAccess
 }: IndependentLowerJawProps): JSX.Element {
   const { t } = useTranslation();
+  const { apiLocation, clientLocale } = envData;
   const showSocratesFlag =
     useFeature('show-socrates').on && clientLocale === 'english';
   const submitChallenge = useSubmit();

--- a/client/src/templates/Challenges/components/independent-lower-jaw.tsx
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.tsx
@@ -29,7 +29,7 @@ import {
   currentBlockIdsSelector,
   socratesHintStateSelector
 } from '../redux/selectors';
-import { apiLocation, clientLocale } from '../../../../config/env.json';
+import envData from '../../../../config/env.json';
 import { openModal, executeChallenge, askSocrates } from '../redux/actions';
 import { saveChallenge } from '../../../redux/actions';
 import Help from '../../../assets/icons/help';
@@ -40,6 +40,8 @@ import { useSubmit } from '../utils/fetch-all-curriculum-data';
 import './independent-lower-jaw.css';
 import Socrates from '../../../assets/icons/socrates';
 import OutlineLightbulb from '../../../assets/icons/outline-lightbulb';
+
+const { apiLocation } = envData;
 
 const SOCRATES_DISCOVERED_KEY = 'fcc-socrates-discovered';
 
@@ -166,7 +168,7 @@ export function IndependentLowerJaw({
 }: IndependentLowerJawProps): JSX.Element {
   const { t } = useTranslation();
   const showSocratesFlag =
-    useFeature('show-socrates').on && clientLocale === 'english';
+    useFeature('show-socrates').on && envData.clientLocale === 'english';
   const submitChallenge = useSubmit();
   const firstFailedTest = tests.find(test => !!test.err);
   const hint = firstFailedTest?.message;

--- a/client/src/templates/Challenges/utils/python-worker-handler.ts
+++ b/client/src/templates/Challenges/utils/python-worker-handler.ts
@@ -1,7 +1,7 @@
-import { version } from '@freecodecamp/browser-scripts/package.json';
+import browserScripts from '@freecodecamp/browser-scripts/package.json';
 
 // TODO: This might be cleaner as a class.
-const pythonWorkerSrc = `/js/workers/${version}/python-worker.js`;
+const pythonWorkerSrc = `/js/workers/${browserScripts.version}/python-worker.js`;
 
 let worker: Worker | null = null;
 let listener: ((event: MessageEvent) => void) | null = null;

--- a/client/tools/generate-search-placeholder.test.ts
+++ b/client/tools/generate-search-placeholder.test.ts
@@ -1,11 +1,13 @@
 import { describe, test, expect } from 'vitest';
 
-import { clientLocale } from '../config/env.json';
+import envData from '../config/env.json';
 import {
   convertToLocalizedString,
   generateSearchPlaceholder,
   roundDownToNearestHundred
 } from './generate-search-placeholder';
+
+const { clientLocale } = envData;
 
 describe('Search bar placeholder tests:', () => {
   describe('Number rounding', () => {

--- a/client/tools/generate-search-placeholder.ts
+++ b/client/tools/generate-search-placeholder.ts
@@ -4,14 +4,11 @@ import algoliasearch from 'algoliasearch';
 import i18n from 'i18next';
 import backend from 'i18next-fs-backend';
 
-import {
-  algoliaAppId,
-  algoliaAPIKey,
-  clientLocale,
-  environment
-} from '../config/env.json';
+import envData from '../config/env.json';
 import { newsIndex } from '../src/utils/algolia-locale-setup';
 import { i18nextCodes } from '@freecodecamp/shared/config/i18n';
+
+const { algoliaAppId, algoliaAPIKey, clientLocale, environment } = envData;
 
 const i18nextCode = i18nextCodes[clientLocale as keyof typeof i18nextCodes];
 

--- a/packages/challenge-builder/src/transformers.js
+++ b/packages/challenge-builder/src/transformers.js
@@ -13,7 +13,7 @@ import {
   transformContents,
   createSource
 } from '@freecodecamp/shared/utils/polyvinyl';
-import { version } from '@freecodecamp/browser-scripts/package.json';
+import browserScripts from '@freecodecamp/browser-scripts/package.json';
 
 import { WorkerExecutor } from './worker-executor';
 import { compileTypeScriptCode } from './typescript-worker-handler';
@@ -199,7 +199,7 @@ function getBabelOptions(
 }
 
 const sassWorkerExecutor = new WorkerExecutor(
-  `workers/${version}/sass-compile`
+  `workers/${browserScripts.version}/sass-compile`
 );
 async function transformSASS(documentElement) {
   // we only teach scss syntax, not sass. Also the compiler does not seem to be

--- a/tools/client-plugins/browser-scripts/copy-scripts.ts
+++ b/tools/client-plugins/browser-scripts/copy-scripts.ts
@@ -1,8 +1,8 @@
 import { cpSync, mkdirSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { version as workerVersion } from '@freecodecamp/browser-scripts/package.json';
-import { version as helperVersion } from '@freecodecamp/curriculum-helpers/package.json';
+import browserScripts from '@freecodecamp/browser-scripts/package.json';
+import curriculumHelpers from '@freecodecamp/curriculum-helpers/package.json';
 
 const __dirname = import.meta.dirname;
 
@@ -15,13 +15,13 @@ mkdirSync(destJsDir, { recursive: true });
 
 cpSync(
   resolve(__dirname, './node_modules/sass.js/dist/sass.sync.js'),
-  resolve(destJsDir, 'workers', workerVersion, 'sass.sync.js')
+  resolve(destJsDir, 'workers', browserScripts.version, 'sass.sync.js')
 );
 cpSync(
   resolve(
     __dirname,
     './node_modules/@freecodecamp/curriculum-helpers/dist/test-runner'
   ),
-  resolve(destJsDir, `test-runner/${helperVersion}/`),
+  resolve(destJsDir, `test-runner/${curriculumHelpers.version}/`),
   { recursive: true }
 );

--- a/tools/client-plugins/browser-scripts/sass-compile.ts
+++ b/tools/client-plugins/browser-scripts/sass-compile.ts
@@ -1,4 +1,4 @@
-import { version } from '@freecodecamp/browser-scripts/package.json';
+import browserScripts from '@freecodecamp/browser-scripts/package.json';
 // work around for SASS error in Edge
 // https://github.com/medialize/sass.js/issues/96#issuecomment-424386171
 interface WorkerWithSass extends Worker {
@@ -21,7 +21,7 @@ if (!ctx.crypto) {
   };
 }
 
-ctx.importScripts(`/js/workers/${version}/sass.sync.js`);
+ctx.importScripts(`/js/workers/${browserScripts.version}/sass.sync.js`);
 
 ctx.onmessage = e => {
   const data: unknown = e.data;

--- a/tools/client-plugins/browser-scripts/test-runner.ts
+++ b/tools/client-plugins/browser-scripts/test-runner.ts
@@ -1,3 +1,5 @@
+import curriculumHelpers from '@freecodecamp/curriculum-helpers/package.json';
+
 export type { FCCTestRunner } from '@freecodecamp/curriculum-helpers/test-runner.js';
 
-export { version } from '@freecodecamp/curriculum-helpers/package.json';
+export const version = curriculumHelpers.version;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

## Problem

Webpack emits warnings when the client imports properties directly from JSON modules, for example:

```text
Should not import the named export 'apiLocation' (imported as 'apiLocation') from default-exporting module (only default export is available soon)
```

The same warning appears for client environment values such as `clientLocale`, `radioLocation`, and the Algolia configuration, as well as package `version` imports used by the challenge builder and browser worker tooling.

## Summary

This replaces named imports and re-exports from JSON modules with default imports followed by property access or destructuring.

It updates client environment configuration imports and package-version imports used by the challenge builder and browser worker tooling. This removes Webpack's deprecated named JSON export warnings without changing runtime behavior.

## Testing

- Client type-check and lint
- 32 focused client tests
- Challenge-builder type-check, lint, and build
- Browser-scripts lint and production Webpack build
- Focused TypeScript checks for the changed browser scripts
