### PR TITLE
fix(curriculum): add section headers to calc() lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-relative-and-absolute-units/672bb851b068e3954a05b9b1.md
@@ -9,6 +9,8 @@ dashedName: what-is-the-calc-function
 
 With the `calc()` function, you can perform calculations directly within your stylesheets to determine property values dynamically. This means that you can create flexible and responsive user interfaces by calculating dimensions based on the viewport size or other elements.
 
+## Understanding Functions
+
 `calc()` is a CSS function. You'll learn more about functions when you start learning about JavaScript, but in this lesson, you're going to learn the basics that you need to know to understand how `calc()` works.
 
 A function is a block of code that performs a specific task. Some functions are already defined in CSS, so you can use them directly and pass any necessary values to them to customize how their tasks will be performed.
@@ -33,6 +35,8 @@ calc(expression)
 
 The expression is evaluated to calculate the final result. "Evaluated" just means that the values and operators are converted into a single value behind the scenes. The result is assigned to the CSS property where the calculation is being made.
 
+## Supported Values and Operators
+
 You can perform calculations on values that represent length, angle, time, percentages, and numbers. You can also combine different units like pixels, percentages, and ems.
 
 For addition and subtraction, all the values in the expression, also called the operands, must have their corresponding units, like `px`, `em`, and percentage (`%`). Depending on the operator, different operands may have different units.
@@ -40,6 +44,8 @@ For addition and subtraction, all the values in the expression, also called the 
 You can use the addition (`+`), subtraction (`-`), multiplication (`*`), and division (`/`) operators in the expression.
 
 If there are multiple operands and operators, `calc()` will follow the standard operator precedence rule. You can also add parentheses to establish the order of the operations if needed.
+
+## Calculating a Responsive Width
 
 In the example below, you can see a `div` with the text `Hello, World!`.
 
@@ -71,6 +77,8 @@ The width of the `div` is approximately half the total width of its container, a
 That's the key advantage of using `calc()`. You can determine the value of a CSS property dynamically based on different aspects of the application or viewport.
 
 The expression can also contain CSS functions and variables if you need to use them in your calculations. You'll learn more about CSS variables in the next lessons.
+
+## Best Practices
 
 Great. Now that you know about the basics of the `calc()` function, let's cover some of its best practices.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69290

<!-- Feel free to add any additional description of changes below this line -->

Adds section headers to break the CSS `calc()` lecture into logical sections without changing the existing prose, code blocks, questions, or front matter.

Tested the affected curriculum block locally. All 11 tests pass, and the file passes the challenge linter and Prettier check.
