### PR TITLE
docs: fix incorrect apostrophe in seed-exams README

### DIFF
--- a/tools/scripts/seed-exams/README.md
+++ b/tools/scripts/seed-exams/README.md
@@ -1,4 +1,4 @@
-## WARNING: Never change any of the ID's or delete anything. Mark things as deprecated instead.
+## WARNING: Never change any of the IDs or delete anything. Mark things as deprecated instead.
 
 ### How to create a new exam:
 
@@ -23,7 +23,7 @@
 
 - `answer`: This is one of the multiple choice options
 
-5. Add the ID's:
+5. Add the IDs:
 
 - Change the `examPath` variable in the `add-nano-ids.js` file to the name of the new exam file
 - Run it with `node add-nano-ids.js`. It will add an `id` to each `question`, and each `answer`.


### PR DESCRIPTION
## Description

Small doc fix in 	ools/scripts/seed-exams/README.md: ID's was used as a plural in two places, but the correct plural form is IDs (no apostrophe — an apostrophe there implies possession, not plurality).

## Checklist

- [x] Docs-only change, no functional/code impact
- [x] Ran the change past the file's full content for context

🤖 Generated with [Claude Code](https://claude.com/claude-code)