### PR TITLE
fix(curriculum): test Digital Pet Game interactions

### DIFF
--- a/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
+++ b/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
@@ -94,11 +94,20 @@ assert.isNotNull(document.querySelector('button'));
 When the input is given a value and the button is pressed, the form should no longer be visible.
 
 ```js
-document.querySelector('#pet-name').value = _PET_NAME;
+const petNameInput = document.querySelector('#pet-name');
+const nativeValueSetter = Object.getOwnPropertyDescriptor(
+  window.HTMLInputElement.prototype,
+  'value'
+).set;
+nativeValueSetter.call(petNameInput, _PET_NAME);
+petNameInput.dispatchEvent(new Event('input', { bubbles: true }));
 document.querySelector('button').click();
 await _clock.tickAsync(500);
 
-assert.isNull(document.querySelector('form'));
+const form = document.querySelector('form');
+assert.isTrue(
+  form === null || window.getComputedStyle(form).display === 'none'
+);
 ```
 
 The second view should contain an element with class `pet-name`.
@@ -1303,4 +1312,3 @@ export function PetGame() {
   );
 }
 ```
-

--- a/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
+++ b/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
@@ -76,7 +76,15 @@ delete globalThis._PET_NAME;
 When the page loads, there should be a visible `form` element.
 
 ```js
-assert.isNotNull(document.querySelector('form'), 'The form element does not exist at load.');
+const form = document.querySelector('form');
+assert.isNotNull(form, 'The form element does not exist at load.');
+assert.isTrue(
+  form.checkVisibility({
+    opacityProperty: true,
+    visibilityProperty: true
+  }),
+  'The form element is not visible at load.'
+);
 ```
 
 This form should contain an input field with an id of `pet-name`.
@@ -106,7 +114,11 @@ await _clock.tickAsync(500);
 
 const form = document.querySelector('form');
 assert.isTrue(
-  form === null || window.getComputedStyle(form).display === 'none'
+  form === null ||
+    !form.checkVisibility({
+      opacityProperty: true,
+      visibilityProperty: true
+    })
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69604
Closes #69158

The Digital Pet Game tests now confirm that the form is visible when the page loads and absent or hidden after submission. The submission test enters the pet name through a bubbling `input` event, so React `onChange` handlers receive the value.
