### PR TITLE
fix(curriculum): remove obsolete python-v9 module intros

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -6455,13 +6455,6 @@
       "review-python": "Python Review",
       "python-certification-exam": "Python Certification Exam"
     },
-    "module-intros": {
-      "python-recursion": {
-        "intro": [
-          "In this module, you will learn how recursion and the call stack work in Python."
-        ]
-      }
-    },
     "blocks": {
       "lecture-introduction-to-python": {
         "title": "Introduction to Python",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69882

### Description of changes

Removes the obsolete `python-recursion` entry from `module-intros` under `python-v9` in `client/i18n/locales/english/intro.json`, and removes the now-empty `module-intros` object per the issue specification. Verified JSON validity after removal.
