### PR TITLE
fix(api): use pnpm dlx to run prisma generate

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -52,7 +52,7 @@ RUN npm i -g pnpm@10
 # consistency.
 RUN pnpm config set dedupe-peer-dependents false
 RUN pnpm install --prod --ignore-scripts -F=api -F=packages/shared --frozen-lockfile
-RUN cd api && npx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
+RUN cd api && pnpm dlx prisma@$(jq -r '.devDependencies.prisma' < package.json) generate
 
 FROM node:24-bookworm
 USER node


### PR DESCRIPTION
Attempt to see if it fixes failures like https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/33174882170/job/98898195478

I could not trace the root cause though.