### PR TITLE
fix: preserve RSVP confirmation data after submission

### DIFF
--- a/curriculum/challenges/english/blocks/lab-event-rsvp/67d936de7055982b02baf186.md
+++ b/curriculum/challenges/english/blocks/lab-event-rsvp/67d936de7055982b02baf186.md
@@ -799,6 +799,7 @@ export function EventRSVPForm() {
   });
 
   const [submitted, setSubmitted] = useState(false);
+  const [submittedData, setSubmittedData] = useState(null);
 
   function handleChange(event) {
     const { name, value, type, checked } = event.target;
@@ -810,6 +811,7 @@ export function EventRSVPForm() {
 
   function handleSubmit(event) {
     event.preventDefault();
+    setSubmittedData({ ...formData });
     setSubmitted(true);
   }
 
@@ -882,25 +884,25 @@ export function EventRSVPForm() {
         </div>
         <button type='submit'>Submit RSVP</button>
       </form>
-      {submitted && (
+      {submitted && submittedData && (
         <div className='submitted-message'>
           <h3>RSVP Submitted!</h3>
           <p>
-            <strong>Name:</strong> {formData.name}
+            <strong>Name:</strong> {submittedData.name}
           </p>
           <p>
-            <strong>Email:</strong> {formData.email}
+            <strong>Email:</strong> {submittedData.email}
           </p>
           <p>
-            <strong>Number of Attendees:</strong> {formData.attendees}
+            <strong>Number of Attendees:</strong> {submittedData.attendees}
           </p>
           <p>
             <strong>Dietary Preferences:</strong>{' '}
-            {formData.dietaryPreferences || 'None'}
+            {submittedData.dietaryPreferences || 'None'}
           </p>
           <p>
             <strong>Bringing Others:</strong>{' '}
-            {formData.bringingOthers ? 'Yes' : 'No'}
+            {submittedData.bringingOthers ? 'Yes' : 'No'}
           </p>
         </div>
       )}


### PR DESCRIPTION
## Description

Fixes #69837.

After submitting the RSVP form, the confirmation message now displays
the data captured at the time of submission instead of the current form values.

### Changes

- Added `submittedData` state to store submitted form data.
- Capture a copy of `formData` when the form is submitted.
- Updated the confirmation message to use `submittedData`.

### Testing

- Prettier check passed.
- `git diff --check` passed.
- Repository test command was blocked by a local `challenge-linter` build issue.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69837