### PR TITLE
fix(curriculum): separate view-category section toggling and no bookmarks tests

### DIFF
--- a/curriculum/challenges/english/blocks/lab-bookmark-manager-app/66def5467aee701733aaf8cc.md
+++ b/curriculum/challenges/english/blocks/lab-bookmark-manager-app/66def5467aee701733aaf8cc.md
@@ -259,6 +259,19 @@ const categoryName = document.querySelector(".category-name").innerText.trim();
 assert.strictEqual(categoryName.toLowerCase(), categoryDropdownTest.value.toLowerCase());
 ```
 
+When you click `#view-category-button`, you should call `displayOrHideCategory` to display the bookmark list section and hide the main section.
+
+```js
+const viewCategoryButtonTest = document.getElementById("view-category-button");
+const categoryListSection = document.getElementById("bookmark-list-section");
+const mainSection = document.getElementById("main-section");
+mainSection.classList.remove("hidden");
+categoryListSection.classList.add("hidden");
+assert.strictEqual(getHidden("bookmark list"), "bookmark list");
+viewCategoryButtonTest.dispatchEvent(new Event("click"));
+assert.strictEqual(getHidden("bookmark list"), "main");
+```
+
 When you click `#view-category-button`, you should add a `p` element with the text `No Bookmarks Found` to `#category-list`'s inner HTML if none of the bookmarks in local storage have the selected category.
 
 ```js
@@ -271,15 +284,13 @@ try {
   mainSection.classList.remove("hidden");
   categoryListSection.classList.add("hidden");
   categoryList.innerHTML = "";
-  setLocalStorage()
+  setLocalStorage();
   categoryDropdownTest.value = "miscellaneous";
   viewCategoryButtonTest.dispatchEvent(new Event("click"));
-  assert.strictEqual(categoryList.innerHTML,"<p>No Bookmarks Found</p>")
-  assert.isFalse(categoryListSection.classList.contains("hidden"));
-  assert.isTrue(mainSection.classList.contains("hidden"));
+  assert.strictEqual(categoryList.innerHTML, "<p>No Bookmarks Found</p>");
 } finally {
-  resetLocalStorage()
-  clearCategoryList()
+  resetLocalStorage();
+  clearCategoryList();
 }
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69845 

<!-- Feel free to add any additional description of changes below this line -->
## Summary

This PR separates the implicit test responsibilities when clicking `#view-category-button` in the Bookmark Manager lab into distinct tests:
- **Dedicated Visibility Test**: Added a separate test to verify that clicking `#view-category-button` toggles section visibility on `#main-section` and `#bookmark-list-section`.
- **Refactored `No Bookmarks Found` Test**: Scope-limited the existing test strictly to checking that `<p>No Bookmarks Found</p>` is set as `#category-list`'s inner HTML.
