### PR TITLE
fix(curriculum): fix variable regex matching in sentence maker lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
+++ b/curriculum/challenges/english/blocks/lab-sentence-maker/66c057041df6394ca796bf33.md
@@ -131,7 +131,7 @@ You should use the correct story format for the first story: `"Once upon a time,
 ```js
 const _initialValues = {}
 for (const name of ['adjective', 'noun', 'noun2', 'place', 'verb', 'adjective2']) {
-    const match = code.match(new RegExp(String.raw`${name}\s*=\s*('|"|${'`'})(?<${name}>.*?)\1(?:,|;|\s|$)`, 'm'));
+    const match = code.match(new RegExp(String.raw`\b${name}\s*=\s*('|"|${'`'})(?<${name}>.*?)\1(?:,|;|\s|$)`, 'm'));
     _initialValues[name] = match ? match.groups[name] : null;
 }
 
@@ -145,7 +145,7 @@ You should assemble your first story using the variables you declared in the cor
 ```js
 assert.match(
   __helpers.removeJSComments(code),
-  /firstStory\s*=\s*.*?adjective.*?noun.*?noun2.*?noun.*?place.*?adjective2.*?verb/
+  /firstStory\s*=\s*.*?\badjective\b.*?\bnoun\b.*?\bnoun2\b.*?\bnoun\b.*?\bplace\b.*?\badjective2\b.*?\bverb\b/
 );
 ```
 
@@ -164,37 +164,37 @@ assert.isNotNull(secondStory);
 You should reassign the `adjective` variable for the second story.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/adjective\s*=\s*/g), 2);
+assert.lengthOf(__helpers.removeJSComments(code).match(/\badjective\s*=\s*/g) || [], 2);
 ```
 
 You should reassign the `noun` variable for the second story.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/noun\s*=\s*/g), 2);
+assert.lengthOf(__helpers.removeJSComments(code).match(/\bnoun\s*=\s*/g) || [], 2);
 ```
 
 You should reassign the `verb` variable for the second story.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/verb\s*=\s*/g), 2);
+assert.lengthOf(__helpers.removeJSComments(code).match(/\bverb\s*=\s*/g) || [], 2);
 ```
 
 You should reassign the `place` variable for the second story.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/place\s*=\s*/g), 2);
+assert.lengthOf(__helpers.removeJSComments(code).match(/\bplace\s*=\s*/g) || [], 2);
 ```
 
 You should reassign the `adjective2` variable for the second story.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/adjective2\s*=\s*/g), 2);
+assert.lengthOf(__helpers.removeJSComments(code).match(/\badjective2\s*=\s*/g) || [], 2);
 ```
 
 You should reassign the `noun2` variable for the second story.
 
 ```js
-assert.lengthOf(__helpers.removeJSComments(code).match(/noun2\s*=\s*/g), 2);
+assert.lengthOf(__helpers.removeJSComments(code).match(/\bnoun2\s*=\s*/g) || [], 2);
 ```
 
 You should use the correct story format for the second story: `"Once upon a time, there was a(n) [adjective] [noun] who loved to eat [noun2]. The [noun] lived in a [place] and had [adjective2] nostrils that blew fire when it was [verb]."`. Pay attention to spaces.
@@ -209,7 +209,7 @@ You should assemble your second story using the variables you declared in the co
 ```js
 assert.match(
   __helpers.removeJSComments(code),
-  /secondStory\s*=\s*.*?adjective.*?noun.*?noun2.*?noun.*?place.*?adjective2.*?verb/
+  /secondStory\s*=\s*.*?\badjective\b.*?\bnoun\b.*?\bnoun2\b.*?\bnoun\b.*?\bplace\b.*?\badjective2\b.*?\bverb\b/
 );
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #68810

In the "Build a Sentence Maker" lab, the hint tests checking variable declarations, reassignments, and story composition relied on unbounded regular expressions like `/noun\s*=\s*/g`. When submitted code contained identifiers that share substrings with variable names (such as `pronoun`), the tests falsely counted extra matches and failed valid learner solutions.

This change adds word boundaries (`\b`) to the variable matching patterns across the hint tests and initial value extraction. The reassignment tests now safely handle cases where no matches are found, preventing unexpected errors and false rejections.
