### PR TITLE
fix: flaky test in ms-trophy

### DIFF
--- a/client/src/templates/Challenges/ms-trophy/show.test.tsx
+++ b/client/src/templates/Challenges/ms-trophy/show.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { SuperBlocks } from '@freecodecamp/shared/config/curriculum';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
@@ -162,8 +162,11 @@ describe('MsTrophy', () => {
       })
     );
 
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+
     expect(
-      screen.getByRole('heading', {
+      within(dialog).getByRole('heading', {
         name: translations.buttons['get-help']
       })
     ).toBeInTheDocument();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is an attempt to resolve:

<img width="882" height="70" alt="Screenshot 2026-08-28 at 18 58 13" src="https://github.com/user-attachments/assets/732b93e2-f276-4e91-889c-b9b53dd0d6a0" />

Log: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/33151375010/job/98792389409#step:10:2097

I suspect the cause is similar to #69500: we need to wait for dialogs to appear / disappear.

<!-- Feel free to add any additional description of changes below this line -->
