### PR TITLE
fix(i18n): align javascript-v9 intro block order with curriculum structure

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -4905,17 +4905,17 @@
           "In these lectures, you will learn about advanced object manipulation techniques in JavaScript, including the optional chaining operator and object destructuring syntax."
         ]
       },
+      "workshop-recipe-tracker": {
+        "title": "Build a Recipe Tracker",
+        "intro": [
+          "In this workshop, you will review working with JavaScript objects by building a recipe tracker."
+        ]
+      },
       "lab-device-loan-ledger": {
         "title": "Build a Device Loan Ledger",
         "intro": [
           "In this lab, you will build a device loan ledger to manage IT hardware provisioned by your company's Service Desk.",
           "You will practice working with nested objects and JSON by implementing functions to check devices in and out, track overdue loans, and convert between JSON strings and JavaScript objects."
-        ]
-      },
-      "workshop-recipe-tracker": {
-        "title": "Build a Recipe Tracker",
-        "intro": [
-          "In this workshop, you will review working with JavaScript objects by building a recipe tracker."
         ]
       },
       "lab-quiz-game": {


### PR DESCRIPTION
The `blocks` object under `javascript-v9` in `client/i18n/locales/english/intro.json` listed `lab-device-loan-ledger` before `workshop-recipe-tracker`, while `curriculum/structure/superblocks/javascript-v9.json` defines the reverse order.

This moves the two entries so the intro file matches the structure file. Both entries are moved intact — no titles or intro text are changed, and the byte count of the file is unchanged.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69933

### On the last checkbox

I did not run the full local test suite, so I have left that box unchecked rather than tick it inaccurately. What I did verify programmatically against both files:

- All **235** block names in `intro.json` under `javascript-v9` are present in the structure file, and all 235 from the structure file are present in `intro.json` — nothing is added, removed or renamed.
- Parsing both the old and new `intro.json` yields **identical data**; only key order differs.
- Comparing the resulting key order against the structure file's order gives **0 mismatches** (it was 2 before this change).
- The diff is 6 additions and 6 deletions in a single file: one complete entry moved.

Happy to run anything else the reviewers would like.