### PR TITLE
fix(curriculum): add section headers to audio/video elements lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -10,7 +10,7 @@ dashedName: what-are-the-roles-of-the-html-audio-and-video-elements
 The `audio` and `video` elements allow you to add sound and video content to your HTML documents. The `audio` element supports popular audio formats like mp3, wav, and ogg.
 The `video` element supports mp4, ogg, and webm formats.
 
-## Adding Audio with the src Attribute
+## Adding Audio with the `src` Attribute
 
 To include audio content on your web page, you can use the `audio` element with the `src` attribute pointing to the location of your audio file. 
 
@@ -42,7 +42,7 @@ The `controls` attribute enables users to manage audio playback, including pausi
 
 **Note:** Some browsers, such as Safari, may not display a volume control by default even when the `controls` attribute is present.
 
-## Looping Audio with the loop Attribute
+## Looping Audio with the `loop` Attribute
 
 Apart from the `src` and `controls` attributes, there are several other attributes that enhance the functionality of the `audio` element. The `loop` attribute is a boolean attribute that makes the audio replay continuously. 
 
@@ -60,7 +60,7 @@ Here's an example of using the `loop` attribute to play one of Quincy Larson's s
 
 :::
 
-## Muting Audio with the muted Attribute
+## Muting Audio with the `muted` Attribute
 
 Another attribute you can use is the `muted` attribute. When present in the `audio` element, this boolean attribute will start the audio in a muted state. Here's an example of using the `muted` attribute.
 
@@ -93,7 +93,7 @@ When it comes to audio file types, there are differences in which browsers suppo
 
 The browser will first start with the ogg type, and if it can't play the audio, then it'll move down to the next type in the list.
 
-## Using the video Element
+## Using the `video` Element
 
 All the attributes we have learned so far are also supported in the `video` element. Here's an example of using a `video` element with the `loop`, `controls`, and `muted` attributes. 
 
@@ -115,7 +115,7 @@ Add the `autoplay` attribute to the opening `video` tag so the video plays autom
 
 :::
 
-## Displaying a Preview Image with the poster Attribute
+## Displaying a Preview Image with the `poster` Attribute
 
 For the `src`, or source attribute, we are using a video called "Big Buck Bunny" from archive.org. If you wanted to display an image while the video is downloading, you can use the `poster` attribute. This attribute is not available for `audio` elements and is unique to the `video` element. Here's an example of using the `poster` attribute with content provided by peach.blender.org.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -10,6 +10,8 @@ dashedName: what-are-the-roles-of-the-html-audio-and-video-elements
 The `audio` and `video` elements allow you to add sound and video content to your HTML documents. The `audio` element supports popular audio formats like mp3, wav, and ogg.
 The `video` element supports mp4, ogg, and webm formats.
 
+## Adding Audio with the src Attribute
+
 To include audio content on your web page, you can use the `audio` element with the `src` attribute pointing to the location of your audio file. 
 
 As you can see in the preview window, nothing shows up on the page. To see the previews, you will need to enable the interactive editor.
@@ -21,6 +23,8 @@ As you can see in the preview window, nothing shows up on the page. To see the p
 ```
 
 :::
+
+## Showing Playback Controls
 
 If you want to see the audio player on the page, then you can add the `audio` element with the `controls` attribute.
 
@@ -38,6 +42,8 @@ The `controls` attribute enables users to manage audio playback, including pausi
 
 **Note:** Some browsers, such as Safari, may not display a volume control by default even when the `controls` attribute is present.
 
+## Looping Audio with the loop Attribute
+
 Apart from the `src` and `controls` attributes, there are several other attributes that enhance the functionality of the `audio` element. The `loop` attribute is a boolean attribute that makes the audio replay continuously. 
 
 Here's an example of using the `loop` attribute to play one of Quincy Larson's songs titled "Can't stay down". To see the looping in action, enable the interactive editor, scrub the play head close to the end of the song, and it will restart once it is finished. 
@@ -53,6 +59,8 @@ Here's an example of using the `loop` attribute to play one of Quincy Larson's s
 ```
 
 :::
+
+## Muting Audio with the muted Attribute
 
 Another attribute you can use is the `muted` attribute. When present in the `audio` element, this boolean attribute will start the audio in a muted state. Here's an example of using the `muted` attribute.
 
@@ -71,6 +79,8 @@ To hear the music, enable the interactive editor and click on the volume icon in
 
 :::
 
+## Supporting Multiple Audio Formats
+
 When it comes to audio file types, there are differences in which browsers support which type. To accommodate this, you can use `source` elements inside the `audio` element and the browser will select the first source that it understands. Here's an example of using multiple `source` elements for an `audio` element:
 
 ```html
@@ -82,6 +92,8 @@ When it comes to audio file types, there are differences in which browsers suppo
 ```
 
 The browser will first start with the ogg type, and if it can't play the audio, then it'll move down to the next type in the list.
+
+## Using the video Element
 
 All the attributes we have learned so far are also supported in the `video` element. Here's an example of using a `video` element with the `loop`, `controls`, and `muted` attributes. 
 
@@ -103,6 +115,8 @@ Add the `autoplay` attribute to the opening `video` tag so the video plays autom
 
 :::
 
+## Displaying a Preview Image with the poster Attribute
+
 For the `src`, or source attribute, we are using a video called "Big Buck Bunny" from archive.org. If you wanted to display an image while the video is downloading, you can use the `poster` attribute. This attribute is not available for `audio` elements and is unique to the `video` element. Here's an example of using the `poster` attribute with content provided by peach.blender.org.
 
 ```html
@@ -115,6 +129,8 @@ For the `src`, or source attribute, we are using a video called "Big Buck Bunny"
   width="400"
 ></video>
 ```
+
+## Supporting Multiple Video Formats
 
 You can also use the `source` element inside a `video` element, just like you did with the `audio` element. This lets you provide the same video in multiple formats, and the browser will choose the first one it can play.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-audio-and-video-elements/67168278ac6df6a799555db5.md
@@ -24,7 +24,7 @@ As you can see in the preview window, nothing shows up on the page. To see the p
 
 :::
 
-## Showing Playback Controls
+## Adding Playback Controls with the `controls` Attribute
 
 If you want to see the audio player on the page, then you can add the `audio` element with the `controls` attribute.
 


### PR DESCRIPTION
Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69311

<!-- Feel free to add any additional description of changes below this line -->

Added `##` section headers to break up the "What Are the Roles of the HTML Audio and Video Elements, and How Do They Work?" lecture into logical sections, following the convention established in the Sort Method lecture (`673362d7f94d551edb532d24.md`).

**Headers added:**
- Adding Audio with the src Attribute
- Showing Playback Controls
- Looping Audio with the loop Attribute
- Muting Audio with the muted Attribute
- Supporting Multiple Audio Formats
- Using the video Element
- Displaying a Preview Image with the poster Attribute
- Supporting Multiple Video Formats

No existing prose was rewritten. The `--questions--` section, code blocks, and front matter were left untouched.