### PR TITLE
fix(client): drop the stray closing paren from formatted Map output

### DIFF
--- a/client/src/utils/format.js
+++ b/client/src/utils/format.js
@@ -9,7 +9,7 @@ export function format(x) {
     return `Map(${x.size}) {${Array.from(
       x.entries(),
       ([k, v]) => `${k} => ${v}`
-    ).join(', ')}})`;
+    ).join(', ')}}`;
   } else if (typeof x === 'bigint') {
     return x.toString() + 'n';
   } else if (typeof x === 'symbol') {

--- a/client/src/utils/format.test.ts
+++ b/client/src/utils/format.test.ts
@@ -43,4 +43,19 @@ describe('format', () => {
   it(`outputs NaN as 'NaN'`, () => {
     expect(format(NaN)).toBe('NaN');
   });
+  it('formats Sets', () => {
+    expect(format(new Set())).toBe('Set(0) {}');
+    expect(format(new Set([1, 2]))).toBe('Set(2) {1, 2}');
+  });
+  it('formats Maps', () => {
+    expect(format(new Map())).toBe('Map(0) {}');
+    expect(
+      format(
+        new Map([
+          ['a', 1],
+          ['b', 2]
+        ])
+      )
+    ).toBe('Map(2) {a => 1, b => 2}');
+  });
 });

--- a/tools/client-plugins/browser-scripts/utils/format.js
+++ b/tools/client-plugins/browser-scripts/utils/format.js
@@ -12,7 +12,7 @@ export function format(x) {
     return `Map(${x.size}) {${Array.from(
       x.entries(),
       ([k, v]) => `${k} => ${v}`
-    ).join(', ')}})`;
+    ).join(', ')}}`;
   } else if (typeof x === 'bigint') {
     return x.toString() + 'n';
   } else if (typeof x === 'symbol') {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

### What

The Map branch of `format()` in `client/src/utils/format.js` closes its template literal with `}})` while the adjacent Set branch correctly closes with `}}`. Every Map printed in the challenge test-runner console panel (format is what `frame.ts` feeds the console) carries a stray trailing `)`:

```
format(new Map([['a', 1], ['b', 2]]))  ->  "Map(2) {a => 1, b => 2})"
format(new Map())                      ->  "Map(0) {})"
```

The file's own comment says it is "trying to mimic console.log", and Node prints `Map(2) { 'a' => 1, 'b' => 2 }` with no trailing paren.

### Changes

The stray `)` is removed in both copies of the file (`client/src/utils/format.js` and `tools/client-plugins/browser-scripts/utils/format.js`), and `formats Sets` / `formats Maps` cases are added to `client/src/utils/format.test.ts`, which previously covered neither branch.

### Verification

With the fix, the format suite passes 9/9. Reverting only the Map line while keeping the tests fails with `expected 'Map(0) {})' to be 'Map(0) {}'`; restoring passes again. Prettier reports no differences on the changed files.