### PR TITLE
fix(curriculum): allow flexible outline property order in greeting card step 23

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-greeting-card/67333b1d5f4a7340a121973a.md
+++ b/curriculum/challenges/english/blocks/workshop-greeting-card/67333b1d5f4a7340a121973a.md
@@ -20,9 +20,9 @@ assert.exists(new __helpers.CSSHelp(document).getStyle(".card-links a:focus"));
 The `.card-links a:focus` selector should have an `outline` property set to `2px solid yellow`.
 
 ```js
-assert.strictEqual(
+assert.oneOf(
   new __helpers.CSSHelp(document).getStyle(".card-links a:focus")?.getPropertyValue("outline"),
-  "yellow solid 2px" // it comes out like this from getPropertyValue
+  ["yellow solid 2px", "2px solid yellow"]
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69993

<!-- Feel free to add any additional description of changes below this line -->

### Summary
Updates the test assertion for Step 23 in the Workshop Greeting Card project (`67333b1d5f4a7340a121973a.md`) from `assert.strictEqual` to `assert.oneOf` to accept both `"yellow solid 2px"` and `"2px solid yellow"`.

### Files Changed
`curriculum/challenges/english/blocks/workshop-greeting-card/67333b1d5f4a7340a121973a.md`

### Changes
Modified the `# --hints--` assertion:
- Changed `assert.strictEqual(..., "yellow solid 2px")` to `assert.oneOf(..., ["yellow solid 2px", "2px solid yellow"])`.

### Why
In some browser engines, `getPropertyValue("outline")` returns `"2px solid yellow"` instead of `"yellow solid 2px"`. Using `assert.oneOf` allows both valid CSS property value orderings so campers don't experience unexpected test failures.