### PR TITLE
fix(api): harden CSRF route matching and fix false-positive token test

### DIFF
--- a/api/src/plugins/csrf.test.ts
+++ b/api/src/plugins/csrf.test.ts
@@ -3,7 +3,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 
 import { COOKIE_DOMAIN } from '../utils/env.js';
 import cookies from './cookies.js';
-import csrf, { CSRF_COOKIE, CSRF_SECRET_COOKIE } from './csrf.js';
+import csrf, { CSRF_COOKIE, CSRF_SECRET_COOKIE, CSRF_HEADER } from './csrf.js';
 
 vi.mock('../utils/env', async importOriginal => {
   const actual = await importOriginal<typeof import('../utils/env.js')>();
@@ -24,6 +24,12 @@ async function setupServer() {
   fastify.get('/', (_req, reply) => {
     void reply.send({ foo: 'bar' });
   });
+
+  // Mock signout route for the exemption test
+  fastify.get('/signout', (_req, reply) => {
+    void reply.send({ ok: true });
+  });
+
   return fastify;
 }
 
@@ -32,21 +38,24 @@ describe('CSRF protection', () => {
   beforeEach(async () => {
     fastify = await setupServer();
   });
+
   test('should receive a new CSRF token with the expected properties', async () => {
     const response = await fastify.inject({
       method: 'GET',
       url: '/'
     });
-    const newCookies = response.cookies;
-    const csrfTokenCookie = newCookies.find(
+
+    // onRequest generates the token even if the unauthenticated request returns 403
+    expect(response.statusCode).toEqual(403);
+
+    const csrfTokenCookie = response.cookies.find(
       cookie => cookie.name === CSRF_COOKIE
     );
 
+    expect(csrfTokenCookie).toBeDefined();
     const { value, ...rest } = csrfTokenCookie!;
 
-    // The value is a random string - it's enough to check that it's not empty
     expect(value).toHaveLength(52);
-
     expect(rest).toStrictEqual({
       name: CSRF_COOKIE,
       path: '/',
@@ -63,8 +72,6 @@ describe('CSRF protection', () => {
     });
 
     expect(response.statusCode).toEqual(403);
-    // The response body is determined by the error-handling plugin, so we don't
-    // check it here.
   });
 
   test('should return 403 if the csrf_token is invalid', async () => {
@@ -72,11 +79,27 @@ describe('CSRF protection', () => {
       method: 'GET',
       url: '/',
       cookies: {
-        _csrf: 'foo',
-        csrf_token: 'bar'
+        _csrf: 'foo'
+      },
+      headers: {
+        [CSRF_HEADER]: 'invalid-token-signature'
       }
     });
+
     expect(response.statusCode).toEqual(403);
+  });
+
+  test('should not set CSRF cookie on /signout even with query parameters', async () => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/signout?redirect=true'
+    });
+
+    const csrfTokenCookie = response.cookies.find(
+      cookie => cookie.name === CSRF_COOKIE
+    );
+
+    expect(csrfTokenCookie).toBeUndefined();
   });
 
   test('should allow the request if the csrf_token is valid', async () => {
@@ -92,6 +115,9 @@ describe('CSRF protection', () => {
       cookie => cookie.name === CSRF_SECRET_COOKIE
     );
 
+    expect(csrfTokenCookie).toBeDefined();
+    expect(csrfSecretCookie).toBeDefined();
+
     const res = await fastify.inject({
       method: 'GET',
       url: '/',
@@ -99,7 +125,7 @@ describe('CSRF protection', () => {
         _csrf: csrfSecretCookie!.value
       },
       headers: {
-        'csrf-token': csrfTokenCookie!.value
+        [CSRF_HEADER]: csrfTokenCookie!.value
       }
     });
 

--- a/api/src/plugins/csrf.test.ts
+++ b/api/src/plugins/csrf.test.ts
@@ -55,6 +55,7 @@ describe('CSRF protection', () => {
     expect(csrfTokenCookie).toBeDefined();
     const { value, ...rest } = csrfTokenCookie!;
 
+    // The value is a random string - it's enough to check that it's not empty
     expect(value).toHaveLength(52);
     expect(rest).toStrictEqual({
       name: CSRF_COOKIE,
@@ -71,6 +72,8 @@ describe('CSRF protection', () => {
       url: '/'
     });
 
+    // The response body is determined by the error-handling plugin, so we don't
+    // check it here.
     expect(response.statusCode).toEqual(403);
   });
 

--- a/api/src/plugins/csrf.ts
+++ b/api/src/plugins/csrf.ts
@@ -28,7 +28,7 @@ const csrf: FastifyPluginCallback = (fastify, _options, done) => {
 
   // All routes except signout should add a CSRF token to the response
   fastify.addHook('onRequest', (req, reply, done) => {
-    const isSignout = req.url === '/signout' || req.url === '/signout/';
+    const isSignout = req.routeOptions?.url === '/signout';
 
     if (!isSignout) {
       req.log.trace('Adding CSRF token to response');

--- a/api/src/plugins/csrf.ts
+++ b/api/src/plugins/csrf.ts
@@ -28,7 +28,7 @@ const csrf: FastifyPluginCallback = (fastify, _options, done) => {
 
   // All routes except signout should add a CSRF token to the response
   fastify.addHook('onRequest', (req, reply, done) => {
-    const isSignout = req.routeOptions?.url === '/signout';
+    const isSignout = req.routeOptions.url === '/signout';
 
     if (!isSignout) {
       req.log.trace('Adding CSRF token to response');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69902

<!-- Feel free to add any additional description of changes below this line -->
This PR addresses the outlined test-quality gaps and routing edge case 

**Changes included:**
1. **Routing Fix:** Updated the `isSignout` check in `api/src/plugins/csrf.ts` to use Fastify's `req.routeOptions?.url` instead of `req.url`. This prevents query strings from breaking the exemption.
2. **Test Fix (False Positive):** Updated the invalid-token test in `api/src/plugins/csrf.test.ts` to pass the token via `headers: { 'csrf-token': '...' }` so the cryptographic rejection is actually exercised.
3. **Test Fix (Coverage):** Added a `response.statusCode` assertion to the new-token test and added a dedicated test for the `/signout` query-string behavior.