### PR TITLE
fix(curriculum): add section headers to repository creation lecture

### DIFF
--- a/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829061f03543726ea6f318.md
+++ b/curriculum/challenges/english/blocks/lecture-introduction-to-git-and-github/68829061f03543726ea6f318.md
@@ -11,7 +11,11 @@ We've talked a bit about Git and GitHub, so now we can start to put it all toget
 
 Repositories can be local on your computer, or remote on a service like GitHub. To create a repository, you can start with either local or remote - the result will be the same, so take whatever approach fits your workflow best. For a workflow where you start with a remote repository, you can create one directly through GitHub's website by following these instructions:
 
+## Creating a Repository on GitHub
+
 Visit <a href="https://github.com" target="_blank">GitHub's website</a>, make sure you are logged in, and then click the plus icon in the top right of the navigation bar. You'll see quite a few options, but the one you care about is "New Repository". Select that to open the UI for creating a new repository.
+
+## Repository Settings
 
 The first option you'll see there is the ability to choose a template. You likely do not have one of these set up yet, but a template is a special kind of repository that you can use as a springboard for your new repositories. These are helpful for including documentation or issue templates in all of your projects.
 
@@ -24,6 +28,8 @@ You can also choose whether the repository will be public or private. A public r
 Finally, if you do not select a template, you will see options to generate files in the repository automatically. A README file will appear on the repository's homepage, and is a great way to provide documentation and descriptions of your project. A `.gitignore` file allows you to specify files that Git will "ignore" - this is great for things like package dependencies, environment files, and other things you don't want to be saved. GitHub will offer templates for this file, which exclude the common items for the specified language or runtime. And a license is a legal document which outlines who may use your software, and what they may do with it.
 
 When you have your settings all configured as you like, you can click the "Create Repository" button to finish the process. You'll automatically be redirected to the landing page for your new repository!
+
+## Cloning a Repository
 
 From here, you can click the "Code" button to get options to clone your repository to your computer.
 
@@ -48,6 +54,8 @@ Additionally, the local copy of your repo will have a remote pointing to the cop
 ```sh
 git remote -v
 ```
+
+## Using the GitHub CLI
 
 Another option for cloning your repository is to use the GitHub CLI. This tool is used to do GitHub-specific tasks without leaving the command line. If you do not have it installed, you can get instructions to do so from GitHub's documentation - but you should have it available in your system's package manager.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

Closes #69980

## Description

Adds `##` section headers to the lecture body of "What Is a Repository, and How Do You Create One?" to break the ~984-word unbroken block into scannable sections.

Headers added:

- Creating a Repository on GitHub
- Repository Settings
- Cloning a Repository
- Using the GitHub CLI

No prose was rewritten - only headers were inserted. Front matter, code blocks, and the `# --questions--` section are untouched.

Screenshots of the rendered lecture below:
<img width="640" height="362" alt="Screenshot 2026-09-12 at 10 12 37 PM" src="https://github.com/user-attachments/assets/5a40348a-f853-4745-ab01-80798ca296b4" />
<img width="640" height="223" alt="Screenshot 2026-09-12 at 9 30 42 PM" src="https://github.com/user-attachments/assets/35d414c1-c11c-4626-b017-834fb0984813" />
<img width="640" height="137" alt="Screenshot 2026-09-12 at 9 31 00 PM" src="https://github.com/user-attachments/assets/4834b853-f0fb-43a1-a3ed-1af6857b326e" />

