### PR TITLE
fix(curriculum): add backticks to lecture section headings

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a539b887ec68c593cdc4b.md
+++ b/curriculum/challenges/english/blocks/lecture-accessible-tables-forms/672a539b887ec68c593cdc4b.md
@@ -64,7 +64,7 @@ For example, the code below creates a table for two pets. Every row has a row he
 
 Notice that the above code has a `caption` element immediately after the opening `table` element. Then, inside the table head (`thead`) element, it has the column headers (`Name`, `Age`, and `Type`). In the second and third rows, inside the table body (`tbody`) element, we find the data for each one of our pets. The names of the pets are the row headers because they are inside table header elements (`th`).
 
-## The Scope Attribute
+## The `scope` Attribute
 
 Associating the data cells with their corresponding headers is also very important for screen readers. The `scope` attribute determines if a header is a row header or a column header.
 Screen readers may guess this correctly from the table's structure, but it's usually recommended to explicitly indicate the `scope` to ensure clarity.

--- a/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a54a6675c168faa84252d.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-aria/672a54a6675c168faa84252d.md
@@ -15,7 +15,7 @@ Let's look at what the `aria-label` and `aria-labelledby` attributes are and the
 
 You'll notice both `aria-label` and `aria-labelledby` are prefixed with `aria-`. So what does that mean? ARIA stands for Accessible Rich Internet Applications. It's a set of attributes prefixed with `aria-`, which lets developers communicate the purpose of elements to assistive technologies. The `aria-label` attribute is an invisible label for interactive elements. It adds a text label to an element that screen readers can read.
 
-## The aria-label Attribute
+## The `aria-label` Attribute
 
 `aria-label` is especially useful for elements that do not have visible text but still need to be described by screen readers. For example, buttons with only icons often need `aria-label` to convey their purpose.
 
@@ -33,7 +33,7 @@ If the button contained the text "Search" instead of an icon, then there would b
 
 For input elements, the `aria-label` attribute provides a label directly if there isn't a visible label associated with the input.
 
-## The aria-labelledby Attribute
+## The `aria-labelledby` Attribute
 
 The `aria-labelledby` attribute does the exact same thing as the `aria-label` attribute, but instead of defining the text directly in the attribute, you use a reference to text that already exists on the page. The existing text must have an `id` attribute, which will be used for the reference value in the `aria-labelledby` attribute.
 
@@ -73,7 +73,7 @@ Combining multiple `id` values into a single `aria-labelledby` attribute value i
 
 For the slider, the screen reader will look out for the content of the `volume-label` and `volume-details` elements and announce `Volume Adjust the volume level`.
 
-## Choosing Between aria-label and aria-labelledby
+## Choosing Between `aria-label` and `aria-labelledby`
 
 You've seen that both `aria-label` and `aria-labelledby` attributes help screen readers understand what elements do. So, which one should you use? Since they both provide the same functionality, either can be used, but there may be a few advantages to using `aria-labelledby` over `aria-label`:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-css-variables/672cf3ca326da9f63683e236.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-css-variables/672cf3ca326da9f63683e236.md
