### PR TITLE
fix(curriculum): add section headers to CSS transform property

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -37,7 +37,7 @@ body {
 
 We have set the `body` to have a solid black border so that you can see the `.box` element nested inside the `body` element.
 
-## Using Translate
+## Using translate
 
 The `translate` function moves an element from its current position. Here's an updated example using the `translate` function:  
 
@@ -66,7 +66,7 @@ body {
 
 This CSS rule will move the element with the class `box` 50 pixels to the right and 100 pixels down from its original position.
 
-## Using Rotate
+## Using rotate
 
 The `rotate` function rotates an element around a fixed point and this is an example of using the `rotate` function for the `.box` element from earlier:  
 
@@ -92,7 +92,7 @@ The `rotate` function rotates an element around a fixed point and this is an exa
 
 This will rotate the element forty five degrees clockwise.
 
-## Using Scale
+## Using scale
 
 The `scale` function allows you to change the size of an element. Here's an example:  
 
@@ -118,7 +118,7 @@ The `scale` function allows you to change the size of an element. Here's an exam
 
 This will make the element one and a half times wider and twice as tall as its original size.
 
-## Combining Transformations
+## Combining transformations
 
 You can combine multiple transformations in a single declaration:  
 
@@ -144,7 +144,7 @@ You can combine multiple transformations in a single declaration:
 
 This will move the element 50 pixels to the right and down, rotate it 45 degrees, and scale it to be one and a half times its original size.
 
-## Accessibility Considerations
+## Accessibility considerations
 
 While the `transform` property is powerful for creating visually appealing designs, it's important to consider accessibility when using it. Here are some important accessibility concerns to keep in mind. 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -118,7 +118,7 @@ The `scale` function allows you to change the size of an element. Here's an exam
 
 This will make the element one and a half times wider and twice as tall as its original size.
 
-## Combining transformations
+## Combining Transformations
 
 You can combine multiple transformations in a single declaration:  
 
@@ -144,7 +144,7 @@ You can combine multiple transformations in a single declaration:
 
 This will move the element 50 pixels to the right and down, rotate it 45 degrees, and scale it to be one and a half times its original size.
 
-## Accessibility considerations
+## Accessibility Considerations
 
 While the `transform` property is powerful for creating visually appealing designs, it's important to consider accessibility when using it. Here are some important accessibility concerns to keep in mind. 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -37,7 +37,7 @@ body {
 
 We have set the `body` to have a solid black border so that you can see the `.box` element nested inside the `body` element.
 
-## Using translate
+## Using `translate`
 
 The `translate` function moves an element from its current position. Here's an updated example using the `translate` function:  
 
@@ -66,7 +66,7 @@ body {
 
 This CSS rule will move the element with the class `box` 50 pixels to the right and 100 pixels down from its original position.
 
-## Using rotate
+## Using `rotate`
 
 The `rotate` function rotates an element around a fixed point and this is an example of using the `rotate` function for the `.box` element from earlier:  
 
@@ -92,7 +92,7 @@ The `rotate` function rotates an element around a fixed point and this is an exa
 
 This will rotate the element forty five degrees clockwise.
 
-## Using scale
+## Using `scale`
 
 The `scale` function allows you to change the size of an element. Here's an example:  
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -37,6 +37,8 @@ body {
 
 We have set the `body` to have a solid black border so that you can see the `.box` element nested inside the `body` element.
 
+## Using Translate
+
 The `translate` function moves an element from its current position. Here's an updated example using the `translate` function:  
 
 :::interactive_editor
@@ -64,6 +66,8 @@ body {
 
 This CSS rule will move the element with the class `box` 50 pixels to the right and 100 pixels down from its original position.
 
+## Using Rotate
+
 The `rotate` function rotates an element around a fixed point and this is an example of using the `rotate` function for the `.box` element from earlier:  
 
 :::interactive_editor
@@ -87,6 +91,8 @@ The `rotate` function rotates an element around a fixed point and this is an exa
 :::
 
 This will rotate the element forty five degrees clockwise.
+
+## Using Scale
 
 The `scale` function allows you to change the size of an element. Here's an example:  
 
@@ -112,6 +118,8 @@ The `scale` function allows you to change the size of an element. Here's an exam
 
 This will make the element one and a half times wider and twice as tall as its original size.
 
+## Combining Transformations
+
 You can combine multiple transformations in a single declaration:  
 
 :::interactive_editor
@@ -135,6 +143,8 @@ You can combine multiple transformations in a single declaration:
 :::
 
 This will move the element 50 pixels to the right and down, rotate it 45 degrees, and scale it to be one and a half times its original size.
+
+## Accessibility Considerations
 
 While the `transform` property is powerful for creating visually appealing designs, it's important to consider accessibility when using it. Here are some important accessibility concerns to keep in mind. 
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-transforms-overflow-and-filters/672bcc8ccc976fd791610f43.md
@@ -148,13 +148,23 @@ This will move the element 50 pixels to the right and down, rotate it 45 degrees
 
 While the `transform` property is powerful for creating visually appealing designs, it's important to consider accessibility when using it. Here are some important accessibility concerns to keep in mind. 
 
+### Screen Reader Order
+
 Screen readers may not accurately convey transformed content. For example, if you use `transform` to rearrange the visual order of elements, screen readers will still read the content in the original DOM order. This can lead to confusion for users relying on screen readers.
+
+### Text Scaling
 
 When using `scale` to resize text be cautious not to make it too small or too large. Extremely small text can be difficult to read while overly large text might overflow its container and become unreadable. It's generally better to use proper font styling techniques for text resizing.
 
+### Motion and Depth Perception
+
 If you are using `transform` for animations effects, be mindful of users who are sensitive to motion. Excessive or rapid animations can cause discomfort or even trigger seizures for some people. Consider providing a way for users to reduce or turn off animations. When using 3D transforms, remember that not all users perceive depth in the same way. Ensure any critical information conveyed through 3D effects is also available in a 2D format or through text.
 
+### Hiding Content Properly
+
 If you are using `transform` to hide or reveal content, make sure the content is still accessible to screen readers and keyboard navigation. Hidden content should be truly hidden such as by using `display: none;` or `visibility: hidden;`, rather than just being visually moved offscreen. 
+
+### Target Size for Interactive Elements
 
 When applying `transform` to interactive elements like buttons or links, ensure that the clickable area remains intuitive and easily targetable. A drastically transformed button might be visually confusing or difficult to click especially for users with motor impairments.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69315

<!-- Feel free to add any additional description of changes below this line -->


### Summary
Adds `##` section headers to the `# --interactive--` body of the CSS transform lecture challenge to improve scannability, following the existing convention used in other lecture challenges (e.g. "How Does the Sort Method Work?").

### Changes
Inserted 6 `##` Title Case headers to break up the ~602-word lecture body into logical sections:
- `## Using Translate`
- `## Using Rotate`
- `## Using Scale`
- `## Combining Transformations`
- `## Accessibility Considerations`

No prose was rewritten — only headers were inserted at existing paragraph/topic boundaries. The `# --questions--` section, code blocks, and front matter are untouched.

### Why
The lecture previously had no internal structure, making it hard to scan on the page — especially since the accessibility discussion runs long. This mirrors the pattern already established in `lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md`, where short headers precede each major sub-topic.
