### PR TITLE
fix: clarify second best laptop challenge

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6821ebe4237de8297eaee794.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/6821ebe4237de8297eaee794.md
@@ -9,8 +9,8 @@ dashedName: challenge-18
 
 Given an array of integers representing the price of different laptops, and an integer representing your budget, return:
 
-1. The second most expensive laptop if it is within your budget, or
-2. The most expensive laptop that is within your budget, or
+1. The second-most expensive laptop in the list if it is within your budget, or
+2. The most expensive laptop you can afford otherwise, or
 3. `0` if no laptops are within your budget.
 
 - Duplicate prices should be ignored.

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ebe4237de8297eaee794.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/6821ebe4237de8297eaee794.md
@@ -9,8 +9,8 @@ dashedName: challenge-18
 
 Given an array of integers representing the price of different laptops, and an integer representing your budget, return:
 
-1. The second most expensive laptop if it is within your budget, or
-2. The most expensive laptop that is within your budget, or
+1. The second-most expensive laptop in the list if it is within your budget, or
+2. The most expensive laptop you can afford otherwise, or
 3. `0` if no laptops are within your budget.
 
 - Duplicate prices should be ignored.


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69794

## Description

Clarified the instructions for Daily Coding Challenge 18: Second Best.

Updated the JavaScript and Python challenge descriptions to explicitly state that:

- The second-most expensive laptop refers to the laptop in the full list.
- If that laptop is outside the budget, the most expensive affordable laptop should be returned.
- `0` should be returned if no laptops are within the budget.

No challenge logic or tests were changed.