### PR TITLE
fix(client): add missing span rtl direction css rule

### DIFF
--- a/client/src/components/layouts/rtl-layout.css
+++ b/client/src/components/layouts/rtl-layout.css
@@ -112,6 +112,8 @@ sections that need to stay left to right
 [dir='rtl'] :has(#learn-app-wrapper) pre,
 /* Code snippet*/
 [dir='rtl'] code,
+/* Language course spans preserved in the language to be taught*/
+[dir='rtl'] .highlighted-text,
 /* trending articles */
 [dir='rtl'] .trending-guides .trending-guides-row div a,
 [dir='rtl'] .overflow-guard,
@@ -121,7 +123,8 @@ sections that need to stay left to right
   direction: ltr;
 }
 
-[dir='rtl'] code {
+[dir='rtl'] code,
+[dir='rtl'] .highlighted-text {
   word-break: normal;
   unicode-bidi: isolate;
 }


### PR DESCRIPTION
This fixes a bug noticed in https://www.freecodecamp.org/arabic/learn/a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/task-2, where spans with the target language to be taught get the final punctuation in the beginning of the span.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitHub Codespaces.
