### PR TITLE
fix(curriculum): remove obsolete front-end-development-libraries-v9 module intros

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -6046,18 +6046,6 @@
       "review-front-end-libraries": "Front-End Libraries Review",
       "front-end-development-libraries-certification-exam": "Front-End Development Libraries Certification Exam"
     },
-    "module-intros": {
-      "typescript-fundamentals": {
-        "intro": [
-          "In this module, you will be introduced to TypeScript, which is a superset of JavaScript that allows you to add static typing to your JavaScript code. You will build several workshops and labs that will give you practice in working with generics, type narrowing, TSX, and more. Then you will test your knowledge of TypeScript fundamentals with a short quiz."
-        ]
-      },
-      "front-end-development-libraries-certification-exam": {
-        "intro": [
-          "Pass this exam to earn your Front-End Development Libraries Certification."
-        ]
-      }
-    },
     "blocks": {
       "lecture-introduction-to-javascript-libraries-and-frameworks": {
         "title": "Introduction to JavaScript Libraries and Frameworks",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69880

### Description of changes

Removes the obsolete `typescript-fundamentals` and `front-end-development-libraries-certification-exam` entries from `module-intros` under `front-end-development-libraries-v9` in `client/i18n/locales/english/intro.json`, and removes the now-empty `module-intros` object per the issue specification. Verified JSON validity after removal.
