### PR TITLE
fix(curriculum): use valid id selector in Envelope Budget App steps 41-42

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c106.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c106.md
@@ -9,9 +9,9 @@ dashedName: step-41
 
 Now you need to target the `.input-container` element within the element that has your `category` id.
 
-Declare a new `targetInputContainer` variable, and assign it the value of `document.querySelector()`. 
+Declare a new `targetInputContainer` variable, and assign it the value of `document.querySelector()`.
 
-Use concatenation to combine the `category` variable, and `' .input-container'` (note the space before `.input-container`), and pass that string to `querySelector()`.
+Use concatenation to combine the string `'#'`, the `category` variable, and `' .input-container'` (note the space before `.input-container`), and pass that string to `querySelector()`. The `'#'` prefix tells `querySelector()` to look for an element with that `id`.
 
 # --hints--
 
@@ -28,10 +28,10 @@ Your `targetInputContainer` variable should be set to `document.querySelector()`
 assert.match(addEntry.toString(), /targetInputContainer\s*=\s*document\.querySelector\(/);
 ```
 
-You should pass `category` to `querySelector()`.
+You should concatenate `'#'` before `category` to target the element by its `id`.
 
 ```js
-assert.match(addEntry.toString(), /document\.querySelector\(\s*category/);
+assert.match(addEntry.toString(), /document\.querySelector\(\s*['"]#['"]\s*\+\s*category/);
 ```
 
 You should concatenate `' .input-container'` after `category`. Remember to include the space at the beginning of `.input-container`.

--- a/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c107.md
+++ b/curriculum/challenges/english/blocks/workshop-envelope-budget-app/69b2c970cb02ddaafff1c107.md
@@ -19,7 +19,7 @@ console.log(templateLiteral);
 
 The console will show the string "Hello, my name is Naomi~!".
 
-Replace your concatenated string in the `querySelector` with a template literal – be sure to add `#` before your `category` variable and the space between `${category}` and ` .input-container `.
+Replace your concatenated string in the `querySelector` with a template literal. Be sure to keep the `#` before `${category}` and the space between `${category}` and `.input-container`.
 
 # --hints--
 
@@ -35,7 +35,7 @@ Your template literal should start with `#${category}`.
 assert.match(code, /`#\$\{category\}/);
 ```
 
-Your template literal should include  ` .input-container ` after `#${category}`. Remember to include the space before `.input-container `.
+Your template literal should include ` .input-container` after `#${category}`. Remember to include the space before `.input-container`.
 
 ```js
 assert.match(code, /`#\$\{category\}\s+\.input-container`/);
@@ -297,7 +297,7 @@ function isInvalidInput(str) {
 function addEntry() {
   const category = entryDropdown.value;
 --fcc-editable-region--
-  const targetInputContainer = document.querySelector(category + ' .input-container');
+  const targetInputContainer = document.querySelector('#' + category + ' .input-container');
 --fcc-editable-region--
 }
 ```


### PR DESCRIPTION
## Summary

Fixes #69805

Steps 41 and 42 of the Envelope Budget App workshop used an invalid CSS selector that caused `targetInputContainer` to always be `null`.

**Root cause:** `category` holds values like `"food"`, `"rent"`, etc. The original instruction told students to build `category + ' .input-container'`, producing selectors like `food .input-container`. This is a descendant selector looking for `.input-container` inside a `<food>` element — which does not exist. The correct selector requires a `#` prefix: `#food .input-container`.

**Changes:**

### Step 41 (`69b2c970cb02ddaafff1c106.md`)
- Updated description to instruct students to concatenate `'#'` before `category`: `'#' + category + ' .input-container'`
- Updated hint 3 text and assertion to check for the `'#' +` prefix

### Step 42 (`69b2c970cb02ddaafff1c107.md`)
- Updated seed code from `document.querySelector(category + ' .input-container')` → `document.querySelector('#' + category + ' .input-container')` so the starting point for step 42 is a valid, working selector
- Updated description from "be sure to add `#`" → "be sure to keep the `#`", since the `#` is now already present from step 41

The step 42 hints are unchanged — they already correctly check for `` `#${category} .input-container` `` in the template literal.

## Test plan

- [ ] Step 41: writing `const targetInputContainer = document.querySelector('#' + category + ' .input-container')` passes all hints
- [ ] Step 42: converting to `` document.querySelector(`#${category} .input-container`) `` passes all hints
- [ ] `targetInputContainer` is no longer `null` when valid categories are selected
