### PR TITLE
fix(curriculum): add missing device loan ledger

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2459,6 +2459,13 @@
           "In this workshop, you will review working with JavaScript objects by building a recipe tracker."
         ]
       },
+      "lab-device-loan-ledger": {
+        "title": "Build a Device Loan Ledger",
+        "intro": [
+          "In this lab, you will build a device loan ledger to manage IT hardware provisioned by your company's Service Desk.",
+          "You will practice working with nested objects and JSON by implementing functions to check devices in and out, track overdue loans, and convert between JSON strings and JavaScript objects."
+        ]
+      },
       "lab-quiz-game": {
         "title": "Build a Quiz Game",
         "intro": [

--- a/curriculum/structure/superblocks/introduction-to-objects-in-javascript.json
+++ b/curriculum/structure/superblocks/introduction-to-objects-in-javascript.json
@@ -6,6 +6,7 @@
     "lecture-working-with-json",
     "lecture-working-with-optional-chaining-and-object-destructuring",
     "workshop-recipe-tracker",
+    "lab-device-loan-ledger",
     "lab-quiz-game",
     "lab-record-collection",
     "review-javascript-objects",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69932

<!-- Feel free to add any additional description of changes below this line -->
## Summary
Fixed the missing `lab-device-loan-ledger` module by adding the module to `curriculum/structure/superblocks/introduction-to-objects-in-javascript.json` and its block to `client/i18n/locales/english/intro.json`

## Changes
- Added `lab-device-loan-ledger` module to `curriculum/structure/superblocks/introduction-to-objects-in-javascript.json`
- Added `lab-device-loan-ledger` block to `client/i18n/locales/english/intro.json`