### PR TITLE
fix(curriculum): add section header to array method section

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
@@ -50,7 +50,7 @@ console.log(colors); // ["red", "yellow", "purple", "green", "blue"]
 
 Here, `splice(1, 0, "yellow", "purple")` starts at index `1`, removes `0` elements, and inserts `yellow` and `purple`. The second parameter (`0`) means no elements are removed before insertion. You can also use `splice()` to simultaneously remove and add elements:
 
-## Removing and Adding Elements Together
+## Array Insertion and Deletion
 
 :::interactive_editor
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
@@ -17,6 +17,8 @@ array.splice(startIndex, itemsToRemove, item1, item2)
 
 `startIndex` specifies the index at which to begin modifying the array, while `itemsToRemove` is an optional parameter indicating how many elements to remove. If `itemsToRemove` is omitted, `splice()` will remove all elements from `startIndex` to the end of the array. The subsequent parameters (`item1`, `item2`, and so on) are the elements to be added to the array, beginning at the start index.
 
+## Removing Elements
+
 Let's start with an example of removing elements from the middle of an array:
 
 :::interactive_editor
@@ -33,6 +35,8 @@ console.log(removed); // ["orange", "mango"]
 
 In this example, `splice(2, 2)` starts at index `2` and removes `2` elements. The modified array will now consist of only `apple`, `banana`, and `kiwi`. Now, let's look at how to add elements to the middle of an array:
 
+## Adding Elements
+
 :::interactive_editor
 
 ```js
@@ -46,6 +50,8 @@ console.log(colors); // ["red", "yellow", "purple", "green", "blue"]
 
 Here, `splice(1, 0, "yellow", "purple")` starts at index `1`, removes `0` elements, and inserts `yellow` and `purple`. The second parameter (`0`) means no elements are removed before insertion. You can also use `splice()` to simultaneously remove and add elements:
 
+## Removing and Adding Elements Together
+
 :::interactive_editor
 
 ```js
@@ -58,6 +64,8 @@ console.log(numbers); // [1, 6, 7, 8, 4, 5]
 :::
 
 In this case, `splice(1, 2, 6, 7, 8)` starts at index `1`, removes `2` elements (`2` and `3`), and inserts `6`, `7`, and `8`. If you need to keep the original array unchanged, you should create a copy before using `splice()`:
+
+## Avoiding Mutation with a Copy
 
 :::interactive_editor
 
@@ -75,6 +83,8 @@ console.log(copy);     // [1, 2, 6, 4, 5]
 In this example, to create a copy of the `original` array without modifying it, we use the spread operator (`...`). The spread operator will create a shallow copy of the elements of the `original` array into a new array.  You will learn more about this in future lessons.
 
 When we use `copy.splice(2, 1, 6)`, it modifies the copy array by removing the element at index `2` (which is `3`) and inserting the new element `6` at that position.
+
+## Removing a Known Element
 
 One common use case for `splice()` is to remove a single element from an array when you know its index:
 
@@ -96,6 +106,8 @@ In this example, we first use the `indexOf()` method to find the index of the el
 
 We then compare `indexToRemove` with `-1` to ensure that the element exists in the array before attempting to remove it. If `indexToRemove` is not equal to `-1` (meaning the element is found), we use `splice()` to remove one element starting from the `indexToRemove` position.
 
+## Clearing an Array
+
 You can also use `splice()` to clear an array by removing all elements:
 
 :::interactive_editor
@@ -108,6 +120,8 @@ console.log(array); // []
 ```
 
 :::
+
+## Performance Considerations
 
 While `splice()` is powerful, it's worth noting that for very large arrays, it can be less efficient than other methods, especially when modifying the beginning of the array. This is because `splice()` may need to shift all subsequent elements. In such cases, if you're only adding or removing elements at the end of the array, methods like `push()`, `pop()`, `unshift()`, and `shift()` might be more appropriate.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md
@@ -33,9 +33,11 @@ console.log(removed); // ["orange", "mango"]
 
 :::
 
-In this example, `splice(2, 2)` starts at index `2` and removes `2` elements. The modified array will now consist of only `apple`, `banana`, and `kiwi`. Now, let's look at how to add elements to the middle of an array:
+In this example, `splice(2, 2)` starts at index `2` and removes `2` elements. The modified array will now consist of only `apple`, `banana`, and `kiwi`.
 
 ## Adding Elements
+
+Now, let's look at how to add elements to the middle of an array:
 
 :::interactive_editor
 
@@ -48,9 +50,11 @@ console.log(colors); // ["red", "yellow", "purple", "green", "blue"]
 
 :::
 
-Here, `splice(1, 0, "yellow", "purple")` starts at index `1`, removes `0` elements, and inserts `yellow` and `purple`. The second parameter (`0`) means no elements are removed before insertion. You can also use `splice()` to simultaneously remove and add elements:
+Here, `splice(1, 0, "yellow", "purple")` starts at index `1`, removes `0` elements, and inserts `yellow` and `purple`. The second parameter (`0`) means no elements are removed before insertion.
 
 ## Array Insertion and Deletion
+
+You can also use `splice()` to simultaneously remove and add elements:
 
 :::interactive_editor
 
@@ -63,9 +67,11 @@ console.log(numbers); // [1, 6, 7, 8, 4, 5]
 
 :::
 
-In this case, `splice(1, 2, 6, 7, 8)` starts at index `1`, removes `2` elements (`2` and `3`), and inserts `6`, `7`, and `8`. If you need to keep the original array unchanged, you should create a copy before using `splice()`:
+In this case, `splice(1, 2, 6, 7, 8)` starts at index `1`, removes `2` elements (`2` and `3`), and inserts `6`, `7`, and `8`.
 
 ## Avoiding Mutation with a Copy
+
+If you need to keep the original array unchanged, you should create a copy before using `splice()`:
 
 :::interactive_editor
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69313

<!-- Feel free to add any additional description of changes below this line -->

Summary

Adds ## section headers to the # --interactive-- body of the splice() lecture challenge to improve scannability, following the existing convention used in other lecture challenges (e.g. "How Does the Sort Method Work?").

File changed

curriculum/challenges/english/blocks/lecture-working-with-common-array-methods/6732b284901f8c1539e20bcb.md

Changes

Inserted 7 ## Title Case headers to break up the ~607-word lecture body into logical sections:

## Removing Elements
## Adding Elements
## Removing and Adding Elements Together
## Avoiding Mutation with a Copy
## Removing a Known Element
## Clearing an Array
## Performance Considerations

No prose was rewritten — only headers were inserted at existing paragraph/topic boundaries. The # --questions-- section, code blocks, and front matter are untouched.

Why

The lecture previously had no internal structure, making it hard to scan on the page, especially given how many distinct splice() use cases are covered in sequence (remove, add, remove+add, copy-safe usage, remove-by-index, clear-all, performance notes). This mirrors the pattern already established in lecture-working-with-higher-order-functions-and-callbacks/673362d7f94d551edb532d24.md, where short headers precede each major sub-topic.
