### PR TITLE
fix(client): correct scrollbar width range check

### DIFF
--- a/client/src/utils/scrollbar-width.test.ts
+++ b/client/src/utils/scrollbar-width.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import store from 'store';
+import { getScrollbarWidth } from './scrollbar-width';
+
+vi.mock('store', () => {
+  const data = new Map<string, unknown>();
+  return {
+    default: {
+      get: vi.fn((key: string) => data.get(key)),
+      set: vi.fn((key: string, value: unknown) => {
+        data.set(key, value);
+      }),
+      remove: vi.fn((key: string) => {
+        data.delete(key);
+      })
+    }
+  };
+});
+
+describe('getScrollbarWidth', () => {
+  beforeEach(() => {
+    store.remove('monacoScrollbarWidth');
+  });
+
+  it('returns the stored width when it is within the valid range', () => {
+    for (const width of [5, 10, 15, 20, 25]) {
+      store.set('monacoScrollbarWidth', width);
+      expect(getScrollbarWidth()).toBe(width);
+    }
+  });
+
+  it('falls back to 5 when nothing is stored', () => {
+    expect(getScrollbarWidth()).toBe(5);
+  });
+
+  it('falls back to 5 when the stored width is below the valid range', () => {
+    store.set('monacoScrollbarWidth', 0);
+    expect(getScrollbarWidth()).toBe(5);
+
+    store.set('monacoScrollbarWidth', -10);
+    expect(getScrollbarWidth()).toBe(5);
+  });
+
+  it('falls back to 5 when the stored width is above the valid range', () => {
+    store.set('monacoScrollbarWidth', 100);
+    expect(getScrollbarWidth()).toBe(5);
+  });
+});

--- a/client/src/utils/scrollbar-width.ts
+++ b/client/src/utils/scrollbar-width.ts
@@ -2,5 +2,5 @@ import store from 'store';
 
 export function getScrollbarWidth(): number {
   const storedWidth = store.get('monacoScrollbarWidth') as number;
-  return storedWidth >= 5 || storedWidth <= 25 ? storedWidth : 5;
+  return storedWidth >= 5 && storedWidth <= 25 ? storedWidth : 5;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

### What

`getScrollbarWidth` in `client/src/utils/scrollbar-width.ts` is meant to sanitize the persisted Monaco scrollbar width to the 5-25 range, but the guard uses `||`:

```ts
return storedWidth >= 5 || storedWidth <= 25 ? storedWidth : 5;
```

Every number is either `>= 5` or `<= 25`, so the condition is a tautology and the fallback is only reachable for `undefined`/`NaN`. A corrupted or hand-edited `monacoScrollbarWidth` in localStorage (`0`, `100`, `-3`) is applied verbatim to the editor: `editor.tsx` feeds this value into Monaco's `verticalScrollbarSize`/`arrowSize` and a width calculation in four places.

The condition wants `&&`. One character, plus a unit test file so the range check cannot regress silently again (the bug shipped with the original feature PR #49975 and was never caught because the file had no tests).

### Verification

`scrollbar-width.test.ts` covers in-range passthrough, both out-of-range sides, and the unset case, with `store` mocked. All 4 pass with the fix. Reverting only `scrollbar-width.ts` fails exactly the two out-of-range tests (`expected +0 to be 5`, `expected 100 to be 5`), so the tests isolate the change.

Opened directly without an issue per the contributing FAQ guidance for small self-contained fixes; happy to open one if preferred.