### PR TITLE
fix: remove unclear multi-column terminology from CSS Grid lecture

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ Checklist:
 
 - [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
 - [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
+- [ ] I understand that AI-generated or AI-assisted code must still follow the contribution guidelines and has been reviewed carefully.
 - [ ] My pull request targets the `main` branch of freeCodeCamp.
 - [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md
@@ -13,7 +13,7 @@ But first we need to review what a track is in CSS grid. A track is the space be
 
 To create gaps between columns in a CSS Grid, you can use the `column-gap` property. Acceptable values for this property include pixels, the `em` unit, percentages, or the `normal` keyword.
 
-If you use the `normal` value for the `column-gap` property, then the result will be `0` for grid layouts and `1em` for multi-column layouts.
+If you use the `normal` value for the `column-gap` property, then the result will be `0` for grid layouts.
 
 Here is an example of the markup for a four column grid layout:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69816

<!-- Feel free to add any additional description of changes below this line -->

## Description
This PR removes unclear terminology about multi-column layouts from the CSS Grid lecture. The phrase "and `1em` for multi-column layouts" was removed because multi-column layouts haven't been introduced in the curriculum yet, causing confusion for beginners.

## Changes Made
- Edited line 16 in `curriculum/challenges/english/blocks/lecture-working-with-css-grid/6732267ecab2151ced471cd4.md`
- Removed the reference to multi-column layouts from the `column-gap` property explanation

## Testing
- Verified the change renders correctly in the lecture
- Confirmed no other references to multi-column layouts appear in the same lecture

## Related Issue
Closes #69816