### PR TITLE
fix(api): ignore placeholder GrowthBook config

### DIFF
--- a/api/src/utils/env.test.ts
+++ b/api/src/utils/env.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const API_HOST_PLACEHOLDER =
+  'fastify_api_sdk_api_host_from_growthbook_dashboard';
+const CLIENT_KEY_PLACEHOLDER =
+  'fastify_api_sdk_client_key_from_growthbook_dashboard';
+
+describe('GrowthBook environment configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  test('ignores the sample environment placeholders in development', async () => {
+    vi.stubEnv('FREECODECAMP_NODE_ENV', 'development');
+    vi.stubEnv('GROWTHBOOK_FASTIFY_API_HOST', API_HOST_PLACEHOLDER);
+    vi.stubEnv('GROWTHBOOK_FASTIFY_CLIENT_KEY', CLIENT_KEY_PLACEHOLDER);
+
+    const { GROWTHBOOK_FASTIFY_API_HOST, GROWTHBOOK_FASTIFY_CLIENT_KEY } =
+      await import('./env.js');
+
+    expect(GROWTHBOOK_FASTIFY_API_HOST).toBeUndefined();
+    expect(GROWTHBOOK_FASTIFY_CLIENT_KEY).toBeUndefined();
+  });
+
+  test('preserves configured GrowthBook credentials', async () => {
+    vi.stubEnv('FREECODECAMP_NODE_ENV', 'development');
+    vi.stubEnv('GROWTHBOOK_FASTIFY_API_HOST', 'https://example.com');
+    vi.stubEnv('GROWTHBOOK_FASTIFY_CLIENT_KEY', 'sdk-test');
+
+    const { GROWTHBOOK_FASTIFY_API_HOST, GROWTHBOOK_FASTIFY_CLIENT_KEY } =
+      await import('./env.js');
+
+    expect(GROWTHBOOK_FASTIFY_API_HOST).toBe('https://example.com');
+    expect(GROWTHBOOK_FASTIFY_CLIENT_KEY).toBe('sdk-test');
+  });
+});

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -33,6 +33,14 @@ function isAllowedEnv(env: string): env is 'development' | 'production' {
 const _EMAIL_PROVIDER = process.env.EMAIL_PROVIDER || 'ses';
 const _FREECODECAMP_NODE_ENV =
   process.env.FREECODECAMP_NODE_ENV || 'production';
+const GROWTHBOOK_API_HOST_PLACEHOLDER =
+  'fastify_api_sdk_api_host_from_growthbook_dashboard';
+const GROWTHBOOK_CLIENT_KEY_PLACEHOLDER =
+  'fastify_api_sdk_client_key_from_growthbook_dashboard';
+
+function ignorePlaceholder(value: string | undefined, placeholder: string) {
+  return value === placeholder ? undefined : value;
+}
 
 function isAllowedProvider(provider: string): provider is 'ses' | 'nodemailer' {
   return ['ses', 'nodemailer'].includes(provider);
@@ -155,7 +163,7 @@ if (process.env.FREECODECAMP_NODE_ENV !== 'development') {
   );
   assert.notEqual(
     process.env.GROWTHBOOK_FASTIFY_API_HOST,
-    'fastify_api_sdk_api_host_from_growthbook_dashboard',
+    GROWTHBOOK_API_HOST_PLACEHOLDER,
     'The GROWTHBOOK_FASTIFY_API_HOST env should be changed from the default value.'
   );
   assert.ok(
@@ -164,7 +172,7 @@ if (process.env.FREECODECAMP_NODE_ENV !== 'development') {
   );
   assert.notEqual(
     process.env.GROWTHBOOK_FASTIFY_CLIENT_KEY,
-    'fastify_api_sdk_client_key_from_growthbook_dashboard',
+    GROWTHBOOK_CLIENT_KEY_PLACEHOLDER,
     'The GROWTHBOOK_FASTIFY_CLIENT_KEY env should be changed from the default value.'
   );
   if (process.env.FCC_ENABLE_CLASSROOM === 'true') {
@@ -267,10 +275,14 @@ export const SES_SMTP_HOST =
 export const SHOW_UPCOMING_CHANGES =
   process.env.SHOW_UPCOMING_CHANGES === 'true';
 export const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
-export const GROWTHBOOK_FASTIFY_API_HOST =
-  process.env.GROWTHBOOK_FASTIFY_API_HOST;
-export const GROWTHBOOK_FASTIFY_CLIENT_KEY =
-  process.env.GROWTHBOOK_FASTIFY_CLIENT_KEY;
+export const GROWTHBOOK_FASTIFY_API_HOST = ignorePlaceholder(
+  process.env.GROWTHBOOK_FASTIFY_API_HOST,
+  GROWTHBOOK_API_HOST_PLACEHOLDER
+);
+export const GROWTHBOOK_FASTIFY_CLIENT_KEY = ignorePlaceholder(
+  process.env.GROWTHBOOK_FASTIFY_CLIENT_KEY,
+  GROWTHBOOK_CLIENT_KEY_PLACEHOLDER
+);
 export const SOCRATES_API_KEY = process.env.SOCRATES_API_KEY;
 export const SOCRATES_ENDPOINT = process.env.SOCRATES_ENDPOINT;
 export const TPA_API_BEARER_TOKEN = process.env.TPA_API_BEARER_TOKEN;


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

## Problem

A development `.env` copied from `sample.env` contains descriptive GrowthBook placeholders. Since those strings are truthy, the API attempts to initialize the GrowthBook SDK and logs this startup error:

```text
Failed to initialize GrowthBook
TypeError: Failed to parse URL from fastify_api_sdk_api_host_from_growthbook_dashboard/api/features/fastify_api_sdk_client_key_from_growthbook_dashboard
```

Other optional integrations keep their descriptive sample values and normalize or gate them before SDK initialization. GrowthBook was the exception.

## Summary

- Treat the two known GrowthBook placeholders as unconfigured before registering the SDK.
- Preserve real GrowthBook credentials unchanged.
- Keep the production assertions against the raw environment values, so production still requires real credentials.
- Keep `sample.env` unchanged and consistent with the repository's placeholder convention.
- Add coverage for both placeholder and configured values.

## Testing

- API type-check and lint
- GrowthBook environment and plugin tests: 3 passed
- Started the API using the legacy placeholder values and confirmed it starts without a GrowthBook initialization error
