### PR TITLE
fix(curriculum): freeze RSVP confirmation message on submit

### DIFF
--- a/curriculum/challenges/english/blocks/lab-event-rsvp/67d936de7055982b02baf186.md
+++ b/curriculum/challenges/english/blocks/lab-event-rsvp/67d936de7055982b02baf186.md
@@ -799,6 +799,7 @@ export function EventRSVPForm() {
   });
 
   const [submitted, setSubmitted] = useState(false);
+  const [rsvpDetails, setRsvpDetails] = useState(null);
 
   function handleChange(event) {
     const { name, value, type, checked } = event.target;
@@ -810,6 +811,7 @@ export function EventRSVPForm() {
 
   function handleSubmit(event) {
     event.preventDefault();
+    setRsvpDetails(formData);
     setSubmitted(true);
   }
 
@@ -882,25 +884,25 @@ export function EventRSVPForm() {
         </div>
         <button type='submit'>Submit RSVP</button>
       </form>
-      {submitted && (
+     {submitted && rsvpDetails && (
         <div className='submitted-message'>
           <h3>RSVP Submitted!</h3>
           <p>
-            <strong>Name:</strong> {formData.name}
+            <strong>Name:</strong> {rsvpDetails.name}
           </p>
           <p>
-            <strong>Email:</strong> {formData.email}
+            <strong>Email:</strong> {rsvpDetails.email}
           </p>
           <p>
-            <strong>Number of Attendees:</strong> {formData.attendees}
+           <strong>Number of Attendees:</strong> {rsvpDetails.attendees}
           </p>
           <p>
             <strong>Dietary Preferences:</strong>{' '}
-            {formData.dietaryPreferences || 'None'}
+           {rsvpDetails.dietaryPreferences || 'None'}
           </p>
           <p>
             <strong>Bringing Others:</strong>{' '}
-            {formData.bringingOthers ? 'Yes' : 'No'}
+            {rsvpDetails.bringingOthers ? 'Yes' : 'No'}
           </p>
         </div>
       )}


### PR DESCRIPTION
Fixes #69837

## Bug
After submitting the RSVP form, the confirmation message read directly from the live form state. This meant editing any input after submission (without resubmitting) would also update the already-displayed confirmation message, even though nothing was resubmitted.

## Fix

Added a separate `rsvpDetails` state that snapshots the form data at the moment of submit (inside `handleSubmit`), and updated the confirmation message to render from that snapshot instead of the live `formData`. This freezes the confirmation at its originally submitted values regardless of further edits to the form.

## Testing

Verified the behavior change in an isolated CodePen reproduction using the same component logic: submitted the form, then edited an input without resubmitting, and confirmed the confirmation message stayed frozen (previously it would update live).

## Note

I noticed #69841 is already open addressing this same issue. Submitting this  on freeCodeCamp's contribution workflow — happy to have this closed if that one merges first.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the #69837 below with the issue number.-->

Closes #69837

<!-- Feel free to add any additional description of changes below this line -->
