### PR TITLE
fix(curriculum): remove undefined multi-column-layout term from CSS Grid lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md
@@ -13,7 +13,7 @@ But first we need to review what a track is in CSS grid. A track is the space be
 
 To create gaps between columns in a CSS Grid, you can use the `column-gap` property. Acceptable values for this property include pixels, the `em` unit, percentages, or the `normal` keyword.
 
-If you use the `normal` value for the `column-gap` property, then the result will be `0` for grid layouts and `1em` for multi-column layouts.
+If you use the `normal` value for the `column-gap` property, then the result will be `0` for grid layouts.
 
 Here is an example of the markup for a four column grid layout:
 


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69816

Removes the "multi-column layouts" comparison from the column-gap explanation in the CSS Grid lecture, since multi-column layout (column-count etc.) hasn't been introduced anywhere earlier in the curriculum. This keeps the lesson scoped to Grid terminology only, per the issue's first suggested fix.