### PR TITLE
fix(curriculum): standardize null-check hints in Step 38 of Shape Manager workshop

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shape-manager/69159948e52168265730f74f.md
+++ b/curriculum/challenges/english/blocks/workshop-shape-manager/69159948e52168265730f74f.md
@@ -28,13 +28,13 @@ assert.match(code, /const\s+val\s*=\s*e\.currentTarget\s+as\s+HTMLSelectElement;
 You should have an `if` statement that checks if `val` is null.
 
 ```js
-assert.match(handleShapeSelect.toString(), /if\s*\((!val|val===null)\)\s*\{?\s*/)
+assert.match(handleShapeSelect.toString(), /if\s*\(\s*(!val|val\s*===\s*null)\s*\)\s*\{?\s*/)
 ```
 
 Your `if` statement should return `target value not found`.
 
 ```js
-assert.match(handleShapeSelect.toString(), /if\s*\((\s*!val\s*)\)\s*\{?\s*return\s*("|')target\s+value\s+not\s+found("|');?\s*\}?/)
+assert.match(handleShapeSelect.toString(), /if\s*\(\s*(!val|val\s*===\s*null)\s*\)\s*\{?\s*return\s*("|'|`)target\s+value\s+not\s+found("|'|`);?\s*\}?/)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69988