### PR TITLE
fix(api): prisma indexes to match prod

### DIFF
--- a/api/prisma/exam-creator.prisma
+++ b/api/prisma/exam-creator.prisma
@@ -15,6 +15,9 @@ model ExamCreatorExam {
   /// Version of the record
   /// The default must be incremented by 1, if anything in the schema changes
   version       Int                          @default(3)
+
+  @@index([version], map: "version_1")
+  @@index([deprecated], map: "deprecated_1")
 }
 
 /// Exam Creator application collection to store authZ users.
@@ -33,6 +36,9 @@ model ExamCreatorUser {
   version   Int                     @default(2)
 
   ExamCreatorSession ExamCreatorSession[]
+
+  @@index([email], map: "email_1")
+  @@index([version], map: "version_1")
 }
 
 type ExamCreatorUserSettings {
@@ -55,4 +61,7 @@ model ExamCreatorSession {
   version Int @default(1)
 
   ExamCreatorUser ExamCreatorUser @relation(fields: [user_id], references: [id])
+
+  @@index([expires_at], map: "expires_at_1")
+  @@index([session_id], map: "session_id_1")
 }

--- a/api/prisma/exam-environment.prisma
+++ b/api/prisma/exam-environment.prisma
@@ -231,7 +231,7 @@ model ExamEnvironmentAuthorizationToken {
   userId   String   @unique @db.ObjectId
   /// NOTE: uniqueness is not enforced on the above field in the database.
   /// Production has a non-unique `userId_1` index. TODO: create a new unique
-  /// index, switch to that, and drop the non-unique `userId_1` one.
+  /// index, switch to that, and drop the non-unique `userId_1` one?
   version  Int      @default(1)
 
   // Relations
@@ -248,7 +248,7 @@ model ExamEnvironmentExamModeration {
   examAttemptId  String                              @unique @db.ObjectId
   /// NOTE: uniqueness is not enforced on the above field in the database.
   /// Production has a non-unique `examAttemptId_1` index. TODO: create a new
-  /// unique index, switch to that, and drop the non-unique `examAttemptId_1` one.
+  /// unique index, switch to that, and drop the non-unique `examAttemptId_1` one?
   /// Optional feedback/note about the moderation decision
   feedback       String?
   /// Date the exam attempt was moderated

--- a/api/prisma/exam-environment.prisma
+++ b/api/prisma/exam-environment.prisma
@@ -18,6 +18,9 @@ model ExamEnvironmentExam {
   generatedExams           ExamEnvironmentGeneratedExam[]
   examAttempts             ExamEnvironmentExamAttempt[]
   ExamEnvironmentChallenge ExamEnvironmentChallenge[]
+
+  @@index([version], map: "version_1")
+  @@index([deprecated], map: "deprecated_1")
 }
 
 /// A grouping of one or more questions of a given type
@@ -143,6 +146,13 @@ model ExamEnvironmentExamAttempt {
   // Error parsing attribute "@relation": The relation fields `examAttempt` on Model `ExamEnvironmentExamModeration` and `examModeration` on Model `ExamEnvironmentExamAttempt` both provide the `references` argument in the @relation attribute. You have to provide it only on one of the two fields.
   // examModeration ExamEnvironmentExamModeration? @relation(fields: [examModerationId], references: [id])
   examEnvironmentExamModeration ExamEnvironmentExamModeration?
+
+  @@index([userId], map: "userId_1")
+  @@index([examId], map: "examId_1")
+  @@index([generatedExamId], map: "generatedExamId_1")
+  @@index([version], map: "version_1")
+  @@index([examModerationId], map: "examModerationId_1")
+  @@index([startTime], map: "startTime_1")
 }
 
 type ExamEnvironmentQuestionSetAttempt {
@@ -178,6 +188,10 @@ model ExamEnvironmentGeneratedExam {
   // Relations
   exam           ExamEnvironmentExam          @relation(fields: [examId], references: [id], onDelete: Cascade)
   EnvExamAttempt ExamEnvironmentExamAttempt[]
+
+  @@index([deprecated], map: "deprecated_1")
+  @@index([examId], map: "examId_1")
+  @@index([version], map: "version_1")
 }
 
 type ExamEnvironmentGeneratedQuestionSet {
@@ -203,6 +217,10 @@ model ExamEnvironmentChallenge {
   version Int @default(1)
 
   exam ExamEnvironmentExam @relation(fields: [examId], references: [id], onDelete: Cascade)
+
+  @@index([examId], map: "examId_1")
+  @@index([challengeId], map: "challengeId_1")
+  @@index([version], map: "version_1")
 }
 
 model ExamEnvironmentAuthorizationToken {
@@ -211,10 +229,15 @@ model ExamEnvironmentAuthorizationToken {
   /// Used to set an `expireAt` index to delete documents
   expireAt DateTime @db.Date
   userId   String   @unique @db.ObjectId
+  /// NOTE: uniqueness is not enforced on the above field in the database.
+  /// Production has a non-unique `userId_1` index. TODO: create a new unique
+  /// index, switch to that, and drop the non-unique `userId_1` one.
   version  Int      @default(1)
 
   // Relations
   user user @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([expireAt], map: "expireAt_1")
 }
 
 model ExamEnvironmentExamModeration {
@@ -223,6 +246,9 @@ model ExamEnvironmentExamModeration {
   status         ExamEnvironmentExamModerationStatus
   /// Foreign key to exam attempt
   examAttemptId  String                              @unique @db.ObjectId
+  /// NOTE: uniqueness is not enforced on the above field in the database.
+  /// Production has a non-unique `examAttemptId_1` index. TODO: create a new
+  /// unique index, switch to that, and drop the non-unique `examAttemptId_1` one.
   /// Optional feedback/note about the moderation decision
   feedback       String?
   /// Date the exam attempt was moderated
@@ -243,6 +269,10 @@ model ExamEnvironmentExamModeration {
 
   // Relations
   examAttempt ExamEnvironmentExamAttempt @relation(fields: [examAttemptId], references: [id], onDelete: Cascade)
+
+  @@index([status], map: "status_1")
+  @@index([version], map: "version_1")
+  @@index([challengesAwarded], map: "challengesAwarded_1")
 }
 
 enum ExamEnvironmentExamModerationStatus {

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -193,6 +193,18 @@ model user {
   // Relations
   examAttempts                      ExamEnvironmentExamAttempt[]
   examEnvironmentAuthorizationToken ExamEnvironmentAuthorizationToken?
+
+  @@index([sendQuincyEmail, email], map: "mailing-list-pull")
+  @@index([email], map: "email_1")
+  @@index([isDonating], map: "isDonating_1")
+  @@index([username], map: "username_1")
+  @@index([unsubscribeId], map: "unsubscribeId_1")
+  @@index([needsModeration], map: "needsModeration_1")
+  @@index([completedExams], map: "completedExams_1")
+  @@index([isFoundationalCSharpCertV8], map: "isFoundationalCSharpCertV8_1")
+  @@index([completedExams.id], map: "completedExams.id_1")
+  @@index([profileUI.isLocked], map: "profileUI.isLocked_1")
+  @@index([completedDailyCodingChallenges.id], map: "completedDailyCodingChallenges.id_1")
 }
 
 // -----------------------------------
@@ -204,6 +216,7 @@ model AccessToken {
   userId  String   @db.ObjectId
 
   @@index([userId], map: "userId_1")
+  @@index([created], map: "created_1")
 }
 
 model AuthToken {
@@ -211,6 +224,8 @@ model AuthToken {
   created DateTime @db.Date
   ttl     Int
   userId  String   @db.ObjectId
+
+  @@index([created], map: "created_1")
 }
 
 model Donation {
@@ -227,6 +242,7 @@ model Donation {
 
   @@index([email], map: "email_1")
   @@index([userId], map: "userId_1")
+  @@index([subscriptionId], map: "subscriptionId_1")
 }
 
 model SocratesUsage {
@@ -237,7 +253,8 @@ model SocratesUsage {
   /// Number of hints used on this day.
   count  Int      @default(0)
 
-  @@unique([userId, date])
+  @@index([date], map: "date_1")
+  @@unique([date, userId], map: "date_1_userId_1")
 }
 
 model UserToken {

--- a/api/src/routes/protected/socrates.test.ts
+++ b/api/src/routes/protected/socrates.test.ts
@@ -596,7 +596,7 @@ describe('socratesRoutes', () => {
           const usage =
             await fastifyTestInstance.prisma.socratesUsage.findUniqueOrThrow({
               where: {
-                userId_date: {
+                date_userId: {
                   userId: defaultUserId,
                   date: new Date(
                     Date.UTC(

--- a/api/src/routes/protected/socrates.ts
+++ b/api/src/routes/protected/socrates.ts
@@ -129,7 +129,7 @@ export const socratesRoutes: FastifyPluginCallbackTypebox = (
       const rollbackUsage = async () => {
         await fastify.prisma.socratesUsage.update({
           where: {
-            userId_date: { userId: req.user!.id, date: todayUTC }
+            date_userId: { userId: req.user!.id, date: todayUTC }
           },
           data: { count: { decrement: 1 } }
         });


### PR DESCRIPTION
 This adds indexes to the prisma schemas which exist in the database, but are not in the schema.

Running `npx prisma migrate diff --from-url="DB_URL" --to-schema-datamodel=prisma` in the `api` folder compares the schema to the database and tells you where they disagree about things that the schema knows about - so it won't look at collections in the DB that aren't in the schema.

<details><summary>The output on the first run of that...</summary>

`-` means in the DB, not in the schema
`+` means in the schema, not in DB
 
It doesn't list the collection name where it differs, but I figured it out. Anything after the `-` was added by me. 

```
[-] Index `userId_1` - ExamEnvironmentExamAttempt
[-] Index `examId_1` - ExamEnvironmentExamAttempt
[-] Index `generatedExamId_1` - ExamEnvironmentExamAttempt
[-] Index `version_1` - ExamEnvironmentExamAttempt
[-] Index `examModerationId_1` - ExamEnvironmentExamAttempt
[-] Index `startTime_1` - ExamEnvironmentExamAttempt
[-] Index `email_1` - ExamCreatorUser
[-] Index `version_1` - ExamCreatorUser
[-] Index `status_1` - ExamEnvironmentExamModeration
[-] Index `version_1` - ExamEnvironmentExamModeration
[-] Index `challengesAwarded_1` - ExamEnvironmentExamModeration
[-] Index `examAttemptId_1` - ExamEnvironmentExamModeration
[-] Index `version_1` - ExamCreatorExam
[-] Index `deprecated_1` - ExamCreatorExam
[-] Index `created_1` - AuthToken
[-] Index `deprecated_1` - ExamEnvironmentGeneratedExam
[-] Index `examId_1` - ExamEnvironmentGeneratedExam
[-] Index `version_1` - ExamEnvironmentGeneratedExam
[-] Index `date_1` - SocratesUsage
[-] Unique index `date_1_userId_1` - SocratesUsage
[-] Index `expireAt_1` - ExamEnvironmentAuthorizationToken
[-] Index `userId_1` - ExamEnvironmentAuthorizationToken
[-] Index `version_1` - ExamEnvironmentExam
[-] Index `deprecated_1` - ExamEnvironmentExam
[-] Index `examId_1` - ExamEnvironmentChallenge
[-] Index `challengeId_1` - ExamEnvironmentChallenge
[-] Index `version_1` - ExamEnvironmentChallenge
[-] Index `subscriptionId_1` - Donation
[-] Index `created_1` - AccessToken
[-] Index `mailing-list-pull` - user
[-] Index `email_1` - user
[-] Index `isDonating_1` - user
[-] Index `username_1` - user
[-] Index `unsubscribeId_1` - user
[-] Index `needsModeration_1` - user
[-] Index `completedExams_1` - user
[-] Index `isFoundationalCSharpCertV8_1` - user
[-] Index `completedExams.id_1` - user
[-] Index `profileUI.isLocked_1` - user
[-] Index `completedDailyCodingChallenges.id_1` - user
[-] Index `expires_at_1` - ExamCreatorSession
[-] Index `session_id_1` - ExamCreatorSession
[+] Unique index `ExamEnvironmentAuthorizationToken_userId_key` on ({"userId":1})
[+] Unique index `ExamEnvironmentExamModeration_examAttemptId_key` on ({"examAttemptId":1})
[+] Unique index `SocratesUsage_userId_date_key` on ({"userId":1,"date":1}) - the index is in the schema but not mapped to a name - so it shows up at in the schema and not in prod, and also in prod under the other name, but not in schema (cause name doesn't match this).
[+] Index `userId_1` on ({"userId":1}) - DripCampaign
[+] Index `email_1` on ({"email":1}) - DripCampaign
```

</details>

<details><summary><s>After the changes in this PR, the output looks like this...</s></summary>

```
[-] Index `examAttemptId_1` - these first four are the unique issue described in the schema comments on this PR
[-] Index `userId_1`
[+] Unique index `ExamEnvironmentAuthorizationToken_userId_key` on ({"userId":1})
[+] Unique index `ExamEnvironmentExamModeration_examAttemptId_key` on ({"examAttemptId":1})

[+] Index `userId_1` on ({"userId":1}) - missing from db.DripCampaign
[+] Index `email_1` on ({"email":1}) - missing from db.DripCampaign
```

~~So we can probably add those two indexes to the `DripCampaign` collection in the DB.~~

</details>

<details><summary>After the changes in this PR, the output looks like this...</summary>

```
[-] Index `examAttemptId_1` - these first four are the unique issue described in the schema comments on this PR
[-] Index `userId_1`
[+] Unique index `ExamEnvironmentAuthorizationToken_userId_key` on ({"userId":1})
[+] Unique index `ExamEnvironmentExamModeration_examAttemptId_key` on ({"examAttemptId":1})
```
</details>

Some other things I found:

- The DB has a `changelog` collection that isn't in the schema. Doesn't look like it gets used, maybe we can delete it?
- The schema can't describe TTL properties. So there's nothing in the schema that describes the `sessions.expires_1` TTL for example, just that the index exists.
- There's some plain indexes in the database that could potentially be made unique. Perhaps the `MsUsername.msUsername_1` index for example - along with probably many others. The code doesn't allow multiple records with the same `MsUsername.msUsername` value, but nothing in the database stops it. So if some other app were to write to that collection without making sure that username is unique, it could just add it I believe. You can't change an existing index to just add uniqueness, so you would have to create a new one and switch to that.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
