### PR TITLE
fix(curriculum): set data-sanitizer challenge type to 32

### DIFF
--- a/curriculum/challenges/english/blocks/lab-data-sanitizer/27dbeadb5c09d8735941a8ea.md
+++ b/curriculum/challenges/english/blocks/lab-data-sanitizer/27dbeadb5c09d8735941a8ea.md
@@ -1,7 +1,7 @@
 ---
 id: 27dbeadb5c09d8735941a8ea
 title: 'Build a Data Sanitizer'
-challengeType: 33
+challengeType: 32
 url: freeCodeCamp/build-a-data-sanitizer
 dashedName: lab-data-sanitizer
 ---


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This change aligns the requirements with what we have for the exam and in freeCodeCampOS.
This was overlooked in recent changes, because the `Certification Project` label has never been assigned.
<img width="625" height="341" alt="image" src="https://github.com/user-attachments/assets/2fa91596-7fa4-4b02-b73d-c512ca8de204" />

This change direction is not negatively consequential; better unsetting a requirement than setting one.