### PR TITLE
fix(curriculum): isolate Euler 13 test fixtures

### DIFF
--- a/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f37a1000cf542c50fe8c.md
+++ b/curriculum/challenges/english/blocks/project-euler-problems-1-to-100/5900f37a1000cf542c50fe8c.md
@@ -116,7 +116,7 @@ Work out the first ten digits of the sum of the following one-hundred 50-digit n
 # --before-each--
 
 ```js
-const fiftyDigitNums = [
+const _fiftyDigitNums = [
   '37107287533902102798797998220837590246510135740250',
   '46376937677490009712648124896970078050417018260538',
   '74324986199524741059474233309513058123726617309629',
@@ -219,7 +219,7 @@ const fiftyDigitNums = [
   '53503534226472524250874054075591789781264330331690'
 ];
 
-const testNums = [
+const _testNums = [
   '37107287533902102798797998220837590246510135740250',
   '46376937677490009712648124896970078050417018260538'
 ];
@@ -230,19 +230,19 @@ const testNums = [
 `largeSum(testNums)` should return a number.
 
 ```js
-assert.isNumber(largeSum(testNums));
+assert.isNumber(largeSum(_testNums));
 ```
 
 `largeSum(testNums)` should return 8348422521.
 
 ```js
-assert.strictEqual(largeSum(testNums), 8348422521);
+assert.strictEqual(largeSum(_testNums), 8348422521);
 ```
 
-`largeSum(fiftyDigitNums)` should return 5537376230.
+`largeSum` should return 5537376230 when called with an array containing the 100 numbers in the description.
 
 ```js
-assert.strictEqual(largeSum(fiftyDigitNums), 5537376230);
+assert.strictEqual(largeSum(_fiftyDigitNums), 5537376230);
 ```
 
 # --seed--
@@ -283,4 +283,11 @@ function largeSum(arr) {
   let firstTen = sum.slice(0, 10);
   return parseInt(firstTen, 10);
 }
+
+const testNums = [
+  '37107287533902102798797998220837590246510135740250',
+  '46376937677490009712648124896970078050417018260538'
+];
+
+largeSum(testNums);
 ```


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally.

The `const` variable in the hook was conflicting with the one in the seed, this PR adds the same variable in the solution to check for these conflicts, and rename the variables in hints to avoid the conflict alltogether.

Then a small rewording of the last hint to not reference a variable that is not shown to the user.
