### PR TITLE
fix: clarify second-best laptop challenge instructions

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6821ebe4237de8297eaee794.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6821ebe4237de8297eaee794.md
@@ -9,8 +9,8 @@ dashedName: challenge-18
 
 Given an array of integers representing the price of different laptops, and an integer representing your budget, return:
 
-1. The second most expensive laptop if it is within your budget, or
-2. The most expensive laptop that is within your budget, or
+1. The second-most expensive laptop in the list if it is within your budget, or
+2. The most expensive laptop you can afford (if the second-most expensive is out of budget), or
 3. `0` if no laptops are within your budget.
 
 - Duplicate prices should be ignored.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ebe4237de8297eaee794.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ebe4237de8297eaee794.md
@@ -9,8 +9,8 @@ dashedName: challenge-18
 
 Given an array of integers representing the price of different laptops, and an integer representing your budget, return:
 
-1. The second most expensive laptop if it is within your budget, or
-2. The most expensive laptop that is within your budget, or
+1. The second-most expensive laptop in the list if it is within your budget, or
+2. The most expensive laptop you can afford (if the second-most expensive is out of budget), or
 3. `0` if no laptops are within your budget.
 
 - Duplicate prices should be ignored.


### PR DESCRIPTION
- Update description to specify 'second-most expensive in the list'
- Add clarification for fallback case when second-most expensive exceeds budget
- Resolves #69794

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69794

<!-- Feel free to add any additional description of changes below this line -->
## Summary
This PR clarifies the ambiguous instructions for the "Second Best" daily coding challenge by:

1. Specifying that "second-most expensive" refers to the second item in the **full sorted list** (not filtered by budget)
2. Explaining the fallback logic when the second-most expensive laptop exceeds the budget
3. Providing clearer guidance on when to return the most affordable option

This matches the existing test cases and resolves confusion reported in issue #69794.