### PR TITLE
fix: Remove redundant comingSoon flags from superblocks

### DIFF
--- a/curriculum/structure/superblocks/python-v9.json
+++ b/curriculum/structure/superblocks/python-v9.json
@@ -177,10 +177,8 @@
     {
       "chapterType": "exam",
       "dashedName": "python-certification-exam",
-      "comingSoon": false,
       "modules": [
         {
-          "comingSoon": false,
           "dashedName": "python-certification-exam",
           "blocks": ["exam-python-certification"]
         }

--- a/curriculum/structure/superblocks/relational-databases-v9.json
+++ b/curriculum/structure/superblocks/relational-databases-v9.json
@@ -93,10 +93,8 @@
     {
       "chapterType": "exam",
       "dashedName": "relational-databases-certification-exam",
-      "comingSoon": false,
       "modules": [
         {
-          "comingSoon": false,
           "dashedName": "relational-databases-certification-exam",
           "blocks": ["exam-relational-databases-certification"]
         }


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally by parsing both modified JSON files.

If it's `false` then it is not necessary to have it explicitly there