### PR TITLE
fix(client): escape console output of JavaScript challenges

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -371,7 +371,7 @@ function* previewChallengeSaga() {
           );
           const output = logs?.map(log => log.msg).join('\n');
 
-          yield put(updateConsole(output));
+          yield put(updateConsole(escape(output)));
         }
       }
     }

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.test.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.test.js
@@ -2,8 +2,13 @@
 // recognize
 /* eslint-disable vitest/expect-expect */
 import { expectSaga } from 'redux-saga-test-plan';
+import * as matchers from 'redux-saga-test-plan/matchers';
 import { describe, it, vi } from 'vitest';
 
+import { buildChallenge } from '@freecodecamp/challenge-builder/build';
+import { challengeTypes } from '@freecodecamp/shared/config/challenge-types';
+
+import { getTestRunner } from '../utils/build';
 import { executeTests, updatePreviewSaga } from './execute-challenge-saga';
 
 vi.mock('i18next', async () => ({
@@ -44,6 +49,40 @@ describe('updatePreviewSaga', () => {
     return expectSaga(updatePreviewSaga, previewMounted)
       .withReducer(reducer)
       .put({ type: 'challenge.initLogs' })
+      .silentRun();
+  });
+});
+
+describe('updatePreviewSaga console output', () => {
+  // The console is rendered with dangerouslySetInnerHTML, so anything the
+  // learner logs has to be escaped before it reaches the store. Without this,
+  // a log of "&amp;" is decoded on render and shown as "&", which breaks
+  // challenges that ask campers to produce HTML entities. See #63788.
+  it('escapes the logs of JavaScript challenges', () => {
+    const runUserCode = () => {};
+    const state = {
+      challenge: {
+        isBuildEnabled: true,
+        isExecuting: false,
+        challengeMeta: { challengeType: challengeTypes.jsLab },
+        challengeFiles: []
+      }
+    };
+
+    return expectSaga(updatePreviewSaga, challengeMounted)
+      .withReducer((s = state) => s)
+      .provide([
+        [matchers.call.fn(buildChallenge), {}],
+        [matchers.call.fn(getTestRunner), runUserCode],
+        [
+          matchers.call.fn(runUserCode),
+          [{ logs: [{ msg: 'Dolce &amp; Gabbana' }] }]
+        ]
+      ])
+      .put({
+        type: 'challenge.updateConsole',
+        payload: 'Dolce &amp;amp; Gabbana'
+      })
       .silentRun();
   });
 });


### PR DESCRIPTION
## Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #63788

### The cause

`Output` renders the console with `dangerouslySetInnerHTML`, so every log has to arrive at the store already escaped:

https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/templates/Challenges/components/output.tsx#L14-L21

`previewChallengeSaga` does that almost everywhere — `takeEveryConsole` uses `escape(args)`, `outputBuildWarnings` uses `escape(warningMessage)`, and the `catch` uses `initConsole(escape(err))`. The JavaScript branch was the one path that skipped it:

```js
const output = logs?.map(log => log.msg).join('\n');

yield put(updateConsole(output));
```

So for an unescaped log, `sanitize-html` parses `&amp;`, decodes it to `&`, and re-encodes it once on the way out. `dangerouslySetInnerHTML` then decodes it a second time, and the camper sees `&`:

| `console.log` value | sanitized HTML | console shows |
| :--- | :--- | :--- |
| `Dolce &amp; Gabbana` | `Dolce &amp; Gabbana` | `Dolce & Gabbana` ❌ |
| `Dolce &amp; Gabbana` (escaped first) | `Dolce &amp;amp; Gabbana` | `Dolce &amp; Gabbana` ✅ |

This is why the entity converter lab looks broken: `implement-an-html-entity-converter` is `challengeType: 26` (`jsLab`), which `challengeHasPreview` excludes and `isJavaScriptChallenge` includes, so its console output is the one kind that was never escaped.

### The change

One line, matching what the three neighbouring paths in the same saga already do:

```js
yield put(updateConsole(escape(output)));
```

This also moves the file a step toward the existing `TODO` above `takeEveryConsole` about giving console formatting a single home.

### Testing

- Added a regression test to `execute-challenge-saga.test.js`. I confirmed it fails on `main` (it receives `Dolce &amp; Gabbana`) and passes with the fix.
- `npx vitest run src/templates/Challenges` — 45 files, 342 tests, all passing.
- `eslint --max-warnings 0` and `prettier --check` clean on both changed files.

### Note

`executeChallengeSaga`'s `catch` block (`updateConsole(e)`) is also unescaped. I left it alone since it handles thrown errors rather than camper output and is outside this issue, but it may be worth folding into the `TODO` cleanup later.
