### PR TITLE
fix(curriculum): add headers to responsive web design lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672aa6c9e379285acca5a2aa.md
+++ b/curriculum/challenges/english/blocks/lecture-user-interface-design-fundamentals/672aa6c9e379285acca5a2aa.md
@@ -11,6 +11,8 @@ dashedName: what-are-common-design-terms-to-help-you-communicate-with-designers
 
 As a developer, you may need to work closely with designers. If you understand basic design terminology, you'll have a shared vocabulary and you'll be able to participate in the design process more actively. This can make your workflow more efficient and result in a better user experience.
 
+## Layout
+
 So let's dive in. We'll start with the term layout. Layout is how the visual elements are arranged on a page or screen to communicate a message. These elements may include text, images, and white space. The layout is like the blueprint of a design. Designers must consider the placement, size, and hierarchy of each element.
 
 :::interactive_editor
@@ -202,6 +204,8 @@ footer {
 
 :::
 
+## Alignment
+
 The term that is closely related to layout is alignment. Alignment is how the elements are placed in relation to one another. Using alignment correctly is helpful for making the design look clean and organized. Designers create visual order by aligning elements along imaginary lines, edges, or a central point.
 
 :::interactive_editor
@@ -279,6 +283,8 @@ body {
 ```
 
 :::
+
+## Composition and Balance
 
 Great. Now let's talk about composition. Composition is the art of arranging elements to create a harmonious design. It determines how elements like images, text, and shapes relate to each other and contribute to the design in an artistic way. While layout mostly focuses on the placement of the elements, composition also considers the artistic impact that this placement will have in the overall design.
 
@@ -362,6 +368,8 @@ h1 {
 
 :::
 
+## Hierarchy
+
 Hierarchy is another important concept that you should know. Hierarchy establishes the order of importance of the elements in a design. It's about making sure the most important information is noticed first. You can implement a visual hierarchy with size, color, contrast, alignment, white space, and even typography.
 
 :::interactive_editor
@@ -434,6 +442,8 @@ body {
 ```
 
 :::
+
+## Contrast
 
 To create clear distinctions between the elements, you can use contrast. Contrast is helpful for guiding user attention to what you want to emphasize. You can do this through variations in color, size, shape, texture, or any other visual characteristic. Strong contrast is also helpful for improving readability.
 
@@ -525,6 +535,8 @@ p {
 
 :::
 
+## White Space
+
 Another helpful term is white space. White Space, also known as "negative space", is the empty space in a design. It's the area surrounding the elements. You might be surprised to know that white space is not necessarily white. Actually, it can be space in any color or texture. Its purpose is to improve the readability and enhance the visual hierarchy of a design.
 
 :::interactive_editor
@@ -604,6 +616,8 @@ p {
 ```
 
 :::
+
+## UI and UX
 
 These are general design concepts that you will find very often, but you may also find design terms that are more closely related to software development.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69312 

<!-- Feel free to add any additional description of changes below this line -->

Changes
- Added 7 section headers grouping the existing content by design term: Layout, Alignment, Composition and Balance, Hierarchy, Contrast, White Space, and UI and UX
- No prose, code blocks, questions, or front matter modified, headers only

Testing
- Ran `pnpm run lint-challenges`, passes with no errors
- Verified locally at `pnpm run develop`, viewed the lecture rendered in app, headers appear correctly at natural breaks