### PR TITLE
fix(curriculum): add section headers to flex properties lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-flexbox/672bd658c0e190f674a5e057.md
@@ -9,6 +9,8 @@ dashedName: what-are-some-common-flex-properties
 
 Flex properties control how elements behave inside a flex layout, from container-level distribution to item-level self-alignment. We'll cover some of the most commonly used ones in this lesson: `flex-wrap`, `flex-flow`, `justify-content`, `align-items`, and `align-self`.
 
+## Wrapping Items with `flex-wrap`
+
 Let's start with `flex-wrap`. This property determines how flex items are wrapped within a flex container to fit the available space. `flex-wrap` can take three possible values: `nowrap`, `wrap`, and `wrap-reverse`. `nowrap` is the default value: flex items won't be wrapped onto a new line, even if their width exceeds the container's width.
 
 In the code below, we have three `div` elements. Let's focus on the `width`. The bordered `main` container has a `width` of `200px`, while its three child `div` elements combined have a `width` of `240px` (`80px` each):
@@ -92,6 +94,8 @@ div {
 
 :::
 
+## Combining Direction and Wrap with `flex-flow`
+
 The `div` elements will be rearranged in rows when they exceed the width of their container. You can wrap flex items in reverse order with `flex-wrap: wrap-reverse`. The `flex-flow` property is a shorthand property for `flex-direction` and `flex-wrap`. In this example, we set `flex-direction` to `column` and `flex-wrap` to `wrap-reverse`:
 
 :::interactive_editor
@@ -133,6 +137,8 @@ div {
 ```
 
 :::
+
+## Aligning Items Along the Main Axis with `justify-content`
 
 Great. Now let's talk about `justify-content`. `justify-content` aligns the child elements along the main axis of the flex container. If you assign the value `flex-start` to `justify-content`, the flex items will be aligned to the start of the main axis. This could be horizontal or vertical:
 
@@ -374,6 +380,8 @@ div {
 
 :::
 
+## Aligning Items Along the Cross Axis with `align-items`
+
 Great. Now you know how to distribute flex items along the main axis. But you may also want to distribute them along the cross axis. Remember that the cross axis is perpendicular to the main axis. You can do this with the `align-items` property. To center the items along the cross axis, you just need to add `align-items: center` to the flex container: 
 
 :::interactive_editor
@@ -538,6 +546,8 @@ div {
 ```
 
 :::
+
+## Overriding Alignment for a Single Item with `align-self`
 
 And finally, you can use the `align-self` property to assign a different alignment on the cross axis to an individual flex item. For example, you can stretch it with `align-self: stretch`. 
 


### PR DESCRIPTION
Added ## Title Case headers to break up the --interactive-- body into logical sections (flex-wrap, flex-flow, justify-content, align-items, align-self), following the convention established in the sort method lecture. No prose changes, --questions-- untouched.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69296

<!-- Feel free to add any additional description of changes below this line -->
