### PR TITLE
feat(curriculum): add lab-device-loan-ledger to introduction-to-objects

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -2459,6 +2459,13 @@
           "In this workshop, you will review working with JavaScript objects by building a recipe tracker."
         ]
       },
+      "lab-device-loan-ledger": {
+        "title": "Build a Device Loan Ledger",
+        "intro": [
+          "In this lab, you will build a device loan ledger to manage IT hardware provisioned by your company's Service Desk.",
+          "You will practice working with nested objects and JSON by implementing functions to check devices in and out, track overdue loans, and convert between JSON strings and JavaScript objects."
+        ]
+      },
       "lab-quiz-game": {
         "title": "Build a Quiz Game",
         "intro": [

--- a/curriculum/structure/superblocks/introduction-to-objects-in-javascript.json
+++ b/curriculum/structure/superblocks/introduction-to-objects-in-javascript.json
@@ -6,6 +6,7 @@
     "lecture-working-with-json",
     "lecture-working-with-optional-chaining-and-object-destructuring",
     "workshop-recipe-tracker",
+    "lab-device-loan-ledger",
     "lab-quiz-game",
     "lab-record-collection",
     "review-javascript-objects",


### PR DESCRIPTION
The standalone introduction-to-objects-in-javascript superblock was missing the lab-device-loan-ledger block that exists in the javascript-v9 module.

This adds it in the correct position (after workshop-recipe-tracker) in both the structure file and the English locale.

Closes #69932