### PR TITLE
fix(curriculum): replace regex-based test cases in leap year calculator lab

### DIFF
--- a/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
+++ b/curriculum/challenges/english/blocks/lab-leap-year-calculator/66c06fad3475cd92421b9ac2.md
@@ -26,6 +26,13 @@ A leap year is a year that is divisible by `4`, except for years that are divisi
 6. You should call the `isLeapYear` function with `year` as the argument and assign the result to a variable named `result`.
 7. You should output the `result` variable to the console using `console.log()`.
 
+# --before-each--
+
+```js
+const spy = __helpers.spyOn(console, 'log');
+const getLogs = () => spy.calls.map(call => call.join(' '));
+```
+
 # --hints--
 
 You should define a function named `isLeapYear`.
@@ -77,7 +84,9 @@ assert.strictEqual(isLeapYear(1900), '1900 is not a leap year.');
 You should call the `isLeapYear` function and pass `year` as a parameter.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /isLeapYear\(\s*year\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.variables.result);
+assert.match(__helpers.removeWhiteSpace(explorer.variables.result.value.toString()), /^isLeapYear\(year\)$/);
 ```
 
 You should declare a `result` variable.
@@ -89,13 +98,15 @@ assert.isDefined(result);
 You should store the result of calling the `isLeapYear` function in a variable named `result`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /result\s*=\s*isLeapYear\(\s*year\s*\)/);
+const explorer = await __helpers.Explorer(code);
+assert.exists(explorer.variables.result);
+assert.match(__helpers.removeWhiteSpace(explorer.variables.result.value.toString()), /^isLeapYear\(year\)$/);
 ```
 
 You should output the `result` to the console using `console.log()`.
 
 ```js
-assert.match(__helpers.removeJSComments(code), /console\.log\(\s*result\s*\)/);
+assert.include(getLogs(), result);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69964

### Description

Replaces the three regex-based test cases in the Build a Leap Year Calculator lab with robust AST and runtime checks, per the umbrella ticket #68417.

### Changes

- The hint verifying that `result` stores the return value of `isLeapYear(year)` now uses an AST check of the variable initializer via the `Explorer` helper.
- The hint checking that `isLeapYear` is called with `year` uses the same AST initializer check.
- The `console.log(result)` hint now uses a `--before-each--` console spy and asserts the logged value equals `result` via `assert.include(getLogs(), result)`.

These checks are insensitive to whitespace/formatting variations (e.g. `isLeapYear( year )`).

### Testing

Ran locally: `pnpm build`, `pnpm -F @freecodecamp/curriculum lint`, `pnpm test-gen` + `pnpm vitest run --project test src/test/blocks-generated/lab-leap-year-calculator.test.js` (all pass). Also verified the new assertions reject invalid code (`isLeapYear(2024)` as the initializer, and a missing `console.log(result)`).