### PR TITLE
fix(curriculum): check donation input order

### DIFF
--- a/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
+++ b/curriculum/challenges/english/blocks/lab-debug-donation-form/690ddb5e6ee94eb73ed172b0.md
@@ -37,31 +37,31 @@ assert.lengthOf(document.querySelectorAll("input"), 5);
 Your first `input` element should have a `name` attribute with a value of `name`.
 
 ```js
-assert.exists(document.querySelector("input:nth-of-type(1)[name='name']"));
+assert.equal(document.querySelectorAll("input")[0]?.getAttribute("name"), "name");
 ```
 
 Your second `input` element should have a `name` attribute with a value of `email`.
 
 ```js
-assert.exists(document.querySelector("input:nth-of-type(2)[name='email']"));
+assert.equal(document.querySelectorAll("input")[1]?.getAttribute("name"), "email");
 ```
 
 Your third `input` element should have a `name` attribute with a value of `amount`.
 
 ```js
-assert.exists(document.querySelector("input:nth-of-type(3)[name='amount']"));
+assert.equal(document.querySelectorAll("input")[2]?.getAttribute("name"), "amount");
 ```
 
 Your fourth `input` element should have a `name` attribute with a value of `newsletter`.
 
 ```js
-assert.exists(document.querySelector("input:nth-of-type(4)[name='newsletter']"));
+assert.equal(document.querySelectorAll("input")[3]?.getAttribute("name"), "newsletter");
 ```
 
 Your fifth `input` element should have a `type` attribute with a value of `submit`.
 
 ```js
-assert.exists(document.querySelector("input:nth-of-type(5)[type='submit']"));
+assert.equal(document.querySelectorAll("input")[4]?.getAttribute("type"), "submit");
 ```
 
 You should have exactly four `label` elements in your form.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

If campers nest the input inside the label previous tests would fail unexplained. Now they pass.
