### PR TITLE
fix(shared): only treat whole-string status codes as reserved usernames

### DIFF
--- a/packages/shared/src/utils/validate.test.ts
+++ b/packages/shared/src/utils/validate.test.ts
@@ -23,6 +23,12 @@ describe('isValidUsername', () => {
     expect(isValidUsername('429')).toStrictEqual(usernameIsHttpStatusCode);
     expect(isValidUsername('789')).toStrictEqual(validationSuccess);
   });
+  it('accepts strings which merely start with a status code', () => {
+    expect(isValidUsername('500px')).toStrictEqual(validationSuccess);
+    expect(isValidUsername('404notfound')).toStrictEqual(validationSuccess);
+    expect(isValidUsername('404_foo')).toStrictEqual(validationSuccess);
+    expect(isValidUsername('0500')).toStrictEqual(validationSuccess);
+  });
   it('rejects non-ASCII characters', () => {
     expect(isValidUsername('👀👂👄')).toStrictEqual(invalidCharError);
   });

--- a/packages/shared/src/utils/validate.ts
+++ b/packages/shared/src/utils/validate.ts
@@ -25,10 +25,11 @@ export const usernameIsHttpStatusCode: Invalid = {
 };
 
 const validCharsRE = /^[a-zA-Z0-9\-_+]*$/;
-export const isHttpStatusCode = (str: string): boolean => {
-  const output = parseInt(str, 10);
-  return !isNaN(output) && output >= 100 && output <= 599;
-};
+// The whole string has to be a status code. parseInt would stop at the first
+// non-digit, making '500px' look like the status code 500.
+const httpStatusCodeRE = /^[1-5][0-9]{2}$/;
+export const isHttpStatusCode = (str: string): boolean =>
+  httpStatusCodeRE.test(str);
 
 export const isValidUsername = (str: string): Validated => {
   if (!validCharsRE.test(str)) return invalidCharError;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!-- Feel free to add any additional description of changes below this line -->

### What

`isHttpStatusCode` in `packages/shared/src/utils/validate.ts` uses `parseInt`, which stops at the first non-digit. Any username that merely starts with a 100-599 prefix is therefore rejected with a factually wrong message:

```
"500px"        -> Username "500px" is a reserved error code
"404notfound"  -> Username "404notfound" is a reserved error code
"200ok"        -> Username "200ok" is a reserved error code
"789"          -> valid (789 is not a status code, correct)
```

The sibling test states the intent: "rejects strings which are http response status codes 100-599". `500px` is not a status code.

### Changes

An anchored regex, `/^[1-5][0-9]{2}$/`, so the whole string must be a status code. Every real status code stays reserved: the existing api test asserting `Username 404 is a reserved error code` is unaffected, and `0500` (no longer a parseable "500") is now accepted, matching the function's name and documented range.

### Verification

A regression test is added ("accepts strings which merely start with a status code"). Reverting only the source while keeping the test fails it with `{"error": "is a reserved error code", "valid": false}`; restoring passes the full shared validate suite (55 tests). Prettier and `tsc --noEmit` are clean on the changed files.