### PR TITLE
fix(api): allow owned origin

### DIFF
--- a/api/src/utils/allowed-origins.ts
+++ b/api/src/utils/allowed-origins.ts
@@ -4,6 +4,7 @@ const ALLOWED_ORIGINS = [
   'https://www.freecodecamp.dev',
   'https://www.freecodecamp.org',
   'https://exam.freecodecamp.org',
+  'https://auth.freecodecamp.org',
   // pretty sure the rest of these can go?
   'https://beta.freecodecamp.dev',
   'https://beta.freecodecamp.org',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Apparently, `auth.freecodecamp.org` requests `/signin` 🤷‍♂️ 