### PR TITLE
fix(curriculum): add section headers to recursion lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-recursion-and-the-call-stack/6733b02d1e556005a544c5e3.md
@@ -9,6 +9,8 @@ dashedName: what-is-recursion-and-how-does-it-work
 
 Recursion is a complicated feature that allows you to call a function repeatedly until a base-case is reached. Unlike a traditional loop, recursion allows you to handle something with an unknown depth, such as deeply nested objects/arrays, or a file tree. But you can also use it for more basic tasks, such as counting down from a given number.
 
+## Building a Recursive Countdown
+
 Let's construct a function to do exactly that. We’ll call our function `recursiveCountdown`, and it needs to accept a number. We’ll have it print this number to the console:
 
 :::interactive_editor
@@ -24,6 +26,8 @@ recursiveCountdown(5);
 :::
 
 Now if we call this and pass the number 5, we’ll see the number print to our terminal. But nothing else happens – and the number 5 certainly isn’t a countdown.
+
+## Establishing a Base Case
 
 Before we start building the recursive portion of our function, we need to establish our base case first. If you don’t have a base case established, your code will run until it exceeds your memory allocation and crashes.
 
@@ -43,6 +47,8 @@ recursiveCountdown(5);
 :::
 
 For our base case, we want the countdown to stop if the number is less than 1. When we hit that base-case, we can return to break out of the function execution.
+
+## Adding the Recursive Call
 
 Now that we’ve safely prepared a base-case, we can set up the recursion. The key point that makes a function recursive is that it calls itself in its execution. In this case, we want to call the function after we print the number. But in order to count down, our new number needs to be one less:
 
@@ -64,6 +70,8 @@ recursiveCountdown(5);
 
 This would log the numbers 5, 4, 3, 2, and 1 to the console.
 
+## Counting Up With Recursion
+
 We do get our five numbers! But what if we wanted to count up instead? Rather than writing an entirely new function, we can swap the order of our log and our recursive call:
 
 :::interactive_editor
@@ -83,6 +91,8 @@ recursiveCountdown(5);
 :::
 
 This would log the numbers 1, 2, 3, 4, and 5 to the console.
+
+## Understanding the Call Stack
 
 But why does that work? Well, to understand this you need to understand the call stack. The call stack is how JavaScript tracks and resolves function calls. The stack functions as a last-in-first-out queue of sorts. To understand this better, let’s add some logging to our function:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69292

## Description
Adds Title Case `##` section headers to the lecture **What Is Recursion, and How Does It Work?** so the ~833-word body is scannable.

Headers follow the convention in the Sort Method lecture (`673362d7f94d551edb532d24.md`): short Title Case `##` markers before major sub-topics. No prose rewrite. Front matter, interactive/code blocks, and `# --questions--` unchanged.

Headers added:
- Building a Recursive Countdown
- Establishing a Base Case
- Adding the Recursive Call
- Counting Up With Recursion
- Understanding the Call Stack