### PR TITLE
perf(client): scope curriculum queries to their superblock

### DIFF
--- a/client/src/templates/Challenges/exam-download/show.tsx
+++ b/client/src/templates/Challenges/exam-download/show.tsx
@@ -483,7 +483,7 @@ export default connect(mapStateToProps)(withTranslation()(ShowExamDownload));
 
 // GraphQL
 export const query = graphql`
-  query ExamEnvironmentExam($id: String!) {
+  query ExamEnvironmentExam($id: String!, $superBlock: String!) {
     challengeNode(id: { eq: $id }) {
       challenge {
         id
@@ -492,7 +492,9 @@ export const query = graphql`
         translationPending
       }
     }
-    allChallengeNode {
+    allChallengeNode(
+      filter: { challenge: { superBlock: { eq: $superBlock } } }
+    ) {
       nodes {
         challenge {
           id

--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -352,8 +352,9 @@ export default connect(
 )(withTranslation()(memo(SuperBlockIntroductionPage)));
 
 export const query = graphql`
-  query SuperBlockIntroPageQuery {
+  query SuperBlockIntroPageQuery($superBlock: String!) {
     allChallengeNode(
+      filter: { challenge: { superBlock: { eq: $superBlock } } }
       sort: [
         { challenge: { superOrder: ASC } }
         { challenge: { order: ASC } }
@@ -379,7 +380,7 @@ export const query = graphql`
         }
       }
     }
-    allSuperBlockStructure {
+    allSuperBlockStructure(filter: { superBlock: { eq: $superBlock } }) {
       nodes {
         superBlock
         chapters {

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -143,7 +143,8 @@ exports.createChallengePages = function (
           node.challenge,
           lastChallengeByBlock
         ),
-        id: node.id
+        id: node.id,
+        superBlock
       }
     });
   };


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Split out of #69761 at review request, so the query work can be assessed on its own. #69761 now contains only the stylesheet change.

## Summary

- Filters superblock introduction page queries to the current superblock instead of serializing every curriculum challenge and structure onto every page.
- Applies the same superblock filtering to downloadable exam pages.
- Threads `superBlock` through the challenge page context so both templates can filter on it.
- Limits CI webpack stats to the fields consumed by `webpack-bundle-analyzer`.

No curriculum pages or challenges are removed. The generated client has the same functionality, but its page data, webpack stats, and Turbo cache archive are smaller.

## Why

Superblock introduction pages each carried roughly 8 MB of curriculum data, and downloadable exam pages roughly 4.18 MB, because their queries returned challenges from every superblock rather than the one being rendered.

Besides the wasted bytes, this duplicated output increased Gatsby rendering, artifact upload, and cache finalization time. The Turbo client archive also exceeded the remote cache's 100 MB request limit and returned `413 Payload Too Large`.

## Local results

| Measurement | Before | After |
| --- | ---: | ---: |
| `page-data.json` for `/learn/javascript-algorithms-and-data-structures-v8/` | 8.0 MB | 594 KB |
| `page-data.json` for a Responsive Web Design downloadable exam | 4.18 MB | 319 KB |
| Total Gatsby page data | approximately 1.1 GB | 276 MB |
| CI webpack stats | 576 MB | 31 MB |

The build-time and Turbo-archive improvements originally reported on #69761 were measured with the stylesheet change applied as well, so they are not attributed here. The page-data and webpack-stats figures above are specific to this PR.

## Testing

- Full `gatsby build`: queries ran 19232/19232, all 19,228 pages built, no query errors.
- Full client suite: 1,098 tests passed.
- `tsc --noEmit` and `eslint` clean.
- Generated a webpack-bundle-analyzer report from the minimized stats file; it contained 178 JavaScript assets.
