### PR TITLE
fix(api): move singout route outside registered csrf plugin

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -119,7 +119,6 @@ export const build = async (
 
   await fastify.register(cors);
   await fastify.register(cookies);
-  await fastify.register(csrf);
 
   await fastify.register(growthBook, {
     apiHost: GROWTHBOOK_FASTIFY_API_HOST,
@@ -163,88 +162,95 @@ export const build = async (
   void fastify.register(bouncer);
   await fastify.register(serviceBearerAuth);
 
-  // Routes requiring authentication:
-  void fastify.register(async function (fastify, _opts) {
-    fastify.addHook('onRequest', fastify.authorize);
-    // CSRF protection enabled:
-    await fastify.register(async function (fastify, _opts) {
-      // TODO: bounce unauthed requests before checking CSRF token. This will
-      // mean moving csrfProtection into custom plugin and testing separately,
-      // because it's a pain to mess around with other cookies/hook order.
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      fastify.addHook('onRequest', fastify.csrfProtection);
+  // Routes requiring csrf cookie
+  await fastify.register(async function (fastify) {
+    await fastify.register(csrf);
+
+    // Routes requiring authentication:
+    void fastify.register(async function (fastify, _opts) {
+      fastify.addHook('onRequest', fastify.authorize);
+      // CSRF protection enabled:
+      await fastify.register(async function (fastify, _opts) {
+        // TODO: bounce unauthed requests before checking CSRF token. This will
+        // mean moving csrfProtection into custom plugin and testing separately,
+        // because it's a pain to mess around with other cookies/hook order.
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        fastify.addHook('onRequest', fastify.csrfProtection);
+        fastify.addHook('onRequest', fastify.send401IfNoUser);
+
+        await fastify.register(protectedRoutes.challengeRoutes);
+        await fastify.register(protectedRoutes.donateRoutes);
+        await fastify.register(protectedRoutes.socratesRoutes);
+        await fastify.register(protectedRoutes.protectedCertificateRoutes);
+        await fastify.register(protectedRoutes.settingRoutes);
+        await fastify.register(protectedRoutes.userRoutes);
+      });
+
+      // Routes that redirect if access is denied:
+      await fastify.register(async function (fastify, _opts) {
+        fastify.addHook('onRequest', fastify.redirectIfNoUser);
+
+        await fastify.register(protectedRoutes.settingRedirectRoutes);
+      });
+    });
+
+    // TODO: The route should not handle its own AuthZ
+    await fastify.register(protectedRoutes.challengeTokenRoutes);
+
+    // CSRF protection disabled:
+    // Routes that work for both authenticated and unauthenticated users:
+    void fastify.register(async function (fastify) {
+      fastify.addHook('onRequest', fastify.authorize);
+
+      await fastify.register(protectedRoutes.userGetRoutes);
+    });
+
+    // Routes for signed out users:
+    void fastify.register(async function (fastify) {
+      fastify.addHook('onRequest', fastify.authorize);
+      // TODO(Post-MVP): add the redirectIfSignedIn hook here, rather than in the
+      // mobileAuth0Routes and authRoutes plugins.
+      await fastify.register(publicRoutes.mobileAuth0Routes);
+      if (FCC_ENABLE_DEV_LOGIN_MODE) {
+        await fastify.register(publicRoutes.devAuthRoutes);
+      } else {
+        await fastify.register(publicRoutes.authRoutes);
+      }
+    });
+
+    void fastify.register(function (fastify, _opts, done) {
+      fastify.addHook('onRequest', fastify.authorizeExamEnvironmentToken);
       fastify.addHook('onRequest', fastify.send401IfNoUser);
 
-      await fastify.register(protectedRoutes.challengeRoutes);
-      await fastify.register(protectedRoutes.donateRoutes);
-      await fastify.register(protectedRoutes.socratesRoutes);
-      await fastify.register(protectedRoutes.protectedCertificateRoutes);
-      await fastify.register(protectedRoutes.settingRoutes);
-      await fastify.register(protectedRoutes.userRoutes);
+      void fastify.register(examEnvironmentValidatedTokenRoutes);
+      done();
     });
+    void fastify.register(examEnvironmentOpenRoutes);
 
-    // Routes that redirect if access is denied:
-    await fastify.register(async function (fastify, _opts) {
-      fastify.addHook('onRequest', fastify.redirectIfNoUser);
-
-      await fastify.register(protectedRoutes.settingRedirectRoutes);
-    });
-  });
-
-  // TODO: The route should not handle its own AuthZ
-  await fastify.register(protectedRoutes.challengeTokenRoutes);
-
-  // CSRF protection disabled:
-  // Routes that work for both authenticated and unauthenticated users:
-  void fastify.register(async function (fastify) {
-    fastify.addHook('onRequest', fastify.authorize);
-
-    await fastify.register(protectedRoutes.userGetRoutes);
-  });
-
-  // Routes for signed out users:
-  void fastify.register(async function (fastify) {
-    fastify.addHook('onRequest', fastify.authorize);
-    // TODO(Post-MVP): add the redirectIfSignedIn hook here, rather than in the
-    // mobileAuth0Routes and authRoutes plugins.
-    await fastify.register(publicRoutes.mobileAuth0Routes);
-    if (FCC_ENABLE_DEV_LOGIN_MODE) {
-      await fastify.register(publicRoutes.devAuthRoutes);
-    } else {
-      await fastify.register(publicRoutes.authRoutes);
+    // Service-to-service app routes (API key auth), gated by the classroom flag:
+    if (FCC_ENABLE_CLASSROOM ?? fastify.gb.isOn('classroom-mode')) {
+      void fastify.register(async function (fastify) {
+        fastify.addHook('onRequest', fastify.validateBearerToken);
+        await fastify.register(classroomRoutes, { prefix: '/apps/classroom' });
+      });
     }
+
+    if (FCC_ENABLE_SENTRY_ROUTES ?? fastify.gb.isOn('sentry-routes')) {
+      void fastify.register(publicRoutes.sentryRoutes);
+    }
+
+    void fastify.register(publicRoutes.chargeStripeRoute);
+    void fastify.register(publicRoutes.emailSubscribtionRoutes);
+    void fastify.register(publicRoutes.userPublicGetRoutes);
+    void fastify.register(publicRoutes.unprotectedCertificateRoutes);
+    void fastify.register(publicRoutes.deprecatedEndpoints);
+    void fastify.register(publicRoutes.statusRoute);
+    void fastify.register(publicRoutes.unsubscribeDeprecated);
+    void fastify.register(dailyCodingChallengeRoutes);
   });
 
-  void fastify.register(function (fastify, _opts, done) {
-    fastify.addHook('onRequest', fastify.authorizeExamEnvironmentToken);
-    fastify.addHook('onRequest', fastify.send401IfNoUser);
-
-    void fastify.register(examEnvironmentValidatedTokenRoutes);
-    done();
-  });
-  void fastify.register(examEnvironmentOpenRoutes);
-
-  // Service-to-service app routes (API key auth), gated by the classroom flag:
-  if (FCC_ENABLE_CLASSROOM ?? fastify.gb.isOn('classroom-mode')) {
-    void fastify.register(async function (fastify) {
-      fastify.addHook('onRequest', fastify.validateBearerToken);
-      await fastify.register(classroomRoutes, { prefix: '/apps/classroom' });
-    });
-  }
-
-  if (FCC_ENABLE_SENTRY_ROUTES ?? fastify.gb.isOn('sentry-routes')) {
-    void fastify.register(publicRoutes.sentryRoutes);
-  }
-
-  void fastify.register(publicRoutes.chargeStripeRoute);
+  // Registered outside the CSRF scope. Signing out clears the CSRF cookies.
   void fastify.register(publicRoutes.signoutRoute);
-  void fastify.register(publicRoutes.emailSubscribtionRoutes);
-  void fastify.register(publicRoutes.userPublicGetRoutes);
-  void fastify.register(publicRoutes.unprotectedCertificateRoutes);
-  void fastify.register(publicRoutes.deprecatedEndpoints);
-  void fastify.register(publicRoutes.statusRoute);
-  void fastify.register(publicRoutes.unsubscribeDeprecated);
-  void fastify.register(dailyCodingChallengeRoutes);
 
   return fastify;
 };

--- a/api/src/plugins/csrf.test.ts
+++ b/api/src/plugins/csrf.test.ts
@@ -25,11 +25,6 @@ async function setupServer() {
     void reply.send({ foo: 'bar' });
   });
 
-  // Mock signout route for the exemption test
-  fastify.get('/signout', (_req, reply) => {
-    void reply.send({ ok: true });
-  });
-
   return fastify;
 }
 
@@ -90,19 +85,6 @@ describe('CSRF protection', () => {
     });
 
     expect(response.statusCode).toEqual(403);
-  });
-
-  test('should not set CSRF cookie on /signout even with query parameters', async () => {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/signout?redirect=true'
-    });
-
-    const csrfTokenCookie = response.cookies.find(
-      cookie => cookie.name === CSRF_COOKIE
-    );
-
-    expect(csrfTokenCookie).toBeUndefined();
   });
 
   test('should allow the request if the csrf_token is valid', async () => {

--- a/api/src/plugins/csrf.ts
+++ b/api/src/plugins/csrf.ts
@@ -26,21 +26,16 @@ const csrf: FastifyPluginCallback = (fastify, _options, done) => {
     logLevel: 'silent'
   });
 
-  // All routes except signout should add a CSRF token to the response
   fastify.addHook('onRequest', (req, reply, done) => {
-    const isSignout = req.routeOptions.url === '/signout';
-
-    if (!isSignout) {
-      req.log.trace('Adding CSRF token to response');
-      const token = reply.generateCsrf();
-      void reply.setCookie(CSRF_COOKIE, token, {
-        sameSite: 'strict',
-        signed: false,
-        // it needs to be read by the client, so that it can be sent in the
-        // header of the next request:
-        httpOnly: false
-      });
-    }
+    req.log.trace('Adding CSRF token to response');
+    const token = reply.generateCsrf();
+    void reply.setCookie(CSRF_COOKIE, token, {
+      sameSite: 'strict',
+      signed: false,
+      // it needs to be read by the client, so that it can be sent in the
+      // header of the next request:
+      httpOnly: false
+    });
     done();
   });
 

--- a/api/src/routes/public/signout.test.ts
+++ b/api/src/routes/public/signout.test.ts
@@ -1,5 +1,39 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { devLogin, setupServer, superRequest } from '../../../vitest.utils.js';
+
+/**
+ * Walks `Fastify` scopes to spy on the `Reply` prototype owning `generateCsrf`.
+ *
+ * @returns Spy on a shared prototype; callers must restore it.
+ */
+function spyOnCsrfTokenGeneration() {
+  const symbolNamed = (instance: object, name: string) =>
+    Object.getOwnPropertySymbols(instance).find(s => String(s) === name);
+
+  const findOwner = (instance: object): object | undefined => {
+    const replySymbol = symbolNamed(instance, 'Symbol(fastify.Reply)');
+    const proto = replySymbol
+      ? (instance[replySymbol as keyof object] as { prototype: object })
+          ?.prototype
+      : undefined;
+    if (proto && Object.hasOwn(proto, 'generateCsrf')) return proto;
+
+    const childrenSymbol = symbolNamed(instance, 'Symbol(fastify.children)');
+    const children = childrenSymbol
+      ? (instance[childrenSymbol as keyof object] as object[])
+      : [];
+    for (const child of children ?? []) {
+      const found = findOwner(child);
+      if (found) return found;
+    }
+    return undefined;
+  };
+
+  const owner = findOwner(fastifyTestInstance);
+  if (!owner) throw Error('could not find the Reply owning generateCsrf');
+
+  return vi.spyOn(owner as { generateCsrf: () => string }, 'generateCsrf');
+}
 
 describe('GET /signout', () => {
   setupServer();
@@ -7,6 +41,11 @@ describe('GET /signout', () => {
   beforeEach(async () => {
     await devLogin();
   });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should clear all the cookies', async () => {
     const res = await superRequest('/signout', { method: 'GET' });
 
@@ -26,6 +65,18 @@ describe('GET /signout', () => {
       ])
     );
     expect(setCookie).toHaveLength(3);
+  });
+
+  // Signout sits outside the token-issuing scope. Spy on generation because `clearOurCookies` would overwrite issued cookies, hiding a scope regression.
+  it('should not generate a CSRF token', async () => {
+    const generateCsrf = spyOnCsrfTokenGeneration();
+
+    await superRequest('/signout', { method: 'GET' });
+    expect(generateCsrf).not.toHaveBeenCalled();
+
+    // Control to confirm the spy works.
+    await superRequest('/status/ping', { method: 'GET' });
+    expect(generateCsrf).toHaveBeenCalled();
   });
 
   it('should respond with an empty object', async () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I suggest viewing the diff in something other than GitHub; it is not nearly as bad as it looks in `app.ts`.

Reason for change is simple: Plugins are scope registered. Do not globally register plugin with route that does not want it.