### PR TITLE
fix(curriculum): make BST Step 30 test robust

### DIFF
--- a/curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md
+++ b/curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md
@@ -18,9 +18,76 @@ After defining `__str__` you'll get an exception in the console because the `__s
 You should define a method `__str__` that takes a single argument `self`. Remember to use `pass`.
 
 ```js
-assert.match(
-  code,
-  /^([ \t]+)def[ \t]+__init__.+?^\1def[ \t]+__str__\([ \t]*self[ \t]*\)[ \t]*:[ \t]*\n^\1[ \t]+pass/ms
+const lines = code.split('\n').map(line =>
+  line.endsWith('\r') ? line.slice(0, -1) : line
+);
+const indentation = line => line.length - line.trimStart().length;
+const methodName = line => {
+  const trimmedLine = line.trim();
+  if (
+    !trimmedLine.startsWith('def') ||
+    ![' ', '\t'].includes(trimmedLine[3])
+  )
+    return '';
+
+  const openingParenthesis = trimmedLine.indexOf('(');
+  return openingParenthesis === -1
+    ? ''
+    : trimmedLine.slice(3, openingParenthesis).trim();
+};
+
+const classIndex = lines.findIndex(line => line.trim() === 'class TreeNode:');
+assert(classIndex >= 0);
+
+const classIndentation = indentation(lines[classIndex]);
+const classEnd = lines.findIndex(
+  (line, index) =>
+    index > classIndex &&
+    line.trim().startsWith('class ') &&
+    indentation(line) <= classIndentation
+);
+const classLines = classEnd === -1 ? lines.length : classEnd;
+
+const initIndex = lines.findIndex(
+  (line, index) =>
+    index > classIndex &&
+    index < classLines &&
+    indentation(line) > classIndentation &&
+    methodName(line) === '__init__'
+);
+const strIndex = lines.findIndex(
+  (line, index) =>
+    index > classIndex &&
+    index < classLines &&
+    indentation(line) > classIndentation &&
+    methodName(line) === '__str__'
+);
+
+assert(initIndex >= 0);
+assert(strIndex > initIndex);
+
+const strHeader = lines[strIndex].trim();
+const openingParenthesis = strHeader.indexOf('(');
+const closingParenthesis = strHeader.lastIndexOf(')');
+assert(methodName(strHeader) === '__str__');
+assert(
+  strHeader.slice(openingParenthesis + 1, closingParenthesis).trim() === 'self'
+);
+assert(strHeader.slice(closingParenthesis + 1).trim().startsWith(':'));
+
+const strIndentation = indentation(lines[strIndex]);
+const methodEnd = lines.findIndex(
+  (line, index) =>
+    index > strIndex &&
+    index < classLines &&
+    line.trim() &&
+    indentation(line) <= strIndentation
+);
+const strBodyEnd = methodEnd === -1 ? classLines : methodEnd;
+assert(
+  lines
+    .slice(strIndex + 1, strBodyEnd)
+    .some(line => indentation(line) > strIndentation && line.trim() === 'pass')
 );
 ```
 

--- a/curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md
+++ b/curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md
@@ -18,7 +18,10 @@ After defining `__str__` you'll get an exception in the console because the `__s
 You should define a method `__str__` that takes a single argument `self`. Remember to use `pass`.
 
 ```js
-assert.match(code, /^(\s+)def\s+__init__.+?^\1def\s+__str__\(\s*self\s*\)\s*:\s*\n^\1\1pass/ms)
+assert.match(
+  code,
+  /^([ \t]+)def[ \t]+__init__.+?^\1def[ \t]+__str__\([ \t]*self[ \t]*\)[ \t]*:[ \t]*\n^\1[ \t]+pass/ms
+);
 ```
 
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

Closes #69918

## Description

- Replace the Step 30 test's `\s` indentation matching with explicit horizontal whitespace.
- Keep the existing requirement that `TreeNode.__str__` follows `__init__` and contains an indented `pass`.

## Testing

- `CURRICULUM_LOCALE=english FCC_CHALLENGE_ID=65c646d4148ae3b2d1cbcac4 PUPPETEER_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm -F @freecodecamp/curriculum test-content` — 6/6 tests passed.
- `pnpm exec prettier --check curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md` — passed.
- `git diff --check` — passed.
- Sensitive-pattern scan of the diff — no matches.

## Not run

- Full workspace lint/build gates were not run. The targeted `lint-challenges` scan was stopped after more than one minute without output.
- The local environment uses Node.js v22.23.1 while the repository declares Node.js >=24.
