### PR TITLE
fix(curriculum): add section headers to ARIA states lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-understanding-aria-expanded-aria-live-and-common-aria-states/672a54f29d783890d1f94740.md
+++ b/curriculum/challenges/english/blocks/lecture-understanding-aria-expanded-aria-live-and-common-aria-states/672a54f29d783890d1f94740.md
@@ -15,6 +15,8 @@ But if you are creating a custom control element, you need to use ARIA attribute
 
 In this lesson, we will discuss a few common ARIA states that you can use on custom control elements.
 
+## The `aria-selected` State
+
 The first ARIA state we will discuss is `aria-selected`. This state is used to indicate that an element is selected. You can use this state on custom controls like a tabbed interface, a listbox, or a grid.
 
 Here is an example of how you can use `aria-selected` on a custom tab control:
@@ -113,6 +115,8 @@ Tabs are used to display multiple panels of content in a limited space. The `ari
 
 When the user selects a tab, the `aria-selected` state of the selected tab is set to `true`, and the `aria-selected` state of the other tabs is set to `false`.
 
+## The `aria-disabled` State
+
 Another common ARIA state is `aria-disabled`. This state is used to indicate that an element is disabled only to people using assistive technologies, such as screen readers. It is important to note that `aria-disabled` does not actually disable the element. It is up to you, the developer, to make it look and act like a disabled element. This attribute is also commonly used on native HTML elements in place of the `disabled` attribute. Which one you choose will depend on the context the button is being used.
 
 Here is an example of how you can use `aria-disabled` on a custom edit button:
@@ -166,6 +170,8 @@ Here is an example of how you can use `aria-disabled` on a custom edit button:
 The `aria-disabled` attribute is used to tell screen reader users that the edit button is disabled and cannot be interacted with. Again, it does not actually disable the button. When using `aria-disabled`,you will need to apply styling and JavaScript to make the control look and behave like a disabled button.
 
 In most cases, you will probably use the native button element, but there are cases where you might need to use a custom control. So, it is essential to know how to convey the state of the control to assistive technologies.
+
+## The `aria-haspopup` State
 
 The next ARIA state we will discuss is `aria-haspopup`. This state is used to indicate that an interactive element will trigger a popup element when activated. You can only use the `aria-haspopup` attribute when the popup has one of the following roles: `menu`, `listbox`, `tree`, `grid`, or `dialog`. The value of `aria-haspopup` must be either one of these roles or `true`, which defaults to the `menu` role. 
 
@@ -245,6 +251,8 @@ The `aria-haspopup` state is used to indicate that the `File` menu button will o
 
 You will need to use JavaScript to show and hide the popup menu, and to implement proper keyboard support for interacting with the menu. Also, please note that the ARIA `menu` role refers to a very specific type of menu. It generally refers to a list of actions that the user can invoke, similar to a menu on a desktop application. It does not include more common uses of what we typically refer to as "menus", such as navigation menus. Realistically, most "menus" you create on the web will not be ARIA menus and you will not use `aria-haspopup` with them.
 
+## The `aria-required` State
+
 The next ARIA state we will discuss is `aria-required`. The `aria-required` attribute is used to indicate that a field needs to be filled out before the form is submitted.
 
 Here is an example of working with the `aria-required` attribute for a custom form control.
@@ -314,6 +322,8 @@ If the label already has the word `required`, then you should omit the `aria-req
 In most cases, you will probably use the native `label` and `form` elements with the `required` attribute. But if you need to create a custom form control, then it is important to add the `aria-required` attribute when necessary.
 
 Additionally, the `aria-required` attribute can also be used on native form inputs, such as the `input`, `textarea`, and `select` elements. This is often preferred to the native required attribute, since the required attribute may have potential usability and accessibility concerns, particularly with the default error handling provided by the browser. Ultimately, you will need to test in order to determine which attribute is best for your situation.
+
+## The `aria-checked` State
 
 The last ARIA state we will discuss is `aria-checked`. This attribute is used to indicate whether an element is in the checked state. It is most commonly used when creating custom checkboxes, radio buttons, switches, and listboxes.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69288

## Description
Adds Title Case `##` section headers to the lecture **What Are Some Common ARIA States Used on Custom Control Elements?** so the ~1034-word body is scannable.

Headers follow the convention in the Sort Method lecture (`673362d7f94d551edb532d24.md`): short Title Case `##` markers before major sub-topics. No prose rewrite. Front matter, interactive/code blocks, and `# --questions--` unchanged.

Headers added:
- The `aria-selected` State
- The `aria-disabled` State
- The `aria-haspopup` State
- The `aria-required` State
- The `aria-checked` State