### PR TITLE
fix(curriculum): update hint regex in step 30 of tree traversal

### DIFF
--- a/curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md
+++ b/curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md
@@ -18,7 +18,7 @@ After defining `__str__` you'll get an exception in the console because the `__s
 You should define a method `__str__` that takes a single argument `self`. Remember to use `pass`.
 
 ```js
-assert.match(code, /^(\s+)def\s+__init__.+?^\1def\s+__str__\(\s*self\s*\)\s*:\s*\n^\1\1pass/ms)
+assert.match(code, /^([ \t]+)def\s+__init__.+?^\1def\s+__str__\(\s*self\s*\)\s*:\s*\r?\n^\1\1pass/ms)
 ```
 
 

--- a/curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md
+++ b/curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md
@@ -18,7 +18,7 @@ After defining `__str__` you'll get an exception in the console because the `__s
 You should define a method `__str__` that takes a single argument `self`. Remember to use `pass`.
 
 ```js
-assert.match(code, /^([ \t]+)def\s+__init__.+?^\1def\s+__str__\(\s*self\s*\)\s*:\s*\r?\n^\1\1pass/ms)
+assert.match(code, /^([ \t]+)def\s+__init__.+?^\1def\s+__str__\(\s*self\s*\)\s*:\s*\n^\1\1pass/ms)
 ```
 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69918

<!-- Feel free to add any additional description of changes below this line -->

### Summary
Updates the hint regex test assertion in Step 30 of Learn Tree Traversal by Building a Binary Search Tree (`65c646d4148ae3b2d1cbcac4.md`). Replaces `^(\s+)` with `^([ \t]+)` to prevent multiline `\s` matching from consuming preceding unindented newlines in JavaScript V8 (Chrome).

### Files Changed
`curriculum/challenges/english/blocks/learn-tree-traversal-by-building-a-binary-search-tree/65c646d4148ae3b2d1cbcac4.md`

### Changes
Modified the `# --hints--` assertion:
- Replaced `^(\s+)def\s+__init__` with `^([ \t]+)def\s+__init__`.
- Added `\r?\n` line-ending compatibility to support both Unix (LF) and Windows (CRLF) environments seamlessly.

### Why
When `/s` (dotAll) and `/m` (multiline) flags are used together with backreference `^\1` in V8 (Chrome), `\s+` consumes preceding unindented blank lines above `def __init__`. This causes capture group `\1` to include newlines (`"\n\n    "`), breaking multiline backreference matching `^\1def \__str__` on valid camper code. Restricting group `\1` strictly to horizontal indentation spaces `[ \t]+` ensures indentation is captured cleanly and hint assertions pass consistently across all browsers.