### PR TITLE
fix(client): add catalog course type filter

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -1608,6 +1608,10 @@
       "duration-singular": "{{duration}} hour",
       "duration": "{{duration}} hours",
       "no-results": "No courses found. Try adjusting your filters to see more results.",
+      "courseType": {
+        "full-stack": "Full Stack Curriculum",
+        "catalog": "Catalog Courses"
+      },
       "topic": {
         "html": "HTML",
         "css": "CSS",

--- a/client/src/pages/catalog.test.tsx
+++ b/client/src/pages/catalog.test.tsx
@@ -37,4 +37,16 @@ describe('CatalogPage', () => {
     expect(screen.getByText(/Level:/)).toBeInTheDocument();
     expect(screen.getByText(/Topic:/)).toBeInTheDocument();
   });
+
+  test('renders a course-type filter and records source metadata', () => {
+    render(<CatalogPage />);
+
+    expect(
+      screen.getByRole('button', {
+        name: /Course Type:/i
+      })
+    ).toBeInTheDocument();
+    expect(catalog.some(course => course.source === 'full-stack')).toBe(true);
+    expect(catalog.some(course => course.source === 'catalog')).toBe(true);
+  });
 });

--- a/client/src/pages/catalog.tsx
+++ b/client/src/pages/catalog.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Col, Spacer, Dropdown, MenuItem, Alert } from '@freecodecamp/ui';
-import { catalog } from '@freecodecamp/shared/config/catalog';
+import {
+  catalog,
+  CourseType
+} from '@freecodecamp/shared/config/catalog';
 import CatalogItem from '../components/catalog-item';
 
 import './catalog.css';
@@ -11,8 +14,11 @@ const CatalogPage = () => {
 
   const [selectedLevels, setSelectedLevels] = useState<string[]>(['all']);
   const [selectedTopics, setSelectedTopics] = useState<string[]>(['all']);
+  const [selectedCourseTypes, setSelectedCourseTypes] = useState<string[]>([
+    'all'
+  ]);
 
-  // Extract unique levels and topics from catalog
+  // Extract unique levels, topics, and course types from catalog
   const uniqueLevels = useMemo(() => {
     const levels = [...new Set(catalog.map(item => item.level))];
     return levels.sort();
@@ -21,6 +27,13 @@ const CatalogPage = () => {
   const uniqueTopics = useMemo(() => {
     const topics = [...new Set(catalog.map(item => item.topic))];
     return topics.sort();
+  }, []);
+
+  const uniqueCourseTypes = useMemo(() => {
+    const sourceValues = [
+      ...new Set(catalog.map(item => item.source ?? CourseType.Catalog))
+    ];
+    return sourceValues.sort();
   }, []);
 
   // Handle level filter change
@@ -57,15 +70,34 @@ const CatalogPage = () => {
     }
   };
 
+  const handleCourseTypeChange = (courseType: string) => {
+    if (courseType === 'all') {
+      setSelectedCourseTypes(['all']);
+    } else {
+      setSelectedCourseTypes(prev => {
+        const filtered = prev.filter(t => t !== 'all');
+        if (filtered.includes(courseType)) {
+          const updated = filtered.filter(t => t !== courseType);
+          return updated.length === 0 ? ['all'] : updated;
+        } else {
+          return [...filtered, courseType];
+        }
+      });
+    }
+  };
+
   const filteredCatalog = useMemo(() => {
     return catalog.filter(course => {
+      const courseTypeMatch =
+        selectedCourseTypes.includes('all') ||
+        selectedCourseTypes.includes(course.source ?? CourseType.Catalog);
       const levelMatch =
         selectedLevels.includes('all') || selectedLevels.includes(course.level);
       const topicMatch =
         selectedTopics.includes('all') || selectedTopics.includes(course.topic);
-      return levelMatch && topicMatch;
+      return courseTypeMatch && levelMatch && topicMatch;
     });
-  }, [selectedLevels, selectedTopics]);
+  }, [selectedCourseTypes, selectedLevels, selectedTopics]);
 
   return (
     <main>
@@ -131,6 +163,39 @@ const CatalogPage = () => {
                     className='filter-checkbox'
                   />
                   {t(`curriculum.catalog.topic.${topic}`)}
+                </MenuItem>
+              ))}
+            </Dropdown.Menu>
+          </Dropdown>
+          <Dropdown block={true}>
+            <Dropdown.Toggle id='course-type-filter-dropdown'>
+              Course Type:{' '}
+              {selectedCourseTypes.includes('all')
+                ? 'All'
+                : `${selectedCourseTypes.length} selected`}
+            </Dropdown.Toggle>
+            <Dropdown.Menu>
+              <MenuItem onClick={() => handleCourseTypeChange('all')}>
+                <input
+                  type='checkbox'
+                  checked={selectedCourseTypes.includes('all')}
+                  onChange={() => {}}
+                  className='filter-checkbox'
+                />
+                All
+              </MenuItem>
+              {uniqueCourseTypes.map(courseType => (
+                <MenuItem
+                  key={courseType}
+                  onClick={() => handleCourseTypeChange(courseType)}
+                >
+                  <input
+                    type='checkbox'
+                    checked={selectedCourseTypes.includes(courseType)}
+                    onChange={() => {}}
+                    className='filter-checkbox'
+                  />
+                  {t(`curriculum.catalog.courseType.${courseType}`)}
                 </MenuItem>
               ))}
             </Dropdown.Menu>


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69947

## Summary

This PR adds a course type filter to the catalog so users can separate full-stack curriculum entries from catalog-only courses.

## Why

The catalog page previously only filtered by level and topic. Because the data lacked source metadata, it was not possible to distinguish curriculum-backed lessons from catalog-exclusive content in a single list.

## Changes

- Added source metadata to catalog entries
- Added a Course Type dropdown to the catalog filters
- Combined the new source filter with the existing level and topic filters
- Added regression coverage for the new filter behavior

## Verification

- Ran:
  `cd C:/Users/lohit/sdd/freeCodeCamp/client ; corepack pnpm exec vitest run src/pages/catalog.test.tsx --reporter=default`

- Result:
  1 file passed, 5 tests passed, exit code 0