### PR TITLE
perf(client): limit webpack stats to analyzer fields

### DIFF
--- a/client/gatsby-config.ts
+++ b/client/gatsby-config.ts
@@ -27,12 +27,24 @@ const config: GatsbyConfig = {
       resolve: 'gatsby-plugin-webpack-bundle-analyser-v2',
       options: {
         analyzerMode: 'disabled',
-        // It doesn't matter if the file is generated or not as far as caching
-        // is concerned. It doesn't affect any tasks in any way, so we can
-        // ignore it.
+        // Stats are diagnostic output and do not affect downstream tasks, so
+        // CI does not need to participate in the Turbo input hash.
 
         // eslint-disable-next-line turbo/no-undeclared-env-vars
-        generateStatsFile: process.env.CI
+        generateStatsFile: process.env.CI,
+        // Only include the data consumed by webpack-bundle-analyzer. The
+        // default stats contain hundreds of MB of duplicate module metadata.
+        statsOptions: {
+          all: false,
+          assets: true,
+          children: true,
+          chunkModules: false,
+          chunks: true,
+          entrypoints: true,
+          ids: true,
+          modules: true,
+          nestedModules: true
+        }
       }
     },
     'gatsby-plugin-react-helmet',


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Split out of #69761 at review request. That PR is now three:
\
## Summary

Restricts `statsOptions` on `gatsby-plugin-webpack-bundle-analyser-v2` to the fields `webpack-bundle-analyzer` actually reads.

## Why

`generateStatsFile` writes webpack's default stats, which include hundreds of megabytes of duplicated module metadata that the analyzer never consumes. On CI the stats file was 576 MB.

| | Before | After |
| --- | ---: | ---: |
| CI webpack stats file | 576 MB | 31 MB |

This is diagnostic output only. Nothing downstream reads it, and it does not affect any Turbo task.

## Testing

Generated a webpack-bundle-analyzer report from the minimized stats file and confirmed it is unchanged: it still lists all 178 JavaScript assets.
