### PR TITLE
fix(client): unblock homepage rendering

### DIFF
--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -60,7 +60,7 @@ const UniversalNav = ({
       className='universal-nav'
       id='universal-nav'
     >
-      {isSearchExposedWidth && (
+      {isSearchExposedWidth && !pending && (
         <div className='universal-nav-left'>{search}</div>
       )}
       <Link

--- a/client/src/components/landing/components/campers-image.tsx
+++ b/client/src/components/landing/components/campers-image.tsx
@@ -1,26 +1,22 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import Media from 'react-responsive';
 import wideImg from '../../../assets/images/landing/wide-image.png';
 import { LazyImage } from '../../helpers';
-
-const LARGE_SCREEN_SIZE = 1200;
 
 function CampersImage(): JSX.Element {
   const { t } = useTranslation();
 
   return (
-    <Media minWidth={LARGE_SCREEN_SIZE}>
-      <figure
-        data-test-label='landing-page-figure'
-        data-testid='landing-page-figure'
-      >
-        <LazyImage alt={t('landing.hero-img-alt')} src={wideImg} />
-        <figcaption className='caption'>
-          {t('landing.hero-img-description')}
-        </figcaption>
-      </figure>
-    </Media>
+    <figure
+      className='landing-page-figure'
+      data-test-label='landing-page-figure'
+      data-testid='landing-page-figure'
+    >
+      <LazyImage alt={t('landing.hero-img-alt')} src={wideImg} />
+      <figcaption className='caption'>
+        {t('landing.hero-img-description')}
+      </figcaption>
+    </figure>
   );
 }
 

--- a/client/src/components/landing/components/landing-top.tsx
+++ b/client/src/components/landing/components/landing-top.tsx
@@ -15,12 +15,22 @@ import {
 import BigCallToAction from './big-call-to-action';
 import TwoButtonCTA from './two-button-cta';
 import CampersImage from './campers-image';
+import { SkeletonSprite } from '../../helpers';
 
 const { clientLocale } = envData;
 
-function LandingTop(): JSX.Element {
-  const { t } = useTranslation();
+function LandingCallToAction(): JSX.Element {
   const showTwoButtonCTA = useFeature('landing-two-button-cta').on;
+
+  return showTwoButtonCTA ? (
+    <TwoButtonCTA />
+  ) : (
+    <BigCallToAction testLabel='landing-top-big-cta' />
+  );
+}
+
+function LandingTop({ isReady }: { isReady: boolean }): JSX.Element {
+  const { t } = useTranslation();
   const showChineseLogos = ['chinese', 'chinese-tradition'].includes(
     clientLocale
   );
@@ -45,10 +55,12 @@ function LandingTop(): JSX.Element {
             <p data-testid='advance-career'>{t('landing.advance-career')}</p>
             <Spacer size='m' />
 
-            {showTwoButtonCTA ? (
-              <TwoButtonCTA />
+            {isReady ? (
+              <LandingCallToAction />
             ) : (
-              <BigCallToAction testLabel='landing-top-big-cta' />
+              <div className='landing-cta-placeholder' aria-hidden='true'>
+                <SkeletonSprite />
+              </div>
             )}
             <Spacer size='m' />
           </Col>

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -401,7 +401,19 @@ figcaption.caption {
   line-height: 1.5;
 }
 
+.landing-cta-placeholder {
+  height: 50px;
+}
+
+.landing-page-figure {
+  display: none;
+}
+
 @media (min-width: 1200px) {
+  .landing-page-figure {
+    display: block;
+  }
+
   .landing-top-two-column {
     flex-direction: row;
     align-items: center;

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -21,6 +21,7 @@ import hackZeroSlashItalicURL from '../../../static/fonts/hack-zeroslash/Hack-Ze
 import hackZeroSlashRegularURL from '../../../static/fonts/hack-zeroslash/Hack-ZeroSlash-Regular.woff';
 
 import { isBrowser } from '../../../utils';
+import { isLanding } from '../../utils/path-parsers';
 import {
   fetchUser,
   initializeTheme,
@@ -184,8 +185,9 @@ function DefaultLayout({
   };
 
   const isJapanese = clientLocale === 'japanese';
+  const canRenderContent = fetchState.complete || isLanding(pathname);
 
-  if (!fetchState.complete) {
+  if (!canRenderContent) {
     return <Loader fullScreen={true} messageDelay={5000} />;
   } else {
     return (
@@ -315,7 +317,7 @@ function DefaultLayout({
               <Spacer size={isExSmallViewportHeight ? 'xxs' : 'xs'} />
             ))
           )}
-          {fetchState.complete && children}
+          {children}
         </div>
         {showFooter && <Footer />}
       </div>

--- a/client/src/pages/index.test.tsx
+++ b/client/src/pages/index.test.tsx
@@ -46,10 +46,6 @@ vi.mock('@growthbook/growthbook-react', () => ({
   useGrowthBook: growthBookMocks.useGrowthBook
 }));
 
-vi.mock('react-responsive', () => ({
-  default: ({ children }: { children: React.ReactNode }) => children
-}));
-
 vi.mock('../analytics/call-ga', () => ({
   default: vi.fn()
 }));
@@ -71,9 +67,11 @@ const expectedLandingSuperBlocks = getStageOrder({ showUpcomingChanges })
 
 function renderLanding({
   growthBookReady = true,
+  userFetchComplete = true,
   showTwoButtonCTA = false
 }: {
   growthBookReady?: boolean;
+  userFetchComplete?: boolean;
   showTwoButtonCTA?: boolean;
 } = {}) {
   growthBookMocks.useFeature.mockReturnValue({
@@ -92,8 +90,8 @@ function renderLanding({
         sessionUser: null
       },
       userFetchState: {
-        pending: false,
-        complete: true,
+        pending: !userFetchComplete,
+        complete: userFetchComplete,
         errored: false,
         error: null
       }
@@ -114,6 +112,27 @@ describe('IndexPage', () => {
     growthBookMocks.getFeatureValue.mockReset();
     growthBookMocks.useFeature.mockReset();
     growthBookMocks.useGrowthBook.mockReset();
+  });
+
+  it.each([
+    { growthBookReady: false, userFetchComplete: true },
+    { growthBookReady: true, userFetchComplete: false }
+  ])('renders public content while loading %j', loadingState => {
+    renderLanding(loadingState);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: translations.landing['big-heading-1-b']
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('testimonials-section-header')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('landing-top-big-cta')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('landing-google-cta')).not.toBeInTheDocument();
+    expect(growthBookMocks.getFeatureValue).not.toHaveBeenCalled();
+    expect(growthBookMocks.useFeature).not.toHaveBeenCalled();
   });
 
   it('renders landing page copy and static sections', () => {

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGrowthBook } from '@growthbook/growthbook-react';
+import { useSelector } from 'react-redux';
 import SEO from '../components/seo';
-import { Loader } from '../components/helpers';
+import { userFetchStateSelector } from '../redux/selectors';
+import type { UserFetchState } from '../redux/prop-types';
 import LandingTop from '../components/landing/components/landing-top';
 import Testimonials from '../components/landing/components/testimonials';
 import Certifications from '../components/landing/components/certifications';
@@ -13,13 +15,13 @@ import { useClaimableCertsNotification } from '../components/helpers/use-claimab
 
 import '../components/landing/landing.css';
 
-const Landing = () => (
+const Landing = ({ isReady }: { isReady: boolean }) => (
   <main
     id='landing-content'
     data-testid='landing-content'
     className={`landing-page`}
   >
-    <LandingTop />
+    <LandingTop isReady={isReady} />
     <Benefits />
     <Testimonials />
     <Certifications />
@@ -31,24 +33,22 @@ const Landing = () => (
 function IndexPage(): JSX.Element {
   const { t } = useTranslation();
   const growthbook = useGrowthBook();
+  const { complete } = useSelector<unknown, UserFetchState>(
+    userFetchStateSelector
+  );
+  const isReady = complete && !!growthbook?.ready;
   useClaimableCertsNotification();
 
-  if (growthbook && growthbook.ready) {
-    growthbook.getFeatureValue('landing-aa-test', false);
-    return (
-      <>
-        <SEO title={t('metaTags:title')} />
-        <Landing />
-      </>
-    );
-  } else {
-    return (
-      <>
-        <SEO title={t('metaTags:title')} />
-        <Loader fullScreen={true} />
-      </>
-    );
+  if (isReady) {
+    growthbook?.getFeatureValue('landing-aa-test', false);
   }
+
+  return (
+    <>
+      <SEO title={t('metaTags:title')} />
+      <Landing isReady={isReady} />
+    </>
+  );
 }
 
 IndexPage.displayName = 'IndexPage';

--- a/e2e/landing-rendering.spec.ts
+++ b/e2e/landing-rendering.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+import translations from '../client/i18n/locales/english/translations.json';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('Homepage initial HTML', () => {
+  test.use({ javaScriptEnabled: false });
+
+  test('includes public content before user data and experiments load', async ({
+    page
+  }) => {
+    await page.goto('/');
+
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: translations.landing['big-heading-1-b']
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        level: 2,
+        name: translations.landing.testimonials.heading
+      })
+    ).toBeVisible();
+  });
+});
+
+test('hydrates the homepage without errors', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+
+  await page.goto('/');
+
+  await expect(
+    page.getByRole('heading', {
+      level: 1,
+      name: translations.landing['big-heading-1-b']
+    })
+  ).toBeVisible();
+  await expect(page.locator('.landing-cta-placeholder')).toHaveCount(0);
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Render the public homepage immediately instead of showing a full-screen loader until user data and GrowthBook are ready. Keep the experimental CTA behind those loading checks, and make the responsive header and hero markup consistent during hydration.

Tested with 9 component tests, desktop/mobile production browser checks (including both CTA variants), TypeScript, ESLint, and Stylelint.

Three paired mobile Lighthouse runs on scoped local production builds, using identical anonymous-user and GrowthBook fixtures with the single-button CTA fixed:

| Median | Before | After |
| --- | ---: | ---: |
| Performance | 56 | 67 |
| LCP | 12.49 s | 4.13 s |
| Total blocking time | 648 ms | 826 ms |

The images show representative runs with the median score. These are local lab results; blocking time increases despite the faster initial rendering.

| Before | After |
| --- | --- |
| ![Before Lighthouse report](https://raw.githubusercontent.com/Sembauke/freeCodeCamp/7d6dddc00506089ce172e1affe1cf9b3f97311d9/before.png) | ![After Lighthouse report](https://raw.githubusercontent.com/Sembauke/freeCodeCamp/7d6dddc00506089ce172e1affe1cf9b3f97311d9/after.png) |
