### PR TITLE
fix(curriculum): improve digital pet test runtime

### DIFF
--- a/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
+++ b/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
@@ -59,7 +59,9 @@ The second view:
 
 ```js
 globalThis._PET_NAME = 'Fitzgerald';
-globalThis._clock = __FakeTimers.install();
+globalThis._clock = __FakeTimers.install({
+  toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+});
 window.fetch = () => Promise.resolve({ json: () => Promise.resolve('Cats sleep for around 13 to 16 hours a day.') });
 ```
 
@@ -231,7 +233,7 @@ const statEls = () => Array.from(document.querySelectorAll('.stat'));
 const hungerBefore = parseFloat(statEls().find(el => /hunger/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const energyBefore = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 document.querySelector('#eat-action').click();
-_clock.tick(50);
+await _clock.tickAsync(50);
 const hungerAfter = parseFloat(statEls().find(el => /hunger/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const energyAfter = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 if (hungerBefore !== 0) assert.isBelow(hungerAfter, hungerBefore);
@@ -247,7 +249,7 @@ const statEls = () => Array.from(document.querySelectorAll('.stat'));
 const energyBefore = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const happinessBefore = parseFloat(statEls().find(el => /happiness/i.test(el.textContent)).querySelector('.stat-value').textContent);
 document.querySelector('#play-action').click();
-_clock.tick(50);
+await _clock.tickAsync(50);
 const energyAfter = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const happinessAfter = parseFloat(statEls().find(el => /happiness/i.test(el.textContent)).querySelector('.stat-value').textContent);
 if (energyBefore !== 0) assert.isBelow(energyAfter, energyBefore);
@@ -263,7 +265,7 @@ const statEls = () => Array.from(document.querySelectorAll('.stat'));
 const hungerBefore = parseFloat(statEls().find(el => /hunger/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const energyBefore = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 document.querySelector('#sleep-action').click();
-_clock.tick(50);
+await _clock.tickAsync(50);
 const hungerAfter = parseFloat(statEls().find(el => /hunger/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const energyAfter = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 if (hungerBefore !== 100) assert.isAbove(hungerAfter, hungerBefore);
@@ -275,7 +277,24 @@ else assert.equal(energyAfter, energyBefore);
 The `Hunger` stat should be 100 after an excessive period of idle time.
 
 ```js
-await _clock.tickAsync(1_200_000);
+function getStatValue(statName) {
+  const statEl = Array.from(document.querySelectorAll('.stat')).find(el =>
+    new RegExp(statName, 'i').test(el.textContent)
+  );
+  return parseFloat(statEl.querySelector('.stat-value').textContent);
+}
+
+// Limit the callbacks so short learner-defined intervals do not make this test slow.
+for (let i = 0; i < 100; i++) {
+  await _clock.nextAsync();
+  if (
+    getStatValue('hunger') === 100 &&
+    getStatValue('energy') === 100 &&
+    getStatValue('happiness') === 0
+  ) {
+    break;
+  }
+}
 
 const hungerStatEl = Array.from(document.querySelectorAll('.stat')).find(el => /hunger/i.test(el.textContent));
 const hungerValue = parseFloat(hungerStatEl.querySelector('.stat-value').textContent);
@@ -305,7 +324,7 @@ const statEls = () => Array.from(document.querySelectorAll('.stat'));
 const hungerBefore = parseFloat(statEls().find(el => /hunger/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const energyBefore = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 document.querySelector('#eat-action').click();
-_clock.tick(50);
+await _clock.tickAsync(50);
 const hungerAfter = parseFloat(statEls().find(el => /hunger/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const energyAfter = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 if (hungerBefore !== 0) assert.isBelow(hungerAfter, hungerBefore);
@@ -321,7 +340,7 @@ const statEls = () => Array.from(document.querySelectorAll('.stat'));
 const energyBefore = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const happinessBefore = parseFloat(statEls().find(el => /happiness/i.test(el.textContent)).querySelector('.stat-value').textContent);
 document.querySelector('#play-action').click();
-_clock.tick(50);
+await _clock.tickAsync(50);
 const energyAfter = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const happinessAfter = parseFloat(statEls().find(el => /happiness/i.test(el.textContent)).querySelector('.stat-value').textContent);
 if (energyBefore !== 0) assert.isBelow(energyAfter, energyBefore);
@@ -337,7 +356,7 @@ const statEls = () => Array.from(document.querySelectorAll('.stat'));
 const hungerBefore = parseFloat(statEls().find(el => /hunger/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const energyBefore = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 document.querySelector('#sleep-action').click();
-_clock.tick(50);
+await _clock.tickAsync(50);
 const hungerAfter = parseFloat(statEls().find(el => /hunger/i.test(el.textContent)).querySelector('.stat-value').textContent);
 const energyAfter = parseFloat(statEls().find(el => /energy/i.test(el.textContent)).querySelector('.stat-value').textContent);
 if (hungerBefore !== 100) assert.isAbove(hungerAfter, hungerBefore);
@@ -1303,4 +1322,3 @@ export function PetGame() {
   );
 }
 ```
-

--- a/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
+++ b/curriculum/challenges/english/blocks/lab-digital-pet-game/68c362b379059c388d3874f2.md
@@ -284,9 +284,13 @@ function getStatValue(statName) {
   return parseFloat(statEl.querySelector('.stat-value').textContent);
 }
 
-// Limit the callbacks so short learner-defined intervals do not make this test slow.
-for (let i = 0; i < 100; i++) {
-  await _clock.nextAsync();
+const idleTime = 1_200_000;
+const idleSteps = 100;
+
+// Advance in slices so each interval fires at most once per slice.
+for (let i = 0; i < idleSteps; i++) {
+  _clock.jump(idleTime / idleSteps);
+  await _clock.tickAsync(0);
   if (
     getStatValue('hunger') === 100 &&
     getStatValue('energy') === 100 &&


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #68948

<!-- Feel free to add any additional description of changes below this line -->

This limits the fake clock to timer APIs so loop protection continues to use real time. The idle test advances a bounded number of scheduled callbacks and exits once the expected stat values are reached, preventing short learner-defined intervals from causing thousands of callbacks.

The action tests now advance the clock asynchronously so React state updates are flushed reliably.

Tested with:

```console
FCC_BLOCK=lab-digital-pet-game pnpm run test-curriculum-content
```
