### PR TITLE
fix(curriculum): add headers to javascript data types lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-javascript/672d496eca926b5df8176a67.md
@@ -26,6 +26,8 @@ Data types help the program understand the kind of data it's working with, wheth
 
 JavaScript has several basic data types that you'll use in your programs. We'll explore each data type in greater detail in future lessons. For now, here is a brief introduction of the different data types in JavaScript.
 
+## Numbers
+
 The first data type we will look at is the `Number` type.
 
 A `Number` represents both integers and floating-point values. Examples of integers include `7`, `19`, and `90`. 
@@ -58,6 +60,8 @@ console.log(-14.5);
 
 :::
 
+## Strings
+
 The next data type is a `String`.
 
 A `String` is a sequence of characters, or text, enclosed in quotes. Here is an example string using double quotes: 
@@ -82,15 +86,21 @@ console.log('I love to code!');
 
 Oftentimes you will use strings to represent names, labels, alert messages, etc.
 
+## Booleans
+
 Another data type used in JavaScript is the `Boolean` type.
 
 A `Boolean` represents one of two values: `true` or `false`. For example, a program might check whether a user is logged in (`true`) or not (`false`) and change the page based on that. If the user is logged in, you probably want to show them the dashboard page. Otherwise, you will want to show them the login page.
+
+## Undefined and Null
 
 The next two data types used in JavaScript are `undefined` and `null`.
 
 `undefined` means a variable has been declared but hasn't been given a value yet. You will learn more about this in the next lesson.
 
 `null` means the variable has been intentionally set to "nothing" and does not hold any value. We will explore more on how this works in future lessons.
+
+## Object, Symbol, and BigInt
 
 The last three data types are more complex in nature. These are `Object`, `Symbol`, and `BigInt`. 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69310

<!-- Feel free to add any additional description of changes below this line -->

Changes
- Added 5 section headers grouping the existing content by data type: Numbers, Strings, Booleans, Undefined and Null, and Object, Symbol, and BigInt.
- No prose, code blocks, questions, or front matter modified, headers only.

Testing
- Ran `pnpm run lint-challenges`, passes with no errors.
- Verified locally at `pnpm run develop`, viewed the lecture rendered in app, headers appear correctly at natural breaks.
