### PR TITLE
fix(curriculum): fix grammar in Vowel Repeater description

### DIFF
--- a/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68adce01c0e1144d0a902956.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-javascript/68adce01c0e1144d0a902956.md
@@ -10,7 +10,7 @@ dashedName: challenge-25
 Given a string, return a new version of the string where each vowel is duplicated one more time than the previous vowel you encountered. For instance, the first vowel in the sentence should remain unchanged. The second vowel should appear twice in a row. The third vowel should appear three times in a row, and so on.
 
 - The letters `a`, `e`, `i`, `o`, and `u`, in either uppercase or lowercase, are considered vowels.
-- The original vowel should keeps its case.
+- The original vowel should keep its case.
 - Repeated vowels should be lowercase.
 - All non-vowel characters should keep their original case.
 

--- a/curriculum/challenges/english/blocks/daily-coding-challenges-python/68adce01c0e1144d0a902956.md
+++ b/curriculum/challenges/english/blocks/daily-coding-challenges-python/68adce01c0e1144d0a902956.md
@@ -10,7 +10,7 @@ dashedName: challenge-25
 Given a string, return a new version of the string where each vowel is duplicated one more time than the previous vowel you encountered. For instance, the first vowel in the sentence should remain unchanged. The second vowel should appear twice in a row. The third vowel should appear three times in a row, and so on.
 
 - The letters `a`, `e`, `i`, `o`, and `u`, in either uppercase or lowercase, are considered vowels.
-- The original vowel should keeps its case.
+- The original vowel should keep its case.
 - Repeated vowels should be lowercase.
 - All non-vowel characters should keep their original case.
 


### PR DESCRIPTION
Closes #69942

Fixes the grammar in the JavaScript and Python Vowel Repeater challenge descriptions: "should keeps" -> "should keep".