### PR TITLE
fix(curriculum): check and verbiage for falsy value in Shape Manager

### DIFF
--- a/curriculum/challenges/english/blocks/workshop-shape-manager/69159948e52168265730f74f.md
+++ b/curriculum/challenges/english/blocks/workshop-shape-manager/69159948e52168265730f74f.md
@@ -25,16 +25,16 @@ Your `val` constant should have a `e.currentTarget` value typed `HTMLSelectEleme
 assert.match(code, /const\s+val\s*=\s*e\.currentTarget\s+as\s+HTMLSelectElement;?/)
 ```
 
-You should have an `if` statement that checks if `val` is null.
+You should have an `if` statement that checks if `val` is a falsy value.
 
 ```js
-assert.match(handleShapeSelect.toString(), /if\s*\((!val|val===null)\)\s*\{?\s*/)
+assert.match(handleShapeSelect.toString(), /if\s*\(\s*!val\s*\)\s*\{?\s*/)
 ```
 
 Your `if` statement should return `target value not found`.
 
 ```js
-assert.match(handleShapeSelect.toString(), /if\s*\((\s*!val\s*)\)\s*\{?\s*return\s*("|')target\s+value\s+not\s+found("|');?\s*\}?/)
+assert.match(handleShapeSelect.toString(), /if\s*\((\s*!val\s*)\)\s*\{?\s*return\s*("|'|`)target\s+value\s+not\s+found("|'|`);?\s*\}?/)
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitHub Codespaces.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69988

<!-- Feel free to add any additional description of changes below this line -->
