### PR TITLE
chore(api/client): remove temp daily challenge transition code

### DIFF
--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.test.ts
@@ -277,32 +277,6 @@ describe('/daily-coding-challenge', () => {
       fastifyTestInstance.Sentry = originalSentry;
     });
 
-    it("should not return a day's challenge if it hasn't been released even once yet (temporary, until the original run finishes on 2026-08-10)", async () => {
-      const res = await superRequest('/daily-coding-challenge/day/10-03', {
-        method: 'GET'
-      }).send({});
-
-      expect(res.status).toBe(404);
-      expect(res.body).toEqual({
-        type: 'error',
-        message: 'Challenge not found.'
-      });
-    });
-
-    it('should return a day once real time has passed the entire original run, even for days that were never released relative to the mocked "today" above', async () => {
-      vi.setSystemTime(addDays(todayUsCentral, 365));
-
-      const res = await superRequest('/daily-coding-challenge/day/10-03', {
-        method: 'GET'
-      }).send({});
-
-      expect(res.status).toBe(200);
-      expect(res.body).toMatchObject({
-        ...tomorrowsChallenge,
-        date: tomorrowsChallenge.date.toISOString()
-      });
-    });
-
     it('should map a Feb 29 day request to the Feb 28 challenge', async () => {
       await fastifyTestInstance.prisma.dailyCodingChallenges.deleteMany();
 

--- a/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
+++ b/api/src/daily-coding-challenge/routes/daily-coding-challenge.ts
@@ -111,18 +111,6 @@ export const dailyCodingChallengeRoutes: FastifyPluginCallbackTypebox = (
 
         const sourceDate = getSourceDate(monthDay);
 
-        // TEMPORARY: blocks days for not yet released challenges
-        // Safe to delete after 2026-08-10 (all challenges released)
-        if (sourceDate > getUtcMidnight(getNowUsCentral())) {
-          req.log.warn({ day }, 'Challenge not found for day');
-          fastify.Sentry?.metrics?.count('dcc.challenge_not_found', 1, {
-            attributes: { route: '/daily-coding-challenge/day/:day' }
-          });
-          return reply
-            .status(404)
-            .send({ type: 'error', message: 'Challenge not found.' });
-        }
-
         const challenge = await fastify.prisma.dailyCodingChallenges.findFirst({
           where: {
             date: sourceDate

--- a/client/src/components/daily-coding-challenge/calendar.test.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.test.tsx
@@ -83,23 +83,4 @@ describe('getMonthInfo', () => {
     expect(isAvailable(days, 5)).toBe(false);
     expect(isAvailable(days, 10)).toBe(true);
   });
-
-  describe('requireExactYear', () => {
-    const map = buildMap({ '08-15': { date: '2025-08-15' } });
-
-    it('hides a day whose stored year does not match the displayed year', () => {
-      const { days } = getMonthInfo(2026, 7, map, undefined, undefined, true);
-      expect(isAvailable(days, 15)).toBe(false);
-    });
-
-    it('shows the day when the displayed year matches the stored year', () => {
-      const { days } = getMonthInfo(2025, 7, map, undefined, undefined, true);
-      expect(isAvailable(days, 15)).toBe(true);
-    });
-
-    it('is ignored when not set, matching evergreen year-agnostic lookup', () => {
-      const { days } = getMonthInfo(2026, 7, map);
-      expect(isAvailable(days, 15)).toBe(true);
-    });
-  });
 });

--- a/client/src/components/daily-coding-challenge/calendar.tsx
+++ b/client/src/components/daily-coding-challenge/calendar.tsx
@@ -14,12 +14,7 @@ import { Loader } from '../helpers';
 import envData from '../../../config/env.json';
 import Login from '../Header/components/login';
 import CalendarDay from './calendar-day';
-import {
-  getTodayUsCentral,
-  toMonthDay,
-  formatDate,
-  lastDailyChallengeIsReleased
-} from './helpers';
+import { getTodayUsCentral, toMonthDay, formatDate } from './helpers';
 
 import './calendar.css';
 import DailyCodingChallengeNotFound from './not-found';
@@ -55,13 +50,6 @@ export interface DailyChallengeMap {
 
 type DailyChallengesMap = Map<string, DailyChallengeMap>;
 
-interface MonthInfo {
-  days: JSX.Element[];
-  index: number;
-  name: string;
-  year: number;
-}
-
 // Cap Feb to 28 days regardless of which "year" is displayed
 export const getDaysInMonth = (year: number, monthIndex: number): number => {
   const realDays = new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
@@ -73,8 +61,7 @@ export const getMonthInfo = (
   monthIndex: number,
   dailyChallengesMap: DailyChallengesMap,
   hideDaysAfter?: number,
-  hideDaysThrough?: number,
-  requireExactYear?: boolean
+  hideDaysThrough?: number
 ) => {
   // Create date for first of the month (handles rollover automatically)
   const firstOfMonth = new Date(Date.UTC(year, monthIndex, 1));
@@ -96,7 +83,6 @@ export const getMonthInfo = (
     const title = challengeData?.title || '';
     const isAvailable =
       challengeData !== undefined &&
-      (!requireExactYear || challengeData.date === formattedDate) &&
       (hideDaysAfter === undefined || day <= hideDaysAfter) &&
       (hideDaysThrough === undefined || day > hideDaysThrough);
     const challengeNumber = challengeData?.challengeNumber;
@@ -132,7 +118,6 @@ function DailyCodingChallengeCalendar({
   const { t } = useTranslation();
 
   const todayUsCentral = getTodayUsCentral();
-  const lastDailyChallengeReleased = lastDailyChallengeIsReleased();
 
   const [todayYear, todayMonth, todayDay] = todayUsCentral
     .split('-')
@@ -190,32 +175,6 @@ function DailyCodingChallengeCalendar({
   const nextMonth = () => setMonthOffset(offset => offset + 1);
   const prevMonth = () => setMonthOffset(offset => offset - 1);
 
-  const hasOlderChallenges = (
-    map: DailyChallengesMap,
-    monthInfo: MonthInfo
-  ): boolean => {
-    return Array.from(map.values()).some(({ date }) => {
-      const [year, month] = date.split('-').map(Number);
-      return (
-        year < monthInfo.year ||
-        (year === monthInfo.year && month - 1 < monthInfo.index)
-      );
-    });
-  };
-
-  const hasNewerChallenges = (
-    map: DailyChallengesMap,
-    monthInfo: MonthInfo
-  ): boolean => {
-    return Array.from(map.values()).some(({ date }) => {
-      const [year, month] = date.split('-').map(Number);
-      return (
-        year > monthInfo.year ||
-        (year === monthInfo.year && month - 1 > monthInfo.index)
-      );
-    });
-  };
-
   // The furthest month back only shows challenges after today
   const isBoundaryMonth = minMonthOffset === -12 && monthOffset === -12;
 
@@ -224,18 +183,13 @@ function DailyCodingChallengeCalendar({
     todayYear,
     todayMonth - 1 + monthOffset,
     dailyChallengesMap,
-    lastDailyChallengeReleased && monthOffset === 0 ? todayDay : undefined,
-    lastDailyChallengeReleased && isBoundaryMonth ? todayDay : undefined,
-    !lastDailyChallengeReleased
+    monthOffset === 0 ? todayDay : undefined,
+    isBoundaryMonth ? todayDay : undefined
   );
 
-  const showPrevButton = lastDailyChallengeReleased
-    ? monthOffset > minMonthOffset
-    : hasOlderChallenges(dailyChallengesMap, monthInfo);
+  const showPrevButton = monthOffset > minMonthOffset;
 
-  const showNextButton = lastDailyChallengeReleased
-    ? monthOffset < 0
-    : hasNewerChallenges(dailyChallengesMap, monthInfo);
+  const showNextButton = monthOffset < 0;
 
   if (isLoading) return <Loader />;
   if (error) return <DailyCodingChallengeNotFound />;

--- a/client/src/components/daily-coding-challenge/helpers.ts
+++ b/client/src/components/daily-coding-challenge/helpers.ts
@@ -18,12 +18,6 @@ export function getTodayUsCentral(dateObj: Date = new Date()) {
   return format(zonedDate, 'yyyy-MM-dd');
 }
 
-const LAST_DAY_OF_NEW_DAILY_CHALLENGES = '2026-08-10';
-
-export function lastDailyChallengeIsReleased() {
-  return getTodayUsCentral() > LAST_DAY_OF_NEW_DAILY_CHALLENGES;
-}
-
 // Validate that dateString is in the format yyyy-MM-dd
 // Leading zero's are accepted for single digit month/day
 export function isValidDateString(dateString: string) {


### PR DESCRIPTION
This deletes some code that was used to transition the daily challenges from having a new one every day, to the rolling 365 calendar.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