@@ -128,7 +128,7 @@ body {
 
 In this case, browsers that support `@property` will use the more strictly defined version, while others will fall back to the standard custom property declaration.
 
-### Fallbacks with the var() Function
+### Fallbacks with the `var()` Function
 
 When using the custom property, you can provide a fallback value using the `var()` function, just as you would with standard custom properties:
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-npm-scripts/692ab9f91d74951aeba05c00.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-npm-scripts/692ab9f91d74951aeba05c00.md
@@ -28,7 +28,7 @@ You can also use npm scripts to automate linting throughout your codebase and fo
 
 They are very powerful, so let's check out their fundamentals.
 
-## How to Create a package.json File
+## How to Create a `package.json` File
 
 To be able to create and run custom npm scripts, you'll need a `package.json` file.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-npm-scripts/692aba0978ca391f10455b4a.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-npm-scripts/692aba0978ca391f10455b4a.md
@@ -95,7 +95,7 @@ npm init --scope=@<scope-name>
 
 The scope name can be your username if you are using a personal account, or the name of your organization if you are using an organizational account.
 
-## Step 4: Create README.md
+## Step 4: Create `README.md`
 
 The README of your package is a markdown file where you describe what your package does and its intended usage.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/673368ccf52205329b729378.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/673368ccf52205329b729378.md
@@ -15,7 +15,7 @@ These are properties that you can access in JavaScript to get or change the cont
 
 Let's start with `innerText`.
 
-## Understanding innerText
+## Understanding `innerText`
 
 `innerText` represents the visible text content of the HTML element and its descendants. This property doesn't include hidden text or HTML tags, only rendered text. 
 
@@ -113,7 +113,7 @@ Since `innerText` takes visibility into account, getting its value triggers a pr
 
 Great. Now let's talk about `textContent`. 
 
-## Understanding textContent
+## Understanding `textContent`
 
 `textContent` returns the plain text content of an element, including all the text within its descendants.
 
@@ -187,7 +187,7 @@ container.textContent = "New content";
 
 :::
 
-## Comparing with innerHTML
+## Comparing with `innerHTML`
 
 And finally, let's talk about how `textContent` and `innerText` differs from `innerHTML`.
 

--- a/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/673368e7bd043f331919514d.md
+++ b/curriculum/challenges/english/blocks/lecture-working-with-the-dom-click-events-and-web-apis/673368e7bd043f331919514d.md
@@ -11,7 +11,7 @@ When working with the DOM, you will often come across the `Navigator`, `Window`,
 
 In this lesson, we will explore how these interfaces work and how you can use them in your web applications.
 
-## Navigator Interface
+## `Navigator` Interface
 
 Let's start by looking at the `Navigator` interface.
 
@@ -51,7 +51,7 @@ console.log(navigator.language);
 
 The result will be a string that contains the language code of the browser. If your preferred language is English, it will return `en-US`.
 
-## Window Interface
+## `Window` Interface
 
 Next, let's look at the `Window` interface.
 
@@ -91,7 +91,7 @@ console.log(location);
 
 You will see the same results as before when you were using `window.location`.
 
-## Document Interface
+## `Document` Interface
 
 Finally, let's look at the `Document` interface.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69943

<!-- Feel free to add any additional description of changes below this line -->

## Description

Adds inline code formatting to thirteen existing section headings across seven lectures. These headings referenced attributes, properties, interface names, a function, and filenames in plain text, which was inconsistent with how the same identifiers are formatted throughout the lesson bodies.

Headings updated:

**What Are Best Practices for Tables and Accessibility?** (`lecture-accessible-tables-forms`)

- `## The Scope Attribute` to ``## The `scope` Attribute``

**What Are the Roles of the aria-label and aria-labelledby Attributes?** (`lecture-introduction-to-aria`)

- `## The aria-label Attribute` to ``## The `aria-label` Attribute``
- `## The aria-labelledby Attribute` to ``## The `aria-labelledby` Attribute``
- `## Choosing Between aria-label and aria-labelledby` to ``## Choosing Between `aria-label` and `aria-labelledby` ``

**What Is the @property Rule, and How Does It Work with Fallbacks?** (`lecture-working-with-css-variables`)

- `### Fallbacks with the var() Function` to ``### Fallbacks with the `var()` Function``

**What Is the Difference Between innerText, textContent, and innerHTML?** (`lecture-working-with-the-dom-click-events-and-web-apis`)

- `## Understanding innerText` to ``## Understanding `innerText` ``
- `## Understanding textContent` to ``## Understanding `textContent` ``
- `## Comparing with innerHTML` to ``## Comparing with `innerHTML` ``

**How Do the Navigator, Window, and Document Work?** (`lecture-working-with-the-dom-click-events-and-web-apis`)

- `## Navigator Interface` to ``## `Navigator` Interface``
- `## Window Interface` to ``## `Window` Interface``
- `## Document Interface` to ``## `Document` Interface``

**What Are npm Scripts?** (`lecture-working-with-npm-scripts`)

- `## How to Create a package.json File` to ``## How to Create a `package.json` File``

**How Can You Publish a Package to the npm Registry?** (`lecture-working-with-npm-scripts`)

- `## Step 4: Create README.md` to ``## Step 4: Create `README.md` ``

> Per the issue, the scope attribute name is lowercased to `scope`. Every other identifier keeps its exact original spelling and casing.

No prose was rewritten and no headings were added, removed, or reordered - only backticks were added to existing heading text. Front matter, code blocks, interactive editor blocks, and the `# --questions--` sections are untouched.

Screenshots of the rendered lectures below:

<!-- paste screenshots here -->
<img width="640" height="283" alt="Screenshot 2026-09-11 at 6 26 48 PM" src="https://github.com/user-attachments/assets/20556b41-9a7c-4f09-b5a2-711926ad05aa" />
<hr>
<img width="640" height="121" alt="Screenshot 2026-09-11 at 6 29 42 PM" src="https://github.com/user-attachments/assets/f1d9f52f-4264-45f9-ae91-908ec05b73b7" />
<img width="640" height="141" alt="Screenshot 2026-09-11 at 6 30 07 PM" src="https://github.com/user-attachments/assets/38c17453-e1f3-4a21-9aa1-33d1931df44e" />
<img width="640" height="138" alt="Screenshot 2026-09-11 at 6 30 44 PM" src="https://github.com/user-attachments/assets/599b4e3e-45b9-4648-ad46-0e1b3432857a" />
<hr>
<img width="640" height="93" alt="Screenshot 2026-09-11 at 6 32 59 PM" src="https://github.com/user-attachments/assets/705e1bef-202e-443d-8d43-9f04d886b928" />
<hr>
<img width="640" height="99" alt="Screenshot 2026-09-11 at 6 38 42 PM" src="https://github.com/user-attachments/assets/7f71b03e-761f-46d4-9d57-c6ce6c9a6bad" />
<img width="640" height="178" alt="Screenshot 2026-09-11 at 6 38 57 PM" src="https://github.com/user-attachments/assets/c62a3f03-7fab-4e07-b821-ff3d202b4463" />
<img width="640" height="136" alt="Screenshot 2026-09-11 at 6 39 18 PM" src="https://github.com/user-attachments/assets/0c0a7ba1-be83-4672-9aa7-efce131e1eb9" />
<hr>
<img width="640" height="166" alt="Screenshot 2026-09-11 at 6 40 03 PM" src="https://github.com/user-attachments/assets/022fb3d7-4965-4343-9ffa-e44091ff50b2" />
<img width="641" height="165" alt="Screenshot 2026-09-11 at 6 40 14 PM" src="https://github.com/user-attachments/assets/f0b60046-b625-48d4-ae2c-c9868490497d" />
<img width="640" height="164" alt="Screenshot 2026-09-11 at 6 40 28 PM" src="https://github.com/user-attachments/assets/808fd269-4674-42de-9f5b-56a639ac2102" />
<hr>
<img width="640" height="137" alt="Screenshot 2026-09-11 at 6 36 14 PM" src="https://github.com/user-attachments/assets/7047f2c3-47ed-4ba8-8218-338f49592d85" />
<hr>
<img width="640" height="98" alt="Screenshot 2026-09-11 at 6 35 34 PM" src="https://github.com/user-attachments/assets/5cd0ad09-5dab-4038-b6d6-d89037ace375" />

