### PR TITLE
fix: clarify second-best laptop instructions

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6821ebe4237de8297eaee794.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6821ebe4237de8297eaee794.md
@@ -9,8 +9,8 @@ dashedName: challenge-18
 
 Given an array of integers representing the price of different laptops, and an integer representing your budget, return:
 
-1. The second most expensive laptop if it is within your budget, or
-2. The most expensive laptop that is within your budget, or
+1. The second-most expensive laptop in the list if it is within your budget, or
+2. The most expensive laptop you can afford otherwise, or
 3. `0` if no laptops are within your budget.
 
 - Duplicate prices should be ignored.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ebe4237de8297eaee794.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ebe4237de8297eaee794.md
@@ -9,8 +9,8 @@ dashedName: challenge-18
 
 Given an array of integers representing the price of different laptops, and an integer representing your budget, return:
 
-1. The second most expensive laptop if it is within your budget, or
-2. The most expensive laptop that is within your budget, or
+1. The second-most expensive laptop in the list if it is within your budget, or
+2. The most expensive laptop you can afford otherwise, or
 3. `0` if no laptops are within your budget.
 
 - Duplicate prices should be ignored.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

* [x] I have read and followed the [[contribution guidelines](https://contribute.freecodecamp.org/)](https://contribute.freecodecamp.org).
* [x] I have read and followed the [[how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/)](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
* [x] My pull request targets the `main` branch of freeCodeCamp.
* [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69794

<!-- Feel free to add any additional description of changes below this line -->

Updated the JavaScript and Python Daily Coding Challenge instructions to make the expected laptop-selection behavior clearer and more precise.

* Clarified the meaning of the second-most expensive laptop.
* Improved the wording for the fallback option when the second-most expensive laptop is outside the budget.
* Kept the behavior consistent between the JavaScript and Python versions.