### PR TITLE
fix: correct pinyin for 60

### DIFF
--- a/curriculum/challenges/english/blocks/zh-a1-quiz-numbers-below-100/697adc426b8d5ed66d1e8b97.md
+++ b/curriculum/challenges/english/blocks/zh-a1-quiz-numbers-below-100/697adc426b8d5ed66d1e8b97.md
@@ -56,7 +56,7 @@ What is the base word in Chinese for numbers in the 60s?
 
 #### --answer--
 
-`六十 (shí li)`
+`六十 (liù shí)`
 
 ### --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69870 

<!-- Feel free to add any additional description of changes below this line -->

This corrects the pinyin in the Chinese A1 numbers quiz from `shí li` to `liù shí`.