### PR TITLE
fix(tests): use exact filename matching in external-curriculum superblock classification

### DIFF
--- a/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
+++ b/client/tools/external-curriculum/build-external-curricula-data-v2.test.ts
@@ -178,8 +178,8 @@ describe('external curriculum data build', () => {
         fileFilter: entry => {
           // The directory contains super block files and other curriculum-related files.
           // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
+          const isSuperBlock = superBlocks.some(
+            superBlock => entry.basename === `${superBlock}.json`
           );
 
           return isSuperBlock;
@@ -213,13 +213,13 @@ describe('external curriculum data build', () => {
         fileFilter: entry => {
           // The directory contains super block files and other curriculum-related files.
           // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
+          const isSuperBlock = superBlocks.some(
+            superBlock => entry.basename === `${superBlock}.json`
           );
 
           const isChapterBasedSuperBlock = chapterBasedSuperBlocks.some(
             chapterBasedSuperBlock =>
-              entry.basename.includes(chapterBasedSuperBlock)
+              entry.basename === `${chapterBasedSuperBlock}.json`
           );
 
           return isSuperBlock && !isChapterBasedSuperBlock;
@@ -267,13 +267,13 @@ describe('external curriculum data build', () => {
         fileFilter: entry => {
           // The directory contains super block files and other curriculum-related files.
           // We're only interested in super block ones.
-          const isSuperBlock = superBlocks.some(superBlock =>
-            entry.basename.includes(superBlock)
+          const isSuperBlock = superBlocks.some(
+            superBlock => entry.basename === `${superBlock}.json`
           );
 
           const isChapterBasedSuperBlock = chapterBasedSuperBlocks.some(
             chapterBasedSuperBlock =>
-              entry.basename.includes(chapterBasedSuperBlock)
+              entry.basename === `${chapterBasedSuperBlock}.json`
           );
 
           return isSuperBlock && isChapterBasedSuperBlock;


### PR DESCRIPTION
Substring matching caused block-based catalog files (e.g. introduction-to-algorithms-and-data-structures.json) to be misclassified as chapter-based when a chapter-based superblock slug (e.g. algorithms-and-data-structure) appeared as a substring in the filename. Switch all three fileFilter callbacks to exact filename comparison (entry.basename === \${superBlock}.json``) to prevent false matches.

Fixes the test failures reported in #69873.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69877 