### PR TITLE
fix(curriculum): remove obsolete javascript-v9 module intros

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4537,32 +4537,6 @@
       "review-javascript": "JavaScript Review",
       "javascript-certification-exam": "JavaScript Certification Exam"
     },
-    "module-intros": {
-      "data-structures": {
-        "note": "Coming Spring 2026",
-        "intro": [
-          "In this module, you will learn about linked lists, stacks, queues and more."
-        ]
-      },
-      "algorithms": {
-        "note": "Coming Spring 2026",
-        "intro": [
-          "In this module, you will learn about common sorting and searching algorithms including bubble sort, binary search and more."
-        ]
-      },
-      "graphs-and-trees": {
-        "note": "Coming Spring 2026",
-        "intro": [
-          "In this module, you will learn about graphs, trees and tries."
-        ]
-      },
-      "dynamic-programming": {
-        "note": "Coming Spring 2026",
-        "intro": [
-          "In this module, you will learn how dynamic programming works."
-        ]
-      }
-    },
     "blocks": {
       "lecture-introduction-to-javascript": {
         "title": "Introduction to JavaScript",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69881

### Description of changes

Removes obsolete entries (`data-structures`, `algorithms`, `graphs-and-trees`, `dynamic-programming`) from `module-intros` under `javascript-v9` in `client/i18n/locales/english/intro.json`, and removes the now-empty `module-intros` object per the issue specification. Verified JSON validity after removal.
