### PR TITLE
fix(api): ignore prototype-inherited names in getChallengeIdsByBlock

### DIFF
--- a/api/src/utils/get-challenges.test.ts
+++ b/api/src/utils/get-challenges.test.ts
@@ -49,4 +49,14 @@ describe('getChallengeIdsByBlock', () => {
     const ids = getChallengeIdsByBlock('');
     expect(ids).toEqual([]);
   });
+
+  test.each([
+    'constructor',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    '__proto__'
+  ])('returns empty array for the inherited property %s', blockId => {
+    expect(getChallengeIdsByBlock(blockId)).toEqual([]);
+  });
 });

--- a/api/src/utils/get-challenges.ts
+++ b/api/src/utils/get-challenges.ts
@@ -91,6 +91,12 @@ export function getChallengeIdsByBlock(blockId: string): string[] {
   const curricula = Object.values(curriculum);
 
   for (const superBlock of curricula) {
+    // `blocks` is parsed from JSON, so it inherits from Object.prototype. Without
+    // this check, a blockId such as 'constructor' would resolve to an inherited
+    // property rather than a block.
+    if (!Object.prototype.hasOwnProperty.call(superBlock.blocks, blockId))
+      continue;
+
     const block = superBlock.blocks[blockId];
     if (block) {
       return block.challenges.map(challenge => challenge.id);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

### What

`getChallengeIdsByBlock` in `api/src/utils/get-challenges.ts` documents "or empty array if block not found", but the curriculum object comes from `JSON.parse`, so `superBlock.blocks` inherits from `Object.prototype`. A block name that collides with an inherited property passes the truthiness guard and crashes:

```
getChallengeIdsByBlock('constructor')  ->  TypeError: Cannot read properties of undefined (reading 'map')
getChallengeIdsByBlock('toString')     ->  same
getChallengeIdsByBlock('non-existent') ->  []   (correct)
```

This is reachable over HTTP: `DELETE /user/reset-module` does `blockIds.flatMap(getChallengeIdsByBlock)` and its schema only constrains `blockIds` to non-empty strings, so `{"blockIds":["constructor"]}` turns the handler's documented 400 ("No matching blocks found") into a 500.

### Changes

An own-property guard using `Object.prototype.hasOwnProperty.call`, the same idiom already used in `packages/shared/src/config/curriculum.ts`, so inherited names fall through to the documented empty-array behavior.

### Verification

Tests added for `constructor`, `toString`, `valueOf`, `hasOwnProperty` and `__proto__` alongside the existing non-existent-block case. Reverting only the source while keeping the tests fails 5 of them with the exact `TypeError` above; restoring passes all 11. Prettier and `tsc --noEmit` are clean on the changed files.