### PR TITLE
fix(curriculum): add section headers to form validation lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-form-validation/6733aae9d25004f60d1e86f2.md
@@ -11,6 +11,8 @@ In a previous lesson, you've learned how to use HTML to restrict the values your
 
 Certain HTML elements, such as the `textarea` and `input` elements, expose a Constraint Validation API. This API allows you to assert that the user's provided value for that element passes any HTML-level validation you have written, such as minimum length or pattern matching.
 
+## Setting Up the Form with HTML Validation
+
 But how can you actually use it? Let's say you wanted employees at a company to send feedback messages through a form like this:
 
 :::interactive_editor
@@ -90,6 +92,8 @@ We are using the email `input` which comes with built in validation to check for
 
 But what if the user provides an email address like `example@email.com`? This would pass the basic validation, but we want to be more specific about accepting emails from those with a company email address.
 
+## Restricting Input with the `pattern` Attribute
+
 This is where we can use the `pattern` attribute to specify that the email address must end in a company email address. Here is what the updated example will look like:
 
 :::interactive_editor
@@ -168,6 +172,8 @@ button[type="submit"]:hover {
 Now, if you try to submit the feedback, you will see a message saying "Please match the requested format."
 
 Even though the `input` does have placeholder text showing them the desired format, it would be better to also include a customized error message using JavaScript.
+
+## Checking Validity with `checkValidity()`
 
 Let's first take a look at the `checkValidity()` method:
 
@@ -259,6 +265,8 @@ We know that `e.target` refers to the element that triggered the event. In this 
 
 This is part of the Constraint Validation API. The `checkValidity()` method returns `true` if the element matches all HTML validation (based on its attributes), and `false` if it fails.
 
+## Reporting Validity with `reportValidity()`
+
 When we try with an invalid input, we see `false` gets logged in the console. Now that we know the input is invalid, let's report the invalidity:
 
 :::interactive_editor
@@ -346,6 +354,8 @@ input.addEventListener("input", (e) => {
 :::
 
 And as a result, you will see the browser's error message "Please match the requested format."
+
+## Setting a Custom Message with `setCustomValidity()`
 
 It reports the invalid state immediately, instead of waiting for us to submit the form. But it's still using the default message. This is because the `reportValidity()` method only tells the browser that the input is invalid. The browser still chooses how to display why it's invalid. That's where the `setCustomValidity()` method comes in.
 
@@ -436,6 +446,8 @@ input.addEventListener("input", (e) => {
 :::
 
 This method accepts a custom error message, which is displayed to the user. As a result, you will see the custom error message `You must use a company email address that ends in @sampleCompany.com`.
+
+## Exploring the `validity` Property
 
 If you are interested in exploring more about the different types of validity states and why a particular validation has failed, you can log out the `validity` property like this:
 


### PR DESCRIPTION
Added ## Title Case headers to break up the --interactive-- body into logical sections (HTML validation setup, pattern attribute, checkValidity, reportValidity, setCustomValidity, validity property), following the convention established in the sort method lecture. No prose changes, --questions-- untouched.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69316

<!-- Feel free to add any additional description of changes below this line -->
