### PR TITLE
fix(docker): install prisma CLI with pnpm dlx in api image

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -52,7 +52,7 @@ RUN npm i -g pnpm@10
 # consistency.
 RUN pnpm config set dedupe-peer-dependents false
 RUN pnpm install --prod --ignore-scripts -F=api -F=packages/shared --frozen-lockfile
-RUN cd api && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
+RUN cd api && pnpm dlx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
 
 FROM node:24-bookworm
 USER node


### PR DESCRIPTION
### Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

Fixes the `Build E2E API (Container)` job, which currently fails on every pull request:

```
#24 [deps 11/11] RUN cd api && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
#24 1.213 sh: 1: prisma: not found
ERROR: failed to build: ... exit code: 127
```

#### What happened

`node:24-bookworm` bumped npm from 11.17.0 to 11.19.0, which pulled in arborist 9.9.1. Even after `pnpm install --prod`, pnpm keeps `prisma` in the virtual store as a peer of `@prisma/client` (`node_modules/.pnpm/@prisma+client@6.19.3_prisma@6.19.3_.../node_modules/prisma`). The newer npx finds it while walking the local tree, concludes the package is already installed, skips the install, and runs `prisma` straight from `PATH`, where pnpm never created a bin link for it.

Nothing changed on our side, which is why the same Dockerfile built fine on 2026-08-27 and fails on 2026-08-28. It also means the production api image build in `docker-docr.yml` is broken, not just CI.

#### The fix

`pnpm dlx` always fetches the pinned CLI instead of guessing whether it is already present, and it generates the client into the same location `npx` did.

#### Verified

Reproduced outside CI against a byte-for-byte copy of the `deps` stage build context (`pnpm-lock.yaml`, `pnpm-workspace.yaml`, root `package.json`, `api/`, `packages/`) with the same pnpm 10.33.3 install command:

| npm | command | result |
| --- | --- | --- |
| 11.17.0 | `npx prisma@6.19.3` | installs, works (old CI behaviour) |
| 11.19.0 | `npx prisma@6.19.3` | `sh: 1: prisma: not found` |
| 11.19.0 | `npx --yes --package=prisma@6.19.3 -- prisma` | `sh: 1: prisma: not found` |
| 11.19.0 | `pnpm dlx prisma@6.19.3` | installs, works |

`pnpm dlx prisma@6.19.3 generate` generated the client to `node_modules/.pnpm/@prisma+client@6.19.3_prisma@6.19.3_typescript@5.9.3__typescript@5.9.3/node_modules/@prisma/client`, matching the path in the last green CI run.
