### PR TITLE
fix(client): preserve spaces in hint code

### DIFF
--- a/client/src/templates/Challenges/components/independent-lower-jaw.css
+++ b/client/src/templates/Challenges/components/independent-lower-jaw.css
@@ -35,6 +35,11 @@
   width: 1.4rem;
 }
 
+.independent-lower-jaw .hint-body code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .independent-lower-jaw .hint-container .hint-body p:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #67697

<!-- Feel free to add any additional description of changes below this line -->

This preserve spaces in inline code blocks when they are displayed in the lower jaw
