### PR TITLE
fix(curriculum): add headers to javascript date object lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -34,6 +34,8 @@ console.log(now);
 
 For the time, it is using the military time format, so `14:30` is `2:30 PM`. `GMT-0700` is the timezone offset, and `Pacific Daylight Time` is the timezone name.
 
+## Creating a Date with a Specific Value
+
 Here is an example of creating a new `Date` object with a specific date string:
 
 :::interactive_editor
@@ -60,9 +62,13 @@ console.log(dateFromArguments);
 
 This is useful when you need to work with a specific date and time rather than the current date and time.
 
+## Getting the Current Time with `Date.now()`
+
 To get the current date and time, you can use the `Date.now()` method, which returns the number of milliseconds since `January 1, 1970, 00:00:00 UTC`. This is known as the Unix epoch time.
 
 Unix epoch time is a common way to represent dates and times in computer systems because it is an integer that can be easily stored and manipulated. UTC stands for Universal Time Coordinated, which is the primary time standard by which the world regulates clocks and time.
+
+## Getting Parts of a Date
 
 If you need to get a day of the month based on the current date, you can use the `getDate` method. Here is an example of using the `getDate` method:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -70,6 +70,8 @@ Unix epoch time is a common way to represent dates and times in computer systems
 
 ## Getting Parts of a Date
 
+### `getDate()`
+
 If you need to get a day of the month based on the current date, you can use the `getDate` method. Here is an example of using the `getDate` method:
 
 :::interactive_editor
@@ -86,6 +88,8 @@ In this example, we create a new date instance using the `Date` object and assig
 
 `getDate` will return an integer value between `1` and `31`, depending on the day of the month. If the date is invalid, it will return `NaN` (Not a Number).
 
+### `getMonth()`
+
 To get the month, you can use the `getMonth` method like this:
 
 :::interactive_editor
@@ -99,6 +103,8 @@ console.log(month);
 :::
 
 The month is zero-based, so `January` is `0`, `February` is `1`, and so on. If the month is invalid, it will return `NaN`.
+
+### `getFullYear()`
 
 If you need to get the full year, then you can use the `getFullYear` method like this:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -120,7 +120,7 @@ console.log(year);
 
 If the year is invalid, it will return `NaN`.
 
-There are many more methods available on the `Date` object including `getHours`, `getMinutes`, `getSeconds`, and so on. I encourage you to explore some more on your own through Mozilla's documentation or other resources.
+There are many more methods available on the `Date` object including `getHours`, `getMinutes`, `getSeconds`, and so on. I encourage you to explore some more on your own through the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date" target="_blank">`Date` documentation on MDN</a> or other resources.
 
 # --questions--
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-dates/6733aafb9c0802f66cc1e056.md
@@ -120,7 +120,7 @@ console.log(year);
 
 If the year is invalid, it will return `NaN`.
 
-There are many more methods available on the `Date` object including `getHours`, `getMinutes`, `getSeconds`, and so on. I encourage you to explore some more on your own through the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date" target="_blank">`Date` documentation on MDN</a> or other resources.
+There are many more methods available on the `Date` object including `getHours`, `getMinutes`, `getSeconds`, and so on. I encourage you to explore some more on your own through Mozilla's documentation or other resources.
 
 # --questions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69318

<!-- Feel free to add any additional description of changes below this line -->

Changes
- Added 3 headers grouping the existing content by topic: "Creating a Date with a Specific Value", "Getting the Current Time with `Date.now()`", and "Getting Parts of a Date".
- No prose, code blocks, questions, or front matter were modified, headers only.

Testing
- Ran `pnpm run lint-challenges`, passes with no errors.
- Verified locally at `pnpm run develop`, viewed the lecture rendered in the app, headers appear correctly at natural breaks.
