### PR TITLE
fix(curriculum): accept both outline orderings in greeting-card step 23

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333b1d5f4a7340a121973a.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333b1d5f4a7340a121973a.md
@@ -20,9 +20,12 @@ assert.exists(new __helpers.CSSHelp(document).getStyle(".card-links a:focus"));
 The `.card-links a:focus` selector should have an `outline` property set to `2px solid yellow`.
 
 ```js
-assert.strictEqual(
+assert.oneOf(
   new __helpers.CSSHelp(document).getStyle(".card-links a:focus")?.getPropertyValue("outline"),
-  "yellow solid 2px" // it comes out like this from getPropertyValue
+  [
+    "yellow solid 2px", // it comes out like this from getPropertyValue
+    "2px solid yellow"
+  ]
 );
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69993

## Summary

In workshop-greeting-card step 23, `getPropertyValue('outline')` can return either `yellow solid 2px` or `2px solid yellow` depending on the browser environment. This updates the test to use `assert.oneOf` so both normalized values pass.