### PR TITLE
fix(curriculum): add section headers to ARIA roles lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a549231b8728f7171ed9d.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a549231b8728f7171ed9d.md
@@ -33,6 +33,8 @@ But non-semantic elements don't have a role. For example, screen readers will no
 </div>
 ```
 
+## Specifying an ARIA Role
+
 To specify the ARIA role of an element, you just need to add the `role` attribute, like this `role="ARIA role"`, where the value is the name of a role in the ARIA specification.
 
 Here is an example of using the `role` attribute with a value of `"alert"`:
@@ -69,6 +71,8 @@ It is important to note that specifying a role on an element only does one thing
 
 For example, adding a `role` of `button` to a `div` does not automatically make it clickable with a mouse or usable with a keyboard. It is the responsibility of the developer to add the expected behavior that allows the `div` to act like a button, and in most cases, it is just better to use the `button` element.
 
+## Categories of ARIA Roles
+
 There are six main categories of ARIA roles:
 
 - Document structure roles
@@ -79,6 +83,8 @@ There are six main categories of ARIA roles:
 - Abstract roles
 
 Let's take a look at them in more detail.
+
+## Document Structure Roles
 
 Document structure roles define the overall structure of the web page. With these roles, assistive technologies can understand the relationships between different sections and help users navigate the content.
 
@@ -117,6 +123,8 @@ There are other similar roles but these are the most commonly used ones. This is
 :::
 
 You'll also notice that the `div` has an `aria-label` attribute. The value of this attribute should be a string that represents the expression.
+
+## Widget Roles
 
 Widget roles define the purpose and functionality of interactive elements, like scrollbars.
 
@@ -193,6 +201,8 @@ button:hover {
 
 Some of these roles have equivalent semantic elements. You should prioritize the semantic element over the role if there is one. For example, you should favor using the HTML `button` element over adding a `role` of `button` to a `div`.
 
+## Landmark Roles
+
 Landmark roles classify and label the primary sections of a web page. Screen readers use them to provide convenient navigation to important sections of a page. You should use them sparingly to keep the overall layout simple and easy to understand. Examples of landmark roles are `banner`, `complementary`, `contentinfo`, `form`, `main`, `navigation`, `region`, and `search`. Each of these roles has a corresponding HTML equivalent, such as `header`, `footer`, `aside`, `form`, `main`, `nav`, `section`, and `search`. If you use the proper HTML elements to define the sections of your page then it is not necessary to explicitly add the `role` attribute to these elements.
 
 Here is an example of a banner:
@@ -249,6 +259,8 @@ Here is an example of a banner:
 ```
 
 :::
+
+## Live Region Roles
 
 Live region roles define elements with content that will change dynamically. This way, screen readers and other assistive technologies can announce changes to users with visual disabilities. These roles include: `alert`, `log`, `marquee`, `status`, and `timer`.
 
@@ -307,6 +319,8 @@ button.addEventListener("click", () => {
 ```
 
 :::
+
+## Window Roles
 
 Window roles define sub-windows, like pop-up modal dialogs. These roles include `alertdialog` and `dialog`. Please note that it is now considered a best practice to use the HTML `dialog` element and its associated JavaScript methods instead of manually creating a dialog.
 
@@ -404,6 +418,8 @@ confirmBtn.addEventListener("click", () => {
 ```
 
 :::
+
+## Abstract Roles
 
 And finally, we have abstract roles. These roles help organize the document. They're only meant to be used internally by the browser, not by developers, so you should know that they exist but you shouldn't use them on your websites or web applications.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69291

<!-- Feel free to add any additional description of changes below this line -->
### Description
Adds `##` section headers to the lecture body of "What Are ARIA Roles?" to break the ~870-word unbroken block into scannable sections.

Headers added:
- Specifying an ARIA Role
- Categories of ARIA Roles
- Document Structure Roles
- Widget Roles
- Landmark Roles
- Live Region Roles
- Window Roles
- Abstract Roles

No prose was rewritten - only headers were inserted. Front matter, code blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below:

<img width="530" height="106" alt="Screenshot 2026-09-05 at 9 49 49 PM" src="https://github.com/user-attachments/assets/f4b1b9c4-e652-44e6-962c-1d1adac144a8" />
<img width="530" height="471" alt="Screenshot 2026-09-05 at 9 50 15 PM" src="https://github.com/user-attachments/assets/22af3a77-573b-4403-8618-1a3502af8280" />
<img width="530" height="192" alt="Screenshot 2026-09-05 at 9 50 34 PM" src="https://github.com/user-attachments/assets/411334c7-8b5e-4d38-b334-8ffd896094d6" />
<img width="530" height="288" alt="Screenshot 2026-09-05 at 9 50 52 PM" src="https://github.com/user-attachments/assets/c4f08293-12dc-40d1-9904-0030fb768075" />
<img width="530" height="125" alt="Screenshot 2026-09-05 at 9 51 09 PM" src="https://github.com/user-attachments/assets/360b8536-beac-41f7-8b12-8c45d150ac5c" />
<img width="530" height="144" alt="Screenshot 2026-09-05 at 9 51 25 PM" src="https://github.com/user-attachments/assets/5be2befd-35a6-4402-8755-d90f9eb61ea7" />
<img width="530" height="218" alt="Screenshot 2026-09-05 at 9 51 51 PM" src="https://github.com/user-attachments/assets/ad73726d-5b84-4ef4-8646-3a8cb87f2018" />
