### PR TITLE
fix(curriculum): add section headers to block-inline-quotes lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995c9e6f69436dbcccc79.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-text-and-time-semantic-elements/672995c9e6f69436dbcccc79.md
@@ -9,6 +9,8 @@ dashedName: how-do-block-and-inline-quotes-work-in-html
 
 In HTML, quoted elements are used to distinguish quoted text from the surrounding content. This gives the quoted text a format that is easy to identify.
 
+## Block Quotations
+
 You should use the block quotation element for representing a section quoted from another source. It's mainly used for extended quotations. If the source of the quote has an address, you can cite it with the `cite` attribute. The value of this attribute should be a valid URL. This is an example of a quote within a block quotation element:
 
 :::interactive_editor
@@ -22,6 +24,8 @@ You should use the block quotation element for representing a section quoted fro
 :::
 
 This element has a `cite` attribute. The value of the `cite` attribute is the URL of the source. While this attribute doesn't change the presentation of the block quote, it's very helpful for giving screen readers and search engines more information about the quote. In the browser, you'll see that the text is slightly indented.
+
+## Multi-Paragraph Quotes
 
 If you want to start and end the block quote with quotation marks, you may need to write them explicitly within the text. You can write the text directly within the block quotation element, like I just did, or wrap it within one or more paragraph elements. This is helpful when the text has multiple paragraphs, but you want to keep them within the same block quote. Here's an example with four paragraphs:
 
@@ -39,6 +43,8 @@ If you want to start and end the block quote with quotation marks, you may need 
 :::
 
 All the paragraphs are contained within the same block quotation element, so they are part of the same quotation. You can see that the element has a `cite` attribute with the URL of the source. In the browser, you'll see that the four paragraphs are aligned relative to each other, but they are indented relative to their container.
+
+## Citing Sources
 
 So far I've been using the `cite` attribute to attribute the source of the quotation, but the attribute doesn't really show the source to the user. It only works behind the scenes.
 
@@ -60,6 +66,8 @@ If you want to attribute the source visually, you can add a citation element, `c
 The block quotation element contains quoted text. Below the element you can see a paragraph element with the name of the author, followed by a citation element. The citation element contains the title of the book where the quotation came from.
 
 If you go to the browser, now the source will be clearly visible and see that the quote comes from a book written by Quincy Larson. The title of this book is `How to Learn to Code and Get a Developer Job`.
+
+## Inline Quotations
 
 You should use block quotes like these for long quotations from other sources. But sometimes you will only need to quote a few words within a larger paragraph.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69304

<!-- Feel free to add any additional description of changes below this line -->

## Description

Adds `##` section headers to the lecture body of "How Do Block and Inline Quotes Work in HTML?" to break the ~648-word unbroken block into scannable sections.

Headers added:

- Block Quotations
- Multi-Paragraph Quotes
- Citing Sources
- Inline Quotations

No prose was rewritten - only headers were inserted. Front matter, code blocks, interactive editor blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below:

<img width="610" height="132" alt="Screenshot 2026-09-03 at 5 08 19 AM" src="https://github.com/user-attachments/assets/e051a027-a9c0-4299-9b66-d4a4d92b0fc1" />
<img width="610" height="152" alt="Screenshot 2026-09-03 at 5 07 57 AM" src="https://github.com/user-attachments/assets/192fc3ca-89c5-4b35-9dc8-b759188fd9a8" />
<img width="610" height="196" alt="Screenshot 2026-09-03 at 5 08 33 AM" src="https://github.com/user-attachments/assets/ef931040-a116-47a5-8d24-98e7d27882da" />
<img width="610" height="167" alt="Screenshot 2026-09-03 at 5 08 55 AM" src="https://github.com/user-attachments/assets/0575871a-140d-42a0-914a-6e82a0e922c4" />
