### PR TITLE
test(api): handle concurrent requests gracefully

### DIFF
--- a/api/vitest.utils.ts
+++ b/api/vitest.utils.ts
@@ -186,6 +186,12 @@ export function setupServer(): void {
     }
     fastify = await build(buildOptions);
     await fastify.ready();
+    // Supertest does not handle multiple concurrent requests gracefully
+    // https://github.com/forwardemail/supertest/issues/709
+    // it calls `server.close` and can end up killing live connections.
+    // By listening to 0, we keep the ephemeral port generation, but the fact
+    // it is listening means supertest will not attempt to close it.
+    fastify.server.listen(0);
 
     await checkCanConnectToDb(fastify.prisma);
 


### PR DESCRIPTION
Without this we can't test concurrency handling

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
